### PR TITLE
Upgrade hs-to-coq to GHC 8.6, 8.8, 8.10

### DIFF
--- a/hs-to-coq.cabal
+++ b/hs-to-coq.cabal
@@ -13,11 +13,19 @@ copyright:           Copyright © 2016 Antal Spector-Zabusky, University of Penn
 category:            Language
 build-type:          Simple
 cabal-version:       >=1.10
-extra-source-files:  src/lib/HsToCoq/ConvertHaskell/Parameters/Parsers.y
+extra-source-files:
+  src/lib/HsToCoq/ConvertHaskell/Parameters/Parsers.y
+  src/include/*.h
+tested-with: GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4 GHC == 8.10.1
 
 source-repository head
   type:     git
   location: https://github.com/antalsz/hs-to-coq
+
+flag legacy-warnings
+  description: Reenable -Wincomplete-patterns for newer versions of GHC
+  manual: True
+  default: False
 
 library
   exposed-modules:     HsToCoq.Util.GHC
@@ -106,30 +114,30 @@ library
                      , TemplateHaskell
                      , CPP
 
-  build-depends:       base                 ==4.11.*
-                     , template-haskell     ==2.13.*
-                     , ghc                  ==8.4.*
-                     , ghc-boot             ==8.4.*
-                     , ghc-paths            ==0.1.*
-                     , bifunctors           ==5.*
-                     , semigroups           ==0.18.*
-                     , transformers         ==0.5.*
-                     , mtl                  ==2.2.*
-                     , array                ==0.5.*
-                     , lens                 ==4.16.*
-                     , pipes                ==4.3.*
-                     , containers           ==0.5.*
-                     , contravariant        >=1.3 && <1.6
-                     , validation           ==1.*
-                     , syb                  ==0.7.*
-                     , text                 ==1.2.*
-                     , directory            ==1.3.*
-                     , filepath             ==1.4.*
-                     , wl-pprint-text       ==1.2.*
-                     , parsec               ==3.1.*
-                     , indents              ==0.5.*
-                     , optparse-applicative ==0.14.*
-                     , yaml                 ==0.8.*
+  build-depends:       base                 >=4.11 && < 4.15
+                     , template-haskell     >=2.13
+                     , ghc                  >=8.4
+                     , ghc-boot
+                     , ghc-paths
+                     , bifunctors
+                     , semigroups
+                     , transformers
+                     , mtl
+                     , array
+                     , lens
+                     , pipes
+                     , containers
+                     , contravariant
+                     , validation
+                     , syb
+                     , text
+                     , directory
+                     , filepath
+                     , wl-pprint-text
+                     , parsec
+                     , indents
+                     , optparse-applicative
+                     , yaml
 
   -- These are actually not used directly by hs-to-coq, but work around a
   -- bug(?) in GHC-8.4 that no longer loads other packages if there is a GHC
@@ -139,14 +147,16 @@ library
     test-framework-quickcheck2 >= 0.2.9,
     test-framework-hunit
 
-
   hs-source-dirs:      src/lib
+  include-dirs:        src/include
   default-language:    Haskell2010
   ghc-options:         -Wall -fno-warn-name-shadowing
+  if !flag(legacy-warnings) && impl(ghc >= 8.6)
+    ghc-options:       -Wno-unused-imports
 
 executable hs-to-coq
   main-is:             Main.hs
-  build-depends:       base == 4.11.*, hs-to-coq
+  build-depends:       base, hs-to-coq
   hs-source-dirs:      src/exe
   default-language:    Haskell2010
   ghc-options:         -Wall -fno-warn-name-shadowing

--- a/src/include/ghc-compat.h
+++ b/src/include/ghc-compat.h
@@ -1,0 +1,49 @@
+#ifndef __GHC_COMPAT__
+#define __GHC_COMPAT__
+
+#if 0
+GHC 8.6 started using extensively the "Trees That Grow" style of ASTs,
+which extends many constructors with a new "extension field".
+
+To maintain compatibility across that change, this header introduces some
+macros that either expand to the new field when it exists (GHC >= 8.6)
+or disappear when it doesn't exist (GHC < 8.6).
+
+> f (HsApp NOEXTP x y) = ...  -- before CPP
+> f (HsApp _ x y) = ...       -- after CPP, GHC >= 8.6
+> f (HsApp x y) = ...         -- after CPP, GHC 8.4
+
+- Since GHC 8.10, inactive extension fields have type 'NoExtField'
+- On GHC 8.6 and GHC 8.8, inactive extension fields have a differently named
+  type 'NoExt'
+- On GHC 8.4, some AST nodes already had "Trees That Grow"-style extension fields,
+  with the default type 'PlaceHolder', that we rename accordingly in newer versions
+  by turning it into a macro.
+
+- The macro 'NOEXT' expands to the constructor name ('NoExtField', 'NoExt'),
+  which can be used as both an expression and a pattern.
+- The macro 'NOEXTP' expands to a wildcard pattern, which can be used for
+  pattern-matching when the extension field is not inactive (not of type
+  'NoExtField' or 'NoExt').
+#endif
+
+#if __GLASGOW_HASKELL__ >= 810
+
+#define PlaceHolder NoExtField
+#define NOEXT NoExtField
+#define NOEXTP _
+
+#elif __GLASGOW_HASKELL__ >= 806
+
+#define PlaceHolder NoExt
+#define NOEXT NoExt
+#define NOEXTP _
+
+#else
+
+#define NOEXT
+#define NOEXTP
+
+#endif
+
+#endif

--- a/src/lib/HsToCoq/ConvertHaskell/Declarations/TyCl.hs
+++ b/src/lib/HsToCoq/ConvertHaskell/Declarations/TyCl.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TupleSections, LambdaCase, RecordWildCards,
              OverloadedLists, OverloadedStrings,
              FlexibleContexts, ScopedTypeVariables,
@@ -48,6 +49,9 @@ import HsToCoq.Coq.FreeVars
 import HsToCoq.Coq.Pretty
 import HsToCoq.Coq.Subst        
 import HsToCoq.Util.FVs
+#if __GLASGOW_HASKELL__ >= 806
+import HsToCoq.Util.GHC.HsTypes (noExtCon)
+#endif
 
 import Data.Generics hiding (Generic, Fixity(..))
 
@@ -131,6 +135,9 @@ convertTyClDecl decl = do
                              SynDecl{}   -> "a type synonym"
                              DataDecl{}  -> "a data type"
                              ClassDecl{} -> "a type class"
+#if __GLASGOW_HASKELL__ >= 806
+                             XTyClDecl v -> noExtCon v
+#endif
                     to   = case redef of
                              CoqDefinitionDef _   -> "a Definition"
                              CoqFixpointDef   _   -> "a Fixpoint"
@@ -146,6 +153,9 @@ convertTyClDecl decl = do
                                   SynDecl{}   -> ("type synonym",     "type synonyms")
                                   DataDecl{}  -> ("data type",        "data types")
                                   ClassDecl{} -> ("type class",       "type classes")
+#if __GLASGOW_HASKELL__ >= 806
+                                  XTyClDecl v -> noExtCon v
+#endif
             in convUnsupportedIn ("axiomatizing " ++ whats ++ " (without `redefine Axiom')") what (showP coqName)
           
           TranslateIt ->
@@ -163,6 +173,9 @@ convertTyClDecl decl = do
            SynDecl{..}   -> ConvSyn              <$> convertSynDecl           tcdLName (hsq_explicit tcdTyVars) tcdRhs
            DataDecl{..}  -> ConvData <$> isCoind <*> convertDataDecl          tcdLName (hsq_explicit tcdTyVars) tcdDataDefn
            ClassDecl{..} -> ConvClass            <$> convertClassDecl tcdCtxt tcdLName (hsq_explicit tcdTyVars) tcdFDs tcdSigs tcdMeths tcdATs tcdATDefs
+#if __GLASGOW_HASKELL__ >= 806
+           XTyClDecl v -> noExtCon v
+#endif
 
 --------------------------------------------------------------------------------
 

--- a/src/lib/HsToCoq/ConvertHaskell/Monad.hs
+++ b/src/lib/HsToCoq/ConvertHaskell/Monad.hs
@@ -185,7 +185,7 @@ type LocalConvMonad r m =
         , HasCurrentDefinition r Qualid
         )
 
-runGlobalMonad :: (GhcMonad m, Monad m) =>
+runGlobalMonad :: GhcMonad m =>
     Edits ->
     Leniency ->
     TypeInfoConfig ->

--- a/src/lib/HsToCoq/ConvertHaskell/Type.hs
+++ b/src/lib/HsToCoq/ConvertHaskell/Type.hs
@@ -1,7 +1,10 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase,
              OverloadedStrings,
              FlexibleContexts,
              GeneralizedNewtypeDeriving #-}
+
+#include "ghc-compat.h"
 
 module HsToCoq.ConvertHaskell.Type
   (convertType,
@@ -9,16 +12,21 @@ module HsToCoq.ConvertHaskell.Type
    convertLHsTyVarBndrs,
    convertLHsSigType,
    convertLHsSigTypeWithExcls,
-   convertLHsSigWcType)
+   convertLHsSigWcType,
+   convertHsSigType_)
 where
 
+import Control.Applicative (liftA2)
 import Control.Lens
 
+import Data.Functor (($>))
 import Data.Traversable
 import Data.List.NonEmpty (nonEmpty)
 import Data.List ((\\))
+import Data.Maybe (maybe)
 
 import GHC hiding (Name)
+import qualified GHC
 import HsToCoq.Util.GHC.FastString
 
 import HsToCoq.Util.GHC
@@ -36,28 +44,39 @@ import HsToCoq.ConvertHaskell.Literals
 
 convertLHsTyVarBndrs :: LocalConvMonad r m => Explicitness -> [LHsTyVarBndr GhcRn] -> m [Binder]
 convertLHsTyVarBndrs ex tvs = for (map unLoc tvs) $ \case
-  UserTyVar   tv   -> Inferred ex . Ident <$> var TypeNS (unLoc tv)
-  KindedTyVar tv k -> Typed Ungeneralizable ex <$> (pure . Ident <$> var TypeNS (unLoc tv)) <*> convertLType k
+  UserTyVar   NOEXTP tv   -> Inferred ex . Ident <$> var TypeNS (unLoc tv)
+  KindedTyVar NOEXTP tv k -> Typed Ungeneralizable ex <$> (pure . Ident <$> var TypeNS (unLoc tv)) <*> convertLType k
+#if __GLASGOW_HASKELL__ >= 806
+  XTyVarBndr v -> noExtCon v
+#endif
 
 --------------------------------------------------------------------------------
 
 convertType :: LocalConvMonad r m => HsType GhcRn -> m Term
-convertType (HsForAllTy tvs ty) = do
+#if __GLASGOW_HASKELL__ >= 810
+convertType (HsForAllTy NOEXTP _ tvs ty) = do
+#else
+convertType (HsForAllTy NOEXTP tvs ty) = do
+#endif
   explicitTVs <- convertLHsTyVarBndrs Coq.Implicit tvs
   tyBody      <- convertLType ty
   pure . maybe tyBody (Forall ?? tyBody) $ nonEmpty explicitTVs
 
-convertType (HsQualTy (L _ ctx) ty) = do
-  classes <- traverse (fmap (Generalized Coq.Implicit) . convertLType) ctx
-  tyBody  <- convertLType ty
-  pure . maybe tyBody (Forall ?? tyBody) $ nonEmpty classes
+convertType (HsQualTy NOEXTP lctx ty) = convertLType ty >>= convertContext lctx
 
-convertType (HsTyVar _ (L _ tv)) =
+convertType (HsTyVar NOEXTP _ (L _ tv)) =
   Qualid <$> var TypeNS tv
 
-convertType (HsAppTy ty1 ty2) =
+convertType (HsAppTy NOEXTP ty1 ty2) =
   App1 <$> convertLType ty1 <*> convertLType ty2
 
+#if __GLASGOW_HASKELL__ >= 808
+convertType HsAppKindTy{} = convUnsupported "type level type application"
+#endif
+#if __GLASGOW_HASKELL__ >= 806
+convertType HsStarTy{} = pure (Sort Type)
+convertType XHsType{} = convUnsupported "NewHsTypeX"
+#else
 -- TODO: This constructor handles '*' and deparses it later.  I'm just gonna
 -- bank on never seeing any infix type things.
 convertType (HsAppsTy tys) =
@@ -69,16 +88,23 @@ convertType (HsAppsTy tys) =
        [] ->
          convUnsupported' "empty lists of type applications"
 
-convertType (HsFunTy ty1 ty2) =
-  Arrow <$> convertLType ty1 <*> convertLType ty2
-
-convertType (HsListTy ty) =
-  App1 (Var "list") <$> convertLType ty
-
 convertType (HsPArrTy _ty) =
   convUnsupported' "parallel arrays (`[:a:]')"
 
-convertType (HsTupleTy tupTy tys) = do
+convertType (HsEqTy _ty1 _ty2) =
+  convUnsupported' "type equality" -- FIXME
+
+convertType (HsCoreTy _) =
+  convUnsupported' "[internal] embedded core types"
+#endif
+
+convertType (HsFunTy NOEXTP ty1 ty2) =
+  Arrow <$> convertLType ty1 <*> convertLType ty2
+
+convertType (HsListTy NOEXTP ty) =
+  App1 (Var "list") <$> convertLType ty
+
+convertType (HsTupleTy NOEXTP tupTy tys) = do
   case tupTy of
     HsUnboxedTuple           -> pure () -- TODO: Mark converted unboxed tuples specially?
     HsBoxedTuple             -> pure ()
@@ -89,38 +115,32 @@ convertType (HsTupleTy tupTy tys) = do
     [ty] -> convertLType ty
     _    -> (`InScope` "type") <$> foldl1 (mkInfix ?? "*") <$> traverse convertLType tys
 
-convertType (HsOpTy ty1 op ty2) =
+convertType (HsOpTy NOEXTP ty1 op ty2) =
   App2 <$> (Qualid <$> var TypeNS (unLoc op)) <*> convertLType ty1 <*> convertLType ty2   -- ???
 
-convertType (HsParTy ty) =
+convertType (HsParTy NOEXTP ty) =
   Parens <$> convertLType ty
 
-convertType (HsIParamTy (L _ (HsIPName ip)) lty) = do
+convertType (HsIParamTy NOEXTP (L _ (HsIPName ip)) lty) = do
   isTyCallStack <- maybe (pure False) (fmap (== "CallStack") . ghcPpr) $ viewLHsTyVar lty
   if isTyCallStack && ip == fsLit "callStack"
     then pure $ "GHC.Stack.CallStack"
     else convUnsupported' "implicit parameter constraints"
 
-convertType (HsEqTy _ty1 _ty2) =
-  convUnsupported' "type equality" -- FIXME
-
-convertType (HsKindSig ty k) =
+convertType (HsKindSig NOEXTP ty k) =
   HasType <$> convertLType ty <*> convertLType k
 
 convertType (HsSpliceTy _ _) =
   convUnsupported' "Template Haskell type splices"
 
-convertType (HsDocTy ty _doc) =
+convertType (HsDocTy NOEXTP ty _doc) =
   convertLType ty
 
-convertType (HsBangTy _bang ty) =
+convertType (HsBangTy NOEXTP _bang ty) =
   convertLType ty -- Strictness annotations are ignored
 
-convertType (HsRecTy _fields) =
+convertType (HsRecTy NOEXTP _fields) =
   convUnsupported' "record types" -- FIXME
-
-convertType (HsCoreTy _) =
-  convUnsupported' "[internal] embedded core types"
 
 convertType (HsExplicitListTy _ _ tys) =
   foldr (App2 $ Var "cons") (Var "nil") <$> traverse convertLType tys
@@ -131,7 +151,7 @@ convertType (HsExplicitTupleTy _PlaceHolders tys) =
     [ty] -> convertLType ty
     _    -> foldl1 (App2 $ Var "pair") <$> traverse convertLType tys
 
-convertType (HsTyLit lit) =
+convertType (HsTyLit NOEXTP lit) =
   case lit of
     HsNumTy _src int -> either convUnsupported' (pure . Num) $ convertInteger "type-level integers" int
     HsStrTy _src str -> pure $ convertFastString str
@@ -139,8 +159,13 @@ convertType (HsTyLit lit) =
 convertType (HsWildCardTy _) =
   convUnsupported' "wildcards"
 
-convertType (HsSumTy _) =
+convertType (HsSumTy NOEXTP _) =
   convUnsupported' "sum types"
+
+convertContext :: LocalConvMonad r m => LHsContext GhcRn -> Term -> m Term
+convertContext lctx tyBody = do
+  classes <- traverse (fmap (Generalized Coq.Implicit) . convertLType) (unLoc lctx)
+  pure . maybe tyBody (Forall ?? tyBody) $ nonEmpty classes
 
 --------------------------------------------------------------------------------
 
@@ -150,17 +175,30 @@ convertLType = convertType . unLoc
 --------------------------------------------------------------------------------
 
 convertLHsSigTypeWithExcls :: LocalConvMonad r m => UnusedTyVarMode -> LHsSigType GhcRn -> [Qualid] -> m Term
+#if __GLASGOW_HASKELL__ >= 808
+convertLHsSigTypeWithExcls utvm (HsIB hs_itvs hs_lty) excls = do
+#elif __GLASGOW_HASKELL__ == 806
+convertLHsSigTypeWithExcls utvm (HsIB (HsIBRn {hsib_vars=hs_itvs}) hs_lty) excls = do
+#else
 convertLHsSigTypeWithExcls utvm (HsIB hs_itvs hs_lty _) excls = do
+#endif
   coq_itvs <- traverse (var TypeNS) hs_itvs
   coq_ty   <- convertLType hs_lty
 
+  finishConvertHsSigTypeWithExcls utvm coq_itvs coq_ty excls
+#if __GLASGOW_HASKELL__ >= 806
+convertLHsSigTypeWithExcls _ (XHsImplicitBndrs v) _ = noExtCon v
+#endif
+
+finishConvertHsSigTypeWithExcls
+  :: LocalConvMonad r m => UnusedTyVarMode -> [Qualid] -> Term -> [Qualid] -> m Term
+finishConvertHsSigTypeWithExcls utvm coq_itvs coq_ty excls =
   let coq_tyVars = case utvm of
         PreserveUnusedTyVars -> coq_itvs
         DeleteUnusedTyVars   -> let fvs = getFreeVars coq_ty
                                 in filter (`elem` fvs) coq_itvs
-  let coq_binders = Inferred Coq.Implicit . Ident <$> coq_tyVars \\ excls
-
-  pure $ maybeForall coq_binders coq_ty
+      coq_binders = Inferred Coq.Implicit . Ident <$> coq_tyVars \\ excls
+  in pure $ maybeForall coq_binders coq_ty
 
 convertLHsSigType :: LocalConvMonad r m => UnusedTyVarMode -> LHsSigType GhcRn -> m Term
 convertLHsSigType utvm sigTy = convertLHsSigTypeWithExcls utvm sigTy []
@@ -169,3 +207,49 @@ convertLHsSigWcType :: LocalConvMonad r m => UnusedTyVarMode -> LHsSigWcType Ghc
 convertLHsSigWcType utvm (HsWC wcs hsib)
   | null wcs  = convertLHsSigType utvm hsib
   | otherwise = convUnsupported' "type wildcards"
+#if __GLASGOW_HASKELL__ >= 806
+convertLHsSigWcType _ (XHsWildCardBndrs v) = noExtCon v
+#endif
+
+--------------------------------------------------------------------------------
+
+convertHsSigType_
+  :: LocalConvMonad r m
+  => UnusedTyVarMode
+  -> LHsQTyVars GhcRn
+  -> Maybe (LHsContext GhcRn)
+  -> HsConDeclDetails GhcRn
+  -> LHsType GhcRn
+  -> [Qualid] -> m Term
+convertHsSigType_ utvm (HsQTvs { hsq_explicit = qvars }) mcxt args resTy excls = do
+  coq_itvs <- traverse (var TypeNS . binderName . unLoc) qvars
+  coq_ty <- convertLType resTy >>= convertArgs args >>= maybe pure convertContext mcxt
+  finishConvertHsSigTypeWithExcls utvm coq_itvs coq_ty excls
+#if __GLASGOW_HASKELL__ >= 806
+convertHsSigType_ _ (XLHsQTyVars v) _ _ _ _ = noExtCon v
+#endif
+
+convertArgs :: LocalConvMonad r m => HsConDeclDetails GhcRn -> Term -> m Term
+convertArgs (PrefixCon args) ty = do
+  coq_args <- traverse convertLType args
+  pure (foldr Arrow ty coq_args)
+convertArgs (RecCon rec) ty = do
+  tyss <- for (unLoc rec) $ \lfield -> case unLoc lfield of
+    -- We must be careful to copy the type when multiple fields @fds@ are under
+    -- the same signature @t@
+    ConDeclField { cd_fld_names = fds, cd_fld_type = t } -> do
+      ty <- convertLType t
+      pure (fds $> ty)
+#if __GLASGOW_HASKELL__ >= 806
+    XConDeclField v -> noExtCon v
+#endif
+  pure (foldr Arrow ty (concat tyss))
+convertArgs (InfixCon t1 t2) ty =
+  liftA2 Arrow (convertLType t1) (liftA2 Arrow (convertLType t2) (pure ty))
+
+binderName :: HsTyVarBndr GhcRn -> GHC.Name
+binderName (UserTyVar NOEXTP lname) = unLoc lname
+binderName (KindedTyVar NOEXTP lname _) = unLoc lname
+#if __GLASGOW_HASKELL__ >= 806
+binderName (XTyVarBndr v) = noExtCon v
+#endif

--- a/src/lib/HsToCoq/Coq/Gallina/Rewrite.hs
+++ b/src/lib/HsToCoq/Coq/Gallina/Rewrite.hs
@@ -59,7 +59,7 @@ rewrite1 (Rewrite patVars lhs rhs) term
 -- (Maybe we should drop InFix completely)
 norm :: Term -> Term
 norm (HsString s) = String s
-norm t | Just (f, args) <- collectArgs t = appList (Qualid f) (map PosArg args)
+norm t | Right (f, args) <- collectArgs t = appList (Qualid f) (map PosArg args)
 norm t = t
 
 match :: [Ident] -> Term -> Term -> Maybe (M.Map Qualid Term)

--- a/src/lib/HsToCoq/Plugin.hs
+++ b/src/lib/HsToCoq/Plugin.hs
@@ -22,6 +22,10 @@ import HsToCoq.Coq.Gallina.Util hiding (Var)
 import HsToCoq.Coq.Pretty
 import HsToCoq.PrettyPrint
 
+#if __GLASGOW_HASKELL__ >= 806
+type PluginPass = CorePluginPass
+#endif
+
 -- | A more convenient Gallina application operator
 (<:) :: Term -> [Term] -> Term
 n <: xs = appList n (map PosArg xs)

--- a/src/lib/HsToCoq/Util/GHC/HsExpr.hs
+++ b/src/lib/HsToCoq/Util/GHC/HsExpr.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE CPP #-}
+
+#include "ghc-compat.h"
+
 module HsToCoq.Util.GHC.HsExpr (
   module HsExpr,
   isNoSyntaxExpr,
@@ -6,12 +10,17 @@ module HsToCoq.Util.GHC.HsExpr (
 ) where
 
 import FastString
+#if __GLASGOW_HASKELL__ >= 810
+import GHC.Hs.Lit
+import GHC.Hs.Expr as HsExpr
+#else
 import HsLit
 import HsExpr
+#endif
 import TcEvidence (HsWrapper(..))
 
 isGenLitString :: String -> HsExpr pass -> Bool
-isGenLitString str (HsLit (HsString _ fstr)) = fsLit str == fstr
+isGenLitString str (HsLit NOEXTP (HsString _ fstr)) = fsLit str == fstr
 isGenLitString _   _                          = False
 
 isNoSyntaxExpr :: SyntaxExpr pass -> Bool

--- a/src/lib/HsToCoq/Util/GHC/HsTypes.hs
+++ b/src/lib/HsToCoq/Util/GHC/HsTypes.hs
@@ -1,17 +1,59 @@
+{-# LANGUAGE CPP #-}
+
 module HsToCoq.Util.GHC.HsTypes (
   module HsTypes,
-  viewHsTyVar, viewLHsTyVar
+  viewHsTyVar, viewLHsTyVar,
+  selectorFieldOcc_, fieldOcc,
+  noExtCon
 ) where
 
-import HsTypes
-import SrcLoc
+#if __GLASGOW_HASKELL__ >= 806 && __GLASGOW_HASKELL__ < 810
+import GHC.Stack (HasCallStack)
+#endif
+#if __GLASGOW_HASKELL__ >= 810
+import GHC.Hs.Extension
+import GHC.Hs.Types as HsTypes
+#else
 import HsExtension
+import HsTypes
+#endif
+import RdrName (RdrName)
+import Name (Name)
+import SrcLoc
 
 viewHsTyVar :: HsType pass -> Maybe (IdP pass)
-viewHsTyVar (HsTyVar _  (L _ name))                   = Just name
+#if __GLASGOW_HASKELL__ >= 806
+viewHsTyVar (HsTyVar _ _ (L _ name))                  = Just name
+#else
+viewHsTyVar (HsTyVar _ (L _ name))                    = Just name
 viewHsTyVar (HsAppsTy [L _ (HsAppInfix  (L _ name))]) = Just name
 viewHsTyVar (HsAppsTy [L _ (HsAppPrefix lty)])        = viewLHsTyVar lty
+#endif
 viewHsTyVar _                                         = Nothing
 
 viewLHsTyVar :: LHsType pass -> Maybe (IdP pass)
 viewLHsTyVar = viewHsTyVar . unLoc
+
+-- Compatibility shim for FieldOcc (the fields were flipped since GHC 8.6)
+#if __GLASGOW_HASKELL__ >= 806
+selectorFieldOcc_ :: FieldOcc GhcRn -> Name
+selectorFieldOcc_ (FieldOcc n _) = n
+selectorFieldOcc_ (XFieldOcc v) = noExtCon v
+
+fieldOcc :: Located RdrName -> Name -> FieldOcc GhcRn
+fieldOcc r n = FieldOcc n r
+
+#if __GLASGOW_HASKELL__ < 810
+noExtCon :: HasCallStack => NoExt -> a
+noExtCon _ = error "cannot happen"
+#endif
+#else
+selectorFieldOcc_ :: FieldOcc GhcRn -> Name
+selectorFieldOcc_ (FieldOcc _ n) = n
+
+fieldOcc :: Located RdrName -> Name -> FieldOcc GhcRn
+fieldOcc = FieldOcc
+
+noExtCon :: ()  -- dummy to not have to put a CPP conditional in the export list
+noExtCon = ()
+#endif

--- a/src/lib/HsToCoq/Util/Monad.hs
+++ b/src/lib/HsToCoq/Util/Monad.hs
@@ -12,11 +12,13 @@ module HsToCoq.Util.Monad (
   -- * Kleisli arrow combinators
   (<***>), (<&&&>), (<+++>), (<|||>),
   -- * Errors
-  exceptEither
+  failIO,
+  exceptEither, failEither, ErrorString
   ) where
 
 import Control.Arrow
 import Control.Monad.Except
+import Control.Monad.Fail (MonadFail)
 import Data.Bool
 
 andM :: Monad m => m Bool -> m Bool -> m Bool
@@ -67,3 +69,12 @@ infixr 2 <|||>
 
 exceptEither :: MonadError e m => Either e a -> m a
 exceptEither = either throwError pure
+
+type ErrorString = String
+
+failEither :: MonadFail m => Either ErrorString a -> m a
+failEither (Left e) = fail e
+failEither (Right a) = pure a
+
+failIO :: MonadIO m => ErrorString -> m a
+failIO = liftIO . fail


### PR DESCRIPTION
This also makes sure to still work with 8.4

I think this PR is already in a mergeable state on its own, but here are some TODOs for the near future:

- Some core types  have changed locations (at least `Maybe`, `GHC.Base.Maybe` -> `GHC.Maybe.Maybe`); this needs to be reflected in the `base/edits` file, and some new modules might need to be added to the Coq-ified base library.  
    I'm not sure whether we should maintain different edits for each GHC version, or have a single file compatible with everything, since the changes are presumably quite minor.
- Test for regressions on examples (I only made simple sanity checks with `intervals` and `graph`)
- Update CI to add those new compilers to the build
- Add a new stack.yaml file with a corresponding resolver