### PR TITLE
Skip pattern synonyms + Warn about skipped definitions

### DIFF
--- a/base/Control/Applicative.v
+++ b/base/Control/Applicative.v
@@ -44,6 +44,8 @@ Definition unwrapArrow {a : Type -> Type -> Type} {b} {c} (arg_0__
 
 (* Converted value declarations: *)
 
+(* Skipping definition `Control.Applicative.optional' *)
+
 (* Skipping all instances of class `GHC.Generics.Generic', including
    `Control.Applicative.Generic__WrappedMonad' *)
 

--- a/base/Control/Arrow.v
+++ b/base/Control/Arrow.v
@@ -221,6 +221,8 @@ Notation "'_^>>_'" := (op_zczgzg__).
 
 Infix "^>>" := (_^>>_) (at level 99).
 
+(* Skipping definition `Control.Arrow.leftApp' *)
+
 Local Definition Arrow__arrow_arr
    : forall {b} {c}, (b -> c) -> GHC.Prim.arrow b c :=
   fun {b} {c} => fun f => f.

--- a/base/Control/Monad.v
+++ b/base/Control/Monad.v
@@ -41,6 +41,10 @@ Definition zipWithM {m} {a} {b} {c} `{_ : GHC.Base.Applicative m}
 Definition unless {f} `{(GHC.Base.Applicative f)} : bool -> f unit -> f unit :=
   fun p s => if p : bool then GHC.Base.pure tt else s.
 
+(* Skipping definition `Control.Monad.replicateM_' *)
+
+(* Skipping definition `Control.Monad.replicateM' *)
+
 Definition op_zlzdznzg__ {m} {a} {b} `{GHC.Base.Monad m}
    : (a -> b) -> m a -> m b :=
   fun f m =>
@@ -66,9 +70,15 @@ Notation "'_<=<_'" := (op_zlzezl__).
 
 Infix "<=<" := (_<=<_) (at level 99).
 
+(* Skipping definition `Control.Monad.mfilter' *)
+
 Definition mapAndUnzipM {m} {a} {b} {c} `{(GHC.Base.Applicative m)}
    : (a -> m (b * c)%type) -> list a -> m (list b * list c)%type :=
   fun f xs => GHC.List.unzip Data.Functor.<$> Data.Traversable.traverse f xs.
+
+(* Skipping definition `Control.Monad.guard' *)
+
+(* Skipping definition `Control.Monad.forever' *)
 
 Definition foldM_ {t} {m} {b} {a} `{Data.Foldable.Foldable t} `{GHC.Base.Monad
   m}

--- a/base/Data/Bifoldable.v
+++ b/base/Data/Bifoldable.v
@@ -88,6 +88,16 @@ Definition bior {t} `{Bifoldable t} : t bool bool -> bool :=
 Definition binull {t} {a} {b} `{Bifoldable t} : t a b -> bool :=
   bifoldr (fun arg_0__ arg_1__ => false) (fun arg_2__ arg_3__ => false) true.
 
+(* Skipping definition `Data.Bifoldable.bimsum' *)
+
+(* Skipping definition `Data.Bifoldable.biminimumBy' *)
+
+(* Skipping definition `Data.Bifoldable.biminimum' *)
+
+(* Skipping definition `Data.Bifoldable.bimaximumBy' *)
+
+(* Skipping definition `Data.Bifoldable.bimaximum' *)
+
 Definition bimapM_ {t} {f} {a} {c} {b} {d} `{Bifoldable t}
   `{GHC.Base.Applicative f}
    : (a -> f c) -> (b -> f d) -> t a b -> f unit :=
@@ -110,6 +120,8 @@ Definition bifoldrM {t} {m} {a} {c} {b} `{Bifoldable t} `{GHC.Base.Monad m}
     let f' := fun k x z => f x z GHC.Base.>>= k in
     bifoldl f' g' GHC.Base.return_ xs z0.
 
+(* Skipping definition `Data.Bifoldable.bifoldr1' *)
+
 Definition bifoldr' {t} {a} {c} {b} `{Bifoldable t}
    : (a -> c -> c) -> (b -> c -> c) -> c -> t a b -> c :=
   fun f g z0 xs =>
@@ -122,6 +134,8 @@ Definition bifoldlM {t} {m} {a} {b} {c} `{Bifoldable t} `{GHC.Base.Monad m}
     let g' := fun x k z => g z x GHC.Base.>>= k in
     let f' := fun x k z => f z x GHC.Base.>>= k in
     bifoldr f' g' GHC.Base.return_ xs z0.
+
+(* Skipping definition `Data.Bifoldable.bifoldl1' *)
 
 Definition bifoldl' {t} {a} {b} {c} `{Bifoldable t}
    : (a -> b -> a) -> (a -> c -> a) -> a -> t b c -> a :=
@@ -150,6 +164,8 @@ Definition biconcatMap {t} {a} {c} {b} `{Bifoldable t}
 
 Definition biconcat {t} {a} `{Bifoldable t} : t (list a) (list a) -> list a :=
   bifold.
+
+(* Skipping definition `Data.Bifoldable.biasum' *)
 
 Definition biany {t} {a} {b} `{Bifoldable t}
    : (a -> bool) -> (b -> bool) -> t a b -> bool :=

--- a/base/Data/Foldable.v
+++ b/base/Data/Foldable.v
@@ -193,6 +193,12 @@ Definition elem {f} `{Foldable f} {a} `{GHC.Base.Eq_ a} : a -> f a -> bool :=
 Definition notElem {t} {a} `{Foldable t} `{GHC.Base.Eq_ a} : a -> t a -> bool :=
   fun x => negb GHC.Base.∘ elem x.
 
+(* Skipping definition `Data.Foldable.msum' *)
+
+(* Skipping definition `Data.Foldable.minimumBy' *)
+
+(* Skipping definition `Data.Foldable.maximumBy' *)
+
 Definition mapM_ {t} {m} {a} {b} `{Foldable t} `{GHC.Base.Monad m}
    : (a -> m b) -> t a -> m unit :=
   fun f => foldr (_GHC.Base.>>_ GHC.Base.∘ f) (GHC.Base.return_ tt).
@@ -287,6 +293,8 @@ Definition concat {t} {a} `{Foldable t} : t (list a) -> list a :=
   fun xs =>
     GHC.Base.build' (fun _ =>
                        fun c n => foldr (fun x y => (@foldr _ Foldable__list _ _ c y x)) n xs).
+
+(* Skipping definition `Data.Foldable.asum' *)
 
 Definition and {t} `{Foldable t} : t bool -> bool :=
   Coq.Program.Basics.compose Data.SemigroupInternal.getAll (foldMap

--- a/base/Data/Function.v
+++ b/base/Data/Function.v
@@ -26,6 +26,8 @@ Infix "&" := (_&_) (at level 99).
 Definition on {b} {c} {a} : (b -> b -> c) -> (a -> b) -> a -> a -> c :=
   fun lop_ziztzi__ f => fun x y => lop_ziztzi__ (f x) (f y).
 
+(* Skipping definition `Data.Function.fix_' *)
+
 Module Notations.
 Notation "'_Data.Function.&_'" := (op_za__).
 Infix "Data.Function.&" := (_&_) (at level 99).

--- a/base/Data/Functor/Classes.v
+++ b/base/Data/Functor/Classes.v
@@ -75,6 +75,54 @@ Definition liftCompare `{g__0__ : Ord1 f}
 
 (* Converted value declarations: *)
 
+(* Skipping definition `Data.Functor.Classes.showsUnaryWith' *)
+
+(* Skipping definition `Data.Functor.Classes.showsUnary1' *)
+
+(* Skipping definition `Data.Functor.Classes.showsUnary' *)
+
+(* Skipping definition `Data.Functor.Classes.showsPrec2' *)
+
+(* Skipping definition `Data.Functor.Classes.showsPrec1' *)
+
+(* Skipping definition `Data.Functor.Classes.showsBinaryWith' *)
+
+(* Skipping definition `Data.Functor.Classes.showsBinary1' *)
+
+(* Skipping definition `Data.Functor.Classes.readsUnaryWith' *)
+
+(* Skipping definition `Data.Functor.Classes.readsUnary1' *)
+
+(* Skipping definition `Data.Functor.Classes.readsUnary' *)
+
+(* Skipping definition `Data.Functor.Classes.readsPrec2' *)
+
+(* Skipping definition `Data.Functor.Classes.readsPrec1' *)
+
+(* Skipping definition `Data.Functor.Classes.readsData' *)
+
+(* Skipping definition `Data.Functor.Classes.readsBinaryWith' *)
+
+(* Skipping definition `Data.Functor.Classes.readsBinary1' *)
+
+(* Skipping definition `Data.Functor.Classes.readUnaryWith' *)
+
+(* Skipping definition `Data.Functor.Classes.readPrec2' *)
+
+(* Skipping definition `Data.Functor.Classes.readPrec1' *)
+
+(* Skipping definition `Data.Functor.Classes.readData' *)
+
+(* Skipping definition `Data.Functor.Classes.readBinaryWith' *)
+
+(* Skipping definition `Data.Functor.Classes.liftReadListPrecDefault' *)
+
+(* Skipping definition `Data.Functor.Classes.liftReadListPrec2Default' *)
+
+(* Skipping definition `Data.Functor.Classes.liftReadListDefault' *)
+
+(* Skipping definition `Data.Functor.Classes.liftReadList2Default' *)
+
 Definition eq2 {f} {a} {b} `{Eq2 f} `{GHC.Base.Eq_ a} `{GHC.Base.Eq_ b}
    : f a b -> f a b -> bool :=
   liftEq2 _GHC.Base.==_ _GHC.Base.==_.

--- a/base/Data/Functor/Utils.v
+++ b/base/Data/Functor/Utils.v
@@ -66,6 +66,8 @@ Instance Unpeel_Max {a} : Prim.Unpeel (Max a) (option a)
 
 (* Converted value declarations: *)
 
+(* Skipping definition `Data.Functor.Utils.hash_compose' *)
+
 Local Definition Semigroup__Max_op_zlzlzgzg__ {inst_a} `{GHC.Base.Ord inst_a}
    : (Max inst_a) -> (Max inst_a) -> (Max inst_a) :=
   fun arg_0__ arg_1__ =>

--- a/base/Data/List/NonEmpty.v
+++ b/base/Data/List/NonEmpty.v
@@ -121,11 +121,21 @@ Definition unzip {f} {a} {b} `{GHC.Base.Functor f}
   fun xs =>
     pair (Data.Tuple.fst Data.Functor.<$> xs) (Data.Tuple.snd Data.Functor.<$> xs).
 
+(* Skipping definition `Data.List.NonEmpty.unfoldr' *)
+
+(* Skipping definition `Data.List.NonEmpty.unfold' *)
+
+(* Skipping definition `Data.List.NonEmpty.transpose' *)
+
+(* Skipping definition `Data.List.NonEmpty.toList' *)
+
 Definition takeWhile {a} : (a -> bool) -> GHC.Base.NonEmpty a -> list a :=
   fun p => GHC.List.takeWhile p GHC.Base.∘ toList.
 
 Definition take {a} : GHC.Num.Int -> GHC.Base.NonEmpty a -> list a :=
   fun n => GHC.List.take n GHC.Base.∘ toList.
+
+(* Skipping definition `Data.List.NonEmpty.tails' *)
 
 Definition tail {a} : GHC.Base.NonEmpty a -> list a :=
   fun '(GHC.Base.NEcons _ as_) => as_.
@@ -138,13 +148,33 @@ Definition span {a}
    : (a -> bool) -> GHC.Base.NonEmpty a -> (list a * list a)%type :=
   fun p => GHC.List.span p GHC.Base.∘ toList.
 
+(* Skipping definition `Data.List.NonEmpty.sortBy' *)
+
 Definition sortWith {o} {a} `{GHC.Base.Ord o}
    : (a -> o) -> GHC.Base.NonEmpty a -> GHC.Base.NonEmpty a :=
   sortBy GHC.Base.∘ Data.Ord.comparing.
 
+(* Skipping definition `Data.List.NonEmpty.sort' *)
+
+(* Skipping definition `Data.List.NonEmpty.some1' *)
+
+(* Skipping definition `Data.List.NonEmpty.scanr1' *)
+
+(* Skipping definition `Data.List.NonEmpty.scanr' *)
+
+(* Skipping definition `Data.List.NonEmpty.scanl1' *)
+
+(* Skipping definition `Data.List.NonEmpty.scanl' *)
+
+(* Skipping definition `Data.List.NonEmpty.reverse' *)
+
+(* Skipping definition `Data.List.NonEmpty.repeat' *)
+
 Definition partition {a}
    : (a -> bool) -> GHC.Base.NonEmpty a -> (list a * list a)%type :=
   fun p => Data.OldList.partition p GHC.Base.∘ toList.
+
+(* Skipping definition `Data.List.NonEmpty.op_znzn__' *)
 
 Definition op_zlzb__ {a} : a -> GHC.Base.NonEmpty a -> GHC.Base.NonEmpty a :=
   fun arg_0__ arg_1__ =>
@@ -187,8 +217,14 @@ Definition map {a} {b}
     | f, GHC.Base.NEcons a as_ => GHC.Base.NEcons (f a) (GHC.Base.fmap f as_)
     end.
 
+(* Skipping definition `Data.List.NonEmpty.lift' *)
+
 Definition length {a} : GHC.Base.NonEmpty a -> GHC.Num.Int :=
   fun '(GHC.Base.NEcons _ xs) => #1 GHC.Num.+ Data.Foldable.length xs.
+
+(* Skipping definition `Data.List.NonEmpty.last' *)
+
+(* Skipping definition `Data.List.NonEmpty.iterate' *)
 
 Definition isPrefixOf {a} `{GHC.Base.Eq_ a}
    : list a -> GHC.Base.NonEmpty a -> bool :=
@@ -199,8 +235,34 @@ Definition isPrefixOf {a} `{GHC.Base.Eq_ a}
         andb (y GHC.Base.== x) (Data.OldList.isPrefixOf ys xs)
     end.
 
+(* Skipping definition `Data.List.NonEmpty.intersperse' *)
+
+(* Skipping definition `Data.List.NonEmpty.insert' *)
+
+(* Skipping definition `Data.List.NonEmpty.inits' *)
+
+(* Skipping definition `Data.List.NonEmpty.init' *)
+
 Definition head {a} : GHC.Base.NonEmpty a -> a :=
   fun '(GHC.Base.NEcons a _) => a.
+
+(* Skipping definition `Data.List.NonEmpty.groupWith1' *)
+
+(* Skipping definition `Data.List.NonEmpty.groupWith' *)
+
+(* Skipping definition `Data.List.NonEmpty.groupBy1' *)
+
+(* Skipping definition `Data.List.NonEmpty.groupBy' *)
+
+(* Skipping definition `Data.List.NonEmpty.groupAllWith1' *)
+
+(* Skipping definition `Data.List.NonEmpty.groupAllWith' *)
+
+(* Skipping definition `Data.List.NonEmpty.group1' *)
+
+(* Skipping definition `Data.List.NonEmpty.group' *)
+
+(* Skipping definition `Data.List.NonEmpty.fromList' *)
 
 Definition filter {a} : (a -> bool) -> GHC.Base.NonEmpty a -> list a :=
   fun p => GHC.List.filter p GHC.Base.∘ toList.
@@ -210,6 +272,8 @@ Definition dropWhile {a} : (a -> bool) -> GHC.Base.NonEmpty a -> list a :=
 
 Definition drop {a} : GHC.Num.Int -> GHC.Base.NonEmpty a -> list a :=
   fun n => GHC.List.drop n GHC.Base.∘ toList.
+
+(* Skipping definition `Data.List.NonEmpty.cycle' *)
 
 Definition cons_ {a} : a -> GHC.Base.NonEmpty a -> GHC.Base.NonEmpty a :=
   _<|_.

--- a/base/Data/Maybe.v
+++ b/base/Data/Maybe.v
@@ -61,6 +61,8 @@ Definition isJust {a} : option a -> bool :=
 Definition fromMaybe {a} : a -> option a -> a :=
   fun d x => match x with | None => d | Some v => v end.
 
+(* Skipping definition `Data.Maybe.fromJust' *)
+
 Definition catMaybes {a} : list (option a) -> list a :=
   fun ls =>
     let cont_0__ arg_1__ :=

--- a/base/Data/OldList.v
+++ b/base/Data/OldList.v
@@ -300,6 +300,10 @@ Definition zip4 {a} {b} {c} {d}
    : list a -> list b -> list c -> list d -> list (a * b * c * d)%type :=
   zipWith4 GHC.Tuple.pair4.
 
+(* Skipping definition `Data.OldList.wordsFB' *)
+
+(* Skipping definition `Data.OldList.words' *)
+
 Definition unzip7 {a} {b} {c} {d} {e} {f} {g}
    : list (a * b * c * d * e * f * g)%type ->
      (list a * list b * list c * list d * list e * list f * list g)%type :=
@@ -359,6 +363,10 @@ Definition unwords : list String -> String :=
 
 Axiom unlines : list String -> String.
 
+(* Skipping definition `Data.OldList.unfoldr' *)
+
+(* Skipping definition `Data.OldList.transpose' *)
+
 Definition toListSB {a} : SnocBuilder a -> list a :=
   fun '(Mk_SnocBuilder _ f r) => Coq.Init.Datatypes.app f (GHC.List.reverse r).
 
@@ -372,6 +380,8 @@ Definition tails {a} : list a -> list (list a) :=
 
 Definition tailUnwords : String -> String :=
   fun arg_0__ => match arg_0__ with | nil => nil | cons _ xs => xs end.
+
+(* Skipping definition `Data.OldList.subsequences' *)
 
 Fixpoint stripPrefix {a} `{Eq_ a} (arg_0__ arg_1__ : list a) : option (list a)
            := match arg_0__, arg_1__ with
@@ -389,6 +399,8 @@ Definition strictGenericLength {i} {b} `{(GHC.Num.Num i)} : list b -> i :=
                  end in
     gl l #0.
 
+(* Skipping definition `Data.OldList.sortBy' *)
+
 Definition sortOn {b} {a} `{Ord b} : (a -> b) -> list a -> list a :=
   fun f =>
     map Data.Tuple.snd ∘
@@ -397,6 +409,8 @@ Definition sortOn {b} {a} `{Ord b} : (a -> b) -> list a -> list a :=
 
 Definition sort {a} `{(Ord a)} : list a -> list a :=
   sortBy compare.
+
+(* Skipping definition `Data.OldList.snocSB' *)
 
 Definition select {a}
    : (a -> bool) -> a -> (list a * list a)%type -> (list a * list a)%type :=
@@ -407,11 +421,15 @@ Definition select {a}
         pair ts (cons x fs)
     end.
 
+(* Skipping definition `Data.OldList.sb' *)
+
 Fixpoint prependToAll {a} (arg_0__ : a) (arg_1__ : list a) : list a
            := match arg_0__, arg_1__ with
               | _, nil => nil
               | sep, cons x xs => cons sep (cons x (prependToAll sep xs))
               end.
+
+(* Skipping definition `Data.OldList.permutations' *)
 
 Definition partition {a} : (a -> bool) -> list a -> (list a * list a)%type :=
   fun p xs => foldr (select p) (pair nil nil) xs.
@@ -481,12 +499,18 @@ Fixpoint mapAccumL {acc} {x} {y} (arg_0__ : (acc -> x -> (acc * y)%type))
                   pair s'' (cons y ys)
               end.
 
+(* Skipping definition `Data.OldList.lines' *)
+
 Fixpoint isPrefixOf {a} `{(Eq_ a)} (arg_0__ arg_1__ : list a) : bool
            := match arg_0__, arg_1__ with
               | nil, _ => true
               | _, nil => false
               | cons x xs, cons y ys => andb (x == y) (isPrefixOf xs ys)
               end.
+
+(* Skipping definition `Data.OldList.isInfixOf' *)
+
+(* Skipping definition `Data.OldList.intersperse' *)
 
 Definition intersectBy {a} : (a -> a -> bool) -> list a -> list a -> list a :=
   fun arg_0__ arg_1__ arg_2__ =>
@@ -502,6 +526,8 @@ Definition intersectBy {a} : (a -> a -> bool) -> list a -> list a -> list a :=
 Definition intersect {a} `{(Eq_ a)} : list a -> list a -> list a :=
   intersectBy _==_.
 
+(* Skipping definition `Data.OldList.intercalate' *)
+
 Fixpoint insertBy {a} (arg_0__ : (a -> a -> comparison)) (arg_1__ : a) (arg_2__
                     : list a) : list a
            := match arg_0__, arg_1__, arg_2__ with
@@ -515,6 +541,12 @@ Fixpoint insertBy {a} (arg_0__ : (a -> a -> comparison)) (arg_1__ : a) (arg_2__
 
 Definition insert {a} `{Ord a} : a -> list a -> list a :=
   fun e ls => insertBy (compare) e ls.
+
+(* Skipping definition `Data.OldList.inits' *)
+
+(* Skipping definition `Data.OldList.groupBy' *)
+
+(* Skipping definition `Data.OldList.group' *)
 
 Fixpoint genericTake {i} {a} `{(GHC.Real.Integral i)} (arg_0__ : i) (arg_1__
                        : list a) : list a
@@ -540,11 +572,15 @@ Fixpoint genericSplitAt {i} {a} `{(GHC.Real.Integral i)} (arg_0__ : i) (arg_1__
                   end
               end.
 
+(* Skipping definition `Data.OldList.genericReplicate' *)
+
 Fixpoint genericLength {i} {a} `{(GHC.Num.Num i)} (arg_0__ : list a) : i
            := match arg_0__ with
               | nil => #0
               | cons _ l => #1 GHC.Num.+ genericLength l
               end.
+
+(* Skipping definition `Data.OldList.genericIndex' *)
 
 Fixpoint genericDrop {i} {a} `{(GHC.Real.Integral i)} (arg_0__ : i) (arg_1__
                        : list a) : list a
@@ -556,6 +592,10 @@ Fixpoint genericDrop {i} {a} `{(GHC.Real.Integral i)} (arg_0__ : i) (arg_1__
                   | n, cons _ xs => genericDrop (n GHC.Num.- #1) xs
                   end
               end.
+
+(* Skipping definition `Data.OldList.findIndices' *)
+
+(* Skipping definition `Data.OldList.findIndex' *)
 
 Definition find {a} : (a -> bool) -> list a -> option a :=
   fun p => Data.Maybe.listToMaybe ∘ GHC.List.filter p.
@@ -583,6 +623,10 @@ Definition nubBy {a} : (a -> a -> bool) -> list a -> list a :=
 
 Definition nub {a} `{(Eq_ a)} : list a -> list a :=
   nubBy _==_.
+
+(* Skipping definition `Data.OldList.elemIndices' *)
+
+(* Skipping definition `Data.OldList.elemIndex' *)
 
 Definition dropWhileEnd {a} : (a -> bool) -> list a -> list a :=
   fun p =>

--- a/base/Data/Semigroup.v
+++ b/base/Data/Semigroup.v
@@ -148,6 +148,8 @@ Program Instance Semigroup__SLast {a} : GHC.Base.Semigroup (Last a) := fun _ k =
 
 (* Converted value declarations: *)
 
+(* Skipping definition `Data.Semigroup.mtimesDefault' *)
+
 Definition diff {m} `{GHC.Base.Semigroup m}
    : m -> Data.SemigroupInternal.Endo m :=
   Data.SemigroupInternal.Mk_Endo GHC.Base.∘ _GHC.Base.<<>>_.
@@ -157,6 +159,8 @@ Definition destruct_option {b} {a} : b -> (a -> b) -> Option a -> b :=
     match arg_0__, arg_1__, arg_2__ with
     | n, j, Mk_Option m => Data.Maybe.maybe n j m
     end.
+
+(* Skipping definition `Data.Semigroup.cycle1' *)
 
 (* Skipping all instances of class `GHC.Enum.Bounded', including
    `Data.Semigroup.Bounded__Min' *)

--- a/base/Data/SemigroupInternal.v
+++ b/base/Data/SemigroupInternal.v
@@ -183,6 +183,12 @@ Instance instance_forall___GHC_Base_Ord__f_a____GHC_Base_Ord__Alt_f_a_  {f}
 
 (* Converted value declarations: *)
 
+(* Skipping definition `Data.SemigroupInternal.stimesMonoid' *)
+
+(* Skipping definition `Data.SemigroupInternal.stimesMaybe' *)
+
+(* Skipping definition `Data.SemigroupInternal.stimesList' *)
+
 Definition stimesIdempotentMonoid {b} {a} `{GHC.Real.Integral b}
   `{GHC.Base.Monoid a}
    : b -> a -> a :=
@@ -194,6 +200,10 @@ Definition stimesIdempotentMonoid {b} {a} `{GHC.Real.Integral b}
     | Eq => GHC.Base.mempty
     | Gt => x
     end.
+
+(* Skipping definition `Data.SemigroupInternal.stimesIdempotent' *)
+
+(* Skipping definition `Data.SemigroupInternal.stimesDefault' *)
 
 Instance Unpeel_Dual a : GHC.Prim.Unpeel (Dual a) a :=
   GHC.Prim.Build_Unpeel _ _ getDual Mk_Dual.

--- a/base/Data/Traversable.v
+++ b/base/Data/Traversable.v
@@ -81,6 +81,8 @@ Definition forM {t} {m} {a} {b} `{Traversable t} `{GHC.Base.Monad m}
    : t a -> (a -> m b) -> m (t b) :=
   GHC.Base.flip mapM.
 
+(* Skipping definition `Data.Traversable.foldMapDefault' *)
+
 Definition fmapDefault {t} {a} {b} `{Traversable t} : (a -> b) -> t a -> t b :=
   GHC.Prim.coerce (traverse : (a -> Data.Functor.Identity.Identity b) ->
                    t a -> Data.Functor.Identity.Identity (t b)).

--- a/base/GHC/Base.v
+++ b/base/GHC/Base.v
@@ -556,8 +556,26 @@ End ManualNotations.
 Definition when {f} `{(Applicative f)} : bool -> f unit -> f unit :=
   fun p s => if p : bool then s else pure tt.
 
+(* Skipping definition `GHC.Base.until' *)
+
+(* Skipping definition `GHC.Base.unsafeChr' *)
+
+(* Skipping definition `GHC.Base.unIO' *)
+
+(* Skipping definition `GHC.Base.thenIO' *)
+
+(* Skipping definition `GHC.Base.returnIO' *)
+
+(* Skipping definition `GHC.Base.remInt' *)
+
+(* Skipping definition `GHC.Base.quotRemInt' *)
+
+(* Skipping definition `GHC.Base.quotInt' *)
+
 Definition otherwise : bool :=
   true.
+
+(* Skipping definition `GHC.Base.ord' *)
 
 Definition op_zlztztzg__ {f} {a} {b} `{Applicative f}
    : f a -> f (a -> b) -> f b :=
@@ -594,6 +612,24 @@ Definition op_z2218U__ {b} {c} {a} : (b -> c) -> (a -> b) -> a -> c :=
 Notation "'_∘_'" := (op_z2218U__).
 
 Infix "∘" := (_∘_) (left associativity, at level 40).
+
+(* Skipping definition `GHC.Base.op_shiftRLzh__' *)
+
+(* Skipping definition `GHC.Base.op_shiftLzh__' *)
+
+(* Skipping definition `GHC.Base.op_iShiftRLzh__' *)
+
+(* Skipping definition `GHC.Base.op_iShiftRAzh__' *)
+
+(* Skipping definition `GHC.Base.op_iShiftLzh__' *)
+
+(* Skipping definition `GHC.Base.op_divModIntzh__' *)
+
+(* Skipping definition `GHC.Base.modInt' *)
+
+(* Skipping definition `GHC.Base.minInt' *)
+
+(* Skipping definition `GHC.Base.maxInt' *)
 
 Definition mapFB {elt} {lst} {a}
    : (elt -> lst -> lst) -> (a -> elt) -> a -> lst -> lst :=
@@ -646,6 +682,8 @@ Definition id {a} : a -> a :=
 Definition join {m} {a} `{(Monad m)} : m (m a) -> m a :=
   fun x => x >>= id.
 
+(* Skipping definition `GHC.Base.getTag' *)
+
 Definition foldr {a} {b} : (a -> b -> b) -> b -> list a -> b :=
   fun k z =>
     let fix go arg_0__
@@ -673,14 +711,24 @@ Fixpoint eqString (arg_0__ arg_1__ : String) : bool
               | _, _ => false
               end.
 
+(* Skipping definition `GHC.Base.divModInt' *)
+
+(* Skipping definition `GHC.Base.divInt' *)
+
 Definition const {a} {b} : a -> b -> a :=
   fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | x, _ => x end.
+
+(* Skipping definition `GHC.Base.build' *)
 
 Definition breakpointCond {a} : bool -> a -> a :=
   fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | _, r => r end.
 
 Definition breakpoint {a} : a -> a :=
   fun r => r.
+
+(* Skipping definition `GHC.Base.bindIO' *)
+
+(* Skipping definition `GHC.Base.augment' *)
 
 Definition assert {a} : bool -> a -> a :=
   fun _pred r => r.
@@ -690,6 +738,8 @@ Definition asTypeOf {a} : a -> a -> a :=
 
 Definition ap {m} {a} {b} `{(Monad m)} : m (a -> b) -> m a -> m b :=
   fun m1 m2 => m1 >>= (fun x1 => m2 >>= (fun x2 => return_ (x1 x2))).
+
+(* Skipping definition `Coq.Init.Datatypes.app' *)
 
 Local Definition Eq___option_op_zeze__ {inst_a} `{Eq_ inst_a}
    : option inst_a -> option inst_a -> bool :=

--- a/base/GHC/List.v
+++ b/base/GHC/List.v
@@ -131,6 +131,8 @@ Definition unzip {a} {b} : list (a * b)%type -> (list a * list b)%type :=
            | pair a b, pair as_ bs => pair (cons a as_) (cons b bs)
            end) (pair nil nil).
 
+(* Skipping definition `GHC.List.unsafeTake' *)
+
 Definition uncons {a} : list a -> option (a * list a)%type :=
   fun arg_0__ =>
     match arg_0__ with
@@ -156,12 +158,13 @@ Definition takeFB {a} {b}
       if num_0__ == #1 : bool then c x n else
       c x (xs (m GHC.Num.- #1)).
 
-Definition sum {a} `{(GHC.Num.Num a)} : list a -> a :=
-  foldl _GHC.Num.+_ #0.
+(* Skipping definition `GHC.List.take' *)
 
 Definition strictUncurryScanr {a} {b} {c}
    : (a -> b -> c) -> (a * b)%type -> c :=
   fun f pair_ => let 'pair x y := pair_ in f x y.
+
+(* Skipping definition `GHC.List.splitAt' *)
 
 Fixpoint span {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : (list a *
                                                                 list a)%type
@@ -191,6 +194,8 @@ Fixpoint scanr1 {a} `{_ : GHC.Err.Default a} (arg_0__ : a -> a -> a) (arg_1__
                   | _ => GHC.Err.patternFailure
                   end
               end.
+
+(* Skipping definition `GHC.List.scanr' *)
 
 Definition scanlFB' {b} {a} {c}
    : (b -> a -> b) -> (b -> c -> c) -> a -> (b -> c) -> b -> c :=
@@ -234,8 +239,11 @@ Definition reverse {a} : list a -> list a :=
                  end in
     rev l nil.
 
-Definition product {a} `{(GHC.Num.Num a)} : list a -> a :=
-  foldl _GHC.Num.*_ #1.
+(* Skipping definition `GHC.List.replicate' *)
+
+(* Skipping definition `GHC.List.repeatFB' *)
+
+(* Skipping definition `GHC.List.repeat' *)
 
 Definition prel_list_str : String :=
   GHC.Base.hs_string__ "Prelude.".
@@ -300,6 +308,14 @@ Fixpoint lenAcc {a} (arg_0__ : list a) (arg_1__ : GHC.Num.Int) : GHC.Num.Int
 Definition length {a} : list a -> GHC.Num.Int :=
   fun xs => lenAcc xs #0.
 
+(* Skipping definition `GHC.List.iterateFB' *)
+
+(* Skipping definition `GHC.List.iterate'FB' *)
+
+(* Skipping definition `GHC.List.iterate'' *)
+
+(* Skipping definition `GHC.List.iterate' *)
+
 Definition idLength : GHC.Num.Int -> GHC.Num.Int :=
   id.
 
@@ -345,21 +361,6 @@ Definition errorEmptyList {a} `{_ : GHC.Err.Default a} : String -> a :=
                                                            (Coq.Init.Datatypes.app fun_ (GHC.Base.hs_string__
                                                                                     ": empty list"))).
 
-Definition foldl1 {a} `{_ : GHC.Err.Default a} : (a -> a -> a) -> list a -> a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, cons x xs => foldl f x xs
-    | _, nil => errorEmptyList (GHC.Base.hs_string__ "foldl1")
-    end.
-
-Definition foldl1' {a} `{_ : GHC.Err.Default a}
-   : (a -> a -> a) -> list a -> a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, cons x xs => foldl' f x xs
-    | _, nil => errorEmptyList (GHC.Base.hs_string__ "foldl1'")
-    end.
-
 Definition foldr1 {a} `{_ : GHC.Err.Default a} : (a -> a -> a) -> list a -> a :=
   fun f =>
     let fix go arg_0__
@@ -386,27 +387,6 @@ Definition init {a} `{_ : GHC.Err.Default a} : list a -> list a :=
 Definition lastError {a} `{_ : GHC.Err.Default a} : a :=
   errorEmptyList (GHC.Base.hs_string__ "last").
 
-Definition last {a} `{_ : GHC.Err.Default a} : list a -> a :=
-  fun xs =>
-    foldl (fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | _, x => x end)
-    lastError xs.
-
-Definition maximum {a} `{_ : GHC.Err.Default a} {_ : Eq_ a} {_ : Ord a}
-   : list a -> a :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | nil => errorEmptyList (GHC.Base.hs_string__ "maximum")
-    | xs => foldl1 max xs
-    end.
-
-Definition minimum {a} `{_ : GHC.Err.Default a} {_ : Eq_ a} {_ : Ord a}
-   : list a -> a :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | nil => errorEmptyList (GHC.Base.hs_string__ "minimum")
-    | xs => foldl1 min xs
-    end.
-
 Definition tail {a} `{_ : GHC.Err.Default a} : list a -> list a :=
   fun arg_0__ =>
     match arg_0__ with
@@ -425,6 +405,10 @@ Fixpoint dropWhile {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : list a
               | _, nil => nil
               | p, (cons x xs' as xs) => if p x : bool then dropWhile p xs' else xs
               end.
+
+(* Skipping definition `GHC.List.drop' *)
+
+(* Skipping definition `GHC.List.cycle' *)
 
 Definition constScanl {a} {b} : a -> b -> a :=
   const.
@@ -465,6 +449,54 @@ Fixpoint all {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : bool
               | _, nil => true
               | p, cons x xs => andb (p x) (all p xs)
               end.
+
+(* Skipping definition `GHC.Base.foldl'' *)
+
+Definition foldl1' {a} `{_ : GHC.Err.Default a}
+   : (a -> a -> a) -> list a -> a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, cons x xs => foldl' f x xs
+    | _, nil => errorEmptyList (GHC.Base.hs_string__ "foldl1'")
+    end.
+
+(* Skipping definition `GHC.Base.foldl' *)
+
+Definition foldl1 {a} `{_ : GHC.Err.Default a} : (a -> a -> a) -> list a -> a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, cons x xs => foldl f x xs
+    | _, nil => errorEmptyList (GHC.Base.hs_string__ "foldl1")
+    end.
+
+Definition maximum {a} `{_ : GHC.Err.Default a} {_ : Eq_ a} {_ : Ord a}
+   : list a -> a :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | nil => errorEmptyList (GHC.Base.hs_string__ "maximum")
+    | xs => foldl1 max xs
+    end.
+
+Definition minimum {a} `{_ : GHC.Err.Default a} {_ : Eq_ a} {_ : Ord a}
+   : list a -> a :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | nil => errorEmptyList (GHC.Base.hs_string__ "minimum")
+    | xs => foldl1 min xs
+    end.
+
+Definition last {a} `{_ : GHC.Err.Default a} : list a -> a :=
+  fun xs =>
+    foldl (fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | _, x => x end)
+    lastError xs.
+
+Definition product {a} `{(GHC.Num.Num a)} : list a -> a :=
+  foldl _GHC.Num.*_ #1.
+
+Definition sum {a} `{(GHC.Num.Num a)} : list a -> a :=
+  foldl _GHC.Num.+_ #0.
+
+(* Skipping definition `Coq.Lists.List.flat_map' *)
 
 Module Notations.
 Notation "'_GHC.List.!!_'" := (op_znzn__).

--- a/examples/containers/hs-spec/IntSetProperties.v
+++ b/examples/containers/hs-spec/IntSetProperties.v
@@ -61,6 +61,18 @@ Definition toSet
      Data.Set.Internal.Set_ Coq.Numbers.BinNums.N :=
   Data.Set.Internal.fromList GHC.Base.∘ Data.IntSet.Internal.toList.
 
+(* Skipping definition `IntSetProperties.test_split' *)
+
+(* Skipping definition `IntSetProperties.test_lookupLT' *)
+
+(* Skipping definition `IntSetProperties.test_lookupLE' *)
+
+(* Skipping definition `IntSetProperties.test_lookupGT' *)
+
+(* Skipping definition `IntSetProperties.test_lookupGE' *)
+
+(* Skipping definition `IntSetProperties.test_LookupSomething' *)
+
 Definition prop_splitRoot : Data.IntSet.Internal.IntSet -> bool :=
   fun s =>
     let loop :=
@@ -119,6 +131,8 @@ Definition prop_size : Data.IntSet.Internal.IntSet -> Prop :=
      Coq.NArith.BinNat.N.of_nat (Coq.Init.Datatypes.length
                                  (Data.IntSet.Internal.toList s))).
 
+(* Skipping definition `IntSetProperties.prop_readShow' *)
+
 Definition prop_partition
    : Data.IntSet.Internal.IntSet -> Coq.Numbers.BinNums.N -> Prop :=
   fun s i =>
@@ -137,6 +151,10 @@ Definition prop_ord
     GHC.Base.compare s1 s2 GHC.Base.==
     GHC.Base.compare (Data.IntSet.Internal.toList s1) (Data.IntSet.Internal.toList
                       s2).
+
+(* Skipping definition `IntSetProperties.prop_minView' *)
+
+(* Skipping definition `IntSetProperties.prop_maxView' *)
 
 Definition prop_map : Data.IntSet.Internal.IntSet -> bool :=
   fun s => Data.IntSet.Internal.map GHC.Base.id s GHC.Base.== s.
@@ -163,6 +181,8 @@ Definition prop_isProperSubsetOf
     Data.IntSet.Internal.isProperSubsetOf a b GHC.Base.==
     Data.Set.Internal.isProperSubsetOf (toSet a) (toSet b).
 
+(* Skipping definition `IntSetProperties.prop_fromList' *)
+
 Definition prop_foldR' : Data.IntSet.Internal.IntSet -> bool :=
   fun s =>
     Data.IntSet.Internal.foldr' cons nil s GHC.Base.==
@@ -182,6 +202,10 @@ Definition prop_foldL : Data.IntSet.Internal.IntSet -> bool :=
     Data.IntSet.Internal.foldl (GHC.Base.flip cons) nil s GHC.Base.==
     Data.Foldable.foldl (GHC.Base.flip cons) nil (Data.IntSet.Internal.toList s).
 
+(* Skipping definition `IntSetProperties.prop_findMin' *)
+
+(* Skipping definition `IntSetProperties.prop_findMax' *)
+
 Definition prop_filter
    : Data.IntSet.Internal.IntSet -> Coq.Numbers.BinNums.N -> Prop :=
   fun s i =>
@@ -197,6 +221,8 @@ Definition prop_disjoint
   fun a b =>
     Data.IntSet.Internal.disjoint a b GHC.Base.==
     Data.IntSet.Internal.null (Data.IntSet.Internal.intersection a b).
+
+(* Skipping definition `IntSetProperties.prop_bitcount' *)
 
 Definition prop_UnionInsert
    : Coq.Numbers.BinNums.N -> Data.IntSet.Internal.IntSet -> Prop :=
@@ -236,6 +262,8 @@ Fixpoint prop_Prefix (arg_0__ : Data.IntSet.Internal.IntSet) : bool
               | _ => true
               end.
 
+(* Skipping definition `IntSetProperties.prop_Ordered' *)
+
 Definition prop_NotMember
    : list Coq.Numbers.BinNums.N -> Coq.Numbers.BinNums.N -> bool :=
   fun xs n =>
@@ -263,6 +291,14 @@ Definition prop_Member
     Data.Foldable.all (fun k =>
                          Data.IntSet.Internal.member k m GHC.Base.== (Data.Foldable.elem k xs)) (cons n
                                                                                                       xs).
+
+(* Skipping definition `IntSetProperties.prop_LookupLT' *)
+
+(* Skipping definition `IntSetProperties.prop_LookupLE' *)
+
+(* Skipping definition `IntSetProperties.prop_LookupGT' *)
+
+(* Skipping definition `IntSetProperties.prop_LookupGE' *)
 
 Definition prop_List : list Coq.Numbers.BinNums.N -> bool :=
   fun xs =>
@@ -339,6 +375,8 @@ Fixpoint prop_MaskPow2 (arg_0__ : Data.IntSet.Internal.IntSet) : bool
                                                                          (prop_MaskPow2 right_))
               | _ => true
               end.
+
+(* Skipping definition `IntSetProperties.main' *)
 
 Definition forValid {a} `{Test.QuickCheck.Property.Testable a}
    : (Data.IntSet.Internal.IntSet -> a) -> Prop :=

--- a/examples/containers/lib/Data/IntMap/Internal.v
+++ b/examples/containers/lib/Data/IntMap/Internal.v
@@ -150,6 +150,10 @@ Require Import Coq.Numbers.BinNums.
 
 (* Converted value declarations: *)
 
+(* Skipping definition `Data.IntSet.Internal.zero' *)
+
+(* Skipping definition `Data.IntSet.Internal.mask' *)
+
 Definition zipWithMaybeMatched {f} {x} {y} {z} `{GHC.Base.Applicative f}
    : (Data.IntSet.Internal.Key -> x -> y -> option z) -> WhenMatched f x y z :=
   fun f => Mk_WhenMatched (fun k x y => GHC.Base.pure (f k x y)).
@@ -167,6 +171,18 @@ Definition zipWithMatched {f} {x} {y} {z} `{GHC.Base.Applicative f}
 Definition zipWithAMatched {f} {x} {y} {z} `{GHC.Base.Applicative f}
    : (Data.IntSet.Internal.Key -> x -> y -> f z) -> WhenMatched f x y z :=
   fun f => Mk_WhenMatched (fun k x y => Some Data.Functor.<$> f k x y).
+
+(* Skipping definition `Data.IntMap.Internal.withEmpty' *)
+
+(* Skipping definition `Data.IntMap.Internal.withBar' *)
+
+(* Skipping definition `Data.IntMap.Internal.updateMinWithKey' *)
+
+(* Skipping definition `Data.IntMap.Internal.updateMin' *)
+
+(* Skipping definition `Data.IntMap.Internal.updateMaxWithKey' *)
+
+(* Skipping definition `Data.IntMap.Internal.updateMax' *)
 
 Fixpoint unsafeFindMin {a} (arg_0__ : IntMap a) : option
                                                   (Data.IntSet.Internal.Key * a)%type
@@ -222,6 +238,20 @@ Definition size {a} : IntMap a -> Coq.Numbers.BinNums.N :=
 Definition singleton {a} : Data.IntSet.Internal.Key -> a -> IntMap a :=
   fun k x => Tip k x.
 
+(* Skipping definition `Data.IntMap.Internal.showsTreeHang' *)
+
+(* Skipping definition `Data.IntMap.Internal.showsTree' *)
+
+(* Skipping definition `Data.IntMap.Internal.showsBars' *)
+
+(* Skipping definition `Data.IntMap.Internal.showWide' *)
+
+(* Skipping definition `Data.IntMap.Internal.showTreeWith' *)
+
+(* Skipping definition `Data.IntMap.Internal.showTree' *)
+
+(* Skipping definition `Data.IntMap.Internal.showBin' *)
+
 Definition shorter : Mask -> Mask -> bool :=
   fun m1 m2 => (m1) GHC.Base.> (m2).
 
@@ -239,6 +269,8 @@ Definition preserveMissing {f} {x} `{GHC.Base.Applicative f}
                     match arg_0__, arg_1__ with
                     | _, v => GHC.Base.pure (Some v)
                     end).
+
+(* Skipping definition `Data.IntMap.Internal.op_zn__' *)
 
 Definition null {a} : IntMap a -> bool :=
   fun arg_0__ => match arg_0__ with | Nil => true | _ => false end.
@@ -259,6 +291,18 @@ Fixpoint nequal {a} `{GHC.Base.Eq_ a} (arg_0__ arg_1__ : IntMap a) : bool
               | _, _ => true
               end.
 
+(* Skipping definition `Data.IntMap.Internal.natFromInt' *)
+
+(* Skipping definition `Data.IntMap.Internal.minViewWithKeySure' *)
+
+(* Skipping definition `Data.IntMap.Internal.minViewWithKey' *)
+
+(* Skipping definition `Data.IntMap.Internal.minView' *)
+
+(* Skipping definition `Data.IntMap.Internal.mergeA' *)
+
+(* Skipping definition `Data.IntMap.Internal.merge' *)
+
 Definition member {a} : Data.IntSet.Internal.Key -> IntMap a -> bool :=
   fun k =>
     let fix go arg_0__
@@ -274,6 +318,12 @@ Definition member {a} : Data.IntSet.Internal.Key -> IntMap a -> bool :=
 
 Definition notMember {a} : Data.IntSet.Internal.Key -> IntMap a -> bool :=
   fun k m => negb (member k m).
+
+(* Skipping definition `Data.IntMap.Internal.maxViewWithKeySure' *)
+
+(* Skipping definition `Data.IntMap.Internal.maxViewWithKey' *)
+
+(* Skipping definition `Data.IntMap.Internal.maxView' *)
 
 Definition match_ : Data.IntSet.Internal.Key -> Prefix -> Mask -> bool :=
   fun i p m => (Data.IntSet.Internal.mask i m) GHC.Base.== p.
@@ -340,6 +390,8 @@ Definition mapLT {a}
     match arg_0__, arg_1__ with
     | f, Mk_SplitLookup lt fnd gt => Mk_SplitLookup (f lt) fnd gt
     end.
+
+(* Skipping definition `Data.IntMap.Internal.mapKeysMonotonic' *)
 
 Definition mapGentlyWhenMissing {f} {a} {b} {x} `{GHC.Base.Functor f}
    : (a -> b) -> WhenMissing f x a -> WhenMissing f x b :=
@@ -692,6 +744,10 @@ Definition isProperSubmapOf {a} `{GHC.Base.Eq_ a}
    : IntMap a -> IntMap a -> bool :=
   fun m1 m2 => isProperSubmapOfBy _GHC.Base.==_ m1 m2.
 
+(* Skipping definition `Data.IntMap.Internal.intMapDataType' *)
+
+(* Skipping definition `Data.IntMap.Internal.intFromNat' *)
+
 Fixpoint fromSet {a} (arg_0__ : (Data.IntSet.Internal.Key -> a)) (arg_1__
                    : Data.IntSet.Internal.IntSet) : IntMap a
            := match arg_0__, arg_1__ with
@@ -724,6 +780,16 @@ Fixpoint fromSet {a} (arg_0__ : (Data.IntSet.Internal.Key -> a)) (arg_1__
                                                                                                        bits2)) in
                   buildTree f kx bm (Data.IntSet.Internal.suffixBitMask GHC.Num.+ #1)
               end.
+
+(* Skipping definition `Data.IntMap.Internal.fromListConstr' *)
+
+(* Skipping definition `Data.IntMap.Internal.fromDistinctAscList' *)
+
+(* Skipping definition `Data.IntMap.Internal.fromAscListWithKey' *)
+
+(* Skipping definition `Data.IntMap.Internal.fromAscListWith' *)
+
+(* Skipping definition `Data.IntMap.Internal.fromAscList' *)
 
 Definition foldrWithKey' {a} {b}
    : (Data.IntSet.Internal.Key -> a -> b -> b) -> b -> IntMap a -> b :=
@@ -891,6 +957,12 @@ Definition findWithDefault {a}
                  end in
     go.
 
+(* Skipping definition `Data.IntMap.Internal.findMin' *)
+
+(* Skipping definition `Data.IntMap.Internal.findMax' *)
+
+(* Skipping definition `Data.IntMap.Internal.find' *)
+
 Fixpoint equal {a} `{GHC.Base.Eq_ a} (arg_0__ arg_1__ : IntMap a) : bool
            := match arg_0__, arg_1__ with
               | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
@@ -911,6 +983,14 @@ Definition dropMissing {f} {x} {y} `{GHC.Base.Applicative f}
    : WhenMissing f x y :=
   Mk_WhenMissing (GHC.Base.const (GHC.Base.pure Nil)) (fun arg_0__ arg_1__ =>
                     GHC.Base.pure None).
+
+(* Skipping definition `Data.IntMap.Internal.deleteMin' *)
+
+(* Skipping definition `Data.IntMap.Internal.deleteMax' *)
+
+(* Skipping definition `Data.IntMap.Internal.deleteFindMin' *)
+
+(* Skipping definition `Data.IntMap.Internal.deleteFindMax' *)
 
 Definition contramapSecondWhenMatched {b} {a} {f} {x} {z}
    : (b -> a) -> WhenMatched f x a z -> WhenMatched f x b z :=

--- a/examples/containers/lib/Data/IntSet/Internal.v
+++ b/examples/containers/lib/Data/IntSet/Internal.v
@@ -87,8 +87,14 @@ Require Import Coq.NArith.NArith.
 
 (* Converted value declarations: *)
 
+(* Skipping definition `Utils.Containers.Internal.BitUtil.lowestBitMask' *)
+
 Definition zero : Coq.Numbers.BinNums.N -> Mask -> bool :=
   fun i m => ((i) Data.Bits..&.(**) (m)) GHC.Base.== #0.
+
+(* Skipping definition `Data.IntSet.Internal.withEmpty' *)
+
+(* Skipping definition `Data.IntSet.Internal.withBar' *)
 
 Definition tip : Prefix -> BitMap -> IntSet :=
   fun arg_0__ arg_1__ =>
@@ -126,6 +132,24 @@ Definition size : IntSet -> Coq.Numbers.BinNums.N :=
                end in
   go #0.
 
+(* Skipping definition `Data.IntSet.Internal.showsTreeHang' *)
+
+(* Skipping definition `Data.IntSet.Internal.showsTree' *)
+
+(* Skipping definition `Data.IntSet.Internal.showsBitMap' *)
+
+(* Skipping definition `Data.IntSet.Internal.showsBars' *)
+
+(* Skipping definition `Data.IntSet.Internal.showWide' *)
+
+(* Skipping definition `Data.IntSet.Internal.showTreeWith' *)
+
+(* Skipping definition `Data.IntSet.Internal.showTree' *)
+
+(* Skipping definition `Data.IntSet.Internal.showBitMap' *)
+
+(* Skipping definition `Data.IntSet.Internal.showBin' *)
+
 Definition shorter : Mask -> Mask -> bool :=
   fun m1 m2 => (m1) GHC.Base.> (m2).
 
@@ -157,8 +181,12 @@ Definition revNat : Nat -> Nat :=
 Definition prefixOf : Coq.Numbers.BinNums.N -> Prefix :=
   fun x => Coq.NArith.BinNat.N.ldiff x suffixBitMask.
 
+(* Skipping definition `Data.IntSet.Internal.prefixBitMask' *)
+
 Definition null : IntSet -> bool :=
   fun arg_0__ => match arg_0__ with | Nil => true | _ => false end.
+
+(* Skipping definition `Data.IntSet.Internal.node' *)
 
 Fixpoint nequal (arg_0__ arg_1__ : IntSet) : bool
            := match arg_0__, arg_1__ with
@@ -169,6 +197,8 @@ Fixpoint nequal (arg_0__ arg_1__ : IntSet) : bool
               | Nil, Nil => false
               | _, _ => true
               end.
+
+(* Skipping definition `Data.IntSet.Internal.natFromInt' *)
 
 Definition maskW : Nat -> Nat -> Prefix :=
   fun i m => Coq.NArith.BinNat.N.ldiff i (2 * m - 1 % N).
@@ -254,6 +284,10 @@ Fixpoint isSubsetOf (arg_0__ arg_1__ : IntSet) : bool
 Definition isProperSubsetOf : IntSet -> IntSet -> bool :=
   fun t1 t2 => match subsetCmp t1 t2 with | Lt => true | _ => false end.
 
+(* Skipping definition `Data.IntSet.Internal.intSetDataType' *)
+
+(* Skipping definition `Data.IntSet.Internal.intFromNat' *)
+
 Definition indexOfTheOnlyBit :=
   fun x => Coq.NArith.BinNat.N.log2 x.
 
@@ -276,6 +310,12 @@ Fixpoint unsafeFindMax (arg_0__ : IntSet) : option Key
               | Tip kx bm => Some (kx GHC.Num.+ highestBitSet bm)
               | Bin _ _ _ r => unsafeFindMax r
               end.
+
+(* Skipping definition `Data.IntSet.Internal.fromListConstr' *)
+
+(* Skipping definition `Data.IntSet.Internal.fromDistinctAscList' *)
+
+(* Skipping definition `Data.IntSet.Internal.fromAscList' *)
 
 Definition revNatSafe n :=
   Coq.NArith.BinNat.N.modulo (revNat n) (Coq.NArith.BinNat.N.pow 2 64).
@@ -438,6 +478,10 @@ Definition toDescList : IntSet -> list Key :=
 Definition fold {b} : (Key -> b -> b) -> b -> IntSet -> b :=
   foldr.
 
+(* Skipping definition `Data.IntSet.Internal.findMin' *)
+
+(* Skipping definition `Data.IntSet.Internal.findMax' *)
+
 Fixpoint equal (arg_0__ arg_1__ : IntSet) : bool
            := match arg_0__, arg_1__ with
               | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
@@ -504,6 +548,10 @@ Program Fixpoint disjoint (arg_0__ arg_1__ : IntSet) {measure (size_nat arg_0__
                       | Nil, _ => true
                       end.
 Solve Obligations with (termination_by_omega).
+
+(* Skipping definition `Data.IntSet.Internal.deleteFindMin' *)
+
+(* Skipping definition `Data.IntSet.Internal.deleteFindMax' *)
 
 Definition branchMask : Prefix -> Prefix -> Mask :=
   fun p1 p2 =>

--- a/examples/containers/lib/Data/IntSet/InternalWord.v
+++ b/examples/containers/lib/Data/IntSet/InternalWord.v
@@ -80,6 +80,10 @@ Ltac termination_by_omega :=
 
 (* Converted value declarations: *)
 
+(* Skipping definition `Data.IntSet.InternalWord.withEmpty' *)
+
+(* Skipping definition `Data.IntSet.InternalWord.withBar' *)
+
 Definition tip : Prefix -> BitMap -> IntSet :=
   fun arg_0__ arg_1__ =>
     match arg_0__, arg_1__ with
@@ -115,6 +119,24 @@ Definition size : IntSet -> IntWord.Int :=
                end in
   go #0.
 
+(* Skipping definition `Data.IntSet.InternalWord.showsTreeHang' *)
+
+(* Skipping definition `Data.IntSet.InternalWord.showsTree' *)
+
+(* Skipping definition `Data.IntSet.InternalWord.showsBitMap' *)
+
+(* Skipping definition `Data.IntSet.InternalWord.showsBars' *)
+
+(* Skipping definition `Data.IntSet.InternalWord.showWide' *)
+
+(* Skipping definition `Data.IntSet.InternalWord.showTreeWith' *)
+
+(* Skipping definition `Data.IntSet.InternalWord.showTree' *)
+
+(* Skipping definition `Data.IntSet.InternalWord.showBitMap' *)
+
+(* Skipping definition `Data.IntSet.InternalWord.showBin' *)
+
 Definition revNat : Nat -> Nat :=
   fun x1 =>
     let 'x2 := ((IntWord.shiftRWord x1 #1) Data.Bits..&.(**) #6148914691236517205)
@@ -143,6 +165,8 @@ Definition prefixOf : IntWord.Int -> Prefix :=
 Definition null : IntSet -> bool :=
   fun arg_0__ => match arg_0__ with | Nil => true | _ => false end.
 
+(* Skipping definition `Data.IntSet.InternalWord.node' *)
+
 Fixpoint nequal (arg_0__ arg_1__ : IntSet) : bool
            := match arg_0__, arg_1__ with
               | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
@@ -164,6 +188,8 @@ Definition zero : IntWord.Int -> Mask -> bool :=
 
 Definition lowestBitMask : Nat -> Nat :=
   fun x => x Data.Bits..&.(**) GHC.Num.negate x.
+
+(* Skipping definition `Data.IntSet.InternalWord.intSetDataType' *)
 
 Definition intFromNat :=
   IntWord.intFromWord.
@@ -276,6 +302,12 @@ Fixpoint unsafeFindMax (arg_0__ : IntSet) : option Key
               | Tip kx bm => Some (kx GHC.Num.+ highestBitSet bm)
               | Bin _ _ _ r => unsafeFindMax r
               end.
+
+(* Skipping definition `Data.IntSet.InternalWord.fromListConstr' *)
+
+(* Skipping definition `Data.IntSet.InternalWord.fromDistinctAscList' *)
+
+(* Skipping definition `Data.IntSet.InternalWord.fromAscList' *)
 
 Program Definition foldrBits {a}
            : IntWord.Int -> (IntWord.Int -> a -> a) -> a -> Nat -> a :=
@@ -431,6 +463,10 @@ Definition toDescList : IntSet -> list Key :=
 Definition fold {b} : (Key -> b -> b) -> b -> IntSet -> b :=
   foldr.
 
+(* Skipping definition `Data.IntSet.InternalWord.findMin' *)
+
+(* Skipping definition `Data.IntSet.InternalWord.findMax' *)
+
 Fixpoint equal (arg_0__ arg_1__ : IntSet) : bool
            := match arg_0__, arg_1__ with
               | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
@@ -497,6 +533,10 @@ Program Fixpoint disjoint (arg_0__ arg_1__ : IntSet) {measure (size_nat arg_0__
                       | Nil, _ => true
                       end.
 Solve Obligations with (termination_by_omega).
+
+(* Skipping definition `Data.IntSet.InternalWord.deleteFindMin' *)
+
+(* Skipping definition `Data.IntSet.InternalWord.deleteFindMax' *)
 
 Definition branchMask : Prefix -> Prefix -> Mask :=
   fun p1 p2 =>

--- a/examples/containers/lib/Data/Map/Internal.v
+++ b/examples/containers/lib/Data/Map/Internal.v
@@ -218,6 +218,8 @@ Definition runWhenMatched {f} {k} {x} {y} {z}
    : WhenMatched f k x y z -> k -> x -> y -> f (option z) :=
   matchedKey.
 
+(* Skipping definition `Data.Map.Internal.replaceAlong' *)
+
 Definition ratio : GHC.Num.Int :=
   #2.
 
@@ -227,6 +229,8 @@ Definition preserveMissing {f} {k} {x} `{GHC.Base.Applicative f}
                     match arg_0__, arg_1__ with
                     | _, v => GHC.Base.pure (Some v)
                     end).
+
+(* Skipping definition `Data.Map.Internal.op_zn__' *)
 
 Definition null {k} {a} : Map k a -> bool :=
   fun arg_0__ => match arg_0__ with | Tip => true | Bin _ _ _ _ _ => false end.
@@ -318,6 +322,8 @@ Definition mapGentlyWhenMatched {f} {a} {b} {k} {x} {y} `{GHC.Base.Functor f}
     zipWithMaybeAMatched (fun k x y =>
                             GHC.Base.fmap f Data.Functor.<$> runWhenMatched t k x y).
 
+(* Skipping definition `Data.Map.Internal.mapDataType' *)
+
 Fixpoint mapAccumRWithKey {a} {k} {b} {c} (arg_0__
                             : (a -> k -> b -> (a * c)%type)) (arg_1__ : a) (arg_2__ : Map k b) : (a *
                                                                                                   Map k c)%type
@@ -352,6 +358,8 @@ Definition mapAccum {a} {b} {c} {k}
                        match arg_0__, arg_1__, arg_2__ with
                        | a', _, x' => f a' x'
                        end) a m.
+
+(* Skipping definition `Data.Map.Internal.lookupTrace' *)
 
 Fixpoint lookupMinSure {k} {a} (arg_0__ : k) (arg_1__ : a) (arg_2__ : Map k a)
            : (k * a)%type
@@ -514,6 +522,8 @@ Fixpoint keysSet {k} {a} (arg_0__ : Map k a) : Data.Set.Internal.Set_ k
               | Bin sz kx _ l r => Data.Set.Internal.Bin sz kx (keysSet l) (keysSet r)
               end.
 
+(* Skipping definition `Data.Map.Internal.insertAlong' *)
+
 Fixpoint fromSet {k} {a} (arg_0__ : (k -> a)) (arg_1__
                    : Data.Set.Internal.Set_ k) : Map k a
            := match arg_0__, arg_1__ with
@@ -521,6 +531,8 @@ Fixpoint fromSet {k} {a} (arg_0__ : (k -> a)) (arg_1__
               | f, Data.Set.Internal.Bin sz x l r =>
                   Bin sz x (f x) (fromSet f l) (fromSet f r)
               end.
+
+(* Skipping definition `Data.Map.Internal.fromListConstr' *)
 
 Definition foldrWithKey' {k} {a} {b}
    : (k -> a -> b -> b) -> b -> Map k a -> b :=
@@ -645,6 +657,10 @@ Definition findWithDefault {k} {a} `{GHC.Base.Ord k} : a -> k -> Map k a -> a :=
                end in
   go.
 
+(* Skipping definition `Data.Map.Internal.findMin' *)
+
+(* Skipping definition `Data.Map.Internal.findMax' *)
+
 Definition findIndex {k} {a} `{GHC.Base.Ord k} : k -> Map k a -> GHC.Num.Int :=
   let go {k} {a} `{GHC.Base.Ord k} : GHC.Num.Int -> k -> Map k a -> GHC.Num.Int :=
     fix go (arg_0__ : GHC.Num.Int) (arg_1__ : k) (arg_2__ : Map k a) : GHC.Num.Int
@@ -660,19 +676,33 @@ Definition findIndex {k} {a} `{GHC.Base.Ord k} : k -> Map k a -> GHC.Num.Int :=
              end in
   go #0.
 
+(* Skipping definition `Data.Map.Internal.find' *)
+
 Definition empty {k} {a} : Map k a :=
   Tip.
 
 Definition elems {k} {a} : Map k a -> list a :=
   foldr cons nil.
 
+(* Skipping definition `Data.Map.Internal.elemAt' *)
+
 Definition dropMissing {f} {k} {x} {y} `{GHC.Base.Applicative f}
    : WhenMissing f k x y :=
   Mk_WhenMissing (GHC.Base.const (GHC.Base.pure Tip)) (fun arg_0__ arg_1__ =>
                     GHC.Base.pure None).
 
+(* Skipping definition `Data.Map.Internal.differenceWithKey' *)
+
+(* Skipping definition `Data.Map.Internal.differenceWith' *)
+
 Definition delta : GHC.Num.Int :=
   #3.
+
+(* Skipping definition `Data.Map.Internal.deleteFindMin' *)
+
+(* Skipping definition `Data.Map.Internal.deleteFindMax' *)
+
+(* Skipping definition `Data.Map.Internal.deleteAlong' *)
 
 Definition contramapSecondWhenMatched {b} {a} {f} {k} {x} {z}
    : (b -> a) -> WhenMatched f k x a z -> WhenMatched f k x b z :=
@@ -688,6 +718,8 @@ Definition boolITE {a} : a -> a -> bool -> a :=
     | f, _, false => f
     | _, t, true => t
     end.
+
+(* Skipping definition `Data.Map.Internal.bogus' *)
 
 Definition bin {k} {a} : k -> a -> Map k a -> Map k a -> Map k a :=
   fun k x l r => Bin ((size l GHC.Num.+ size r) GHC.Num.+ #1) k x l r.
@@ -2101,6 +2133,8 @@ Definition atKeyPlain {k} {a} `{GHC.Base.Ord k}
     | AltSame => t
     end.
 
+(* Skipping definition `Data.Map.Internal.atKeyImpl' *)
+
 Definition atKeyIdentity {k} {a} `{GHC.Base.Ord k}
    : k ->
      (option a -> Data.Functor.Identity.Identity (option a)) ->
@@ -2110,6 +2144,8 @@ Definition atKeyIdentity {k} {a} `{GHC.Base.Ord k}
 
 Definition assocs {k} {a} : Map k a -> list (k * a)%type :=
   fun m => toAscList m.
+
+(* Skipping definition `Data.Map.Internal.alterF' *)
 
 Definition alter {k} {a} `{GHC.Base.Ord k}
    : (option a -> option a) -> k -> Map k a -> Map k a :=

--- a/examples/containers/lib/Data/Set/Internal.v
+++ b/examples/containers/lib/Data/Set/Internal.v
@@ -74,6 +74,10 @@ Instance MergeSetDefault {a} : Default (MergeSet a) :=
 
 (* Converted value declarations: *)
 
+(* Skipping definition `Data.Set.Internal.withEmpty' *)
+
+(* Skipping definition `Data.Set.Internal.withBar' *)
+
 Definition size {a} : Set_ a -> GHC.Num.Int :=
   fun arg_0__ => match arg_0__ with | Tip => #0 | Bin sz _ _ _ => sz end.
 
@@ -102,6 +106,20 @@ Definition splitRoot {a} : Set_ a -> list (Set_ a) :=
     | Bin _ v l r => cons l (cons (singleton v) (cons r nil))
     end.
 
+(* Skipping definition `Data.Set.Internal.showsTreeHang' *)
+
+(* Skipping definition `Data.Set.Internal.showsTree' *)
+
+(* Skipping definition `Data.Set.Internal.showsBars' *)
+
+(* Skipping definition `Data.Set.Internal.showWide' *)
+
+(* Skipping definition `Data.Set.Internal.showTreeWith' *)
+
+(* Skipping definition `Data.Set.Internal.showTree' *)
+
+(* Skipping definition `Data.Set.Internal.setDataType' *)
+
 Definition ratio : GHC.Num.Int :=
   #2.
 
@@ -118,6 +136,8 @@ Definition ordered {a} `{GHC.Base.Ord a} : Set_ a -> bool :=
 
 Definition null {a} : Set_ a -> bool :=
   fun arg_0__ => match arg_0__ with | Tip => true | Bin _ _ _ _ => false end.
+
+(* Skipping definition `Data.Set.Internal.node' *)
 
 Definition member {a} `{GHC.Base.Ord a} : a -> Set_ a -> bool :=
   let fix go arg_0__ arg_1__
@@ -264,6 +284,8 @@ Definition lookupGE {a} `{GHC.Base.Ord a} : a -> Set_ a -> option a :=
                end in
   goNothing.
 
+(* Skipping definition `Data.Set.Internal.fromListConstr' *)
+
 Definition foldr' {a} {b} : (a -> b -> b) -> b -> Set_ a -> b :=
   fun f z =>
     let fix go arg_0__ arg_1__
@@ -318,14 +340,28 @@ Definition toDescList {a} : Set_ a -> list a :=
 Definition fold {a} {b} : (a -> b -> b) -> b -> Set_ a -> b :=
   foldr.
 
+(* Skipping definition `Data.Set.Internal.findMin' *)
+
+(* Skipping definition `Data.Set.Internal.findMax' *)
+
+(* Skipping definition `Data.Set.Internal.findIndex' *)
+
 Definition empty {a} : Set_ a :=
   Tip.
 
 Definition elems {a} : Set_ a -> list a :=
   toAscList.
 
+(* Skipping definition `Data.Set.Internal.elemAt' *)
+
 Definition delta : GHC.Num.Int :=
   #3.
+
+(* Skipping definition `Data.Set.Internal.deleteFindMin' *)
+
+(* Skipping definition `Data.Set.Internal.deleteFindMax' *)
+
+(* Skipping definition `Data.Set.Internal.deleteAt' *)
 
 Definition combineEq {a} `{GHC.Base.Eq_ a} : list a -> list a :=
   fun arg_0__ =>

--- a/examples/containers/lib/Utils/Containers/Internal/BitUtil.v
+++ b/examples/containers/lib/Utils/Containers/Internal/BitUtil.v
@@ -33,3 +33,13 @@ Definition bitcount : Coq.Numbers.BinNums.N -> Coq.Numbers.BinNums.N -> Coq.Numb
 (* No type declarations to convert. *)
 
 (* No value declarations to convert. *)
+
+(* Skipping definition `Utils.Containers.Internal.BitUtil.wordSize' *)
+
+(* Skipping definition `Utils.Containers.Internal.BitUtil.shiftRL' *)
+
+(* Skipping definition `Utils.Containers.Internal.BitUtil.shiftLL' *)
+
+(* Skipping definition `Utils.Containers.Internal.BitUtil.highestBitMask' *)
+
+(* Skipping definition `Utils.Containers.Internal.BitUtil.bitcount' *)

--- a/examples/ghc/deps/CoreUtils.mk
+++ b/examples/ghc/deps/CoreUtils.mk
@@ -1,1 +1,1 @@
-lib/CoreUtils.v: lib/Core.h2ci lib/Literal.h2ci lib/Pair.h2ci
+lib/CoreUtils.v: lib/Core.h2ci lib/Pair.h2ci

--- a/examples/ghc/lib/BasicTypes.v
+++ b/examples/ghc/lib/BasicTypes.v
@@ -480,6 +480,8 @@ Definition tupleSortBoxity : TupleSort -> Boxity :=
     | ConstraintTuple => Boxed
     end.
 
+(* Skipping definition `BasicTypes.tupleParens' *)
+
 Definition treatZeroAsInf : GHC.Num.Int -> IntWithInf :=
   fun arg_0__ =>
     let 'num_1__ := arg_0__ in
@@ -557,6 +559,14 @@ Definition pprShortTailCallInfo : TailCallInfo -> GHC.Base.String :=
     | NoTailCallInfo => Panic.someSDoc
     end.
 
+(* Skipping definition `BasicTypes.pprSafeOverlap' *)
+
+(* Skipping definition `BasicTypes.pprRuleName' *)
+
+(* Skipping definition `BasicTypes.pprOneShotInfo' *)
+
+(* Skipping definition `BasicTypes.pprAlternative' *)
+
 Definition pp_ws : list (SrcLoc.Located StringLiteral) -> GHC.Base.String :=
   fun arg_0__ =>
     match arg_0__ with
@@ -606,6 +616,10 @@ Definition zapFragileOcc : OccInfo -> OccInfo :=
     | occ => zapOccTailCallInfo occ
     end.
 
+(* Skipping definition `BasicTypes.negateIntegralLit' *)
+
+(* Skipping definition `BasicTypes.negateFractionalLit' *)
+
 Definition negateFixity : Fixity :=
   Mk_Fixity NoSourceText #6 InfixL.
 
@@ -617,11 +631,17 @@ Definition mulWithInf : IntWithInf -> IntWithInf -> IntWithInf :=
     | Int a, Int b => Int (a GHC.Num.* b)
     end.
 
+(* Skipping definition `BasicTypes.mkIntegralLit' *)
+
 Definition mkIntWithInf : GHC.Num.Int -> IntWithInf :=
   Int.
 
+(* Skipping definition `BasicTypes.mkFractionalLit' *)
+
 Definition minPrecedence : GHC.Num.Int :=
   #0.
+
+(* Skipping definition `BasicTypes.maybeParen' *)
 
 Definition maxPrecedence : GHC.Num.Int :=
   #9.
@@ -778,6 +798,8 @@ Definition isActive : CompilerPhase -> Activation -> bool :=
     | Phase p, act => isActiveIn p act
     end.
 
+(* Skipping definition `BasicTypes.integralFractionalLit' *)
+
 Definition intGtLimit : GHC.Num.Int -> IntWithInf -> bool :=
   fun arg_0__ arg_1__ =>
     match arg_0__, arg_1__ with
@@ -859,6 +881,8 @@ Definition neverInlinePragma : InlinePragma :=
   let 'Mk_InlinePragma inl_src_0__ inl_inline_1__ inl_sat_2__ inl_act_3__
      inl_rule_4__ := defaultInlinePragma in
   Mk_InlinePragma inl_src_0__ inl_inline_1__ inl_sat_2__ NeverActive inl_rule_4__.
+
+(* Skipping definition `BasicTypes.defaultFixity' *)
 
 Definition competesWith : Activation -> Activation -> bool :=
   fun arg_0__ arg_1__ =>

--- a/examples/ghc/lib/BooleanFormula.v
+++ b/examples/ghc/lib/BooleanFormula.v
@@ -181,6 +181,14 @@ Local Definition BooleanFormula_foldr
 
 (* Converted value declarations: *)
 
+(* Skipping definition `BooleanFormula.pprBooleanFormulaNormal' *)
+
+(* Skipping definition `BooleanFormula.pprBooleanFormulaNice' *)
+
+(* Skipping definition `BooleanFormula.pprBooleanFormula'' *)
+
+(* Skipping definition `BooleanFormula.pprBooleanFormula' *)
+
 Definition mkVar {a} : a -> BooleanFormula a :=
   Var.
 

--- a/examples/ghc/lib/Constants.v
+++ b/examples/ghc/lib/Constants.v
@@ -34,6 +34,8 @@ Axiom mAX_REDUCTION_DEPTH : nat.
 
 Axiom mAX_CTUPLE_SIZE : nat.
 
+(* Skipping definition `Constants.hiVersion' *)
+
 Axiom fLOAT_SIZE : nat.
 
 (* External variables:

--- a/examples/ghc/lib/Core.v
+++ b/examples/ghc/lib/Core.v
@@ -2696,7 +2696,23 @@ Axiom tyCoVarsOfCoDSet : Coercion -> DTyCoVarSet.
 
 Axiom tyCoVarsOfCo : Coercion -> TyCoVarSet.
 
+(* Skipping definition `Core.tyCoFVsOfTypes' *)
+
+(* Skipping definition `Core.tyCoFVsOfType' *)
+
+(* Skipping definition `Core.tyCoFVsOfProv' *)
+
+(* Skipping definition `Core.tyCoFVsOfCos' *)
+
+(* Skipping definition `Core.tyCoFVsOfCoVar' *)
+
+(* Skipping definition `Core.tyCoFVsOfCo' *)
+
+(* Skipping definition `Core.tyCoFVsBndr' *)
+
 Axiom tyBinderType : TyBinder -> Type_.
+
+(* Skipping definition `Core.trimToType' *)
 
 Axiom trimCPRInfo : bool -> bool -> DmdResult -> DmdResult.
 
@@ -2714,6 +2730,8 @@ Axiom topNormaliseNewType_maybe : Type_ -> option (Coercion * Type_)%type.
 Axiom topDmd : Demand.
 
 Axiom toPhantomCo : Coercion -> Coercion.
+
+(* Skipping definition `Core.toCleanDmd' *)
 
 Axiom toBothDmdArg : DmdType -> BothDmdArg.
 
@@ -2736,6 +2754,14 @@ Axiom tidyTyCoVarBndrs : TidyEnv ->
 Axiom tidyTyCoVarBndr : TidyEnv -> TyCoVar -> (TidyEnv * TyCoVar)%type.
 
 Axiom tidyTopType : Type_ -> Type_.
+
+(* Skipping definition `Core.tidyToIfaceTypeSty' *)
+
+(* Skipping definition `Core.tidyToIfaceType' *)
+
+(* Skipping definition `Core.tidyToIfaceCoSty' *)
+
+(* Skipping definition `Core.tidyToIfaceCo' *)
 
 Axiom tidyPatSynIds : (Id -> Id) -> PatSyn -> PatSyn.
 
@@ -2867,6 +2893,8 @@ Axiom substCo : forall `{Util.HasDebugCallStack},
                 TCvSubst -> Coercion -> Coercion.
 
 Axiom stripCoercionTy : Type_ -> Coercion.
+
+(* Skipping definition `Core.strictifyDictDmd' *)
 
 Axiom strictenDmd : Demand -> CleanDemand.
 
@@ -3043,6 +3071,8 @@ Axiom promoteDataCon : DataCon -> TyCon.
 
 Axiom promoteCoercion : Coercion -> Coercion.
 
+(* Skipping definition `Core.primRepSizeB' *)
+
 Axiom primRepIsFloat : PrimRep -> option bool.
 
 Axiom primElemRepSizeB : PrimElemRep -> nat.
@@ -3087,6 +3117,8 @@ Axiom pprPromotionQuote : TyCon -> GHC.Base.String.
 
 Axiom pprPrecType : BasicTypes.TyPrec -> Type_ -> GHC.Base.String.
 
+(* Skipping definition `Core.pprPatSynType' *)
+
 Axiom pprParendType : Type_ -> GHC.Base.String.
 
 Axiom pprParendTheta : ThetaType -> GHC.Base.String.
@@ -3097,7 +3129,15 @@ Axiom pprParendCo : Coercion -> GHC.Base.String.
 
 Axiom pprKind : Kind -> GHC.Base.String.
 
+(* Skipping definition `Core.pprIfaceStrictSig' *)
+
+(* Skipping definition `Core.pprFundeps' *)
+
+(* Skipping definition `Core.pprFunDep' *)
+
 Axiom pprForAll : list TyVarBinder -> GHC.Base.String.
+
+(* Skipping definition `Core.pprDefMethInfo' *)
 
 Axiom pprDataCons : TyCon -> GHC.Base.String.
 
@@ -3293,6 +3333,10 @@ Program Instance Eq___UseDmd : GHC.Base.Eq_ UseDmd :=
 Axiom mkUProd : list ArgUse -> UseDmd.
 
 Axiom mkUCall : Count -> UseDmd -> UseDmd.
+
+(* Skipping definition `Core.mkTyVarTys' *)
+
+(* Skipping definition `Core.mkTyVarTy' *)
 
 Axiom mkTyConTy : TyCon -> Type_.
 
@@ -3512,9 +3556,15 @@ Axiom mkCoercionType : Role -> Type_ -> Type_ -> Type_.
 
 Axiom mkCoercionTy : Coercion -> Type_.
 
+(* Skipping definition `Core.mkCoVarCos' *)
+
+(* Skipping definition `Core.mkCoVarCo' *)
+
 Axiom mkCoCast : Coercion -> Coercion -> Coercion.
 
 Axiom mkClosedStrictSig : list Demand -> DmdResult -> StrictSig.
+
+(* Skipping definition `Core.mkCleanAnonTyConBinders' *)
 
 Axiom mkClassTyCon : Name.Name ->
                      list TyConBinder -> list Role -> AlgTyConRhs -> Class -> Name.Name -> TyCon.
@@ -3572,6 +3622,8 @@ Axiom mkAbstractClass : Name.Name ->
                         list TyVar -> list (FunDep TyVar) -> TyCon -> Class.
 
 Axiom mightBeUnsaturatedTyCon : TyCon -> bool.
+
+(* Skipping definition `Core.maybeSubCo' *)
 
 Axiom markReusedDmd : ArgUse -> ArgUse.
 
@@ -3937,6 +3989,10 @@ Axiom instCoercions : Coercion -> list Coercion -> option Coercion.
 
 Axiom instCoercion : Pair.Pair Type_ -> Coercion -> Coercion -> option Coercion.
 
+(* Skipping definition `Core.injectiveVarsOfType' *)
+
+(* Skipping definition `Core.injectiveVarsOfBinder' *)
+
 Axiom initRecTc : RecTcChecker.
 
 Axiom increaseStrictSigArity : nat -> StrictSig -> StrictSig.
@@ -3988,6 +4044,8 @@ Axiom getCastedTyVar_maybe : Type_ -> option (TyVar * CoercionN)%type.
 Axiom funResultTy : Type_ -> Type_.
 
 Axiom funArgTy : Type_ -> Type_.
+
+(* Skipping definition `Core.freshNames' *)
 
 Axiom findIdDemand : DmdType -> Var -> Demand.
 
@@ -4185,6 +4243,8 @@ Axiom dataConImplicitTyThings : DataCon -> list TyThing.
 
 Axiom dataConImplBangs : DataCon -> list HsImplBang.
 
+(* Skipping definition `Core.dataConIdentity' *)
+
 Axiom dataConFullSig : DataCon ->
                        (list TyVar * list TyVar * list EqSpec * ThetaType * list Type_ * Type_)%type.
 
@@ -4264,6 +4324,8 @@ Axiom coAxNthLHS : forall {br}, CoAxiom br -> nat -> Type_.
 
 Axiom closeOverKindsList : list TyVar -> list TyVar.
 
+(* Skipping definition `Core.closeOverKindsFV' *)
+
 Axiom closeOverKindsDSet : DTyVarSet -> DTyVarSet.
 
 Axiom closeOverKinds : TyVarSet -> TyVarSet.
@@ -4285,6 +4347,8 @@ Axiom classifyPredType : PredType -> PredTree.
 Axiom classTvsFds : Class -> (list TyVar * list (FunDep TyVar))%type.
 
 Axiom classSCTheta : Class -> list PredType.
+
+(* Skipping definition `Core.classSCSelId' *)
 
 Axiom classOpItems : Class -> list ClassOpItem.
 
@@ -4374,6 +4438,8 @@ Axiom appIsBottom : StrictSig -> nat -> bool.
 Axiom algTyConRhs : TyCon -> AlgTyConRhs.
 
 Axiom addDemand : Demand -> DmdType -> DmdType.
+
+(* Skipping definition `Core.addCaseBndrDmd' *)
 
 Axiom absDmd : Demand.
 
@@ -4608,6 +4674,12 @@ Axiom tickishCounts : forall {id}, Tickish id -> bool.
 Definition tickishFloatable {id} : Tickish id -> bool :=
   fun t => andb (tickishScopesLike t SoftScope) (negb (tickishCounts t)).
 
+(* Skipping definition `Core.tickishContains' *)
+
+(* Skipping definition `Core.tickishCanSplit' *)
+
+(* Skipping definition `Core.tcTyVarDetails' *)
+
 Definition sizeVarSet : VarSet -> nat :=
   UniqSet.sizeUniqSet.
 
@@ -4654,6 +4726,8 @@ Definition setTyVarKind : TyVar -> Kind -> TyVar :=
     let 'Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__ id_details_4__
        id_info_5__ := tv in
     Mk_Id varName_0__ realUnique_1__ k idScope_3__ id_details_4__ id_info_5__.
+
+(* Skipping definition `Core.setTcTyVarDetails' *)
 
 Definition setStrictnessInfo : IdInfo -> StrictSig -> IdInfo :=
   fun info dd =>
@@ -4737,6 +4811,8 @@ Definition setNeverLevPoly `{Util.HasDebugCallStack}
                    oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
                    callArityInfo_9__ NeverLevityPolymorphic.
 
+(* Skipping definition `Core.setLevityInfoWithType' *)
+
 Definition setInlinePragInfo : IdInfo -> BasicTypes.InlinePragma -> IdInfo :=
   fun info pr =>
     GHC.Prim.seq pr (let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__
@@ -4745,6 +4821,10 @@ Definition setInlinePragInfo : IdInfo -> BasicTypes.InlinePragma -> IdInfo :=
                   Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
                             oneShotInfo_4__ pr occInfo_6__ strictnessInfo_7__ demandInfo_8__
                             callArityInfo_9__ levityInfo_10__).
+
+(* Skipping definition `Core.setIdNotExported' *)
+
+(* Skipping definition `Core.setIdExported' *)
 
 Definition setIdDetails : Id -> IdDetails -> Id :=
   fun id details =>
@@ -4862,6 +4942,20 @@ Definition rhssOfAlts {b} : list (Alt b) -> list (Expr b) :=
     let cont_0__ arg_1__ := let 'pair (pair _ _) e := arg_1__ in cons e nil in
     Coq.Lists.List.flat_map cont_0__ alts.
 
+(* Skipping definition `Core.ppr_id_scope' *)
+
+(* Skipping definition `Core.ppr_debug' *)
+
+(* Skipping definition `Core.pprVarSet' *)
+
+(* Skipping definition `Core.pprStrictness' *)
+
+(* Skipping definition `Core.pprIdDetails' *)
+
+(* Skipping definition `Core.ppCafInfo' *)
+
+(* Skipping definition `Core.ppArityInfo' *)
+
 Definition plusVarEnv_CD {a}
    : (a -> a -> a) -> VarEnv a -> a -> VarEnv a -> a -> VarEnv a :=
   UniqFM.plusUFM_CD.
@@ -4886,6 +4980,10 @@ Definition plusDVarEnv_C {a}
 
 Definition plusDVarEnv {a} : DVarEnv a -> DVarEnv a -> DVarEnv a :=
   UniqFM.plusUFM.
+
+(* Skipping definition `Core.pluralVarSet' *)
+
+(* Skipping definition `Core.partitionVarSet' *)
 
 Definition partitionVarEnv {a}
    : (a -> bool) -> VarEnv a -> (VarEnv a * VarEnv a)%type :=
@@ -4929,6 +5027,12 @@ Definition mk_id : Name.Name -> Type_ -> IdScope -> IdDetails -> IdInfo -> Id :=
   fun name ty scope details info =>
     Mk_Id name (Unique.getKey (Name.nameUnique name)) ty scope details info.
 
+(* Skipping definition `Core.mkWordLitWord' *)
+
+(* Skipping definition `Core.mkWordLit' *)
+
+(* Skipping definition `Core.mkWord64LitWord64' *)
+
 Definition mkDVarEnv {a} : list (Var * a)%type -> DVarEnv a :=
   UniqFM.listToUFM.
 
@@ -4957,6 +5061,8 @@ Definition mkTyVarBinder : ArgFlag -> Var -> TyVarBinder :=
 Definition mkTyVarBinders : ArgFlag -> list TyVar -> list TyVarBinder :=
   fun vis => GHC.Base.map (mkTyVarBinder vis).
 
+(* Skipping definition `Core.mkTyVar' *)
+
 Definition mkTyBind : TyVar -> Type_ -> CoreBind :=
   fun tv ty => NonRec tv (Mk_Type ty).
 
@@ -4970,11 +5076,19 @@ Definition mkTyArg {b} : Type_ -> Expr b :=
 Definition mkTyApps {b} : Expr b -> list Type_ -> Expr b :=
   fun f args => Data.Foldable.foldl (fun e a => App e (mkTyArg a)) f args.
 
+(* Skipping definition `Core.mkTcTyVar' *)
+
 Definition mkStringLit {b} : GHC.Base.String -> Expr b :=
   fun s => Lit (mkMachString s).
 
 Definition mkRuleEnv : RuleBase -> list Module.Module -> RuleEnv :=
   fun rules vis_orphs => Mk_RuleEnv rules (Module.mkModuleSet vis_orphs).
+
+(* Skipping definition `Core.mkOtherCon' *)
+
+(* Skipping definition `Core.mkNoScope' *)
+
+(* Skipping definition `Core.mkNoCount' *)
 
 Definition mkLocalVar : IdDetails -> Name.Name -> Type_ -> IdInfo -> Id :=
   fun details name ty info => mk_id name ty (LocalId NotExported) details info.
@@ -5002,11 +5116,19 @@ Definition mkLets {b} : list (Bind b) -> Expr b -> Expr b :=
 Definition mkLams {b} : list b -> Expr b -> Expr b :=
   fun binders body => Data.Foldable.foldr Lam body binders.
 
+(* Skipping definition `Core.mkIntLitInt' *)
+
+(* Skipping definition `Core.mkIntLit' *)
+
+(* Skipping definition `Core.mkInt64LitInt64' *)
+
 Definition mkInScopeSet : VarSet -> InScopeSet :=
   fun in_scope => InScope in_scope #1.
 
 Definition mkGlobalVar : IdDetails -> Name.Name -> Type_ -> IdInfo -> Id :=
   fun details name ty info => mk_id name ty GlobalId details info.
+
+(* Skipping definition `Core.mkFloatLitFloat' *)
 
 Definition mkFloatLit {b} : GHC.Real.Rational -> Expr b :=
   fun f => Lit (mkMachFloat f).
@@ -5015,8 +5137,12 @@ Definition mkExportedLocalVar
    : IdDetails -> Name.Name -> Type_ -> IdInfo -> Id :=
   fun details name ty info => mk_id name ty (LocalId Exported) details info.
 
+(* Skipping definition `Core.mkDoubleLitDouble' *)
+
 Definition mkDoubleLit {b} : GHC.Real.Rational -> Expr b :=
   fun d => Lit (mkMachDouble d).
+
+(* Skipping definition `Core.mkCoVar' *)
 
 Definition mkCoBind : CoVar -> Coercion -> CoreBind :=
   fun cv co => NonRec cv (Mk_Coercion co).
@@ -5055,6 +5181,8 @@ Definition maybeUnfoldingTemplate : Unfolding -> option CoreExpr :=
 
 Definition mayHaveCafRefs : CafInfo -> bool :=
   fun arg_0__ => match arg_0__ with | MayHaveCafRefs => true | _ => false end.
+
+(* Skipping definition `Core.mapVarSet' *)
 
 Definition mapVarEnv {a} {b} : (a -> b) -> VarEnv a -> VarEnv b :=
   UniqFM.mapUFM.
@@ -5337,6 +5465,8 @@ Definition idDetails : Id -> IdDetails :=
 Definition hasSomeUnfolding : Unfolding -> bool :=
   fun '(NoUnfolding) => false.
 
+(* Skipping definition `Core.globaliseId' *)
+
 Definition getInScopeVars : InScopeSet -> VarSet :=
   fun '(InScope vs _) => vs.
 
@@ -5490,11 +5620,15 @@ Definition modifyDVarEnv {a} : (a -> a) -> DVarEnv a -> Var -> DVarEnv a :=
     | Some xx => extendDVarEnv env key (mangle_fn xx)
     end.
 
+(* Skipping definition `Core.exprToType' *)
+
 Definition exprToCoercion_maybe : CoreExpr -> option Coercion :=
   fun arg_0__ => match arg_0__ with | Mk_Coercion co => Some co | _ => None end.
 
 Definition expandUnfolding_maybe : Unfolding -> option CoreExpr :=
   fun arg_0__ => None.
+
+(* Skipping definition `Core.evaldUnfolding' *)
 
 Definition emptyVarSet : VarSet :=
   UniqSet.emptyUniqSet.
@@ -5912,6 +6046,8 @@ Definition collectNBinders {b} : nat -> Expr b -> (list b * Expr b)%type :=
                  end in
     go orig_n nil orig_expr.
 
+(* Skipping definition `Core.collectNAnnBndrs' *)
+
 Definition collectBinders {b} : Expr b -> (list b * Expr b)%type :=
   fun expr =>
     let fix go arg_0__ arg_1__
@@ -5980,6 +6116,8 @@ Program Definition collectAnnArgs {b} {a}
             go expr nil.
 Solve Obligations with (solve_collectAnnArgsTicks).
 
+(* Skipping definition `Core.coVarDetails' *)
+
 Definition cmpAltCon : AltCon -> AltCon -> comparison :=
   fun arg_0__ arg_1__ =>
     match arg_0__, arg_1__ with
@@ -6025,6 +6163,8 @@ Definition boringCxtOk : bool :=
 Definition boringCxtNotOk : bool :=
   false.
 
+(* Skipping definition `Core.bootUnfolding' *)
+
 Definition bindersOf {b} : Bind b -> list b :=
   fun arg_0__ =>
     match arg_0__ with
@@ -6049,6 +6189,8 @@ Definition binderKind {argf} : TyVarBndr TyVar argf -> Kind :=
 
 Definition binderArgFlag {tv} {argf} : TyVarBndr tv argf -> argf :=
   fun '(TvBndr _ argf) => argf.
+
+(* Skipping definition `Core.applyTypeToArg' *)
 
 Definition anyVarSet : (Var -> bool) -> VarSet -> bool :=
   UniqSet.uniqSetAny.

--- a/examples/ghc/lib/CoreFVs.v
+++ b/examples/ghc/lib/CoreFVs.v
@@ -70,13 +70,37 @@ Definition tickish_fvs : Core.Tickish Core.Id -> FV.FV :=
     | _ => FV.emptyFV
     end.
 
+(* Skipping definition `CoreFVs.stableUnfoldingVars' *)
+
 Definition stableUnfoldingFVs : Core.Unfolding -> option FV.FV :=
   fun '(_other) => None.
+
+(* Skipping definition `CoreFVs.orphNamesOfTypes' *)
+
+(* Skipping definition `CoreFVs.orphNamesOfType' *)
+
+(* Skipping definition `CoreFVs.orphNamesOfTyCon' *)
 
 Definition orphNamesOfThings {a}
    : (a -> NameSet.NameSet) -> list a -> NameSet.NameSet :=
   fun f =>
     Data.Foldable.foldr (NameSet.unionNameSet GHC.Base.∘ f) NameSet.emptyNameSet.
+
+(* Skipping definition `CoreFVs.orphNamesOfProv' *)
+
+(* Skipping definition `CoreFVs.orphNamesOfFamInst' *)
+
+(* Skipping definition `CoreFVs.orphNamesOfCos' *)
+
+(* Skipping definition `CoreFVs.orphNamesOfCoCon' *)
+
+(* Skipping definition `CoreFVs.orphNamesOfCoAxBranches' *)
+
+(* Skipping definition `CoreFVs.orphNamesOfCoAxBranch' *)
+
+(* Skipping definition `CoreFVs.orphNamesOfCo' *)
+
+(* Skipping definition `CoreFVs.orphNamesOfAxiom' *)
 
 Definition noFVs : Core.VarSet :=
   Core.emptyVarSet.
@@ -98,6 +122,10 @@ Definition freeVarsOfAnn : FVAnn -> Core.DIdSet :=
 
 Definition freeVarsOf : CoreExprWithFVs -> Core.DIdSet :=
   fun '(pair fvs _) => fvs.
+
+(* Skipping definition `CoreFVs.exprsOrphNames' *)
+
+(* Skipping definition `CoreFVs.exprOrphNames' *)
 
 Definition dVarTypeTyCoVars : Core.Var -> Core.DTyCoVarSet :=
   fun var => FV.fvDVarSet (varTypeTyCoFVs var).

--- a/examples/ghc/lib/CoreMonad.v
+++ b/examples/ghc/lib/CoreMonad.v
@@ -246,11 +246,15 @@ Axiom tickToTag : Tick -> nat.
 
 Axiom tickString : Tick -> GHC.Base.String.
 
+(* Skipping definition `CoreMonad.thNameToGhcName' *)
+
 Axiom simplCountN : SimplCount -> nat.
 
 Axiom runWhen : bool -> CoreToDo -> CoreToDo.
 
 Axiom runMaybe : forall {a}, option a -> (a -> CoreToDo) -> CoreToDo.
+
+(* Skipping definition `CoreMonad.runCoreM' *)
 
 Axiom reinitializeGlobals : CoreM unit.
 
@@ -279,7 +283,11 @@ Axiom plusSimplCount : SimplCount -> SimplCount -> SimplCount.
 Axiom nop : forall {a},
             CoreState -> a -> CoreIOEnv (a * CoreState * CoreWriter)%type.
 
+(* Skipping definition `CoreMonad.msg' *)
+
 Axiom modifyS : (CoreState -> CoreState) -> CoreM unit.
+
+(* Skipping definition `CoreMonad.liftIOWithCount' *)
 
 Axiom liftIOEnv : forall {a}, CoreIOEnv a -> CoreM a.
 
@@ -296,6 +304,18 @@ Axiom getSrcSpanM : CoreM SrcLoc.SrcSpan.
 Axiom getS : forall {a}, (CoreState -> a) -> CoreM a.
 
 Axiom getRuleBase : CoreM Core.RuleBase.
+
+(* Skipping definition `CoreMonad.getPrintUnqualified' *)
+
+(* Skipping definition `CoreMonad.getPackageFamInstEnv' *)
+
+(* Skipping definition `CoreMonad.getOrigNameCache' *)
+
+(* Skipping definition `CoreMonad.getHscEnv' *)
+
+(* Skipping definition `CoreMonad.getFirstAnnotations' *)
+
+(* Skipping definition `CoreMonad.getAnnotations' *)
 
 Axiom fatalErrorMsgS : GHC.Base.String -> CoreM unit.
 
@@ -321,6 +341,8 @@ Axiom debugTraceMsg : GHC.Base.String -> CoreM unit.
 Axiom cmpTick : Tick -> Tick -> comparison.
 
 Axiom cmpEqTick : Tick -> Tick -> comparison.
+
+(* Skipping definition `CoreMonad.bindsOnlyPass' *)
 
 Axiom addTick : TickCounts -> Tick -> TickCounts.
 

--- a/examples/ghc/lib/CoreSubst.v
+++ b/examples/ghc/lib/CoreSubst.v
@@ -123,6 +123,8 @@ Definition mkOpenSubst : InScopeSet -> list (Var * CoreArg)%type -> Subst :=
 Definition mkEmptySubst : InScopeSet -> Subst :=
   fun in_scope => Mk_Subst in_scope emptyVarEnv emptyVarEnv emptyVarEnv.
 
+(* Skipping definition `CoreSubst.lookupTCvSubst' *)
+
 Definition lookupIdSubst : String -> Subst -> Id -> CoreExpr :=
   fun arg_0__ arg_1__ arg_2__ =>
     match arg_0__, arg_1__, arg_2__ with

--- a/examples/ghc/lib/CoreTidy.v
+++ b/examples/ghc/lib/CoreTidy.v
@@ -49,6 +49,10 @@ Definition tidyTickish
     | _, other_tickish => other_tickish
     end.
 
+(* Skipping definition `CoreTidy.tidyRules' *)
+
+(* Skipping definition `CoreTidy.tidyRule' *)
+
 Definition tidyNameOcc : Core.TidyEnv -> Name.Name -> Name.Name :=
   fun arg_0__ arg_1__ =>
     match arg_0__, arg_1__ with

--- a/examples/ghc/lib/CoreUtils.v
+++ b/examples/ghc/lib/CoreUtils.v
@@ -67,9 +67,15 @@ Definition trimConArgs
     | Core.DataAlt dc, args => Util.dropList (Core.dataConUnivTyVars dc) args
     end.
 
+(* Skipping definition `CoreUtils.tickHNFArgs' *)
+
+(* Skipping definition `CoreUtils.stripTicksTopT' *)
+
 Definition stripTicksTopE {b}
    : (Core.Tickish Core.Id -> bool) -> Core.Expr b -> Core.Expr b :=
   fun p => let go := fun '(other) => other in go.
+
+(* Skipping definition `CoreUtils.stripTicksTop' *)
 
 Definition stripTicksT {b}
    : (Core.Tickish Core.Id -> bool) ->
@@ -174,10 +180,18 @@ Definition stripTicksE {b}
       fun '(pair (pair c bs) e) => pair (pair c bs) (go e) in
     go expr.
 
+(* Skipping definition `CoreUtils.rhsIsStatic' *)
+
 Axiom refineDefaultAlt : list Unique.Unique ->
                          Core.TyCon ->
                          list AxiomatizedTypes.Type_ ->
                          list Core.AltCon -> list Core.CoreAlt -> (bool * list Core.CoreAlt)%type.
+
+(* Skipping definition `CoreUtils.mkTicks' *)
+
+(* Skipping definition `CoreUtils.mkTickNoHNF' *)
+
+(* Skipping definition `CoreUtils.mkTick' *)
 
 Definition mkAltExpr
    : Core.AltCon ->

--- a/examples/ghc/lib/Digraph.v
+++ b/examples/ghc/lib/Digraph.v
@@ -55,9 +55,27 @@ Definition node_payload {key} {payload} (arg_0__ : Node key payload) :=
 
 Axiom verticesG : forall {node}, Graph node -> list node.
 
+(* Skipping definition `Digraph.vertexReady' *)
+
+(* Skipping definition `Digraph.vertexGroupsS' *)
+
+(* Skipping definition `Digraph.vertexGroupsG' *)
+
+(* Skipping definition `Digraph.vertexGroups' *)
+
 Axiom transposeG : forall {node}, Graph node -> Graph node.
 
 Axiom topologicalSortG : forall {node}, Graph node -> list node.
+
+(* Skipping definition `Digraph.stronglyConnCompG' *)
+
+(* Skipping definition `Digraph.stronglyConnCompFromEdgedVerticesUniqR' *)
+
+(* Skipping definition `Digraph.stronglyConnCompFromEdgedVerticesUniq' *)
+
+(* Skipping definition `Digraph.stronglyConnCompFromEdgedVerticesOrdR' *)
+
+(* Skipping definition `Digraph.stronglyConnCompFromEdgedVerticesOrd' *)
 
 Axiom reduceNodesIntoVerticesUniq : forall {key} {payload},
                                     forall `{Unique.Uniquable key}, ReduceFn key payload.
@@ -65,13 +83,25 @@ Axiom reduceNodesIntoVerticesUniq : forall {key} {payload},
 Axiom reduceNodesIntoVerticesOrd : forall {key} {payload},
                                    forall `{GHC.Base.Ord key}, ReduceFn key payload.
 
+(* Skipping definition `Digraph.reduceNodesIntoVertices' *)
+
 Axiom reachablesG : forall {node}, Graph node -> list node -> list node.
 
 Axiom reachableG : forall {node}, Graph node -> node -> list node.
 
+(* Skipping definition `Digraph.reachable' *)
+
+(* Skipping definition `Digraph.preorderF' *)
+
 Axiom outdegreeG : forall {node}, Graph node -> node -> option nat.
 
+(* Skipping definition `Digraph.noOutEdges' *)
+
+(* Skipping definition `Digraph.mkEmpty' *)
+
 Axiom indegreeG : forall {node}, Graph node -> node -> option nat.
+
+(* Skipping definition `Digraph.include' *)
 
 Axiom hasVertexG : forall {node}, Graph node -> node -> bool.
 
@@ -85,6 +115,8 @@ Axiom graphFromEdgedVerticesOrd : forall {key} {payload},
 Axiom graphFromEdgedVertices : forall {key} {payload},
                                ReduceFn key payload -> list (Node key payload) -> Graph (Node key payload).
 
+(* Skipping definition `Digraph.graphEmpty' *)
+
 Axiom findCycle : forall {payload} {key},
                   forall `{GHC.Base.Ord key}, list (Node key payload) -> option (list payload).
 
@@ -95,6 +127,12 @@ Axiom emptyG : forall {node}, Graph node -> bool.
 Axiom edgesG : forall {node}, Graph node -> list (Edge node).
 
 Axiom dfsTopSortG : forall {node}, Graph node -> list (list node).
+
+(* Skipping definition `Digraph.degreeG' *)
+
+(* Skipping definition `Digraph.decodeSccs' *)
+
+(* Skipping definition `Digraph.contains' *)
 
 Axiom componentsG : forall {node}, Graph node -> list (list node).
 

--- a/examples/ghc/lib/DynFlags.v
+++ b/examples/ghc/lib/DynFlags.v
@@ -590,15 +590,45 @@ Admitted.
 
 (* Converted value declarations: *)
 
+(* Skipping definition `DynFlags.xopt_unset' *)
+
+(* Skipping definition `DynFlags.xopt_set' *)
+
+(* Skipping definition `DynFlags.xopt' *)
+
+(* Skipping definition `DynFlags.xFlagsDeps' *)
+
+(* Skipping definition `DynFlags.xFlags' *)
+
 Axiom wopt_unset_fatal : DynFlags -> WarningFlag -> DynFlags.
+
+(* Skipping definition `DynFlags.wopt_unset' *)
 
 Axiom wopt_set_fatal : DynFlags -> WarningFlag -> DynFlags.
 
+(* Skipping definition `DynFlags.wopt_set' *)
+
 Axiom wopt_fatal : WarningFlag -> DynFlags -> bool.
+
+(* Skipping definition `DynFlags.wopt' *)
+
+(* Skipping definition `DynFlags.whenGeneratingDynamicToo' *)
+
+(* Skipping definition `DynFlags.whenCannotGenerateDynamicToo' *)
+
+(* Skipping definition `DynFlags.wayUnsetGeneralFlags' *)
 
 Axiom wayTag : Way -> GHC.Base.String.
 
 Axiom wayRTSOnly : Way -> bool.
+
+(* Skipping definition `DynFlags.wayOptl' *)
+
+(* Skipping definition `DynFlags.wayOptc' *)
+
+(* Skipping definition `DynFlags.wayOptP' *)
+
+(* Skipping definition `DynFlags.wayGeneralFlags' *)
 
 Axiom wayDesc : Way -> GHC.Base.String.
 
@@ -618,9 +648,23 @@ Axiom wORDS_BIGENDIAN : DynFlags -> bool.
 
 Axiom versionedFilePath : DynFlags -> GHC.Base.String.
 
+(* Skipping definition `DynFlags.versionedAppDir' *)
+
+(* Skipping definition `DynFlags.v_unsafeGlobalDynFlags' *)
+
 Axiom useUnicodeSyntax : DynFlags -> bool.
 
+(* Skipping definition `DynFlags.useInstead' *)
+
 Axiom updateWays : DynFlags -> DynFlags.
+
+(* Skipping definition `DynFlags.updOptLevel' *)
+
+(* Skipping definition `DynFlags.updM' *)
+
+(* Skipping definition `DynFlags.upd' *)
+
+(* Skipping definition `DynFlags.unusedBindsFlags' *)
 
 Axiom unsafeGlobalDynFlags : DynFlags.
 
@@ -633,9 +677,25 @@ Axiom unsafeFlags : list (GHC.Base.String * (DynFlags -> SrcLoc.SrcSpan) *
                           (DynFlags -> bool) *
                           (DynFlags -> DynFlags))%type.
 
+(* Skipping definition `DynFlags.unrecognisedWarning' *)
+
+(* Skipping definition `DynFlags.unSetWarningFlag' *)
+
+(* Skipping definition `DynFlags.unSetGeneralFlag'' *)
+
+(* Skipping definition `DynFlags.unSetGeneralFlag' *)
+
+(* Skipping definition `DynFlags.unSetFatalWarningFlag' *)
+
+(* Skipping definition `DynFlags.unSetExtensionFlag'' *)
+
+(* Skipping definition `DynFlags.unSetExtensionFlag' *)
+
 Axiom turnOn : TurnOnFlag.
 
 Axiom turnOff : TurnOnFlag.
+
+(* Skipping definition `DynFlags.trustPackage' *)
 
 Axiom topDir : DynFlags -> GHC.Base.String.
 
@@ -649,6 +709,8 @@ Axiom thisPackage : DynFlags -> Module.UnitId.
 Axiom thisComponentId : DynFlags -> Module.ComponentId.
 
 Axiom targetRetainsAllBindings : HscTarget -> bool.
+
+(* Skipping definition `DynFlags.targetPlatform' *)
 
 Axiom tablesNextToCode : DynFlags -> bool.
 
@@ -670,6 +732,10 @@ Axiom supportedLanguagesAndExtensions : list GHC.Base.String.
 
 Axiom supportedLanguages : list GHC.Base.String.
 
+(* Skipping definition `DynFlags.supportedLanguageOverlays' *)
+
+(* Skipping definition `DynFlags.supportedExtensions' *)
+
 Axiom standardWarnings : list WarningFlag.
 
 Axiom split_marker : GHC.Char.Char.
@@ -682,11 +748,41 @@ Axiom showOpt : Option -> GHC.Base.String.
 
 Axiom shouldUseColor : DynFlags -> bool.
 
+(* Skipping definition `DynFlags.setWarningFlag' *)
+
+(* Skipping definition `DynFlags.setWarnUnsafe' *)
+
+(* Skipping definition `DynFlags.setWarnSafe' *)
+
+(* Skipping definition `DynFlags.setVerbosity' *)
+
+(* Skipping definition `DynFlags.setVerboseCore2Core' *)
+
+(* Skipping definition `DynFlags.setUnsafeGlobalDynFlags' *)
+
 Axiom setUnitIdInsts : GHC.Base.String -> DynFlags -> DynFlags.
+
+(* Skipping definition `DynFlags.setUnitId' *)
+
+(* Skipping definition `DynFlags.setTmpDir' *)
+
+(* Skipping definition `DynFlags.setTargetWithPlatform' *)
+
+(* Skipping definition `DynFlags.setTarget' *)
 
 Axiom setStubDir : GHC.Base.String -> DynFlags -> DynFlags.
 
+(* Skipping definition `DynFlags.setSafeHaskell' *)
+
+(* Skipping definition `DynFlags.setRtsOptsEnabled' *)
+
+(* Skipping definition `DynFlags.setRtsOpts' *)
+
 Axiom setPgmP : GHC.Base.String -> DynFlags -> DynFlags.
+
+(* Skipping definition `DynFlags.setPackageTrust' *)
+
+(* Skipping definition `DynFlags.setOverlappingInsts' *)
 
 Axiom setOutputHi : option GHC.Base.String -> DynFlags -> DynFlags.
 
@@ -694,19 +790,45 @@ Axiom setOutputFile : option GHC.Base.String -> DynFlags -> DynFlags.
 
 Axiom setOutputDir : GHC.Base.String -> DynFlags -> DynFlags.
 
+(* Skipping definition `DynFlags.setOptLevel' *)
+
+(* Skipping definition `DynFlags.setOptHpcDir' *)
+
 Axiom setObjectSuf : GHC.Base.String -> DynFlags -> DynFlags.
 
 Axiom setObjectDir : GHC.Base.String -> DynFlags -> DynFlags.
 
+(* Skipping definition `DynFlags.setObjTarget' *)
+
+(* Skipping definition `DynFlags.setMainIs' *)
+
+(* Skipping definition `DynFlags.setLogAction' *)
+
+(* Skipping definition `DynFlags.setLanguage' *)
+
 Axiom setJsonLogAction : DynFlags -> DynFlags.
 
 Axiom setInteractivePrint : GHC.Base.String -> DynFlags -> DynFlags.
+
+(* Skipping definition `DynFlags.setIncoherentInsts' *)
 
 Axiom setHiSuf : GHC.Base.String -> DynFlags -> DynFlags.
 
 Axiom setHiDir : GHC.Base.String -> DynFlags -> DynFlags.
 
 Axiom setHcSuf : GHC.Base.String -> DynFlags -> DynFlags.
+
+(* Skipping definition `DynFlags.setGeneralFlag'' *)
+
+(* Skipping definition `DynFlags.setGeneralFlag' *)
+
+(* Skipping definition `DynFlags.setGenDeriving' *)
+
+(* Skipping definition `DynFlags.setFatalWarningFlag' *)
+
+(* Skipping definition `DynFlags.setExtensionFlag'' *)
+
+(* Skipping definition `DynFlags.setExtensionFlag' *)
 
 Axiom setDynOutputFile : option GHC.Base.String -> DynFlags -> DynFlags.
 
@@ -718,17 +840,29 @@ Axiom setDylibInstallName : GHC.Base.String -> DynFlags -> DynFlags.
 
 Axiom setDumpPrefixForce : option GHC.Base.String -> DynFlags -> DynFlags.
 
+(* Skipping definition `DynFlags.setDumpFlag'' *)
+
+(* Skipping definition `DynFlags.setDumpFlag' *)
+
 Axiom setDumpDir : GHC.Base.String -> DynFlags -> DynFlags.
 
 Axiom setDepMakefile : GHC.Base.String -> DynFlags -> DynFlags.
 
 Axiom setDepIncludePkgDeps : bool -> DynFlags -> DynFlags.
 
+(* Skipping definition `DynFlags.setDebugLevel' *)
+
+(* Skipping definition `DynFlags.setDPHOpt' *)
+
 Axiom setComponentId : GHC.Base.String -> DynFlags -> DynFlags.
+
+(* Skipping definition `DynFlags.sepArg' *)
 
 Axiom safeLanguageOn : DynFlags -> bool.
 
 Axiom safeInferOn : DynFlags -> bool.
+
+(* Skipping definition `DynFlags.safeImportsOn' *)
 
 Axiom safeImplicitImpsReq : DynFlags -> bool.
 
@@ -757,11 +891,21 @@ Axiom sIZEOF_StgArrBytes_NoHdr : DynFlags -> BinNums.N.
 
 Axiom sIZEOF_CostCentreStack : DynFlags -> BinNums.N.
 
+(* Skipping definition `DynFlags.rtsIsProfiled' *)
+
+(* Skipping definition `DynFlags.removeWayDyn' *)
+
+(* Skipping definition `DynFlags.removeUserPkgConf' *)
+
+(* Skipping definition `DynFlags.removeGlobalPkgConf' *)
+
 Axiom rawSettings : DynFlags -> list (GHC.Base.String * GHC.Base.String)%type.
 
 Axiom rESERVED_STACK_WORDS : DynFlags -> BinNums.N.
 
 Axiom rESERVED_C_STACK_BYTES : DynFlags -> BinNums.N.
+
+(* Skipping definition `DynFlags.putLogMsg' *)
 
 Axiom projectVersion : DynFlags -> GHC.Base.String.
 
@@ -810,7 +954,21 @@ Axiom pgm_F : DynFlags -> GHC.Base.String.
 Axiom parseUnitIdInsts : GHC.Base.String ->
                          list (Module.ModuleName * Module.Module)%type.
 
+(* Skipping definition `DynFlags.parseUnitIdArg' *)
+
+(* Skipping definition `DynFlags.parsePackageFlag' *)
+
+(* Skipping definition `DynFlags.parsePackageArg' *)
+
+(* Skipping definition `DynFlags.parseDynamicFlagsFull' *)
+
+(* Skipping definition `DynFlags.parseDynamicFlagsCmdLine' *)
+
+(* Skipping definition `DynFlags.parseDynamicFilePragma' *)
+
 Axiom parseDynLibLoaderMode : GHC.Base.String -> DynFlags -> DynFlags.
+
+(* Skipping definition `DynFlags.package_flags_deps' *)
 
 Axiom packageTrustOn : DynFlags -> bool.
 
@@ -843,6 +1001,8 @@ Axiom opt_L : DynFlags -> list GHC.Base.String.
 Axiom opt_F : DynFlags -> list GHC.Base.String.
 
 Axiom optLevelFlags : list (list BinNums.N * GeneralFlag)%type.
+
+(* Skipping definition `DynFlags.optIntSuffixM' *)
 
 Axiom oFFSET_stgGCFun : DynFlags -> BinNums.N.
 
@@ -1000,9 +1160,17 @@ Axiom oFFSET_CostCentreStack_mem_alloc : DynFlags -> BinNums.N.
 
 Axiom oFFSET_Capability_r : DynFlags -> BinNums.N.
 
+(* Skipping definition `DynFlags.nop' *)
+
+(* Skipping definition `DynFlags.noArgM' *)
+
+(* Skipping definition `DynFlags.noArg' *)
+
 Axiom negatableFlagsDeps : list (Deprecation * FlagSpec GeneralFlag)%type.
 
 Axiom mkTablesNextToCode : bool -> bool.
+
+(* Skipping definition `DynFlags.mkFlag' *)
 
 Axiom mkBuildTag : list Way -> GHC.Base.String.
 
@@ -1013,6 +1181,10 @@ Axiom minusWcompatOpts : list WarningFlag.
 Axiom minusWallOpts : list WarningFlag.
 
 Axiom minusWOpts : list WarningFlag.
+
+(* Skipping definition `DynFlags.make_ord_flag' *)
+
+(* Skipping definition `DynFlags.make_dep_flag' *)
 
 Axiom makeDynFlagsConsistent : DynFlags ->
                                (DynFlags * list (SrcLoc.Located GHC.Base.String))%type.
@@ -1057,7 +1229,17 @@ Axiom mAX_CHARLIKE : DynFlags -> BinNums.N.
 
 Axiom languageFlagsDeps : list (Deprecation * FlagSpec Language)%type.
 
+(* Skipping definition `DynFlags.languageExtensions' *)
+
+(* Skipping definition `DynFlags.lang_set' *)
+
 Axiom lDV_SHIFT : DynFlags -> BinNums.N.
+
+(* Skipping definition `DynFlags.jsonLogOutput' *)
+
+(* Skipping definition `DynFlags.jsonLogFinaliser' *)
+
+(* Skipping definition `DynFlags.jsonLogAction' *)
 
 Axiom isSseEnabled : DynFlags -> bool.
 
@@ -1089,15 +1271,37 @@ Axiom isAvx2Enabled : DynFlags -> bool.
 
 Axiom interpreterProfiled : DynFlags -> bool.
 
+(* Skipping definition `DynFlags.interpreterDynamic' *)
+
+(* Skipping definition `DynFlags.interpretPackageEnv' *)
+
 Axiom interpWays : list Way.
 
+(* Skipping definition `DynFlags.intSuffixM' *)
+
+(* Skipping definition `DynFlags.intSuffix' *)
+
+(* Skipping definition `DynFlags.initDynFlags' *)
+
+(* Skipping definition `DynFlags.impliedXFlags' *)
+
 Axiom impliedOffGFlags : list (GeneralFlag * TurnOnFlag * GeneralFlag)%type.
+
+(* Skipping definition `DynFlags.impliedGFlags' *)
+
+(* Skipping definition `DynFlags.ignorePackage' *)
+
+(* Skipping definition `DynFlags.ifGeneratingDynamicToo' *)
+
+(* Skipping definition `DynFlags.ifCannotGenerateDynamicToo' *)
 
 Axiom iLDV_STATE_USE : DynFlags -> GHC.Num.Integer.
 
 Axiom iLDV_STATE_CREATE : DynFlags -> GHC.Num.Integer.
 
 Axiom iLDV_CREATE_MASK : DynFlags -> GHC.Num.Integer.
+
+(* Skipping definition `DynFlags.hidePackage' *)
 
 Axiom hideFlag : forall {a},
                  (Deprecation * FlagSpec a)%type -> (Deprecation * FlagSpec a)%type.
@@ -1110,9 +1314,15 @@ Axiom hasNoOptCoercion : DynFlags -> bool.
 
 Axiom hasNoDebugOutput : DynFlags -> bool.
 
+(* Skipping definition `DynFlags.hasArg' *)
+
+(* Skipping definition `DynFlags.gopt_unset' *)
+
 Axiom gopt_set : DynFlags -> GeneralFlag -> DynFlags.
 
 Axiom gopt : GeneralFlag -> DynFlags -> bool.
+
+(* Skipping definition `DynFlags.glasgowExtsFlags' *)
 
 Axiom ghciUsagePath : DynFlags -> GHC.Base.String.
 
@@ -1122,18 +1332,44 @@ Axiom getVerbFlags : DynFlags -> list GHC.Base.String.
 
 Axiom getOpts : forall {a}, DynFlags -> (DynFlags -> list a) -> list a.
 
+(* Skipping definition `DynFlags.generateDynamicTooConditional' *)
+
+(* Skipping definition `DynFlags.forceRecompile' *)
+
+(* Skipping definition `DynFlags.floatSuffix' *)
+
+(* Skipping definition `DynFlags.flattenExtensionFlags' *)
+
+(* Skipping definition `DynFlags.flagsPackage' *)
+
 Axiom flagsForCompletion : bool -> list GHC.Base.String.
 
+(* Skipping definition `DynFlags.flagsDynamic' *)
+
+(* Skipping definition `DynFlags.flagsAllDeps' *)
+
+(* Skipping definition `DynFlags.flagsAll' *)
+
 Axiom flagSpecOf : WarningFlag -> option (FlagSpec WarningFlag).
+
+(* Skipping definition `DynFlags.flagSpec'' *)
 
 Axiom flagSpec : forall {flag},
                  GHC.Base.String -> flag -> (Deprecation * FlagSpec flag)%type.
 
+(* Skipping definition `DynFlags.flagHiddenSpec'' *)
+
 Axiom flagHiddenSpec : forall {flag},
                        GHC.Base.String -> flag -> (Deprecation * FlagSpec flag)%type.
 
+(* Skipping definition `DynFlags.flagGhciSpec'' *)
+
 Axiom flagGhciSpec : forall {flag},
                      GHC.Base.String -> flag -> (Deprecation * FlagSpec flag)%type.
+
+(* Skipping definition `DynFlags.fLangFlagsDeps' *)
+
+(* Skipping definition `DynFlags.fLangFlags' *)
 
 Axiom fFlagsDeps : list (Deprecation * FlagSpec GeneralFlag)%type.
 
@@ -1141,34 +1377,84 @@ Axiom fFlags : list (FlagSpec GeneralFlag).
 
 Axiom extraGccViaCFlags : DynFlags -> list GHC.Base.String.
 
+(* Skipping definition `DynFlags.exposePluginPackageId' *)
+
+(* Skipping definition `DynFlags.exposePluginPackage' *)
+
+(* Skipping definition `DynFlags.exposePackageId' *)
+
 Axiom exposePackage' : GHC.Base.String -> DynFlags -> DynFlags.
+
+(* Skipping definition `DynFlags.exposePackage' *)
+
+(* Skipping definition `DynFlags.enableUnusedBinds' *)
+
+(* Skipping definition `DynFlags.enableGlasgowExts' *)
 
 Axiom emptyFilesToClean : FilesToClean.
 
+(* Skipping definition `DynFlags.dynamic_flags_deps' *)
+
 Axiom dynamicTooMkDynamicDynFlags : DynFlags -> DynFlags.
+
+(* Skipping definition `DynFlags.dynamicGhc' *)
+
+(* Skipping definition `DynFlags.dynFlagDependencies' *)
 
 Axiom dopt_unset : DynFlags -> DumpFlag -> DynFlags.
 
 Axiom dopt_set : DynFlags -> DumpFlag -> DynFlags.
 
+(* Skipping definition `DynFlags.dopt' *)
+
+(* Skipping definition `DynFlags.distrustPackage' *)
+
+(* Skipping definition `DynFlags.disableUnusedBinds' *)
+
+(* Skipping definition `DynFlags.disableGlasgowExts' *)
+
 Axiom deprecatedForExtension : GHC.Base.String -> TurnOnFlag -> GHC.Base.String.
+
+(* Skipping definition `DynFlags.depFlagSpecOp'' *)
+
+(* Skipping definition `DynFlags.depFlagSpecOp' *)
 
 Axiom depFlagSpecCond : forall {flag},
                         GHC.Base.String ->
                         flag ->
                         (TurnOnFlag -> bool) -> GHC.Base.String -> (Deprecation * FlagSpec flag)%type.
 
+(* Skipping definition `DynFlags.depFlagSpec'' *)
+
 Axiom depFlagSpec : forall {flag},
                     GHC.Base.String ->
                     flag -> GHC.Base.String -> (Deprecation * FlagSpec flag)%type.
 
+(* Skipping definition `DynFlags.default_PIC' *)
+
 Axiom defaultWays : Settings -> list Way.
+
+(* Skipping definition `DynFlags.defaultObjectTarget' *)
+
+(* Skipping definition `DynFlags.defaultLogOutput' *)
+
+(* Skipping definition `DynFlags.defaultLogActionHPutStrDoc' *)
+
+(* Skipping definition `DynFlags.defaultLogActionHPrintDoc' *)
+
+(* Skipping definition `DynFlags.defaultLogAction' *)
+
+(* Skipping definition `DynFlags.defaultHscTarget' *)
 
 Axiom defaultGlobalDynFlags : DynFlags.
 
 Axiom defaultFlushOut : FlushOut.
 
+(* Skipping definition `DynFlags.defaultFlushErr' *)
+
 Axiom defaultFlags : Settings -> list GeneralFlag.
+
+(* Skipping definition `DynFlags.defaultFatalMessager' *)
 
 Axiom defaultDynFlags : Settings -> LlvmTargets -> DynFlags.
 
@@ -1181,6 +1467,12 @@ Axiom dOUBLE_SIZE : DynFlags -> BinNums.N.
 Axiom dFlagsDeps : list (Deprecation * FlagSpec GeneralFlag)%type.
 
 Axiom compilerInfo : DynFlags -> list (GHC.Base.String * GHC.Base.String)%type.
+
+(* Skipping definition `DynFlags.combineSafeFlags' *)
+
+(* Skipping definition `DynFlags.clearPkgConf' *)
+
+(* Skipping definition `DynFlags.checkTemplateHaskellOk' *)
 
 Axiom checkOptLevel : BinNums.N ->
                       DynFlags -> Data.Either.Either GHC.Base.String DynFlags.
@@ -1211,11 +1503,19 @@ Axiom allowed_combination : list Way -> bool.
 
 Axiom allNonDeprecatedFlags : list GHC.Base.String.
 
+(* Skipping definition `DynFlags.allFlagsDeps' *)
+
+(* Skipping definition `DynFlags.add_dep_message' *)
+
 Axiom addWay' : Way -> DynFlags -> DynFlags.
+
+(* Skipping definition `DynFlags.addWay' *)
 
 Axiom addPluginModuleNameOption : GHC.Base.String -> DynFlags -> DynFlags.
 
 Axiom addPluginModuleName : GHC.Base.String -> DynFlags -> DynFlags.
+
+(* Skipping definition `DynFlags.addPkgConfRef' *)
 
 Axiom addOptl : GHC.Base.String -> DynFlags -> DynFlags.
 
@@ -1223,7 +1523,13 @@ Axiom addOptc : GHC.Base.String -> DynFlags -> DynFlags.
 
 Axiom addOptP : GHC.Base.String -> DynFlags -> DynFlags.
 
+(* Skipping definition `DynFlags.addLibraryPath' *)
+
 Axiom addLdInputs : Option -> DynFlags -> DynFlags.
+
+(* Skipping definition `DynFlags.addIncludePath' *)
+
+(* Skipping definition `DynFlags.addImportPath' *)
 
 Axiom addHaddockOpts : GHC.Base.String -> DynFlags -> DynFlags.
 
@@ -1232,6 +1538,8 @@ Axiom addGhciScript : GHC.Base.String -> DynFlags -> DynFlags.
 Axiom addGhcVersionFile : GHC.Base.String -> DynFlags -> DynFlags.
 
 Axiom addFrontendPluginOption : GHC.Base.String -> DynFlags -> DynFlags.
+
+(* Skipping definition `DynFlags.addFrameworkPath' *)
 
 Axiom addDepSuffix : GHC.Base.String -> DynFlags -> DynFlags.
 

--- a/examples/ghc/lib/FloatIn.v
+++ b/examples/ghc/lib/FloatIn.v
@@ -159,6 +159,8 @@ Definition sepBindsByDropPoint
     else go floaters (GHC.Base.map (fun fvs => pair fvs nil) (cons Core.emptyDVarSet
                                                                    drop_pts)).
 
+(* Skipping definition `FloatIn.floatInwards' *)
+
 Axiom fiExpr : DynFlags.DynFlags ->
                FloatInBinds -> CoreFVs.CoreExprWithFVs -> Core.CoreExpr.
 

--- a/examples/ghc/lib/FloatOut.v
+++ b/examples/ghc/lib/FloatOut.v
@@ -169,6 +169,8 @@ Definition installUnderLambdas
 Definition get_stats : FloatStats -> (nat * nat * nat)%type :=
   fun '(FlS a b c) => pair (pair a b) c.
 
+(* Skipping definition `FloatOut.floatOutwards' *)
+
 Axiom floatExpr : SetLevels.LevelledExpr ->
                   (FloatStats * FloatBinds * Core.CoreExpr)%type.
 

--- a/examples/ghc/lib/Id.v
+++ b/examples/ghc/lib/Id.v
@@ -46,8 +46,14 @@ Definition setIdUnique : Core.Id -> Unique.Unique -> Core.Id :=
 Definition setIdType : Core.Id -> AxiomatizedTypes.Type_ -> Core.Id :=
   fun id ty => Core.setVarType id ty.
 
+(* Skipping definition `Id.setIdNotExported' *)
+
 Definition setIdName : Core.Id -> Name.Name -> Core.Id :=
   Core.setVarName.
+
+(* Skipping definition `Id.setIdExported' *)
+
+(* Skipping definition `Id.setCaseBndrEvald' *)
 
 Definition recordSelectorTyCon : Core.Id -> Core.RecSelParent :=
   fun id =>
@@ -125,6 +131,8 @@ Definition mkUserLocal
     then (Panic.assertPanic (GHC.Base.hs_string__ "ghc/compiler/basicTypes/Id.hs")
           #330)
     else mkLocalId (Name.mkInternalName uniq occ loc) ty.
+
+(* Skipping definition `Id.mkLocalCoVar' *)
 
 Definition mkGlobalId
    : Core.IdDetails ->
@@ -528,6 +536,8 @@ Definition idInlineActivation : Core.Id -> BasicTypes.Activation :=
 
 Definition idHasRules : Core.Id -> bool :=
   fun id => negb (Core.isEmptyRuleInfo (idSpecialisation id)).
+
+(* Skipping definition `Id.idFunRepArity' *)
 
 Definition idDemandInfo : Core.Id -> Core.Demand :=
   fun id => Core.demandInfo (Core.idInfo id).

--- a/examples/ghc/lib/ListSetOps.v
+++ b/examples/ghc/lib/ListSetOps.v
@@ -73,6 +73,10 @@ Definition hasNoDups {a} `{(GHC.Base.Eq_ a)} : list a -> bool :=
                  end in
     f nil xs.
 
+(* Skipping definition `ListSetOps.getNth' *)
+
+(* Skipping definition `ListSetOps.findDupsEq' *)
+
 Axiom equivClasses : forall {a},
                      (a -> a -> comparison) -> list a -> list (GHC.Base.NonEmpty a).
 

--- a/examples/ghc/lib/Literal.v
+++ b/examples/ghc/lib/Literal.v
@@ -50,9 +50,41 @@ Instance Default__Literal : GHC.Err.Default Literal :=
 
 Axiom word2IntLit : DynFlags.DynFlags -> Literal -> Literal.
 
+(* Skipping definition `Literal.pprLiteral' *)
+
+(* Skipping definition `Literal.pprIntegerVal' *)
+
 Axiom nullAddrLit : Literal.
 
+(* Skipping definition `Literal.narrow8WordLit' *)
+
+(* Skipping definition `Literal.narrow8IntLit' *)
+
+(* Skipping definition `Literal.narrow32WordLit' *)
+
+(* Skipping definition `Literal.narrow32IntLit' *)
+
+(* Skipping definition `Literal.narrow16WordLit' *)
+
+(* Skipping definition `Literal.narrow16IntLit' *)
+
+(* Skipping definition `Literal.mkMachWordWrap' *)
+
+(* Skipping definition `Literal.mkMachWord64Wrap' *)
+
+(* Skipping definition `Literal.mkMachWord64' *)
+
+(* Skipping definition `Literal.mkMachWord' *)
+
 Axiom mkMachString : GHC.Base.String -> Literal.
+
+(* Skipping definition `Literal.mkMachIntWrap' *)
+
+(* Skipping definition `Literal.mkMachInt64Wrap' *)
+
+(* Skipping definition `Literal.mkMachInt64' *)
+
+(* Skipping definition `Literal.mkMachInt' *)
 
 Axiom mkMachFloat : GHC.Real.Rational -> Literal.
 
@@ -61,6 +93,8 @@ Axiom mkMachDouble : GHC.Real.Rational -> Literal.
 Axiom mkMachChar : GHC.Char.Char -> Literal.
 
 Axiom mkLitInteger : GHC.Num.Integer -> AxiomatizedTypes.Type_ -> Literal.
+
+(* Skipping definition `Literal.mapLitValue' *)
 
 Axiom literalType : Literal -> AxiomatizedTypes.Type_.
 
@@ -92,11 +126,19 @@ Axiom int2CharLit : Literal -> Literal.
 
 Axiom inWordRange : DynFlags.DynFlags -> GHC.Num.Integer -> bool.
 
+(* Skipping definition `Literal.inWord64Range' *)
+
 Axiom inIntRange : DynFlags.DynFlags -> GHC.Num.Integer -> bool.
+
+(* Skipping definition `Literal.inInt64Range' *)
 
 Axiom inCharRange : GHC.Char.Char -> bool.
 
+(* Skipping definition `Literal.float2IntLit' *)
+
 Axiom float2DoubleLit : Literal -> Literal.
+
+(* Skipping definition `Literal.double2IntLit' *)
 
 Axiom double2FloatLit : Literal -> Literal.
 
@@ -105,6 +147,8 @@ Axiom cmpLit : Literal -> Literal -> comparison.
 Axiom char2IntLit : Literal -> Literal.
 
 Axiom absent_lits : UniqFM.UniqFM Literal.
+
+(* Skipping definition `Literal.absentLiteralOf' *)
 
 (* Skipping all instances of class `Data.Data.Data', including
    `Literal.Data__Literal' *)

--- a/examples/ghc/lib/Maybes.v
+++ b/examples/ghc/lib/Maybes.v
@@ -39,6 +39,8 @@ Definition whenIsJust {m} {a} `{GHC.Base.Monad m}
     | None, _ => GHC.Base.return_ tt
     end.
 
+(* Skipping definition `Maybes.tryMaybeT' *)
+
 Definition orElse {a} : option a -> a -> a :=
   GHC.Base.flip Data.Maybe.fromMaybe.
 
@@ -48,6 +50,10 @@ Definition liftMaybeT {m} {a} `{GHC.Base.Monad m}
 
 Definition isSuccess {err} {val} : MaybeErr err val -> bool :=
   fun arg_0__ => match arg_0__ with | Succeeded _ => true | Failed _ => false end.
+
+(* Skipping definition `Maybes.firstJusts' *)
+
+(* Skipping definition `Maybes.firstJust' *)
 
 Definition failME {err} {val} : err -> MaybeErr err val :=
   fun e => Failed e.

--- a/examples/ghc/lib/MkCore.v
+++ b/examples/ghc/lib/MkCore.v
@@ -105,6 +105,10 @@ Definition mkWildCase
   fun scrut scrut_ty res_ty alts =>
     Core.Case scrut (mkWildValBinder scrut_ty) res_ty alts.
 
+(* Skipping definition `MkCore.mkStringExprFS' *)
+
+(* Skipping definition `MkCore.mkStringExpr' *)
+
 Definition mkSmallTupleSelector1
    : list Core.Id -> Core.Id -> Core.Id -> Core.CoreExpr -> Core.CoreExpr :=
   fun vars the_var scrut_var scrut =>
@@ -226,10 +230,14 @@ Definition mkRuntimeErrorApp
 Definition mkNothingExpr : AxiomatizedTypes.Type_ -> Core.CoreExpr :=
   fun ty => Core.mkConApp TysWiredIn.nothingDataCon (cons (Core.Mk_Type ty) nil).
 
+(* Skipping definition `MkCore.mkNaturalExpr' *)
+
 Definition mkJustExpr
    : AxiomatizedTypes.Type_ -> Core.CoreExpr -> Core.CoreExpr :=
   fun ty val =>
     Core.mkConApp TysWiredIn.justDataCon (cons (Core.Mk_Type ty) (cons val nil)).
+
+(* Skipping definition `MkCore.mkIntegerExpr' *)
 
 Axiom mkIntExprInt : DynFlags.DynFlags -> nat -> Core.CoreExpr.
 
@@ -250,6 +258,12 @@ Definition mkIfThenElse
                                                                                                            TysWiredIn.trueDataCon)
                                                                                                           nil)
                                                                                                     then_expr) nil)).
+
+(* Skipping definition `MkCore.mkFoldrExpr' *)
+
+(* Skipping definition `MkCore.mkFloatExpr' *)
+
+(* Skipping definition `MkCore.mkDoubleExpr' *)
 
 Definition mkCoreVarTupTy : list Core.Id -> AxiomatizedTypes.Type_ :=
   fun ids => TysWiredIn.mkBoxedTupleTy (GHC.Base.map Id.idType ids).
@@ -381,6 +395,8 @@ Definition mkListExpr
 
 Definition mkCharExpr : GHC.Char.Char -> Core.CoreExpr :=
   fun c => mkCoreConApps TysWiredIn.charDataCon (cons (Core.mkCharLit c) nil).
+
+(* Skipping definition `MkCore.mkBuildExpr' *)
 
 Axiom mkBigCoreTupTy : list AxiomatizedTypes.Type_ -> AxiomatizedTypes.Type_.
 

--- a/examples/ghc/lib/Module.v
+++ b/examples/ghc/lib/Module.v
@@ -201,6 +201,8 @@ Instance Unpeel_NDModule : Prim.Unpeel NDModule Module :=
 
 (* Converted value declarations: *)
 
+(* Skipping definition `Module.wiredInUnitIds' *)
+
 Definition unitModuleSet : Module -> ModuleSet :=
   GHC.Prim.coerce Data.Set.Internal.singleton.
 
@@ -340,12 +342,26 @@ Definition unionModuleSet : ModuleSet -> ModuleSet -> ModuleSet :=
 Definition stableUnitIdCmp : UnitId -> UnitId -> comparison :=
   fun p1 p2 => GHC.Base.compare (unitIdFS p1) (unitIdFS p2).
 
+(* Skipping definition `Module.renameHoleUnitId'' *)
+
+(* Skipping definition `Module.renameHoleUnitId' *)
+
+(* Skipping definition `Module.renameHoleModule'' *)
+
+(* Skipping definition `Module.renameHoleModule' *)
+
+(* Skipping definition `Module.rawHashUnitId' *)
+
 Definition pprUnitId : UnitId -> GHC.Base.String :=
   fun arg_0__ =>
     match arg_0__ with
     | DefiniteUnitId uid => Panic.someSDoc
     | IndefiniteUnitId uid => Panic.someSDoc
     end.
+
+(* Skipping definition `Module.pprModuleName' *)
+
+(* Skipping definition `Module.pprModule' *)
 
 Definition plusModuleEnv_C {a}
    : (a -> a -> a) -> ModuleEnv a -> ModuleEnv a -> ModuleEnv a :=
@@ -361,6 +377,20 @@ Definition plusModuleEnv {a} : ModuleEnv a -> ModuleEnv a -> ModuleEnv a :=
     | Mk_ModuleEnv e1, Mk_ModuleEnv e2 =>
         Mk_ModuleEnv (Data.Map.Internal.union e1 e2)
     end.
+
+(* Skipping definition `Module.parseUnitId' *)
+
+(* Skipping definition `Module.parseModuleName' *)
+
+(* Skipping definition `Module.parseModuleId' *)
+
+(* Skipping definition `Module.parseModSubst' *)
+
+(* Skipping definition `Module.parseComponentId' *)
+
+(* Skipping definition `Module.newUnitId' *)
+
+(* Skipping definition `Module.newIndefUnitId' *)
 
 Local Definition Ord__ModuleName_compare
    : ModuleName -> ModuleName -> comparison :=
@@ -483,6 +513,8 @@ Definition moduleStableString : Module -> GHC.Base.String :=
                             (unitIdString moduleUnitId) (Coq.Init.Datatypes.app (GHC.Base.hs_string__ "$")
                                                                                 (moduleNameString moduleName))).
 
+(* Skipping definition `Module.moduleNameSlashes' *)
+
 Definition moduleNameFS : ModuleName -> FastString.FastString :=
   fun '(Mk_ModuleName mod_) => mod_.
 
@@ -524,6 +556,8 @@ Definition mkModuleSet : list Module -> ModuleSet :=
 
 Definition mkModuleNameFS : FastString.FastString -> ModuleName :=
   fun s => Mk_ModuleName s.
+
+(* Skipping definition `Module.mkModuleName' *)
 
 Definition mkModuleEnv {a} : list (Module * a)%type -> ModuleEnv a :=
   fun xs =>
@@ -693,8 +727,20 @@ Definition isEmptyModuleEnv {a} : ModuleEnv a -> bool :=
 Definition intersectModuleSet : ModuleSet -> ModuleSet -> ModuleSet :=
   GHC.Prim.coerce Data.Set.Internal.intersection.
 
+(* Skipping definition `Module.integerUnitId' *)
+
 Definition installedUnitIdString : InstalledUnitId -> GHC.Base.String :=
   FastString.unpackFS GHC.Base.∘ installedUnitIdFS.
+
+(* Skipping definition `Module.indefUnitIdToUnitId' *)
+
+(* Skipping definition `Module.indefModuleToModule' *)
+
+(* Skipping definition `Module.hashUnitId' *)
+
+(* Skipping definition `Module.generalizeIndefUnitId' *)
+
+(* Skipping definition `Module.generalizeIndefModule' *)
 
 Definition fsToUnitId : FastString.FastString -> UnitId :=
   DefiniteUnitId GHC.Base.∘ (Mk_DefUnitId GHC.Base.∘ Mk_InstalledUnitId).
@@ -748,6 +794,10 @@ Definition fsToInstalledUnitId : FastString.FastString -> InstalledUnitId :=
 
 Definition stringToInstalledUnitId : GHC.Base.String -> InstalledUnitId :=
   fsToInstalledUnitId GHC.Base.∘ FastString.mkFastString.
+
+(* Skipping definition `Module.fingerprintUnitId' *)
+
+(* Skipping definition `Module.fingerprintByteString' *)
 
 Definition filterModuleEnv {a}
    : (Module -> a -> bool) -> ModuleEnv a -> ModuleEnv a :=
@@ -902,6 +952,12 @@ Definition toInstalledUnitId : UnitId -> InstalledUnitId :=
 
 Definition baseUnitId : UnitId :=
   fsToUnitId (FastString.fsLit (GHC.Base.hs_string__ "base")).
+
+(* Skipping definition `Module.addBootSuffix_maybe' *)
+
+(* Skipping definition `Module.addBootSuffixLocn' *)
+
+(* Skipping definition `Module.addBootSuffix' *)
 
 (* Skipping all instances of class `GHC.Show.Show', including
    `Module.Show__ModLocation' *)

--- a/examples/ghc/lib/MonadUtils.v
+++ b/examples/ghc/lib/MonadUtils.v
@@ -38,6 +38,8 @@ Axiom zipWith3M : forall {m} {a} {b} {c} {d},
 Axiom whenM : forall {m},
               forall `{GHC.Base.Monad m}, m bool -> m unit -> m unit.
 
+(* Skipping definition `MonadUtils.unlessM' *)
+
 Axiom orM : forall {m}, forall `{GHC.Base.Monad m}, m bool -> m bool -> m bool.
 
 Axiom maybeMapM : forall {m} {a} {b},
@@ -67,6 +69,14 @@ Axiom mapAndUnzip3M : forall {m} {a} {b} {c} {d},
 Axiom mapAccumLM : forall {m} {acc} {x} {y},
                    forall `{GHC.Base.Monad m},
                    (acc -> x -> m (acc * y)%type) -> acc -> list x -> m (acc * list y)%type.
+
+(* Skipping definition `MonadUtils.liftIO4' *)
+
+(* Skipping definition `MonadUtils.liftIO3' *)
+
+(* Skipping definition `MonadUtils.liftIO2' *)
+
+(* Skipping definition `MonadUtils.liftIO1' *)
 
 Axiom foldrM : forall {m} {b} {a},
                forall `{(GHC.Base.Monad m)}, (b -> a -> m a) -> a -> list b -> m a.

--- a/examples/ghc/lib/Name.v
+++ b/examples/ghc/lib/Name.v
@@ -90,6 +90,8 @@ Instance Default__Name : Default Name := Build_Default _ (Mk_Name default defaul
 
 (* Converted value declarations: *)
 
+(* Skipping definition `Name.wiredInNameTyThing_maybe' *)
+
 Definition tidyNameOcc : Name -> OccName.OccName -> Name :=
   fun arg_0__ arg_1__ =>
     match arg_0__, arg_1__ with
@@ -132,6 +134,32 @@ Definition setNameLoc : Name -> SrcLoc.SrcSpan -> Name :=
   fun name loc =>
     let 'Mk_Name n_sort_0__ n_occ_1__ n_uniq_2__ n_loc_3__ := name in
     Mk_Name n_sort_0__ n_occ_1__ n_uniq_2__ loc.
+
+(* Skipping definition `Name.ppr_z_occ_name' *)
+
+(* Skipping definition `Name.ppr_underscore_unique' *)
+
+(* Skipping definition `Name.ppr_occ_name' *)
+
+(* Skipping definition `Name.pprUnique' *)
+
+(* Skipping definition `Name.pprSystem' *)
+
+(* Skipping definition `Name.pprPrefixName' *)
+
+(* Skipping definition `Name.pprNameDefnLoc' *)
+
+(* Skipping definition `Name.pprName' *)
+
+(* Skipping definition `Name.pprModulePrefix' *)
+
+(* Skipping definition `Name.pprInternal' *)
+
+(* Skipping definition `Name.pprInfixName' *)
+
+(* Skipping definition `Name.pprExternal' *)
+
+(* Skipping definition `Name.pprDefinedAt' *)
 
 Definition nameUnique : Name -> Unique.Unique :=
   fun name => n_uniq name.
@@ -209,6 +237,8 @@ Definition nameIsFromExternalPackage : Module.UnitId -> Name -> bool :=
         false
     | _ => false
     end.
+
+(* Skipping definition `Name.mkWiredInName' *)
 
 Definition mkSystemNameAt
    : Unique.Unique -> OccName.OccName -> SrcLoc.SrcSpan -> Name :=
@@ -289,6 +319,8 @@ Definition isSystemName : Name -> bool :=
     | Mk_Name System _ _ _ => true
     | _ => false
     end.
+
+(* Skipping definition `Name.isHoleName' *)
 
 Definition isExternalName : Name -> bool :=
   fun arg_0__ =>

--- a/examples/ghc/lib/NameEnv.v
+++ b/examples/ghc/lib/NameEnv.v
@@ -50,6 +50,8 @@ Definition mapNameEnv {elt1} {elt2}
 Definition mapDNameEnv {a} {b} : (a -> b) -> DNameEnv a -> DNameEnv b :=
   UniqFM.mapUFM.
 
+(* Skipping definition `NameEnv.lookupNameEnv_NF' *)
+
 Definition lookupNameEnv {a} : NameEnv a -> Name.Name -> option a :=
   fun x y => UniqFM.lookupUFM x y.
 
@@ -92,6 +94,8 @@ Definition elemNameEnv {a} : Name.Name -> NameEnv a -> bool :=
 
 Definition disjointNameEnv {a} : NameEnv a -> NameEnv a -> bool :=
   fun x y => UniqFM.isNullUFM (UniqFM.intersectUFM x y).
+
+(* Skipping definition `NameEnv.depAnal' *)
 
 Definition delListFromNameEnv {a} : NameEnv a -> list Name.Name -> NameEnv a :=
   fun x y => UniqFM.delListFromUFM x y.

--- a/examples/ghc/lib/OccName.v
+++ b/examples/ghc/lib/OccName.v
@@ -126,6 +126,16 @@ Definition setOccNameSpace : NameSpace -> OccName -> OccName :=
     | sp, Mk_OccName _ occ => Mk_OccName sp occ
     end.
 
+(* Skipping definition `OccName.pprOccName' *)
+
+(* Skipping definition `OccName.pprOccEnv' *)
+
+(* Skipping definition `OccName.pprNonVarNameSpace' *)
+
+(* Skipping definition `OccName.pprNameSpaceBrief' *)
+
+(* Skipping definition `OccName.pprNameSpace' *)
+
 Definition plusOccEnv_C {a}
    : (a -> a -> a) -> OccEnv a -> OccEnv a -> OccEnv a :=
   fun arg_0__ arg_1__ arg_2__ =>
@@ -138,6 +148,8 @@ Definition plusOccEnv {a} : OccEnv a -> OccEnv a -> OccEnv a :=
     match arg_0__, arg_1__ with
     | A x, A y => A (UniqFM.plusUFM x y)
     end.
+
+(* Skipping definition `OccName.parenSymOcc' *)
 
 Definition otherNameSpace : NameSpace -> NameSpace :=
   fun arg_0__ =>

--- a/examples/ghc/lib/OccurAnal.v
+++ b/examples/ghc/lib/OccurAnal.v
@@ -265,6 +265,8 @@ Axiom occAnalRecBind : OccEnv ->
                        list (Core.Var * Core.CoreExpr)%type ->
                        UsageDetails -> (UsageDetails * list Core.CoreBind)%type.
 
+(* Skipping definition `OccurAnal.occAnalRec' *)
+
 Axiom occAnalLamOrRhs : OccEnv ->
                         list Core.CoreBndr ->
                         Core.CoreExpr -> (UsageDetails * list Core.CoreBndr * Core.CoreExpr)%type.

--- a/examples/ghc/lib/OrdList.v
+++ b/examples/ghc/lib/OrdList.v
@@ -70,6 +70,8 @@ Fixpoint mapOL {a} {b} (arg_0__ : (a -> b)) (arg_1__ : OrdList a) : OrdList b
               | f, Many xs => Many (GHC.Base.map f xs)
               end.
 
+(* Skipping definition `OrdList.lastOL' *)
+
 Definition isNilOL {a} : OrdList a -> bool :=
   fun arg_0__ => match arg_0__ with | None => true | _ => false end.
 

--- a/examples/ghc/lib/Panic.v
+++ b/examples/ghc/lib/Panic.v
@@ -32,6 +32,12 @@ Inductive GhcException : Type
 
 (* Converted value declarations: *)
 
+(* Skipping definition `Panic.withSignalHandlers' *)
+
+(* Skipping definition `Panic.tryMost' *)
+
+(* Skipping definition `Panic.throwGhcExceptionIO' *)
+
 Axiom throwGhcException : forall {a} `{GHC.Err.Default a}, GhcException -> a.
 
 Axiom sorryDoc : forall {a} `{GHC.Err.Default a},
@@ -39,7 +45,15 @@ Axiom sorryDoc : forall {a} `{GHC.Err.Default a},
 
 Axiom sorry : forall {a} `{GHC.Err.Default a}, GHC.Base.String -> a.
 
+(* Skipping definition `Panic.signalHandlersRefCount' *)
+
+(* Skipping definition `Panic.showGhcException' *)
+
+(* Skipping definition `Panic.showException' *)
+
 Axiom short_usage : GHC.Base.String.
+
+(* Skipping definition `Panic.safeShowException' *)
 
 Axiom progName : GHC.Base.String.
 
@@ -52,6 +66,8 @@ Axiom panicDoc : forall {a} `{GHC.Err.Default a},
                  GHC.Base.String -> GHC.Base.String -> a.
 
 Axiom panic : forall {a} `{GHC.Err.Default a}, GHC.Base.String -> a.
+
+(* Skipping definition `Panic.handleGhcException' *)
 
 Axiom assertPanic : forall {a} `{GHC.Err.Default a},
                     GHC.Base.String -> GHC.Num.Int -> a.

--- a/examples/ghc/lib/SrcLoc.v
+++ b/examples/ghc/lib/SrcLoc.v
@@ -136,6 +136,12 @@ Definition srcLocFile : RealSrcLoc -> FastString.FastString :=
 Definition srcLocCol : RealSrcLoc -> GHC.Num.Int :=
   fun '(ASrcLoc _ _ c) => c.
 
+(* Skipping definition `SrcLoc.spans' *)
+
+(* Skipping definition `SrcLoc.sortLocated' *)
+
+(* Skipping definition `SrcLoc.rightmost' *)
+
 Definition realSrcLocSpan : RealSrcLoc -> RealSrcSpan :=
   fun '(ASrcLoc file line col) => RealSrcSpan' file line col line col.
 
@@ -145,6 +151,10 @@ Definition srcLocSpan : SrcLoc -> SrcSpan :=
     | UnhelpfulLoc str => UnhelpfulSpan str
     | ARealSrcLoc l => ARealSrcSpan (realSrcLocSpan l)
     end.
+
+(* Skipping definition `SrcLoc.pprUserSpan' *)
+
+(* Skipping definition `SrcLoc.pprUserRealSpan' *)
 
 Definition noSrcSpan : SrcSpan :=
   UnhelpfulSpan (FastString.fsLit (GHC.Base.hs_string__ "<no location info>")).
@@ -218,6 +228,12 @@ Definition mkGeneralSrcLoc : FastString.FastString -> SrcLoc :=
 Definition mkGeneralLocated {e} : GHC.Base.String -> e -> Located e :=
   fun s e => L (mkGeneralSrcSpan (FastString.fsLit s)) e.
 
+(* Skipping definition `SrcLoc.leftmost_smallest' *)
+
+(* Skipping definition `SrcLoc.leftmost_largest' *)
+
+(* Skipping definition `SrcLoc.isSubspanOf' *)
+
 Definition isPointRealSpan : RealSrcSpan -> bool :=
   fun '(RealSrcSpan' _ line1 col1 line2 col2) =>
     andb (line1 GHC.Base.== line2) (col1 GHC.Base.== col2).
@@ -255,9 +271,21 @@ Definition generatedSrcLoc : SrcLoc :=
 Definition eqLocated {a} `{GHC.Base.Eq_ a} : Located a -> Located a -> bool :=
   fun a b => unLoc a GHC.Base.== unLoc b.
 
+(* Skipping definition `SrcLoc.containsSpan' *)
+
+(* Skipping definition `SrcLoc.combineSrcSpans' *)
+
+(* Skipping definition `SrcLoc.combineRealSrcSpans' *)
+
+(* Skipping definition `SrcLoc.combineLocs' *)
+
 Definition cmpLocated {a} `{GHC.Base.Ord a}
    : Located a -> Located a -> comparison :=
   fun a b => GHC.Base.compare (unLoc a) (unLoc b).
+
+(* Skipping definition `SrcLoc.advanceSrcLoc' *)
+
+(* Skipping definition `SrcLoc.addCLoc' *)
 
 Local Definition Eq___RealSrcLoc_op_zeze__ : RealSrcLoc -> RealSrcLoc -> bool :=
   fun arg_0__ arg_1__ =>

--- a/examples/ghc/lib/TrieMap.v
+++ b/examples/ghc/lib/TrieMap.v
@@ -187,6 +187,8 @@ Admitted.
 
 (* Converted value declarations: *)
 
+(* Skipping definition `TrieMap.xtTyLit' *)
+
 Local Definition TrieMap__Map_Key {k} `{GHC.Base.Ord k} : Type :=
   k.
 
@@ -647,6 +649,8 @@ Definition xtVar {a} : CmEnv -> Core.Var -> XT a -> VarMap a -> VarMap a :=
         let 'VM vm_bvar_4__ vm_fvar_5__ := m in
         VM vm_bvar_4__ (vm_fvar m |> xtDFreeVar v f)
     end.
+
+(* Skipping definition `TrieMap.lkTyLit' *)
 
 Definition lkTickish {a} : Core.Tickish Core.Id -> TickishMap a -> option a :=
   lookupTM (m := TickishMap).

--- a/examples/ghc/lib/TysWiredIn.v
+++ b/examples/ghc/lib/TysWiredIn.v
@@ -96,7 +96,11 @@ Axiom unboxedTupleSumKind : Core.TyCon ->
 
 Axiom unboxedTupleKind : list AxiomatizedTypes.Type_ -> AxiomatizedTypes.Kind.
 
+(* Skipping definition `TysWiredIn.unboxedTupleArr' *)
+
 Axiom unboxedSumKind : list AxiomatizedTypes.Type_ -> AxiomatizedTypes.Kind.
+
+(* Skipping definition `TysWiredIn.unboxedSumArr' *)
 
 Axiom typeSymbolKindConName : Name.Name.
 
@@ -211,6 +215,8 @@ Axiom parrTyConName : Name.Name.
 
 Axiom parrTyCon : Core.TyCon.
 
+(* Skipping definition `TysWiredIn.parrFakeConArr' *)
+
 Axiom parrFakeCon : BasicTypes.Arity -> Core.DataCon.
 
 Axiom parrDataConName : Name.Name.
@@ -230,6 +236,8 @@ Axiom nilDataConName : Name.Name.
 Axiom nilDataCon : Core.DataCon.
 
 Axiom mk_tuple : BasicTypes.Boxity -> nat -> (Core.TyCon * Core.DataCon)%type.
+
+(* Skipping definition `TysWiredIn.mk_sum' *)
 
 Axiom mk_special_dc_name : FastString.FastString ->
                            Unique.Unique -> Core.DataCon -> Name.Name.
@@ -425,6 +433,8 @@ Axiom boxing_constr_env : NameEnv.NameEnv Core.DataCon.
 
 Axiom boxingDataCon_maybe : Core.TyCon -> option Core.DataCon.
 
+(* Skipping definition `TysWiredIn.boxedTupleArr' *)
+
 Axiom boolTyCon_RDR : PrelNames.RdrName.
 
 Axiom boolTyConName : Name.Name.
@@ -444,6 +454,10 @@ Axiom anyTy : AxiomatizedTypes.Type_.
 Axiom alpha_tyvar : list Core.TyVar.
 
 Axiom alpha_ty : list AxiomatizedTypes.Type_.
+
+(* Skipping definition `AxiomatizedTypes.liftedTypeKind' *)
+
+(* Skipping definition `AxiomatizedTypes.constraintKind' *)
 
 (* External variables:
      bool list nat op_zt__ option AxiomatizedTypes.CType AxiomatizedTypes.Kind

--- a/examples/ghc/lib/UniqFM.v
+++ b/examples/ghc/lib/UniqFM.v
@@ -52,6 +52,10 @@ Definition ufmToIntMap {elt} : UniqFM elt -> IntMap.IntMap elt :=
 Definition sizeUFM {elt} : UniqFM elt -> nat :=
   fun '(UFM m) => IntMap.size m.
 
+(* Skipping definition `UniqFM.pprUniqFM' *)
+
+(* Skipping definition `UniqFM.pprUFM' *)
+
 Axiom plusUFM_CD : forall {elt},
                    (elt -> elt -> elt) -> UniqFM elt -> elt -> UniqFM elt -> elt -> UniqFM elt.
 
@@ -70,6 +74,8 @@ Definition plusUFM {elt} : UniqFM elt -> UniqFM elt -> UniqFM elt :=
 
 Axiom plusMaybeUFM_C : forall {elt},
                        (elt -> elt -> option elt) -> UniqFM elt -> UniqFM elt -> UniqFM elt.
+
+(* Skipping definition `UniqFM.pluralUFM' *)
 
 Definition partitionUFM {elt}
    : (elt -> bool) -> UniqFM elt -> (UniqFM elt * UniqFM elt)%type :=
@@ -196,6 +202,8 @@ Definition filterUFM {elt} : (elt -> bool) -> UniqFM elt -> UniqFM elt :=
     match arg_0__, arg_1__ with
     | p, UFM m => UFM (IntMap.filter p m)
     end.
+
+(* Skipping definition `UniqFM.equalKeysUFM' *)
 
 Definition emptyUFM {elt} : UniqFM elt :=
   UFM IntMap.empty.

--- a/examples/ghc/lib/UniqSet.v
+++ b/examples/ghc/lib/UniqSet.v
@@ -73,6 +73,8 @@ Definition restrictUniqSetToUFM {a} {b}
     | Mk_UniqSet s, m => Mk_UniqSet (UniqFM.intersectUFM s m)
     end.
 
+(* Skipping definition `UniqSet.pprUniqSet' *)
+
 Instance Unpeel_UniqSet ele
    : GHC.Prim.Unpeel (UniqSet ele) (UniqFM.UniqFM ele) :=
   GHC.Prim.Build_Unpeel _ _ (fun '(Mk_UniqSet y) => y) Mk_UniqSet.

--- a/examples/ghc/lib/UniqSupply.v
+++ b/examples/ghc/lib/UniqSupply.v
@@ -102,6 +102,8 @@ Definition splitUniqSupply4
 Definition returnUs {a} : a -> UniqSM a :=
   fun result => USM (fun us => pair result us).
 
+(* Skipping definition `UniqSupply.mkSplitUniqSupply' *)
+
 Fixpoint listSplitUniqSupply (arg_0__ : UniqSupply) : list UniqSupply
            := let 'MkSplitUniqSupply _ s1 s2 := arg_0__ in
               cons s1 (listSplitUniqSupply s2).

--- a/examples/ghc/lib/Unique.v
+++ b/examples/ghc/lib/Unique.v
@@ -68,6 +68,10 @@ Definition stepUnique : Unique -> BinNums.N -> Unique :=
     | MkUnique i, n => MkUnique (i GHC.Num.+ n)
     end.
 
+(* Skipping definition `Unique.showUnique' *)
+
+(* Skipping definition `Unique.pprUniqueAlways' *)
+
 Definition nonDetCmpUnique : Unique -> Unique -> comparison :=
   fun arg_0__ arg_1__ =>
     match arg_0__, arg_1__ with
@@ -78,6 +82,8 @@ Definition nonDetCmpUnique : Unique -> Unique -> comparison :=
              then Lt
              else Gt
     end.
+
+(* Skipping definition `Unique.newTagUnique' *)
 
 Definition mkUniqueGrimily : BinNums.N -> Unique :=
   MkUnique.
@@ -168,6 +174,8 @@ Definition incrUnique : Unique -> Unique :=
 Definition tyConRepNameUnique : Unique -> Unique :=
   fun u => incrUnique u.
 
+(* Skipping definition `Unique.iToBase62' *)
+
 Definition eqUnique : Unique -> Unique -> bool :=
   fun arg_0__ arg_1__ =>
     match arg_0__, arg_1__ with
@@ -190,6 +198,8 @@ Definition hasKey {a} `{Uniquable a} : a -> Unique -> bool :=
 
 Definition getKey : Unique -> BinNums.N :=
   fun '(MkUnique x) => x.
+
+(* Skipping definition `Unique.finish_show' *)
 
 Definition deriveUnique : Unique -> BinNums.N -> Unique :=
   fun arg_0__ arg_1__ =>

--- a/examples/ghc/lib/Util.v
+++ b/examples/ghc/lib/Util.v
@@ -144,6 +144,10 @@ Definition transitiveClosure {a}
                                       end) in
     go nil xs.
 
+(* Skipping definition `Util.toCmdArgs' *)
+
+(* Skipping definition `Util.toArgs' *)
+
 Definition third3 {c} {d} {a} {b}
    : (c -> d) -> (a * b * c)%type -> (a * b * d)%type :=
   fun arg_0__ arg_1__ =>
@@ -182,6 +186,8 @@ Fixpoint stretchZipWith {a} {b} {c} (arg_0__ : (a -> bool)) (arg_1__ : b)
                   | cons y ys => cons (f x y) (stretchZipWith p z f xs ys)
                   end
               end.
+
+(* Skipping definition `Util.splitLongestPrefix' *)
 
 Fixpoint splitEithers {a} {b} (arg_0__ : list (Data.Either.Either a b)) : (list
                                                                            a *
@@ -258,11 +264,35 @@ Definition sizedComplement {bv} `{Data.Bits.Bits bv} : bv -> bv -> bv :=
 Definition singleton {a} : a -> list a :=
   fun x => cons x nil.
 
+(* Skipping definition `Util.sharedGlobalM' *)
+
+(* Skipping definition `Util.sharedGlobal' *)
+
 Fixpoint seqList {a} {b} (arg_0__ : list a) (arg_1__ : b) : b
            := match arg_0__, arg_1__ with
               | nil, b => b
               | cons x xs, b => GHC.Prim.seq x (seqList xs b)
               end.
+
+(* Skipping definition `Util.restrictedDamerauLevenshteinDistanceWorker' *)
+
+(* Skipping definition `Util.restrictedDamerauLevenshteinDistanceWithLengths' *)
+
+(* Skipping definition `Util.restrictedDamerauLevenshteinDistance'' *)
+
+(* Skipping definition `Util.restrictedDamerauLevenshteinDistance' *)
+
+(* Skipping definition `Util.reslash' *)
+
+(* Skipping definition `Util.removeSpaces' *)
+
+(* Skipping definition `Util.readRational__' *)
+
+(* Skipping definition `Util.readRational' *)
+
+(* Skipping definition `Util.readHexRational__' *)
+
+(* Skipping definition `Util.readHexRational' *)
 
 Fixpoint partitionWith {a} {b} {c} (arg_0__ : (a -> Data.Either.Either b c))
                        (arg_1__ : list a) : (list b * list c)%type
@@ -317,6 +347,8 @@ Definition only {a} `{GHC.Err.Default a} : list a -> a :=
     | _ => Panic.panic (GHC.Base.hs_string__ "Util: only")
     end.
 
+(* Skipping definition `Util.nubSort' *)
+
 Definition notNull {a} : list a -> bool :=
   fun arg_0__ => match arg_0__ with | nil => false | _ => true end.
 
@@ -330,8 +362,22 @@ Fixpoint neLength {a} {b} (arg_0__ : list a) (arg_1__ : list b) : bool
 Definition ncgDebugIsOn : bool :=
   false.
 
+(* Skipping definition `Util.nTimes' *)
+
 Definition nOfThem {a} : nat -> a -> list a :=
   fun n thing => Coq.Lists.List.repeat thing n.
+
+(* Skipping definition `Util.mulHi' *)
+
+(* Skipping definition `Util.modificationTimeIfExists' *)
+
+(* Skipping definition `Util.minWith' *)
+
+(* Skipping definition `Util.maybeReadFuzzy' *)
+
+(* Skipping definition `Util.maybeRead' *)
+
+(* Skipping definition `Util.matchVectors' *)
 
 Definition mapSnd {b} {c} {a}
    : (b -> c) -> list (a * b)%type -> list (a * c)%type :=
@@ -365,9 +411,13 @@ Fixpoint mapAndUnzip {a} {b} {c} (arg_0__ : (a -> (b * c)%type)) (arg_1__
                   pair (cons r1 rs1) (cons r2 rs2)
               end.
 
+(* Skipping definition `Util.mapAccumL2' *)
+
 Axiom makeRelativeTo : GHC.Base.String -> GHC.Base.String -> GHC.Base.String.
 
 Axiom looksLikePackageName : GHC.Base.String -> bool.
+
+(* Skipping definition `Util.looksLikeModuleName' *)
 
 Definition liftSnd {a} {b} {c} : (a -> b) -> (c * a)%type -> (c * b)%type :=
   fun arg_0__ arg_1__ =>
@@ -398,11 +448,33 @@ Definition isIn {a} `{GHC.Base.Eq_ a}
 Definition isEqual : comparison -> bool :=
   fun arg_0__ => match arg_0__ with | Gt => false | Eq => true | Lt => false end.
 
+(* Skipping definition `Util.isDarwinHost' *)
+
+(* Skipping definition `Util.hashString' *)
+
+(* Skipping definition `Util.hashInt32' *)
+
+(* Skipping definition `Util.hSetTranslit' *)
+
+(* Skipping definition `Util.golden' *)
+
+(* Skipping definition `Util.globalM' *)
+
+(* Skipping definition `Util.global' *)
+
 Definition ghciTablesNextToCode : bool :=
   false.
 
 Definition ghciSupported : bool :=
   false.
+
+(* Skipping definition `Util.getModificationUTCTime' *)
+
+(* Skipping definition `Util.getCmd' *)
+
+(* Skipping definition `Util.fuzzyMatch' *)
+
+(* Skipping definition `Util.fuzzyLookup' *)
 
 Definition fstOf3 {a} {b} {c} : (a * b * c)%type -> a :=
   fun '(pair (pair a _) _) => a.
@@ -470,6 +542,8 @@ Definition exactLog2 : GHC.Num.Integer -> option GHC.Num.Integer :=
          then None
          else Some (pow2 x).
 
+(* Skipping definition `Util.escapeSpaces' *)
+
 Fixpoint equalLength {a} {b} (arg_0__ : list a) (arg_1__ : list b) : bool
            := match arg_0__, arg_1__ with
               | nil, nil => true
@@ -516,6 +590,8 @@ Fixpoint dropList {b} {a} (arg_0__ : list b) (arg_1__ : list a) : list a
               | cons _ xs, cons _ ys => dropList xs ys
               end.
 
+(* Skipping definition `Util.doesDirNameExist' *)
+
 Axiom debugIsOn : bool.
 
 Definition count {a} : (a -> bool) -> list a -> nat :=
@@ -526,6 +602,8 @@ Definition count {a} : (a -> bool) -> list a -> nat :=
                  | n, cons x xs => if p x : bool then go (n GHC.Num.+ #1) xs else go n xs
                  end in
     go #0.
+
+(* Skipping definition `Util.consIORef' *)
 
 Fixpoint compareLength {a} {b} (arg_0__ : list a) (arg_1__ : list b)
            : comparison
@@ -565,10 +643,14 @@ Fixpoint cmpList {a} (arg_0__ : (a -> a -> comparison)) (arg_1__ arg_2__
                   end
               end.
 
+(* Skipping definition `Util.chunkList' *)
+
 Definition chkAppend {a} : list a -> list a -> list a :=
   fun xs ys =>
     if Data.Foldable.null ys : bool then xs else
     Coq.Init.Datatypes.app xs ys.
+
+(* Skipping definition `Util.charToC' *)
 
 Fixpoint changeLast {a} (arg_0__ : list a) (arg_1__ : a) : list a
            := match arg_0__, arg_1__ with
@@ -631,6 +713,10 @@ Fixpoint all2 {a} {b} (arg_0__ : (a -> b -> bool)) (arg_1__ : list a) (arg_2__
               | p, cons x xs, cons y ys => andb (p x y) (all2 p xs ys)
               | _, _, _ => false
               end.
+
+(* Skipping definition `Util.abstractDataType' *)
+
+(* Skipping definition `Util.abstractConstr' *)
 
 (* Skipping all instances of class `GHC.Show.Show', including
    `Util.Show__OverridingBool' *)

--- a/examples/transformers/lib/Control/Monad/Trans/Identity.v
+++ b/examples/transformers/lib/Control/Monad/Trans/Identity.v
@@ -43,6 +43,8 @@ Definition mapIdentityT {m} {a} {n} {b}
    : (m a -> n b) -> IdentityT m a -> IdentityT n b :=
   fun f => Mk_IdentityT GHC.Base.∘ (f GHC.Base.∘ runIdentityT).
 
+(* Skipping definition `Control.Monad.Trans.Identity.liftCatch' *)
+
 Definition liftCallCC {m} {a} {b}
    : Control.Monad.Signatures.CallCC m a b ->
      Control.Monad.Signatures.CallCC (IdentityT m) a b :=

--- a/examples/transformers/lib/Control/Monad/Trans/Maybe.v
+++ b/examples/transformers/lib/Control/Monad/Trans/Maybe.v
@@ -92,6 +92,8 @@ Definition liftListen {m} {w} {a} `{(GHC.Base.Monad m)}
                    GHC.Base.return_ (GHC.Base.fmap (fun r => pair r w) a) in
                  listen m GHC.Base.>>= cont_0__).
 
+(* Skipping definition `Control.Monad.Trans.Maybe.liftCatch' *)
+
 Definition liftCallCC {m} {a} {b}
    : Control.Monad.Signatures.CallCC m (option a) (option b) ->
      Control.Monad.Signatures.CallCC (MaybeT m) a b :=

--- a/examples/transformers/lib/Control/Monad/Trans/RWS/Lazy.v
+++ b/examples/transformers/lib/Control/Monad/Trans/RWS/Lazy.v
@@ -151,6 +151,8 @@ Definition listen {m} {r} {w} {s} {a} `{(GHC.Base.Monad m)}
                  GHC.Base.return_ (pair (pair (pair a w) s') w) in
                runRWST m r s GHC.Base.>>= cont_0__).
 
+(* Skipping definition `Control.Monad.Trans.RWS.Lazy.liftCatch' *)
+
 Definition liftCallCC' {w} {m} {a} {s} {b} {r} `{(GHC.Base.Monoid w)}
    : Control.Monad.Signatures.CallCC m (a * s * w)%type (b * s * w)%type ->
      Control.Monad.Signatures.CallCC (RWST r w s m) a b :=

--- a/examples/transformers/lib/Control/Monad/Trans/Reader.v
+++ b/examples/transformers/lib/Control/Monad/Trans/Reader.v
@@ -65,6 +65,8 @@ Definition local {r} {m} {a} : (r -> r) -> ReaderT r m a -> ReaderT r m a :=
 Definition liftReaderT {m} {a} {r} : m a -> ReaderT r m a :=
   fun m => Mk_ReaderT (GHC.Base.const m).
 
+(* Skipping definition `Control.Monad.Trans.Reader.liftCatch' *)
+
 Definition liftCallCC {m} {a} {b} {r}
    : Control.Monad.Signatures.CallCC m a b ->
      Control.Monad.Signatures.CallCC (ReaderT r m) a b :=

--- a/examples/transformers/lib/Control/Monad/Trans/State/Lazy.v
+++ b/examples/transformers/lib/Control/Monad/Trans/State/Lazy.v
@@ -85,6 +85,8 @@ Definition liftListen {m} {w} {a} {s} `{(GHC.Base.Monad m)}
                    GHC.Base.return_ (pair (pair a w) s') in
                  listen (runStateT m s) GHC.Base.>>= cont_0__).
 
+(* Skipping definition `Control.Monad.Trans.State.Lazy.liftCatch' *)
+
 Definition liftCallCC' {m} {a} {s} {b}
    : Control.Monad.Signatures.CallCC m (a * s)%type (b * s)%type ->
      Control.Monad.Signatures.CallCC (StateT s m) a b :=

--- a/examples/transformers/lib/Control/Monad/Trans/Writer/Lazy.v
+++ b/examples/transformers/lib/Control/Monad/Trans/Writer/Lazy.v
@@ -106,6 +106,8 @@ Definition listen {m} {w} {a} `{(GHC.Base.Monad m)}
                   GHC.Base.return_ (pair (pair a w) w) in
                 runWriterT m GHC.Base.>>= cont_0__).
 
+(* Skipping definition `Control.Monad.Trans.Writer.Lazy.liftCatch' *)
+
 Definition liftCallCC {w} {m} {a} {b} `{(GHC.Base.Monoid w)}
    : Control.Monad.Signatures.CallCC m (a * w)%type (b * w)%type ->
      Control.Monad.Signatures.CallCC (WriterT w m) a b :=

--- a/src/lib/HsToCoq/CLI.hs
+++ b/src/lib/HsToCoq/CLI.hs
@@ -342,11 +342,16 @@ printConvertedModule withModulePrinter cmod@ConvertedModule{..} = do
  where
   gap out = hPutStrLn out "" >> hFlush out
 
-  printThe out what _   [] = hPutStrLn out $ "(* No " ++ what ++ " to convert. *)"
-  printThe out what sep ds = do hPutStrLn out $ "(* Converted " ++ what ++ ": *)"
-                                gap out
-                                traverse_ (hPrettyPrint out) . intersperse sep $
-                                  map ((<> line) . renderGallina) ds
+  printThe out what sep ds = do
+    printTheHeader out what ds
+    unless (null ds) $ do
+      gap out
+      traverse_ (hPrettyPrint out) . intersperse sep $
+        map ((<> line) . renderGallina) ds
+
+  printTheHeader out what ds
+    | all isComment ds = hPutStrLn out $ "(* No " ++ what ++ " to convert. *)"
+    | otherwise = hPutStrLn out $ "(* Converted " ++ what ++ ": *)"
 
 printConvertedModules :: GlobalMonad r m
                       => WithModulePrinter m

--- a/src/lib/HsToCoq/ConvertHaskell/Declarations/Class.hs
+++ b/src/lib/HsToCoq/ConvertHaskell/Declarations/Class.hs
@@ -183,6 +183,8 @@ convertClassDecl (L _ hsCtx) (L _ hsName) ltvs fds lsigs defaults types typeDefa
                       convUnsupportedHere "axiom bindings in class declarations"
                   Just (RedefinedBinding           _ _)                     ->
                       convUnsupportedHere "redefining class method declarations"
+                  Just (SkippedBinding _) ->
+                      convUnsupportedHere "skipping a binding (use `skip method')"
                   Nothing                                                   ->
                       convUnsupportedHere "skipping a type class method (use `skip method`)"
   let defs = type_defs <> value_defs

--- a/src/lib/HsToCoq/ConvertHaskell/Declarations/Instances.hs
+++ b/src/lib/HsToCoq/ConvertHaskell/Declarations/Instances.hs
@@ -285,6 +285,7 @@ convertClsInstDecl cid@ClsInstDecl{..} = do
                   CoqInstanceDef         _   -> editFailure   "cannot redefine an instance method definition into an Instance"
                   CoqAxiomDef            _   -> pure ()
                   CoqAssertionDef        apf -> editFailure $ "cannot redefine an instance method definition into " ++ anAssertionVariety apf
+              SkippedBinding _ -> convUnsupportedHere "skipping binding in instance"
 
           (Nothing, Just assoc, _) ->
             let convertedType = withCurrentDefinition meth $ convertType assoc in

--- a/src/lib/HsToCoq/ConvertHaskell/Expr.hs
+++ b/src/lib/HsToCoq/ConvertHaskell/Expr.hs
@@ -862,7 +862,7 @@ convertTypedBinding convHsTy FunBind{..}   = do
     -- Skip it?  Axiomatize it?
     definitionTask name >>= \case
       SkipIt ->
-        pure Nothing
+        pure . Just $ SkippedBinding name
       
       RedefineIt def ->
         pure . Just $ RedefinedBinding name def
@@ -1204,8 +1204,9 @@ convertLocalBinds (HsValBinds (ValBindsOut recBinds lsigs)) body = do
       toLet ConvertedDefinition{..} = pure . Let _convDefName _convDefArgs _convDefType _convDefBody
       noLetAx ax _ty _body = convUnsupported $ "local axiom `" ++ T.unpack (qualidToIdent ax) ++ "' unsupported"
       noLetRd _nm _sn _body = convUnsupported "redefining local bindings"
+      noSkp _nm _body = convUnsupported "skipping local binding"
       
-  (foldrM (withConvertedBinding toLet matchLet noLetAx noLetRd) ?? convDefs) =<< body
+  (foldrM (withConvertedBinding toLet matchLet noLetAx noLetRd noSkp) ?? convDefs) =<< body
 
 convertLocalBinds (HsIPBinds _) _ =
   convUnsupported "local implicit parameter bindings"

--- a/src/lib/HsToCoq/ConvertHaskell/Module.hs
+++ b/src/lib/HsToCoq/ConvertHaskell/Module.hs
@@ -55,6 +55,7 @@ import HsToCoq.ConvertHaskell.Declarations.Instances
 import HsToCoq.ConvertHaskell.Declarations.Notations
 import HsToCoq.ConvertHaskell.Axiomatize
 import HsToCoq.Coq.Preamble
+import HsToCoq.Coq.Pretty (textP)
 
 --------------------------------------------------------------------------------
 
@@ -131,6 +132,8 @@ convertHsGroup HsGroup{..} = do
                       CoqInstanceDef         _   -> editFailure   "cannot redefine a value definition into an Instance"
                       CoqAxiomDef            _   -> pure ()
                       CoqAssertionDef        apf -> editFailure $ "cannot redefine a value definition into " ++ anAssertionVariety apf)
+                   (\name -> pure (Just name, [CommentSentence . Comment $
+                      "Skipping definition `" <> textP name <> "'"]))
         let unnamedSentences = concat [ sentences | (Nothing, sentences) <- defns ]
         let namedSentences   = [ (name, sentences) | (Just name, sentences) <- defns ]
         let defnsMap = M.fromList namedSentences

--- a/src/lib/HsToCoq/ConvertHaskell/Module.hs
+++ b/src/lib/HsToCoq/ConvertHaskell/Module.hs
@@ -107,7 +107,7 @@ convertBinding sigs (ConvertedDefinitionBinding cdef@ConvertedDefinition{_convDe
              [ NotationSentence n | n <- buildInfixNotations sigs (cdef^.convDefName) ]
 
 convertBinding _ (ConvertedPatternBinding _ _) =
-  -- TODO add a warning that the top-level pattern was skipped
+  -- Already skipped with a warning in 'HsToCoq.ConvertnHaskell.Expr.withHsBindName'
   pure [] -- convUnsupported' "top-level pattern bindings"
 
 convertBinding _ (ConvertedAxiomBinding ax ty) = pure [typedAxiom ax ty]

--- a/src/lib/HsToCoq/Coq/Gallina/Util.hs
+++ b/src/lib/HsToCoq/Coq/Gallina/Util.hs
@@ -36,7 +36,10 @@ module HsToCoq.Coq.Gallina.Util (
   nameToTerm, nameToPattern,
   binderArgs,
   consolidateTypedBinders,
-  stripBinderType
+  stripBinderType,
+
+  -- * Manipulating 'Sentence's
+  isComment
   ) where
 
 import Control.Lens
@@ -310,3 +313,7 @@ unconsOneBinderFromType (Forall bbs t) = Just $ second (maybeForall ?? t) (uncon
 unconsOneBinderFromType (t `Arrow` t') = Just (BinderInfo Ungeneralizable Explicit Nothing (Just t), t')
 unconsOneBinderFromType (Parens t)     = unconsOneBinderFromType t
 unconsOneBinderFromType _              = Nothing
+
+isComment :: Sentence -> Bool
+isComment CommentSentence{} = True
+isComment _ = False


### PR DESCRIPTION
Related to #164. One day there should be some way of actually translating them, but just skipping them can already be helpful to handle some existing modules such as `Data.Sequence.Internal` in containers.

I also added some warnings because I got confused about whether I was doing something wrong when something wasn't getting translated, for example:

```
x, y :: ()
(x, y) = ((), ())
```