### PR TITLE
"Except in" edit

### DIFF
--- a/doc/source/edits.rst
+++ b/doc/source/edits.rst
@@ -1204,8 +1204,8 @@ Effect:
 Meta-edits
 ----------
 
-Localizing edits - restrict scope of an edit
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``in`` edit - restrict scope of an edit to a single definition
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. index::
    single: in, edit
@@ -1227,6 +1227,40 @@ Examples:
 
      in SrcLoc.Ord__RealSrcLoc_op_zl__ rewrite forall, SrcLoc.Ord__RealSrcLoc_compare = GHC.Base.compare
      in Util.exactLog2 termination pow2 deferred
+
+``except in`` edit - exclude definitions from an edit
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. index::
+   single: except in, edit
+
+
+Format:
+ | **except in** *qualified_names* *edit*
+
+Effect:
+
+  This is essentially the opposite of an ``in`` edit. The given edit is applied as normal,
+  except during the translation of the given definition(s). This is most useful to rename
+  or rewrite a definition everywhere except within one or more functions. In addition, it 
+  can be used when there is a local function with the same name in multiple definitions,
+  in order to give termination arguments to all occurrences of that local function except
+  those in the specified definitions.
+
+  As with ``in`` edits, while all edits are allowed, for many edits it doesn't make sense to
+  apply ``except in``.
+
+
+Examples:
+  .. code-block:: shell
+
+     except in SrcLoc.Ord__RealSrcLoc_op_zl__ rewrite forall, SrcLoc.Ord__RealSrcLoc_compare = GHC.Base.compare
+     except in Util.exactLog2 termination pow2 deferred
+     except in ModuleName.def_1 skip case pattern _
+
+     # Multiple qualified names are separated with commas
+     except in ModuleName.def_1, ModuleName.def_2 rename type GHC.Types.[] = list
+
 
 Deprecated edits
 ----------------

--- a/examples/tests/ExceptIn.hs
+++ b/examples/tests/ExceptIn.hs
@@ -1,0 +1,25 @@
+module ExceptIn(Test1(..), Test2(..), test1_1, test1_2, foo, bar, baz) where
+
+    data Test1 = A Int | B String
+        deriving Show
+
+    data Test2 = X Int | Y String
+        deriving Show
+
+    test1_1 :: Test1
+    test1_1 = A 5
+
+    test1_2 :: Test1
+    test1_2 = B "hello"
+
+    foo :: Test1 -> Test1
+    foo (A n) = A (n + 1)
+    foo (B str) = B $ str <> "."
+
+    bar :: Test1 -> Test1
+    bar (A n) = A (n + 2)
+    bar (B str) = B $ str <> "!"
+
+    baz :: Test1 -> Test1
+    baz (A n) = A (2 * n)
+    baz (B str) = B $ str <> "?"

--- a/examples/tests/ExceptIn.hs
+++ b/examples/tests/ExceptIn.hs
@@ -1,10 +1,8 @@
 module ExceptIn(Test1(..), Test2(..), test1_1, test1_2, foo, bar, baz) where
 
     data Test1 = A Int | B String
-        deriving Show
 
     data Test2 = X Int | Y String
-        deriving Show
 
     test1_1 :: Test1
     test1_1 = A 5

