### PR TITLE
examples/ghc: Fix a rewrite rule by qualifying an identifier

### DIFF
--- a/examples/ghc/module-edits/CoreFVs/edits
+++ b/examples/ghc/module-edits/CoreFVs/edits
@@ -41,7 +41,7 @@ in CoreFVs.expr_fvs rewrite forall x, CoreFVs.rhs_fvs x = (match x with | pair b
 
 # replace mapUnionFV with unions . map  (and also inline an occurrence of rhs_fvs)
 in CoreFVs.expr_fvs rewrite forall alts,  (FV.mapUnionFV alt_fvs alts)  = FV.unionsFV (Lists.List.map alt_fvs alts)
-in CoreFVs.expr_fvs rewrite forall pairs, (FV.mapUnionFV CoreFVs.rhs_fvs pairs) = FV.unionsFV (Lists.List.map (fun x => match x with | pair bndr rhs => FV.unionFV (expr_fvs rhs) (bndrRuleAndUnfoldingFVs bndr) end) pairs)
+in CoreFVs.expr_fvs rewrite forall pairs, (FV.mapUnionFV CoreFVs.rhs_fvs pairs) = FV.unionsFV (Lists.List.map (fun x => match x with | pair bndr rhs => FV.unionFV (expr_fvs rhs) (CoreFVs.bndrRuleAndUnfoldingFVs bndr) end) pairs)
 
 
 # `freeVars = go where go = …`.  Since `go` is a function but `freeVars` isn't,


### PR DESCRIPTION
The extra toposort reintroduced in #163 is actually unnecessary. The fact that it "works" is a fluke. The reordering problem in `CoreFVs` that Eric ran into was due to the rewrite rule using an unqualified name, which hs-to-coq doesn't know how to resolve so it can't see the dependency. This PR fixes that.

Removing the unnecessary toposort would break more stuff because `order` rules are incomplete, so I haven't done that yet.