### PR TITLE
Translating signatures now takes into account local edits

### DIFF
--- a/src/lib/HsToCoq/ConvertHaskell/Declarations/Class.hs
+++ b/src/lib/HsToCoq/ConvertHaskell/Declarations/Class.hs
@@ -87,7 +87,7 @@ convertAssociatedType classArgs FamilyDecl{..} = do
   unless (null fdInjectivityAnn) $ badAssociation "injective associated type families" "associated type"
   
   name   <- var TypeNS $ unLoc fdLName
-  args   <- convertLHsTyVarBndrs Coq.Explicit $ hsq_explicit fdTyVars
+  args   <- withCurrentDefinition name (convertLHsTyVarBndrs Coq.Explicit $ hsq_explicit fdTyVars)
   -- Could losen this in future?
   unless (classArgs == foldMap (toListOf binderIdents) args) $
     badAssociation "associated type families with argument lists that differ from the class's" "associated type"
@@ -95,9 +95,9 @@ convertAssociatedType classArgs FamilyDecl{..} = do
   
   result <- case unLoc fdResultSig of
     NoSig                            -> pure $ Sort Type
-    KindSig   k                      -> convertLType k
+    KindSig   k                      -> withCurrentDefinition name $ convertLType k
     TyVarSig (L _ (UserTyVar _))     -> pure $ Sort Type -- Maybe not a thing inside type classes?
-    TyVarSig (L _ (KindedTyVar _ k)) -> convertLType k   -- Maybe not a thing inside type classes?
+    TyVarSig (L _ (KindedTyVar _ k)) -> withCurrentDefinition name $ convertLType k   -- Maybe not a thing inside type classes?
   
   pure (name, result)
 
@@ -108,8 +108,9 @@ convertAssociatedTypeDefault classArgs FamEqn{..} = do
     convUnsupportedIn_lname "associated type family defaults with argument lists that differ from the class's"
                             "associated type equation"
                             feqn_tycon
-  (,) <$> var TypeNS (unLoc feqn_tycon)
-      <*> convertLType feqn_rhs
+  n <- var TypeNS (unLoc feqn_tycon)
+  (,) <$> n
+      <*> withCurrentDefinition n $ convertLType feqn_rhs
   -- Skipping feqn_fixity
     
 convertClassDecl :: ConversionMonad r m
@@ -128,12 +129,14 @@ convertClassDecl (L _ hsCtx) (L _ hsName) ltvs fds lsigs defaults types typeDefa
   let convUnsupportedHere what = convUnsupportedIn what "type class" (showP name)
   unless (null fds) $ convUnsupportedHere "functional dependencies"
 
-  ctx  <- traverse (fmap (Generalized Coq.Implicit) . convertLType) hsCtx
+  let aux x = withCurrentDefinition name $ convertLType x
+  ctx  <- traverse (fmap (Generalized Coq.Implicit) . aux) hsCtx
+
   storeSuperclassCount name . sum <=< for ctx $ \case
     Generalized _ (termHead -> Just super) -> maybe 1 (+ 1) <$> lookupSuperclassCount super
     _                                      -> pure 1
 
-  args <- convertLHsTyVarBndrs Coq.Explicit ltvs
+  args <- withCurrentDefinition name $ convertLHsTyVarBndrs Coq.Explicit ltvs
   kinds <- (++ repeat Nothing) . map Just . maybe [] NE.toList <$> view (edits.classKinds.at name)
   let args' = zipWith go args kinds
        where go (Inferred exp name) (Just t) = Typed Ungeneralizable exp (name NE.:| []) t
@@ -164,7 +167,7 @@ convertClassDecl (L _ hsCtx) (L _ hsName) ltvs fds lsigs defaults types typeDefa
 
   -- ugh! doesnt work for operators
   -- memberSigs.at name ?= sigs
-  
+
   type_defs  <- M.fromList <$> traverse (convertAssociatedTypeDefault argNames . unLoc) typeDefaults
   value_defs <- fmap M.fromList $ for (bagToList defaults) $
                 convertTypedModuleBinding Nothing . unLoc >=> \case

--- a/src/lib/HsToCoq/ConvertHaskell/Declarations/TypeSynonym.hs
+++ b/src/lib/HsToCoq/ConvertHaskell/Declarations/TypeSynonym.hs
@@ -31,7 +31,8 @@ instance HasBV Qualid SynBody where
   bvOf (SynBody name args oty def) =
     binder name <> bindsNothing (foldScopes bvOf args $ fvOf oty <> fvOf def)
 
-convertSynDecl :: ConversionMonad r m
+-- might make sense to use ConversionMonad instead
+convertSynDecl :: LocalConvMonad r m
                => Located GHC.Name -> [LHsTyVarBndr GhcRn] -> LHsType GhcRn
                -> m SynBody
 convertSynDecl name args def  = do

--- a/src/lib/HsToCoq/ConvertHaskell/Expr.hs
+++ b/src/lib/HsToCoq/ConvertHaskell/Expr.hs
@@ -879,6 +879,8 @@ convertTypedBinding convHsTy FunBind{..}   = do
               let peelForall (Forall tvs body) = first (NEL.toList tvs ++) $ peelForall body
                   peelForall ty                = ([], ty)
               in maybe ([], Nothing) (second Just . peelForall) convHsTy
+              -- in maybe ([], Nothing) (second Just . peelForall) (Just $ Qualid $ Bare "test")
+
 
         let tryCollapseLet defn = do
               view (edits.collapsedLets.contains name) >>= \case

--- a/src/lib/HsToCoq/ConvertHaskell/Sigs.hs
+++ b/src/lib/HsToCoq/ConvertHaskell/Sigs.hs
@@ -80,9 +80,9 @@ collectSigsWithErrors =
         multiplesError _ (Right sig) =
           pure sig
 
-convertSignature :: ConversionMonad r m => UnusedTyVarMode -> HsSignature -> m Signature
-convertSignature utvm (HsSignature sigTy _hsFix) = do
-  Signature <$> convertLHsSigType utvm sigTy <*> pure Nothing
+convertSignature :: ConversionMonad r m => Qualid -> UnusedTyVarMode -> HsSignature -> m Signature
+convertSignature coqName utvm (HsSignature sigTy _hsFix) = do
+  withCurrentDefinition coqName (Signature <$> convertLHsSigType utvm sigTy <*> pure Nothing)
 
 -- Incorporates @set type …@ edits ('replacedTypes') for all bindings that
 -- /already had/ a type signature; use 'lookupSig' to get the rest.
@@ -95,7 +95,7 @@ convertSignatures = fmap (M.fromList . catMaybes) . traverse conv . M.toList whe
       Just Nothing   -> pure Nothing
       Nothing -> do
         utvm <- unusedTyVarModeFor coqName
-        Just . (coqName,) <$> convertSignature utvm hsSig
+        Just . (coqName,) <$> convertSignature coqName utvm hsSig
 
 -- Incorporates @set type …@ edits ('replacedTypes') for all bindings that
 -- /already had/ a type signature; use 'lookupSig' to get the rest.


### PR DESCRIPTION
This is a fix for #156. In the current version of `hs-to-coq`, when we translate signatures, local edits are not taken into consideration. Thus, trying to use an `in` edit to perform a renaming in a definition does not perform the renaming in the signature of the definition. The work in this branch fixes this behavior.