### PR TITLE
Pretty print GHC errors

### DIFF
--- a/src/lib/HsToCoq/Util/GHC.hs
+++ b/src/lib/HsToCoq/Util/GHC.hs
@@ -16,8 +16,9 @@ import Outputable
 ghcPpr :: (GhcMonad m, Outputable a) => a -> m Text
 ghcPpr x = fmap T.pack $ showPpr <$> getSessionDynFlags <*> pure x
 
-defaultRunGhc :: Ghc a -> IO a
+defaultRunGhc :: Ghc () -> IO ()
 defaultRunGhc ghc = defaultErrorHandler defaultFatalMessager defaultFlushOut
-                  . runGhc (Just libdir) $ do
+                  . runGhc (Just libdir)
+                  . handleSourceError printException $ do
                       void $ setSessionDynFlags =<< getSessionDynFlags
                       ghc


### PR DESCRIPTION
Currently all errors are reported as panics, and the source location is missing. This patch catches those errors that are not actually panics, but problems with the file being compiled, to print them nicely.