### PR TITLE
Promote edit

### DIFF
--- a/doc/source/edits.rst
+++ b/doc/source/edits.rst
@@ -860,9 +860,10 @@ Format:
   | **promote** *qualified_name* ...
 
 Effect:
-  ``hs-to-coq`` divides Haskell definitions into two kinds: type-level and term-level.
-  The ``promote`` edit "prmotes" a term-level definition to the type level.
-  It also recursively promotes the transitive closure of all definitions on which the
+  `hs-to-coq` divides Haskell definitions into two "levels": type-level and term-level.
+  Type-level definitions always appear above term-level definitions in the Coq output.
+  The ``promote`` edit moves a term-level definition to the type level.
+  It also recursively moves the transitive closure of all definitions on which the
   specified definition depends.
 
 Examples:

--- a/doc/source/edits.rst
+++ b/doc/source/edits.rst
@@ -849,6 +849,28 @@ Examples:
 
     order GHC.Base.Functor__arrow GHC.Base.Applicative__arrow_op_ztzg__ GHC.Base.Applicative__arrow GHC.Base.Monad__arrow_return_ GHC.Base.Monad__arrow GHC.Base.Alternative__arrow GHC.Base.MonadPlus__arrow
 
+
+``promote`` -- promote a definition from the term level to the type level
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. index::
+   single: promote, edit
+
+Format:
+  | **promote** *qualified_name* ...
+
+Effect:
+  ``hs-to-coq`` divides Haskell definitions into two kinds: type-level and term-level.
+  The ``promote`` edit "prmotes" a term-level definition to the type level.
+  It also recursively promotes the transitive closure of all definitions on which the
+  specified definition depends.
+
+Examples:
+  .. code-block:: shell
+
+    promote MyModule.foo
+
+
 ``manual notation`` -- Indicate presence of manual notation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/examples/tests/Makefile
+++ b/examples/tests/Makefile
@@ -34,8 +34,10 @@ PASS = \
   RedefineAddAxiom \
   AddTheorem \
   Existential \
-	SkipConstructor \
-	SkipMatches
+  SkipConstructor \
+  SkipMatches \
+  Promote \
+  Promote2
 
 # tests that *should* pass but currently fail
 TODO_PASS = \

--- a/examples/tests/Promote.hs
+++ b/examples/tests/Promote.hs
@@ -1,0 +1,12 @@
+module Promote where
+
+  data Ty1 = A Bool
+
+  f :: Ty1 -> Ty1
+  f x = x
+
+  i :: Ty1 -> Ty1
+  i x = x
+
+
+

--- a/examples/tests/Promote/edits
+++ b/examples/tests/Promote/edits
@@ -1,0 +1,3 @@
+promote Promote.f
+
+

--- a/examples/tests/Promote/midamble.v
+++ b/examples/tests/Promote/midamble.v
@@ -1,0 +1,4 @@
+Fail Definition f := True.
+
+Definition i := True.
+Reset i.

--- a/examples/tests/Promote2.hs
+++ b/examples/tests/Promote2.hs
@@ -1,0 +1,17 @@
+module Promote2 where
+
+  data Ty1 = A Bool
+
+  h :: Ty1 -> Ty1
+  h x = x
+
+  g :: Ty1 -> Ty1
+  g x = h x
+
+  f :: Ty1 -> Ty1
+  f x = g x
+
+  i :: Ty1 -> Ty1
+  i x = x
+
+

--- a/examples/tests/Promote2/edits
+++ b/examples/tests/Promote2/edits
@@ -1,0 +1,3 @@
+promote Promote2.f
+
+

--- a/examples/tests/Promote2/midamble.v
+++ b/examples/tests/Promote2/midamble.v
@@ -1,0 +1,6 @@
+Fail Definition h := True.
+Fail Definition g := True.
+Fail Definition f := True.
+
+Definition i := True.
+Reset i.

--- a/src/lib/HsToCoq/ConvertHaskell/Parameters/Edits.hs
+++ b/src/lib/HsToCoq/ConvertHaskell/Parameters/Edits.hs
@@ -266,7 +266,8 @@ subtractEdits edits1 edits2 =
   , _replacedTypes                  = edits1^.replacedTypes
   , _collapsedLets                  = edits1^.collapsedLets
   , _inEdits                        = edits1^.inEdits
-  , _exceptInEdits                  = edits1^.exceptInEdits 
+  , _exceptInEdits                  = edits1^.exceptInEdits
+  , _promotions                     = edits1^.promotions
   }
 
 -- Derived edits

--- a/src/lib/HsToCoq/ConvertHaskell/Parameters/Parsers.y
+++ b/src/lib/HsToCoq/ConvertHaskell/Parameters/Parsers.y
@@ -93,6 +93,7 @@ import HsToCoq.ConvertHaskell.Parameters.Parsers.Lexing
   pattern         { TokWord    "pattern"        }
   original        { TokWord    "original"       }
   name            { TokWord    "name"           }
+  promote         { TokWord    "promote"        }
   '='             { TokOp      "="              }
   ':->'           { TokOp      ":->"            }
   -- Tokens: Coq terms
@@ -316,6 +317,8 @@ Edit :: { Edit }
   | set type Qualid TypeAnnotationOrNot                   { SetTypeEdit                      $3 $4                                 }
   | collapse 'let' Qualid                                 { CollapseLetEdit                  $3                                    }
   | 'in' Qualid Edit                                      { InEdit                           $2 $3                                 }
+  | promote Qualid                                        { PromoteEdit                      $2                                    }
+
 
 Edits :: { [Edit] }
   : Lines(Edit)    { $1 }


### PR DESCRIPTION
Adds a new `promote` edit, which allows the user to specify that a definition that normally would be placed in the set of term-level definitions in the resulting Coq file should instead be "promoted" to the set of type-level definitions.