### PR TITLE
Optimise pattern incompleteness check

### DIFF
--- a/src/lib/HsToCoq/ConvertHaskell/Pattern.hs
+++ b/src/lib/HsToCoq/ConvertHaskell/Pattern.hs
@@ -264,7 +264,7 @@ type Missings = [Missing]
 
 isCompleteMultiPattern :: forall m. TypeInfoMonad m => [MultPattern] -> m Bool
 isCompleteMultiPattern [] = pure True -- Maybe an empty data type?
-isCompleteMultiPattern mpats = null <$> goGroup mpats
+isCompleteMultiPattern mpats = null <$> goGroup (reverse mpats)
   where
     -- Initially, we miss everything
     initMissings = [[]]


### PR DESCRIPTION
Reverse the list of patterns when checking for completeness. In Haskell
more general patterns follow specialized patterns and in particular the
catch-all clause is always last.

Fixes #112