--- a/examples/tests/ExceptIn/edits
+++ b/examples/tests/ExceptIn/edits
@@ -1,0 +1,36 @@
+# This edit works.
+except in ExceptIn.bar, ExceptIn.baz rename value ExceptIn.A = ExceptIn.X
+
+
+# The following edit has a couple of issues; see below for more information.
+except in ExceptIn.Test1, ExceptIn.bar, ExceptIn.baz rename type ExceptIn.Test1 = ExceptIn.Test2
+
+# 1.
+# In the type signature of ExceptIn.bar and ExceptIn.baz, Test1 is renamed to
+# Test2, even though we excluded ExceptIn.bar and ExceptIn.baz when we specified
+# the rename edit.
+
+# This is not an issue specific to "except in" edits, but rather with the fact that
+# local edits are not taken into account when translating signatures. This has been
+# documented; see issue #156 on github (https://github.com/antalsz/hs-to-coq/issues/156).
+
+# 2.
+# In the declaration of Test1 (Inductive Test1 : Type), "Test1" is renamed to
+# "Test2", even though we excluded ExceptIn.Test1 when we specified the rename
+# edit. Since there is already a data type called Test2, the new definition of
+# Test2 (i.e. the definition of Test1 before the renaming) is removed by
+# hs-to-coq and does not appear at all in the resulting Coq code.
+
+# Why does the renaming happen, despite the fact that we excluded ExceptIn.Test1?
+# Note that when we specified ExceptIn.Test1 in the "except in" edit, we told
+# hs-to-coq not to rename Test1 to Test2 *inside* the definition of Test1, but
+# the declaration is not considered to be inside the definition.
+
+# Perhaps it would make sense to consider the declaration to be part of the
+# definition, so that we can prevent the name in the declaration from
+# being renamed.
+
+
+
+
+

--- a/examples/tests/Makefile
+++ b/examples/tests/Makefile
@@ -36,7 +36,6 @@ PASS = \
   Existential \
   SkipConstructor \
   SkipMatches \
-  ExceptIn
 
 # tests that *should* pass but currently fail
 TODO_PASS = \
@@ -44,7 +43,8 @@ TODO_PASS = \
   TypeAnnotations \
   StrictPair \
   MutrecInst \
-  TopBind
+  TopBind \
+  ExceptIn
 
 # tests that *should* pass but currently don't even translate
 TODO_TRANSLATE = \

--- a/examples/tests/Makefile
+++ b/examples/tests/Makefile
@@ -34,8 +34,9 @@ PASS = \
   RedefineAddAxiom \
   AddTheorem \
   Existential \
-	SkipConstructor \
-	SkipMatches
+  SkipConstructor \
+  SkipMatches \
+  ExceptIn
 
 # tests that *should* pass but currently fail
 TODO_PASS = \

--- a/src/lib/HsToCoq/ConvertHaskell/Monad.hs
+++ b/src/lib/HsToCoq/ConvertHaskell/Monad.hs
@@ -213,10 +213,14 @@ withCurrentDefinition newDef act = do
     local_edits <- view (edits.inEdits.at newDef.non mempty)
     let edits_in_scope = local_edits <> global_edits
     
+    -- Subtract out the edits to be excluded for this definition.
+    excluded_edits <- view (edits.exceptInEdits.at newDef.non mempty)
+    let edits_final = subtractEdits edits_in_scope excluded_edits
+    
     _leniency      <- view leniency
     _currentModule <- view currentModule
     runCounterT . runReaderT act $ LocalEnv
-        { _localEnvEdits             = edits_in_scope
+        { _localEnvEdits             = edits_final
         , _localEnvLeniency          = _leniency
         , _localEnvCurrentModule     = _currentModule
         , _localEnvCurrentDefinition = newDef

--- a/src/lib/HsToCoq/ConvertHaskell/Parameters/Edits.hs
+++ b/src/lib/HsToCoq/ConvertHaskell/Parameters/Edits.hs
@@ -233,7 +233,7 @@ subtractEdits edits1 edits2 =
   Edits {
     _typeSynonymTypes               = edits1^.typeSynonymTypes
   , _dataTypeArguments              = edits1^.dataTypeArguments 
-  , _termination                    = edits1^.termination
+  , _termination                    = (edits1^.termination) M.\\ (edits2^.termination)
   , _redefinitions                  = edits1^.redefinitions
   , _additions                      = edits1^.additions
   , _skipped                        = edits1^.skipped

--- a/src/lib/HsToCoq/ConvertHaskell/Parameters/Parsers.y
+++ b/src/lib/HsToCoq/ConvertHaskell/Parameters/Parsers.y
@@ -317,7 +317,7 @@ Edit :: { Edit }
   | set type Qualid TypeAnnotationOrNot                   { SetTypeEdit                      $3 $4                                 }
   | collapse 'let' Qualid                                 { CollapseLetEdit                  $3                                    }
   | 'in' Qualid Edit                                      { InEdit                           $2 $3                                 }
-  | except 'in' Some(Qualid) Edit                         { ExceptInEdit                     $3 $4                                 }
+  | except 'in' SepBy1(Qualid, ',') Edit                  { ExceptInEdit                     $3 $4                                 }
 
 Edits :: { [Edit] }
   : Lines(Edit)    { $1 }

--- a/src/lib/HsToCoq/ConvertHaskell/Parameters/Parsers.y
+++ b/src/lib/HsToCoq/ConvertHaskell/Parameters/Parsers.y
@@ -93,6 +93,7 @@ import HsToCoq.ConvertHaskell.Parameters.Parsers.Lexing
   pattern         { TokWord    "pattern"        }
   original        { TokWord    "original"       }
   name            { TokWord    "name"           }
+  except          { TokWord    "except"         }
   '='             { TokOp      "="              }
   ':->'           { TokOp      ":->"            }
   -- Tokens: Coq terms
@@ -316,6 +317,7 @@ Edit :: { Edit }
   | set type Qualid TypeAnnotationOrNot                   { SetTypeEdit                      $3 $4                                 }
   | collapse 'let' Qualid                                 { CollapseLetEdit                  $3                                    }
   | 'in' Qualid Edit                                      { InEdit                           $2 $3                                 }
+  | except 'in' Some(Qualid) Edit                         { ExceptInEdit                     $3 $4                                 }
 
 Edits :: { [Edit] }
   : Lines(Edit)    { $1 }


### PR DESCRIPTION
Adds support for an "except in" edit, which allows the user to specify an edit and one or more identifiers, and applies the given edit everywhere except for within the definitions of the given identifiers.

Also adds an entry for this new edit to the documentation, and includes an example/test case illustrating the edit. Note that there are currently a couple of important caveats regarding the behavior of this edit.

1. Type signatures are not subject to the exceptions specified by "except in" edits.
For example, suppose we have a module `MyModule` with a type `Ty1` and a function `foo :: Ty1 -> Ty1`. Suppose our edit file contains

    ```except in MyModule.foo rename type MyModule.Ty1 = MyModule.Ty2 ```

    Then after running hs-to-coq, the signature of `foo` will be `Ty2 -> Ty2`, even though we 
excluded MyModule.foo when we specified the rename edit.
This is not an issue with "except in" edits; it is a result of the fact that local edits are not taken into account when translating signatures. See issue #156 for more.

2. Using an "except in" edit to rename a user-defined type will also rename the type in its original declaration and definition; this may not be what you want to do.

    For example, suppose we have a module `MyModule` with a user-defined type `Ty1`:

    ````data Ty1 = A Int | B String````

    Without applying any edits, the resulting Coq file will contain the following declaration and definition:

    ````
    Inductive Ty1 : Type
      := | A : GHC.Num.Int -> Ty1
      |  B : GHC.Base.String -> Ty1.
    ````

    Suppose we apply the following edit:

    ```except in MyModule.foo rename type MyModule.Ty1 = MyModule.Ty2 ```

    (where `foo` is a function in the Haskell module). In the resulting Coq file, `Ty1` will be renamed to `Ty2` in the declaration and definition of `Ty1`:

    ````
    Inductive Ty2 : Type
      := | A : GHC.Num.Int -> Ty2
      |  B : GHC.Base.String -> Ty2.
    ````

    This may be useful, but if the Haskell module already contains a type called `Ty2`, then hs-to-coq will simply discard `Ty1`. However, in this case, what we probably want is for the declaration and definition of `Ty1` to remain, and in particular, to remain as `Ty1`. All other occurrences of `Ty1`, except for the ones in definitions given in the except in edit, should be renamed to `Ty2`. 

    To try to exclude the declaration and definition of `Ty1` from the renaming, we could try adding `MyModule.Ty1` to the except in edit, but this does not seem to work (see examples/tests/ExceptIn/edits). Alternatively, it might make sense to consider the declaration to be part of the definition, so that we can prevent the name of the type in the declaration from being renamed. To do this, we would need to be able to apply rename edits locally within a declaration.

Both of these issues occur in the example I included, and they are discussed in the edits file (examples/tests/ExceptIn/edits).