### PR TITLE
Improve ordering of declarations

### DIFF
--- a/base/Control/Applicative.v
+++ b/base/Control/Applicative.v
@@ -44,8 +44,6 @@ Definition unwrapArrow {a : Type -> Type -> Type} {b} {c} (arg_0__
 
 (* Converted value declarations: *)
 
-(* Skipping definition `Control.Applicative.optional' *)
-
 (* Skipping all instances of class `GHC.Generics.Generic', including
    `Control.Applicative.Generic__WrappedMonad' *)
 
@@ -176,30 +174,6 @@ Program Instance Monad__WrappedMonad {m} `{GHC.Base.Monad m}
 (* Skipping all instances of class `GHC.Base.Alternative', including
    `Control.Applicative.Alternative__WrappedMonad' *)
 
-(* Skipping all instances of class `GHC.Base.Alternative', including
-   `Control.Applicative.Alternative__WrappedArrow' *)
-
-Local Definition Applicative__WrappedArrow_liftA2 {inst_a} {inst_b}
-  `{Control.Arrow.Arrow inst_a}
-   : forall {a} {b} {c},
-     (a -> b -> c) ->
-     (WrappedArrow inst_a inst_b) a ->
-     (WrappedArrow inst_a inst_b) b -> (WrappedArrow inst_a inst_b) c :=
-  fun {a} {b} {c} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | f, WrapArrow u, WrapArrow v =>
-          WrapArrow ((u Control.Arrow.&&& v) Control.Category.>>>
-                     Control.Arrow.arr (Data.Tuple.uncurry f))
-      end.
-
-Local Definition Applicative__WrappedArrow_op_zlztzg__ {inst_a} {inst_b}
-  `{Control.Arrow.Arrow inst_a}
-   : forall {a} {b},
-     (WrappedArrow inst_a inst_b) (a -> b) ->
-     (WrappedArrow inst_a inst_b) a -> (WrappedArrow inst_a inst_b) b :=
-  fun {a} {b} => Applicative__WrappedArrow_liftA2 GHC.Base.id.
-
 Local Definition Functor__WrappedArrow_fmap {inst_a} {inst_b}
   `{Control.Arrow.Arrow inst_a}
    : forall {a} {b},
@@ -221,6 +195,27 @@ Program Instance Functor__WrappedArrow {a} {b} `{Control.Arrow.Arrow a}
   fun _ k__ =>
     k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__WrappedArrow_fmap ;
            GHC.Base.op_zlzd____ := fun {a} {b} => Functor__WrappedArrow_op_zlzd__ |}.
+
+Local Definition Applicative__WrappedArrow_liftA2 {inst_a} {inst_b}
+  `{Control.Arrow.Arrow inst_a}
+   : forall {a} {b} {c},
+     (a -> b -> c) ->
+     (WrappedArrow inst_a inst_b) a ->
+     (WrappedArrow inst_a inst_b) b -> (WrappedArrow inst_a inst_b) c :=
+  fun {a} {b} {c} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | f, WrapArrow u, WrapArrow v =>
+          WrapArrow ((u Control.Arrow.&&& v) Control.Category.>>>
+                     Control.Arrow.arr (Data.Tuple.uncurry f))
+      end.
+
+Local Definition Applicative__WrappedArrow_op_zlztzg__ {inst_a} {inst_b}
+  `{Control.Arrow.Arrow inst_a}
+   : forall {a} {b},
+     (WrappedArrow inst_a inst_b) (a -> b) ->
+     (WrappedArrow inst_a inst_b) a -> (WrappedArrow inst_a inst_b) b :=
+  fun {a} {b} => Applicative__WrappedArrow_liftA2 GHC.Base.id.
 
 Local Definition Applicative__WrappedArrow_op_ztzg__ {inst_a} {inst_b}
   `{Control.Arrow.Arrow inst_a}
@@ -246,10 +241,15 @@ Program Instance Applicative__WrappedArrow {a} {b} `{Control.Arrow.Arrow a}
            GHC.Base.pure__ := fun {a} => Applicative__WrappedArrow_pure |}.
 
 (* Skipping all instances of class `GHC.Base.Alternative', including
-   `Control.Applicative.Alternative__ZipList' *)
+   `Control.Applicative.Alternative__WrappedArrow' *)
 
 (* Skipping instance `Control.Applicative.Applicative__ZipList' of class
    `GHC.Base.Applicative' *)
+
+(* Skipping all instances of class `GHC.Base.Alternative', including
+   `Control.Applicative.Alternative__ZipList' *)
+
+(* Skipping definition `Control.Applicative.optional' *)
 
 Instance Unpeel_WrappedArrow {a} {b} {c}
    : GHC.Prim.Unpeel (WrappedArrow a b c) (a b c) :=

--- a/base/Control/Arrow.v
+++ b/base/Control/Arrow.v
@@ -186,43 +186,6 @@ Definition arrow_second {b}{c}{d} (f : (b -> c)) : (d * b)%type -> (d * c)%type 
 
 (* Converted value declarations: *)
 
-Definition returnA {a} {b} `{Arrow a} : a b b :=
-  arr Control.Category.id.
-
-Definition op_zlzlzc__ {a} {c} {d} {b} `{Arrow a}
-   : a c d -> (b -> c) -> a b d :=
-  fun a f => a Control.Category.<<< arr f.
-
-Notation "'_<<^_'" := (op_zlzlzc__).
-
-Infix "<<^" := (_<<^_) (at level 99).
-
-Definition op_zgzgzc__ {a} {b} {c} {d} `{Arrow a}
-   : a b c -> (c -> d) -> a b d :=
-  fun a f => a Control.Category.>>> arr f.
-
-Notation "'_>>^_'" := (op_zgzgzc__).
-
-Infix ">>^" := (_>>^_) (at level 99).
-
-Definition op_zczlzl__ {a} {c} {d} {b} `{Arrow a}
-   : (c -> d) -> a b c -> a b d :=
-  fun f a => arr f Control.Category.<<< a.
-
-Notation "'_^<<_'" := (op_zczlzl__).
-
-Infix "^<<" := (_^<<_) (at level 99).
-
-Definition op_zczgzg__ {a} {b} {c} {d} `{Arrow a}
-   : (b -> c) -> a c d -> a b d :=
-  fun f a => arr f Control.Category.>>> a.
-
-Notation "'_^>>_'" := (op_zczgzg__).
-
-Infix "^>>" := (_^>>_) (at level 99).
-
-(* Skipping definition `Control.Arrow.leftApp' *)
-
 Local Definition Arrow__arrow_arr
    : forall {b} {c}, (b -> c) -> GHC.Prim.arrow b c :=
   fun {b} {c} => fun f => f.
@@ -265,11 +228,11 @@ Program Instance Arrow__arrow : Arrow GHC.Prim.arrow :=
            op_ztztzt____ := fun {b} {c} {b'} {c'} => Arrow__arrow_op_ztztzt__ ;
            second__ := fun {b} {c} {d} => Arrow__arrow_second |}.
 
-(* Skipping instance `Control.Arrow.Arrow__Kleisli' of class
-   `Control.Arrow.Arrow' *)
-
 (* Skipping instance `Control.Arrow.Category__Kleisli' of class
    `Control.Category.Category' *)
+
+(* Skipping instance `Control.Arrow.Arrow__Kleisli' of class
+   `Control.Arrow.Arrow' *)
 
 (* Skipping instance `Control.Arrow.ArrowZero__Kleisli' of class
    `Control.Arrow.ArrowZero' *)
@@ -277,14 +240,11 @@ Program Instance Arrow__arrow : Arrow GHC.Prim.arrow :=
 (* Skipping instance `Control.Arrow.ArrowPlus__Kleisli' of class
    `Control.Arrow.ArrowPlus' *)
 
-(* Skipping instance `Control.Arrow.ArrowChoice__Kleisli' of class
-   `Control.Arrow.ArrowChoice' *)
-
 (* Skipping instance `Control.Arrow.ArrowChoice__arrow' of class
    `Control.Arrow.ArrowChoice' *)
 
-(* Skipping instance `Control.Arrow.ArrowApply__Kleisli' of class
-   `Control.Arrow.ArrowApply' *)
+(* Skipping instance `Control.Arrow.ArrowChoice__Kleisli' of class
+   `Control.Arrow.ArrowChoice' *)
 
 Local Definition ArrowApply__arrow_app
    : forall {b} {c}, GHC.Prim.arrow (GHC.Prim.arrow b c * b)%type c :=
@@ -293,17 +253,8 @@ Local Definition ArrowApply__arrow_app
 Program Instance ArrowApply__arrow : ArrowApply GHC.Prim.arrow :=
   fun _ k__ => k__ {| app__ := fun {b} {c} => ArrowApply__arrow_app |}.
 
-(* Skipping all instances of class `GHC.Base.MonadPlus', including
-   `Control.Arrow.MonadPlus__ArrowMonad' *)
-
-(* Skipping all instances of class `GHC.Base.Alternative', including
-   `Control.Arrow.Alternative__ArrowMonad' *)
-
-(* Skipping instance `Control.Arrow.Monad__ArrowMonad' of class
-   `GHC.Base.Monad' *)
-
-(* Skipping instance `Control.Arrow.Applicative__ArrowMonad' of class
-   `GHC.Base.Applicative' *)
+(* Skipping instance `Control.Arrow.ArrowApply__Kleisli' of class
+   `Control.Arrow.ArrowApply' *)
 
 Local Definition Functor__ArrowMonad_fmap {inst_a} `{Arrow inst_a}
    : forall {a} {b}, (a -> b) -> (ArrowMonad inst_a) a -> (ArrowMonad inst_a) b :=
@@ -323,11 +274,60 @@ Program Instance Functor__ArrowMonad {a} `{Arrow a}
     k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__ArrowMonad_fmap ;
            GHC.Base.op_zlzd____ := fun {a} {b} => Functor__ArrowMonad_op_zlzd__ |}.
 
-(* Skipping instance `Control.Arrow.ArrowLoop__Kleisli' of class
-   `Control.Arrow.ArrowLoop' *)
+(* Skipping instance `Control.Arrow.Applicative__ArrowMonad' of class
+   `GHC.Base.Applicative' *)
+
+(* Skipping instance `Control.Arrow.Monad__ArrowMonad' of class
+   `GHC.Base.Monad' *)
+
+(* Skipping all instances of class `GHC.Base.Alternative', including
+   `Control.Arrow.Alternative__ArrowMonad' *)
+
+(* Skipping all instances of class `GHC.Base.MonadPlus', including
+   `Control.Arrow.MonadPlus__ArrowMonad' *)
 
 (* Skipping instance `Control.Arrow.ArrowLoop__arrow' of class
    `Control.Arrow.ArrowLoop' *)
+
+(* Skipping instance `Control.Arrow.ArrowLoop__Kleisli' of class
+   `Control.Arrow.ArrowLoop' *)
+
+Definition returnA {a} {b} `{Arrow a} : a b b :=
+  arr Control.Category.id.
+
+Definition op_zczgzg__ {a} {b} {c} {d} `{Arrow a}
+   : (b -> c) -> a c d -> a b d :=
+  fun f a => arr f Control.Category.>>> a.
+
+Notation "'_^>>_'" := (op_zczgzg__).
+
+Infix "^>>" := (_^>>_) (at level 99).
+
+Definition op_zgzgzc__ {a} {b} {c} {d} `{Arrow a}
+   : a b c -> (c -> d) -> a b d :=
+  fun a f => a Control.Category.>>> arr f.
+
+Notation "'_>>^_'" := (op_zgzgzc__).
+
+Infix ">>^" := (_>>^_) (at level 99).
+
+Definition op_zlzlzc__ {a} {c} {d} {b} `{Arrow a}
+   : a c d -> (b -> c) -> a b d :=
+  fun a f => a Control.Category.<<< arr f.
+
+Notation "'_<<^_'" := (op_zlzlzc__).
+
+Infix "<<^" := (_<<^_) (at level 99).
+
+Definition op_zczlzl__ {a} {c} {d} {b} `{Arrow a}
+   : (c -> d) -> a b c -> a b d :=
+  fun f a => arr f Control.Category.<<< a.
+
+Notation "'_^<<_'" := (op_zczlzl__).
+
+Infix "^<<" := (_^<<_) (at level 99).
+
+(* Skipping definition `Control.Arrow.leftApp' *)
 
 Module Notations.
 Notation "'_Control.Arrow.&&&_'" := (op_zazaza__).
@@ -340,14 +340,14 @@ Notation "'_Control.Arrow.+++_'" := (op_zpzpzp__).
 Infix "Control.Arrow.+++" := (_+++_) (at level 99).
 Notation "'_Control.Arrow.<+>_'" := (op_zlzpzg__).
 Infix "Control.Arrow.<+>" := (_<+>_) (at level 99).
-Notation "'_Control.Arrow.<<^_'" := (op_zlzlzc__).
-Infix "Control.Arrow.<<^" := (_<<^_) (at level 99).
-Notation "'_Control.Arrow.>>^_'" := (op_zgzgzc__).
-Infix "Control.Arrow.>>^" := (_>>^_) (at level 99).
-Notation "'_Control.Arrow.^<<_'" := (op_zczlzl__).
-Infix "Control.Arrow.^<<" := (_^<<_) (at level 99).
 Notation "'_Control.Arrow.^>>_'" := (op_zczgzg__).
 Infix "Control.Arrow.^>>" := (_^>>_) (at level 99).
+Notation "'_Control.Arrow.>>^_'" := (op_zgzgzc__).
+Infix "Control.Arrow.>>^" := (_>>^_) (at level 99).
+Notation "'_Control.Arrow.<<^_'" := (op_zlzlzc__).
+Infix "Control.Arrow.<<^" := (_<<^_) (at level 99).
+Notation "'_Control.Arrow.^<<_'" := (op_zczlzl__).
+Infix "Control.Arrow.^<<" := (_^<<_) (at level 99).
 End Notations.
 
 (* External variables:

--- a/base/Control/Category.v
+++ b/base/Control/Category.v
@@ -42,6 +42,28 @@ Infix "∘" := (_∘_) (left associativity, at level 40).
 
 (* Converted value declarations: *)
 
+Local Definition Category__arrow_id : forall {a}, GHC.Prim.arrow a a :=
+  fun {a} => GHC.Base.id.
+
+Local Definition Category__arrow_op_z2218U__
+   : forall {b} {c} {a},
+     GHC.Prim.arrow b c -> GHC.Prim.arrow a b -> GHC.Prim.arrow a c :=
+  fun {b} {c} {a} => _GHC.Base.∘_.
+
+Program Instance Category__arrow : Category GHC.Prim.arrow :=
+  fun _ k__ =>
+    k__ {| id__ := fun {a} => Category__arrow_id ;
+           op_z2218U____ := fun {b} {c} {a} => Category__arrow_op_z2218U__ |}.
+
+(* Skipping instance `Control.Category.Category__op_ZCz7eUZC__' of class
+   `Control.Category.Category' *)
+
+(* Skipping instance `Control.Category.Category__op_ZCz7eUz7eUZC__' of class
+   `Control.Category.Category' *)
+
+(* Skipping instance `Control.Category.Category__Coercion' of class
+   `Control.Category.Category' *)
+
 Definition op_zlzlzl__ {cat} {b} {c} {a} `{Category cat}
    : cat b c -> cat a b -> cat a c :=
   _∘_.
@@ -57,28 +79,6 @@ Definition op_zgzgzg__ {cat} {a} {b} {c} `{Category cat}
 Notation "'_>>>_'" := (op_zgzgzg__).
 
 Infix ">>>" := (_>>>_) (at level 99).
-
-(* Skipping instance `Control.Category.Category__Coercion' of class
-   `Control.Category.Category' *)
-
-(* Skipping instance `Control.Category.Category__op_ZCz7eUz7eUZC__' of class
-   `Control.Category.Category' *)
-
-(* Skipping instance `Control.Category.Category__op_ZCz7eUZC__' of class
-   `Control.Category.Category' *)
-
-Local Definition Category__arrow_id : forall {a}, GHC.Prim.arrow a a :=
-  fun {a} => GHC.Base.id.
-
-Local Definition Category__arrow_op_z2218U__
-   : forall {b} {c} {a},
-     GHC.Prim.arrow b c -> GHC.Prim.arrow a b -> GHC.Prim.arrow a c :=
-  fun {b} {c} {a} => _GHC.Base.∘_.
-
-Program Instance Category__arrow : Category GHC.Prim.arrow :=
-  fun _ k__ =>
-    k__ {| id__ := fun {a} => Category__arrow_id ;
-           op_z2218U____ := fun {b} {c} {a} => Category__arrow_op_z2218U__ |}.
 
 Module Notations.
 Notation "'_Control.Category.∘_'" := (op_z2218U__).

--- a/base/Control/Monad.v
+++ b/base/Control/Monad.v
@@ -29,30 +29,16 @@ Import GHC.Base.Notations.
 
 (* Converted value declarations: *)
 
-Definition zipWithM_ {m} {a} {b} {c} `{(GHC.Base.Applicative m)}
-   : (a -> b -> m c) -> list a -> list b -> m unit :=
-  fun f xs ys => Data.Foldable.sequenceA_ (GHC.List.zipWith f xs ys).
+(* Skipping definition `Control.Monad.guard' *)
 
-Definition zipWithM {m} {a} {b} {c} `{_ : GHC.Base.Applicative m}
-   : (a -> b -> m c) -> list a -> list b -> m (list c) :=
-  fun f xs ys =>
-    (@Data.Traversable.sequenceA _ _ _ _ m _ _ _ (GHC.List.zipWith f xs ys)).
-
-Definition unless {f} `{(GHC.Base.Applicative f)} : bool -> f unit -> f unit :=
-  fun p s => if p : bool then GHC.Base.pure tt else s.
-
-(* Skipping definition `Control.Monad.replicateM_' *)
-
-(* Skipping definition `Control.Monad.replicateM' *)
-
-Definition op_zlzdznzg__ {m} {a} {b} `{GHC.Base.Monad m}
-   : (a -> b) -> m a -> m b :=
-  fun f m =>
-    m GHC.Base.>>= (fun x => let z := f x in GHC.Prim.seq z (GHC.Base.return_ z)).
-
-Notation "'_<$!>_'" := (op_zlzdznzg__).
-
-Infix "<$!>" := (_<$!>_) (at level 99).
+Definition filterM {m} {a} `{(GHC.Base.Applicative m)}
+   : (a -> m bool) -> list a -> m (list a) :=
+  fun p =>
+    GHC.Base.foldr (fun x =>
+                      GHC.Base.liftA2 (fun flg =>
+                                         if flg : bool
+                                         then (fun arg_0__ => cons x arg_0__)
+                                         else GHC.Base.id) (p x)) (GHC.Base.pure nil).
 
 Definition op_zgzezg__ {m} {a} {b} {c} `{GHC.Base.Monad m}
    : (a -> m b) -> (b -> m c) -> (a -> m c) :=
@@ -70,41 +56,55 @@ Notation "'_<=<_'" := (op_zlzezl__).
 
 Infix "<=<" := (_<=<_) (at level 99).
 
-(* Skipping definition `Control.Monad.mfilter' *)
+(* Skipping definition `Control.Monad.forever' *)
 
 Definition mapAndUnzipM {m} {a} {b} {c} `{(GHC.Base.Applicative m)}
    : (a -> m (b * c)%type) -> list a -> m (list b * list c)%type :=
   fun f xs => GHC.List.unzip Data.Functor.<$> Data.Traversable.traverse f xs.
 
-(* Skipping definition `Control.Monad.guard' *)
+Definition zipWithM {m} {a} {b} {c} `{_ : GHC.Base.Applicative m}
+   : (a -> b -> m c) -> list a -> list b -> m (list c) :=
+  fun f xs ys =>
+    (@Data.Traversable.sequenceA _ _ _ _ m _ _ _ (GHC.List.zipWith f xs ys)).
 
-(* Skipping definition `Control.Monad.forever' *)
+Definition zipWithM_ {m} {a} {b} {c} `{(GHC.Base.Applicative m)}
+   : (a -> b -> m c) -> list a -> list b -> m unit :=
+  fun f xs ys => Data.Foldable.sequenceA_ (GHC.List.zipWith f xs ys).
+
+Definition foldM {t} {m} {b} {a} `{Data.Foldable.Foldable t} `{GHC.Base.Monad m}
+   : (b -> a -> m b) -> b -> t a -> m b :=
+  Data.Foldable.foldlM.
 
 Definition foldM_ {t} {m} {b} {a} `{Data.Foldable.Foldable t} `{GHC.Base.Monad
   m}
    : (b -> a -> m b) -> b -> t a -> m unit :=
   fun f a xs => Data.Foldable.foldlM f a xs GHC.Base.>> GHC.Base.return_ tt.
 
-Definition foldM {t} {m} {b} {a} `{Data.Foldable.Foldable t} `{GHC.Base.Monad m}
-   : (b -> a -> m b) -> b -> t a -> m b :=
-  Data.Foldable.foldlM.
+(* Skipping definition `Control.Monad.replicateM' *)
 
-Definition filterM {m} {a} `{(GHC.Base.Applicative m)}
-   : (a -> m bool) -> list a -> m (list a) :=
-  fun p =>
-    GHC.Base.foldr (fun x =>
-                      GHC.Base.liftA2 (fun flg =>
-                                         if flg : bool
-                                         then (fun arg_0__ => cons x arg_0__)
-                                         else GHC.Base.id) (p x)) (GHC.Base.pure nil).
+(* Skipping definition `Control.Monad.replicateM_' *)
+
+Definition unless {f} `{(GHC.Base.Applicative f)} : bool -> f unit -> f unit :=
+  fun p s => if p : bool then GHC.Base.pure tt else s.
+
+Definition op_zlzdznzg__ {m} {a} {b} `{GHC.Base.Monad m}
+   : (a -> b) -> m a -> m b :=
+  fun f m =>
+    m GHC.Base.>>= (fun x => let z := f x in GHC.Prim.seq z (GHC.Base.return_ z)).
+
+Notation "'_<$!>_'" := (op_zlzdznzg__).
+
+Infix "<$!>" := (_<$!>_) (at level 99).
+
+(* Skipping definition `Control.Monad.mfilter' *)
 
 Module Notations.
-Notation "'_Control.Monad.<$!>_'" := (op_zlzdznzg__).
-Infix "Control.Monad.<$!>" := (_<$!>_) (at level 99).
 Notation "'_Control.Monad.>=>_'" := (op_zgzezg__).
 Infix "Control.Monad.>=>" := (_>=>_) (at level 99).
 Notation "'_Control.Monad.<=<_'" := (op_zlzezl__).
 Infix "Control.Monad.<=<" := (_<=<_) (at level 99).
+Notation "'_Control.Monad.<$!>_'" := (op_zlzdznzg__).
+Infix "Control.Monad.<$!>" := (_<$!>_) (at level 99).
 End Notations.
 
 (* External variables:

--- a/base/Control/Monad/Fail.v
+++ b/base/Control/Monad/Fail.v
@@ -28,8 +28,12 @@ Definition fail `{g__0__ : MonadFail m} : forall {a}, GHC.Base.String -> m a :=
 
 (* Converted value declarations: *)
 
-(* Skipping instance `Control.Monad.Fail.MonadFail__IO' of class
-   `Control.Monad.Fail.MonadFail' *)
+Local Definition MonadFail__option_fail
+   : forall {a}, GHC.Base.String -> option a :=
+  fun {a} => fun arg_0__ => None.
+
+Program Instance MonadFail__option : MonadFail option :=
+  fun _ k__ => k__ {| fail__ := fun {a} => MonadFail__option_fail |}.
 
 Local Definition MonadFail__list_fail : forall {a}, GHC.Base.String -> list a :=
   fun {a} => fun arg_0__ => nil.
@@ -37,12 +41,8 @@ Local Definition MonadFail__list_fail : forall {a}, GHC.Base.String -> list a :=
 Program Instance MonadFail__list : MonadFail list :=
   fun _ k__ => k__ {| fail__ := fun {a} => MonadFail__list_fail |}.
 
-Local Definition MonadFail__option_fail
-   : forall {a}, GHC.Base.String -> option a :=
-  fun {a} => fun arg_0__ => None.
-
-Program Instance MonadFail__option : MonadFail option :=
-  fun _ k__ => k__ {| fail__ := fun {a} => MonadFail__option_fail |}.
+(* Skipping instance `Control.Monad.Fail.MonadFail__IO' of class
+   `Control.Monad.Fail.MonadFail' *)
 
 (* External variables:
      None Type list nil option GHC.Base.Monad GHC.Base.String

--- a/base/Control/Monad/Zip.v
+++ b/base/Control/Monad/Zip.v
@@ -47,45 +47,227 @@ Definition mzipWith `{g__0__ : MonadZip m}
 
 (* Converted value declarations: *)
 
-(* Skipping instance `Control.Monad.Zip.MonadZip__op_ZCztZC__' of class
-   `Control.Monad.Zip.MonadZip' *)
+Local Definition MonadZip__list_munzip
+   : forall {a} {b}, list (a * b)%type -> (list a * list b)%type :=
+  fun {a} {b} => GHC.List.unzip.
 
-(* Skipping instance `Control.Monad.Zip.MonadZip__M1' of class
-   `Control.Monad.Zip.MonadZip' *)
+Local Definition MonadZip__list_mzip
+   : forall {a} {b}, list a -> list b -> list (a * b)%type :=
+  fun {a} {b} => GHC.List.zip.
 
-(* Skipping instance `Control.Monad.Zip.MonadZip__Rec1' of class
-   `Control.Monad.Zip.MonadZip' *)
+Local Definition MonadZip__list_mzipWith
+   : forall {a} {b} {c}, (a -> b -> c) -> list a -> list b -> list c :=
+  fun {a} {b} {c} => GHC.List.zipWith.
 
-(* Skipping instance `Control.Monad.Zip.MonadZip__Par1' of class
-   `Control.Monad.Zip.MonadZip' *)
+Program Instance MonadZip__list : MonadZip list :=
+  fun _ k__ =>
+    k__ {| munzip__ := fun {a} {b} => MonadZip__list_munzip ;
+           mzip__ := fun {a} {b} => MonadZip__list_mzip ;
+           mzipWith__ := fun {a} {b} {c} => MonadZip__list_mzipWith |}.
 
-(* Skipping instance `Control.Monad.Zip.MonadZip__U1' of class
-   `Control.Monad.Zip.MonadZip' *)
-
-Local Definition MonadZip__Proxy_munzip
+Local Definition MonadZip__NonEmpty_munzip
    : forall {a} {b},
-     Data.Proxy.Proxy (a * b)%type ->
-     (Data.Proxy.Proxy a * Data.Proxy.Proxy b)%type :=
+     GHC.Base.NonEmpty (a * b)%type ->
+     (GHC.Base.NonEmpty a * GHC.Base.NonEmpty b)%type :=
+  fun {a} {b} => Data.List.NonEmpty.unzip.
+
+Local Definition MonadZip__NonEmpty_mzip
+   : forall {a} {b},
+     GHC.Base.NonEmpty a -> GHC.Base.NonEmpty b -> GHC.Base.NonEmpty (a * b)%type :=
+  fun {a} {b} => Data.List.NonEmpty.zip.
+
+Local Definition MonadZip__NonEmpty_mzipWith
+   : forall {a} {b} {c},
+     (a -> b -> c) ->
+     GHC.Base.NonEmpty a -> GHC.Base.NonEmpty b -> GHC.Base.NonEmpty c :=
+  fun {a} {b} {c} => Data.List.NonEmpty.zipWith.
+
+Program Instance MonadZip__NonEmpty : MonadZip GHC.Base.NonEmpty :=
+  fun _ k__ =>
+    k__ {| munzip__ := fun {a} {b} => MonadZip__NonEmpty_munzip ;
+           mzip__ := fun {a} {b} => MonadZip__NonEmpty_mzip ;
+           mzipWith__ := fun {a} {b} {c} => MonadZip__NonEmpty_mzipWith |}.
+
+Local Definition MonadZip__Identity_munzip
+   : forall {a} {b},
+     Data.Functor.Identity.Identity (a * b)%type ->
+     (Data.Functor.Identity.Identity a * Data.Functor.Identity.Identity b)%type :=
+  fun {a} {b} =>
+    fun '(Data.Functor.Identity.Mk_Identity (pair a b)) =>
+      pair (Data.Functor.Identity.Mk_Identity a) (Data.Functor.Identity.Mk_Identity
+            b).
+
+Local Definition MonadZip__Identity_mzipWith
+   : forall {a} {b} {c},
+     (a -> b -> c) ->
+     Data.Functor.Identity.Identity a ->
+     Data.Functor.Identity.Identity b -> Data.Functor.Identity.Identity c :=
+  fun {a} {b} {c} => GHC.Base.liftM2.
+
+Local Definition MonadZip__Identity_mzip
+   : forall {a} {b},
+     Data.Functor.Identity.Identity a ->
+     Data.Functor.Identity.Identity b ->
+     Data.Functor.Identity.Identity (a * b)%type :=
+  fun {a} {b} => MonadZip__Identity_mzipWith GHC.Tuple.pair2.
+
+Program Instance MonadZip__Identity : MonadZip Data.Functor.Identity.Identity :=
+  fun _ k__ =>
+    k__ {| munzip__ := fun {a} {b} => MonadZip__Identity_munzip ;
+           mzip__ := fun {a} {b} => MonadZip__Identity_mzip ;
+           mzipWith__ := fun {a} {b} {c} => MonadZip__Identity_mzipWith |}.
+
+Local Definition MonadZip__Dual_munzip
+   : forall {a} {b},
+     Data.SemigroupInternal.Dual (a * b)%type ->
+     (Data.SemigroupInternal.Dual a * Data.SemigroupInternal.Dual b)%type :=
   fun {a} {b} =>
     fun mab =>
       pair (GHC.Base.liftM Data.Tuple.fst mab) (GHC.Base.liftM Data.Tuple.snd mab).
 
-Local Definition MonadZip__Proxy_mzipWith
+Local Definition MonadZip__Dual_mzipWith
    : forall {a} {b} {c},
      (a -> b -> c) ->
-     Data.Proxy.Proxy a -> Data.Proxy.Proxy b -> Data.Proxy.Proxy c :=
-  fun {a} {b} {c} => fun arg_0__ arg_1__ arg_2__ => Data.Proxy.Mk_Proxy.
+     Data.SemigroupInternal.Dual a ->
+     Data.SemigroupInternal.Dual b -> Data.SemigroupInternal.Dual c :=
+  fun {a} {b} {c} => GHC.Base.liftM2.
 
-Local Definition MonadZip__Proxy_mzip
+Local Definition MonadZip__Dual_mzip
    : forall {a} {b},
-     Data.Proxy.Proxy a -> Data.Proxy.Proxy b -> Data.Proxy.Proxy (a * b)%type :=
-  fun {a} {b} => MonadZip__Proxy_mzipWith GHC.Tuple.pair2.
+     Data.SemigroupInternal.Dual a ->
+     Data.SemigroupInternal.Dual b -> Data.SemigroupInternal.Dual (a * b)%type :=
+  fun {a} {b} => MonadZip__Dual_mzipWith GHC.Tuple.pair2.
 
-Program Instance MonadZip__Proxy : MonadZip Data.Proxy.Proxy :=
+Program Instance MonadZip__Dual : MonadZip Data.SemigroupInternal.Dual :=
   fun _ k__ =>
-    k__ {| munzip__ := fun {a} {b} => MonadZip__Proxy_munzip ;
-           mzip__ := fun {a} {b} => MonadZip__Proxy_mzip ;
-           mzipWith__ := fun {a} {b} {c} => MonadZip__Proxy_mzipWith |}.
+    k__ {| munzip__ := fun {a} {b} => MonadZip__Dual_munzip ;
+           mzip__ := fun {a} {b} => MonadZip__Dual_mzip ;
+           mzipWith__ := fun {a} {b} {c} => MonadZip__Dual_mzipWith |}.
+
+Local Definition MonadZip__Sum_munzip
+   : forall {a} {b},
+     Data.SemigroupInternal.Sum (a * b)%type ->
+     (Data.SemigroupInternal.Sum a * Data.SemigroupInternal.Sum b)%type :=
+  fun {a} {b} =>
+    fun mab =>
+      pair (GHC.Base.liftM Data.Tuple.fst mab) (GHC.Base.liftM Data.Tuple.snd mab).
+
+Local Definition MonadZip__Sum_mzipWith
+   : forall {a} {b} {c},
+     (a -> b -> c) ->
+     Data.SemigroupInternal.Sum a ->
+     Data.SemigroupInternal.Sum b -> Data.SemigroupInternal.Sum c :=
+  fun {a} {b} {c} => GHC.Base.liftM2.
+
+Local Definition MonadZip__Sum_mzip
+   : forall {a} {b},
+     Data.SemigroupInternal.Sum a ->
+     Data.SemigroupInternal.Sum b -> Data.SemigroupInternal.Sum (a * b)%type :=
+  fun {a} {b} => MonadZip__Sum_mzipWith GHC.Tuple.pair2.
+
+Program Instance MonadZip__Sum : MonadZip Data.SemigroupInternal.Sum :=
+  fun _ k__ =>
+    k__ {| munzip__ := fun {a} {b} => MonadZip__Sum_munzip ;
+           mzip__ := fun {a} {b} => MonadZip__Sum_mzip ;
+           mzipWith__ := fun {a} {b} {c} => MonadZip__Sum_mzipWith |}.
+
+Local Definition MonadZip__Product_munzip
+   : forall {a} {b},
+     Data.SemigroupInternal.Product (a * b)%type ->
+     (Data.SemigroupInternal.Product a * Data.SemigroupInternal.Product b)%type :=
+  fun {a} {b} =>
+    fun mab =>
+      pair (GHC.Base.liftM Data.Tuple.fst mab) (GHC.Base.liftM Data.Tuple.snd mab).
+
+Local Definition MonadZip__Product_mzipWith
+   : forall {a} {b} {c},
+     (a -> b -> c) ->
+     Data.SemigroupInternal.Product a ->
+     Data.SemigroupInternal.Product b -> Data.SemigroupInternal.Product c :=
+  fun {a} {b} {c} => GHC.Base.liftM2.
+
+Local Definition MonadZip__Product_mzip
+   : forall {a} {b},
+     Data.SemigroupInternal.Product a ->
+     Data.SemigroupInternal.Product b ->
+     Data.SemigroupInternal.Product (a * b)%type :=
+  fun {a} {b} => MonadZip__Product_mzipWith GHC.Tuple.pair2.
+
+Program Instance MonadZip__Product : MonadZip Data.SemigroupInternal.Product :=
+  fun _ k__ =>
+    k__ {| munzip__ := fun {a} {b} => MonadZip__Product_munzip ;
+           mzip__ := fun {a} {b} => MonadZip__Product_mzip ;
+           mzipWith__ := fun {a} {b} {c} => MonadZip__Product_mzipWith |}.
+
+Local Definition MonadZip__option_munzip
+   : forall {a} {b}, option (a * b)%type -> (option a * option b)%type :=
+  fun {a} {b} =>
+    fun mab =>
+      pair (GHC.Base.liftM Data.Tuple.fst mab) (GHC.Base.liftM Data.Tuple.snd mab).
+
+Local Definition MonadZip__option_mzipWith
+   : forall {a} {b} {c}, (a -> b -> c) -> option a -> option b -> option c :=
+  fun {a} {b} {c} => GHC.Base.liftM2.
+
+Local Definition MonadZip__option_mzip
+   : forall {a} {b}, option a -> option b -> option (a * b)%type :=
+  fun {a} {b} => MonadZip__option_mzipWith GHC.Tuple.pair2.
+
+Program Instance MonadZip__option : MonadZip option :=
+  fun _ k__ =>
+    k__ {| munzip__ := fun {a} {b} => MonadZip__option_munzip ;
+           mzip__ := fun {a} {b} => MonadZip__option_mzip ;
+           mzipWith__ := fun {a} {b} {c} => MonadZip__option_mzipWith |}.
+
+Local Definition MonadZip__First_munzip
+   : forall {a} {b},
+     Data.Monoid.First (a * b)%type ->
+     (Data.Monoid.First a * Data.Monoid.First b)%type :=
+  fun {a} {b} =>
+    fun mab =>
+      pair (GHC.Base.liftM Data.Tuple.fst mab) (GHC.Base.liftM Data.Tuple.snd mab).
+
+Local Definition MonadZip__First_mzipWith
+   : forall {a} {b} {c},
+     (a -> b -> c) ->
+     Data.Monoid.First a -> Data.Monoid.First b -> Data.Monoid.First c :=
+  fun {a} {b} {c} => GHC.Base.liftM2.
+
+Local Definition MonadZip__First_mzip
+   : forall {a} {b},
+     Data.Monoid.First a -> Data.Monoid.First b -> Data.Monoid.First (a * b)%type :=
+  fun {a} {b} => MonadZip__First_mzipWith GHC.Tuple.pair2.
+
+Program Instance MonadZip__First : MonadZip Data.Monoid.First :=
+  fun _ k__ =>
+    k__ {| munzip__ := fun {a} {b} => MonadZip__First_munzip ;
+           mzip__ := fun {a} {b} => MonadZip__First_mzip ;
+           mzipWith__ := fun {a} {b} {c} => MonadZip__First_mzipWith |}.
+
+Local Definition MonadZip__Last_munzip
+   : forall {a} {b},
+     Data.Monoid.Last (a * b)%type ->
+     (Data.Monoid.Last a * Data.Monoid.Last b)%type :=
+  fun {a} {b} =>
+    fun mab =>
+      pair (GHC.Base.liftM Data.Tuple.fst mab) (GHC.Base.liftM Data.Tuple.snd mab).
+
+Local Definition MonadZip__Last_mzipWith
+   : forall {a} {b} {c},
+     (a -> b -> c) ->
+     Data.Monoid.Last a -> Data.Monoid.Last b -> Data.Monoid.Last c :=
+  fun {a} {b} {c} => GHC.Base.liftM2.
+
+Local Definition MonadZip__Last_mzip
+   : forall {a} {b},
+     Data.Monoid.Last a -> Data.Monoid.Last b -> Data.Monoid.Last (a * b)%type :=
+  fun {a} {b} => MonadZip__Last_mzipWith GHC.Tuple.pair2.
+
+Program Instance MonadZip__Last : MonadZip Data.Monoid.Last :=
+  fun _ k__ =>
+    k__ {| munzip__ := fun {a} {b} => MonadZip__Last_munzip ;
+           mzip__ := fun {a} {b} => MonadZip__Last_mzip ;
+           mzipWith__ := fun {a} {b} {c} => MonadZip__Last_mzipWith |}.
 
 Local Definition MonadZip__Alt_munzip {inst_f} `{MonadZip inst_f}
    : forall {a} {b},
@@ -123,227 +305,45 @@ Program Instance MonadZip__Alt {f} `{MonadZip f}
            mzip__ := fun {a} {b} => MonadZip__Alt_mzip ;
            mzipWith__ := fun {a} {b} {c} => MonadZip__Alt_mzipWith |}.
 
-Local Definition MonadZip__Last_munzip
+Local Definition MonadZip__Proxy_munzip
    : forall {a} {b},
-     Data.Monoid.Last (a * b)%type ->
-     (Data.Monoid.Last a * Data.Monoid.Last b)%type :=
+     Data.Proxy.Proxy (a * b)%type ->
+     (Data.Proxy.Proxy a * Data.Proxy.Proxy b)%type :=
   fun {a} {b} =>
     fun mab =>
       pair (GHC.Base.liftM Data.Tuple.fst mab) (GHC.Base.liftM Data.Tuple.snd mab).
 
-Local Definition MonadZip__Last_mzipWith
+Local Definition MonadZip__Proxy_mzipWith
    : forall {a} {b} {c},
      (a -> b -> c) ->
-     Data.Monoid.Last a -> Data.Monoid.Last b -> Data.Monoid.Last c :=
-  fun {a} {b} {c} => GHC.Base.liftM2.
+     Data.Proxy.Proxy a -> Data.Proxy.Proxy b -> Data.Proxy.Proxy c :=
+  fun {a} {b} {c} => fun arg_0__ arg_1__ arg_2__ => Data.Proxy.Mk_Proxy.
 
-Local Definition MonadZip__Last_mzip
+Local Definition MonadZip__Proxy_mzip
    : forall {a} {b},
-     Data.Monoid.Last a -> Data.Monoid.Last b -> Data.Monoid.Last (a * b)%type :=
-  fun {a} {b} => MonadZip__Last_mzipWith GHC.Tuple.pair2.
+     Data.Proxy.Proxy a -> Data.Proxy.Proxy b -> Data.Proxy.Proxy (a * b)%type :=
+  fun {a} {b} => MonadZip__Proxy_mzipWith GHC.Tuple.pair2.
 
-Program Instance MonadZip__Last : MonadZip Data.Monoid.Last :=
+Program Instance MonadZip__Proxy : MonadZip Data.Proxy.Proxy :=
   fun _ k__ =>
-    k__ {| munzip__ := fun {a} {b} => MonadZip__Last_munzip ;
-           mzip__ := fun {a} {b} => MonadZip__Last_mzip ;
-           mzipWith__ := fun {a} {b} {c} => MonadZip__Last_mzipWith |}.
+    k__ {| munzip__ := fun {a} {b} => MonadZip__Proxy_munzip ;
+           mzip__ := fun {a} {b} => MonadZip__Proxy_mzip ;
+           mzipWith__ := fun {a} {b} {c} => MonadZip__Proxy_mzipWith |}.
 
-Local Definition MonadZip__First_munzip
-   : forall {a} {b},
-     Data.Monoid.First (a * b)%type ->
-     (Data.Monoid.First a * Data.Monoid.First b)%type :=
-  fun {a} {b} =>
-    fun mab =>
-      pair (GHC.Base.liftM Data.Tuple.fst mab) (GHC.Base.liftM Data.Tuple.snd mab).
+(* Skipping instance `Control.Monad.Zip.MonadZip__U1' of class
+   `Control.Monad.Zip.MonadZip' *)
 
-Local Definition MonadZip__First_mzipWith
-   : forall {a} {b} {c},
-     (a -> b -> c) ->
-     Data.Monoid.First a -> Data.Monoid.First b -> Data.Monoid.First c :=
-  fun {a} {b} {c} => GHC.Base.liftM2.
+(* Skipping instance `Control.Monad.Zip.MonadZip__Par1' of class
+   `Control.Monad.Zip.MonadZip' *)
 
-Local Definition MonadZip__First_mzip
-   : forall {a} {b},
-     Data.Monoid.First a -> Data.Monoid.First b -> Data.Monoid.First (a * b)%type :=
-  fun {a} {b} => MonadZip__First_mzipWith GHC.Tuple.pair2.
+(* Skipping instance `Control.Monad.Zip.MonadZip__Rec1' of class
+   `Control.Monad.Zip.MonadZip' *)
 
-Program Instance MonadZip__First : MonadZip Data.Monoid.First :=
-  fun _ k__ =>
-    k__ {| munzip__ := fun {a} {b} => MonadZip__First_munzip ;
-           mzip__ := fun {a} {b} => MonadZip__First_mzip ;
-           mzipWith__ := fun {a} {b} {c} => MonadZip__First_mzipWith |}.
+(* Skipping instance `Control.Monad.Zip.MonadZip__M1' of class
+   `Control.Monad.Zip.MonadZip' *)
 
-Local Definition MonadZip__option_munzip
-   : forall {a} {b}, option (a * b)%type -> (option a * option b)%type :=
-  fun {a} {b} =>
-    fun mab =>
-      pair (GHC.Base.liftM Data.Tuple.fst mab) (GHC.Base.liftM Data.Tuple.snd mab).
-
-Local Definition MonadZip__option_mzipWith
-   : forall {a} {b} {c}, (a -> b -> c) -> option a -> option b -> option c :=
-  fun {a} {b} {c} => GHC.Base.liftM2.
-
-Local Definition MonadZip__option_mzip
-   : forall {a} {b}, option a -> option b -> option (a * b)%type :=
-  fun {a} {b} => MonadZip__option_mzipWith GHC.Tuple.pair2.
-
-Program Instance MonadZip__option : MonadZip option :=
-  fun _ k__ =>
-    k__ {| munzip__ := fun {a} {b} => MonadZip__option_munzip ;
-           mzip__ := fun {a} {b} => MonadZip__option_mzip ;
-           mzipWith__ := fun {a} {b} {c} => MonadZip__option_mzipWith |}.
-
-Local Definition MonadZip__Product_munzip
-   : forall {a} {b},
-     Data.SemigroupInternal.Product (a * b)%type ->
-     (Data.SemigroupInternal.Product a * Data.SemigroupInternal.Product b)%type :=
-  fun {a} {b} =>
-    fun mab =>
-      pair (GHC.Base.liftM Data.Tuple.fst mab) (GHC.Base.liftM Data.Tuple.snd mab).
-
-Local Definition MonadZip__Product_mzipWith
-   : forall {a} {b} {c},
-     (a -> b -> c) ->
-     Data.SemigroupInternal.Product a ->
-     Data.SemigroupInternal.Product b -> Data.SemigroupInternal.Product c :=
-  fun {a} {b} {c} => GHC.Base.liftM2.
-
-Local Definition MonadZip__Product_mzip
-   : forall {a} {b},
-     Data.SemigroupInternal.Product a ->
-     Data.SemigroupInternal.Product b ->
-     Data.SemigroupInternal.Product (a * b)%type :=
-  fun {a} {b} => MonadZip__Product_mzipWith GHC.Tuple.pair2.
-
-Program Instance MonadZip__Product : MonadZip Data.SemigroupInternal.Product :=
-  fun _ k__ =>
-    k__ {| munzip__ := fun {a} {b} => MonadZip__Product_munzip ;
-           mzip__ := fun {a} {b} => MonadZip__Product_mzip ;
-           mzipWith__ := fun {a} {b} {c} => MonadZip__Product_mzipWith |}.
-
-Local Definition MonadZip__Sum_munzip
-   : forall {a} {b},
-     Data.SemigroupInternal.Sum (a * b)%type ->
-     (Data.SemigroupInternal.Sum a * Data.SemigroupInternal.Sum b)%type :=
-  fun {a} {b} =>
-    fun mab =>
-      pair (GHC.Base.liftM Data.Tuple.fst mab) (GHC.Base.liftM Data.Tuple.snd mab).
-
-Local Definition MonadZip__Sum_mzipWith
-   : forall {a} {b} {c},
-     (a -> b -> c) ->
-     Data.SemigroupInternal.Sum a ->
-     Data.SemigroupInternal.Sum b -> Data.SemigroupInternal.Sum c :=
-  fun {a} {b} {c} => GHC.Base.liftM2.
-
-Local Definition MonadZip__Sum_mzip
-   : forall {a} {b},
-     Data.SemigroupInternal.Sum a ->
-     Data.SemigroupInternal.Sum b -> Data.SemigroupInternal.Sum (a * b)%type :=
-  fun {a} {b} => MonadZip__Sum_mzipWith GHC.Tuple.pair2.
-
-Program Instance MonadZip__Sum : MonadZip Data.SemigroupInternal.Sum :=
-  fun _ k__ =>
-    k__ {| munzip__ := fun {a} {b} => MonadZip__Sum_munzip ;
-           mzip__ := fun {a} {b} => MonadZip__Sum_mzip ;
-           mzipWith__ := fun {a} {b} {c} => MonadZip__Sum_mzipWith |}.
-
-Local Definition MonadZip__Dual_munzip
-   : forall {a} {b},
-     Data.SemigroupInternal.Dual (a * b)%type ->
-     (Data.SemigroupInternal.Dual a * Data.SemigroupInternal.Dual b)%type :=
-  fun {a} {b} =>
-    fun mab =>
-      pair (GHC.Base.liftM Data.Tuple.fst mab) (GHC.Base.liftM Data.Tuple.snd mab).
-
-Local Definition MonadZip__Dual_mzipWith
-   : forall {a} {b} {c},
-     (a -> b -> c) ->
-     Data.SemigroupInternal.Dual a ->
-     Data.SemigroupInternal.Dual b -> Data.SemigroupInternal.Dual c :=
-  fun {a} {b} {c} => GHC.Base.liftM2.
-
-Local Definition MonadZip__Dual_mzip
-   : forall {a} {b},
-     Data.SemigroupInternal.Dual a ->
-     Data.SemigroupInternal.Dual b -> Data.SemigroupInternal.Dual (a * b)%type :=
-  fun {a} {b} => MonadZip__Dual_mzipWith GHC.Tuple.pair2.
-
-Program Instance MonadZip__Dual : MonadZip Data.SemigroupInternal.Dual :=
-  fun _ k__ =>
-    k__ {| munzip__ := fun {a} {b} => MonadZip__Dual_munzip ;
-           mzip__ := fun {a} {b} => MonadZip__Dual_mzip ;
-           mzipWith__ := fun {a} {b} {c} => MonadZip__Dual_mzipWith |}.
-
-Local Definition MonadZip__Identity_munzip
-   : forall {a} {b},
-     Data.Functor.Identity.Identity (a * b)%type ->
-     (Data.Functor.Identity.Identity a * Data.Functor.Identity.Identity b)%type :=
-  fun {a} {b} =>
-    fun '(Data.Functor.Identity.Mk_Identity (pair a b)) =>
-      pair (Data.Functor.Identity.Mk_Identity a) (Data.Functor.Identity.Mk_Identity
-            b).
-
-Local Definition MonadZip__Identity_mzipWith
-   : forall {a} {b} {c},
-     (a -> b -> c) ->
-     Data.Functor.Identity.Identity a ->
-     Data.Functor.Identity.Identity b -> Data.Functor.Identity.Identity c :=
-  fun {a} {b} {c} => GHC.Base.liftM2.
-
-Local Definition MonadZip__Identity_mzip
-   : forall {a} {b},
-     Data.Functor.Identity.Identity a ->
-     Data.Functor.Identity.Identity b ->
-     Data.Functor.Identity.Identity (a * b)%type :=
-  fun {a} {b} => MonadZip__Identity_mzipWith GHC.Tuple.pair2.
-
-Program Instance MonadZip__Identity : MonadZip Data.Functor.Identity.Identity :=
-  fun _ k__ =>
-    k__ {| munzip__ := fun {a} {b} => MonadZip__Identity_munzip ;
-           mzip__ := fun {a} {b} => MonadZip__Identity_mzip ;
-           mzipWith__ := fun {a} {b} {c} => MonadZip__Identity_mzipWith |}.
-
-Local Definition MonadZip__NonEmpty_munzip
-   : forall {a} {b},
-     GHC.Base.NonEmpty (a * b)%type ->
-     (GHC.Base.NonEmpty a * GHC.Base.NonEmpty b)%type :=
-  fun {a} {b} => Data.List.NonEmpty.unzip.
-
-Local Definition MonadZip__NonEmpty_mzip
-   : forall {a} {b},
-     GHC.Base.NonEmpty a -> GHC.Base.NonEmpty b -> GHC.Base.NonEmpty (a * b)%type :=
-  fun {a} {b} => Data.List.NonEmpty.zip.
-
-Local Definition MonadZip__NonEmpty_mzipWith
-   : forall {a} {b} {c},
-     (a -> b -> c) ->
-     GHC.Base.NonEmpty a -> GHC.Base.NonEmpty b -> GHC.Base.NonEmpty c :=
-  fun {a} {b} {c} => Data.List.NonEmpty.zipWith.
-
-Program Instance MonadZip__NonEmpty : MonadZip GHC.Base.NonEmpty :=
-  fun _ k__ =>
-    k__ {| munzip__ := fun {a} {b} => MonadZip__NonEmpty_munzip ;
-           mzip__ := fun {a} {b} => MonadZip__NonEmpty_mzip ;
-           mzipWith__ := fun {a} {b} {c} => MonadZip__NonEmpty_mzipWith |}.
-
-Local Definition MonadZip__list_munzip
-   : forall {a} {b}, list (a * b)%type -> (list a * list b)%type :=
-  fun {a} {b} => GHC.List.unzip.
-
-Local Definition MonadZip__list_mzip
-   : forall {a} {b}, list a -> list b -> list (a * b)%type :=
-  fun {a} {b} => GHC.List.zip.
-
-Local Definition MonadZip__list_mzipWith
-   : forall {a} {b} {c}, (a -> b -> c) -> list a -> list b -> list c :=
-  fun {a} {b} {c} => GHC.List.zipWith.
-
-Program Instance MonadZip__list : MonadZip list :=
-  fun _ k__ =>
-    k__ {| munzip__ := fun {a} {b} => MonadZip__list_munzip ;
-           mzip__ := fun {a} {b} => MonadZip__list_mzip ;
-           mzipWith__ := fun {a} {b} {c} => MonadZip__list_mzipWith |}.
+(* Skipping instance `Control.Monad.Zip.MonadZip__op_ZCztZC__' of class
+   `Control.Monad.Zip.MonadZip' *)
 
 (* External variables:
      list op_zt__ option pair Data.Functor.Identity.Identity

--- a/base/Data/Bifoldable.v
+++ b/base/Data/Bifoldable.v
@@ -57,253 +57,247 @@ Definition bifoldr `{g__0__ : Bifoldable p}
 
 (* Converted value declarations: *)
 
-Definition bitraverse_ {t} {f} {a} {c} {b} {d} `{Bifoldable t}
-  `{GHC.Base.Applicative f}
-   : (a -> f c) -> (b -> f d) -> t a b -> f unit :=
-  fun f g =>
-    bifoldr (_GHC.Base.*>_ GHC.Base.∘ f) (_GHC.Base.*>_ GHC.Base.∘ g) (GHC.Base.pure
-                                                                       tt).
-
-Definition bisum {t} {a} `{Bifoldable t} `{GHC.Num.Num a} : t a a -> a :=
-  Coq.Program.Basics.compose Data.SemigroupInternal.getSum (bifoldMap
-                              Data.SemigroupInternal.Mk_Sum Data.SemigroupInternal.Mk_Sum).
-
-Definition bisequence_ {t} {f} {a} {b} `{Bifoldable t} `{GHC.Base.Applicative f}
-   : t (f a) (f b) -> f unit :=
-  bifoldr _GHC.Base.*>_ _GHC.Base.*>_ (GHC.Base.pure tt).
-
-Definition bisequenceA_ {t} {f} {a} {b} `{Bifoldable t} `{GHC.Base.Applicative
-  f}
-   : t (f a) (f b) -> f unit :=
-  bisequence_.
-
-Definition biproduct {t} {a} `{Bifoldable t} `{GHC.Num.Num a} : t a a -> a :=
-  Coq.Program.Basics.compose Data.SemigroupInternal.getProduct (bifoldMap
-                              Data.SemigroupInternal.Mk_Product Data.SemigroupInternal.Mk_Product).
-
-Definition bior {t} `{Bifoldable t} : t bool bool -> bool :=
-  Coq.Program.Basics.compose Data.SemigroupInternal.getAny (bifoldMap
-                              Data.SemigroupInternal.Mk_Any Data.SemigroupInternal.Mk_Any).
-
-Definition binull {t} {a} {b} `{Bifoldable t} : t a b -> bool :=
-  bifoldr (fun arg_0__ arg_1__ => false) (fun arg_2__ arg_3__ => false) true.
-
-(* Skipping definition `Data.Bifoldable.bimsum' *)
-
-(* Skipping definition `Data.Bifoldable.biminimumBy' *)
-
-(* Skipping definition `Data.Bifoldable.biminimum' *)
-
-(* Skipping definition `Data.Bifoldable.bimaximumBy' *)
-
-(* Skipping definition `Data.Bifoldable.bimaximum' *)
-
-Definition bimapM_ {t} {f} {a} {c} {b} {d} `{Bifoldable t}
-  `{GHC.Base.Applicative f}
-   : (a -> f c) -> (b -> f d) -> t a b -> f unit :=
-  bitraverse_.
-
-Definition bifor_ {t} {f} {a} {b} {c} {d} `{Bifoldable t} `{GHC.Base.Applicative
-  f}
-   : t a b -> (a -> f c) -> (b -> f d) -> f unit :=
-  fun t f g => bitraverse_ f g t.
-
-Definition biforM_ {t} {f} {a} {b} {c} {d} `{Bifoldable t}
-  `{GHC.Base.Applicative f}
-   : t a b -> (a -> f c) -> (b -> f d) -> f unit :=
-  bifor_.
-
-Definition bifoldrM {t} {m} {a} {c} {b} `{Bifoldable t} `{GHC.Base.Monad m}
-   : (a -> c -> m c) -> (b -> c -> m c) -> c -> t a b -> m c :=
-  fun f g z0 xs =>
-    let g' := fun k x z => g x z GHC.Base.>>= k in
-    let f' := fun k x z => f x z GHC.Base.>>= k in
-    bifoldl f' g' GHC.Base.return_ xs z0.
-
-(* Skipping definition `Data.Bifoldable.bifoldr1' *)
-
-Definition bifoldr' {t} {a} {c} {b} `{Bifoldable t}
-   : (a -> c -> c) -> (b -> c -> c) -> c -> t a b -> c :=
-  fun f g z0 xs =>
-    let g' := fun k x z => k (g x z) in
-    let f' := fun k x z => k (f x z) in bifoldl f' g' GHC.Base.id xs z0.
-
-Definition bifoldlM {t} {m} {a} {b} {c} `{Bifoldable t} `{GHC.Base.Monad m}
-   : (a -> b -> m a) -> (a -> c -> m a) -> a -> t b c -> m a :=
-  fun f g z0 xs =>
-    let g' := fun x k z => g z x GHC.Base.>>= k in
-    let f' := fun x k z => f z x GHC.Base.>>= k in
-    bifoldr f' g' GHC.Base.return_ xs z0.
-
-(* Skipping definition `Data.Bifoldable.bifoldl1' *)
-
-Definition bifoldl' {t} {a} {b} {c} `{Bifoldable t}
-   : (a -> b -> a) -> (a -> c -> a) -> a -> t b c -> a :=
-  fun f g z0 xs =>
-    let g' := fun x k z => k (g z x) in
-    let f' := fun x k z => k (f z x) in bifoldr f' g' GHC.Base.id xs z0.
-
-Definition bilength {t} {a} {b} `{Bifoldable t} : t a b -> GHC.Num.Int :=
-  bifoldl' (fun arg_0__ arg_1__ =>
-              match arg_0__, arg_1__ with
-              | c, _ => c GHC.Num.+ #1
-              end) (fun arg_4__ arg_5__ =>
-                      match arg_4__, arg_5__ with
-                      | c, _ => c GHC.Num.+ #1
-                      end) #0.
-
-Definition bifind {t} {a} `{Bifoldable t} : (a -> bool) -> t a a -> option a :=
-  fun p =>
-    let finder :=
-      fun x => Data.Monoid.Mk_First (if p x : bool then Some x else None) in
-    Data.Monoid.getFirst GHC.Base.∘ bifoldMap finder finder.
-
-Definition biconcatMap {t} {a} {c} {b} `{Bifoldable t}
-   : (a -> list c) -> (b -> list c) -> t a b -> list c :=
-  bifoldMap.
-
-Definition biconcat {t} {a} `{Bifoldable t} : t (list a) (list a) -> list a :=
-  bifold.
-
-(* Skipping definition `Data.Bifoldable.biasum' *)
-
-Definition biany {t} {a} {b} `{Bifoldable t}
-   : (a -> bool) -> (b -> bool) -> t a b -> bool :=
-  fun p q =>
-    Coq.Program.Basics.compose Data.SemigroupInternal.getAny (bifoldMap
-                                (Data.SemigroupInternal.Mk_Any GHC.Base.∘ p) (Data.SemigroupInternal.Mk_Any
-                                 GHC.Base.∘
-                                 q)).
-
-Definition bielem {t} {a} `{Bifoldable t} `{GHC.Base.Eq_ a}
-   : a -> t a a -> bool :=
-  fun x =>
-    biany (fun arg_0__ => arg_0__ GHC.Base.== x) (fun arg_1__ =>
-                                                    arg_1__ GHC.Base.== x).
-
-Definition binotElem {t} {a} `{Bifoldable t} `{GHC.Base.Eq_ a}
-   : a -> t a a -> bool :=
-  fun x => negb GHC.Base.∘ bielem x.
-
-Definition biand {t} `{Bifoldable t} : t bool bool -> bool :=
-  Coq.Program.Basics.compose Data.SemigroupInternal.getAll (bifoldMap
-                              Data.SemigroupInternal.Mk_All Data.SemigroupInternal.Mk_All).
-
-Definition biall {t} {a} {b} `{Bifoldable t}
-   : (a -> bool) -> (b -> bool) -> t a b -> bool :=
-  fun p q =>
-    Coq.Program.Basics.compose Data.SemigroupInternal.getAll (bifoldMap
-                                (Data.SemigroupInternal.Mk_All GHC.Base.∘ p) (Data.SemigroupInternal.Mk_All
-                                 GHC.Base.∘
-                                 q)).
-
-Definition biList {t} {a} `{Bifoldable t} : t a a -> list a :=
-  bifoldr cons cons nil.
-
-Local Definition Bifoldable__Either_bifoldMap
+Local Definition Bifoldable__pair_type_bifoldMap
    : forall {m} {a} {b},
      forall `{GHC.Base.Monoid m},
-     (a -> m) -> (b -> m) -> Data.Either.Either a b -> m :=
+     (a -> m) -> (b -> m) -> GHC.Tuple.pair_type a b -> m :=
   fun {m} {a} {b} `{GHC.Base.Monoid m} =>
     fun arg_0__ arg_1__ arg_2__ =>
       match arg_0__, arg_1__, arg_2__ with
-      | f, _, Data.Either.Left a => f a
-      | _, g, Data.Either.Right b => g b
+      | f, g, pair a b => GHC.Base.mappend (f a) (g b)
       end.
 
-Local Definition Bifoldable__Either_bifold
-   : forall {m}, forall `{GHC.Base.Monoid m}, Data.Either.Either m m -> m :=
+Local Definition Bifoldable__pair_type_bifold
+   : forall {m}, forall `{GHC.Base.Monoid m}, GHC.Tuple.pair_type m m -> m :=
   fun {m} `{GHC.Base.Monoid m} =>
-    Bifoldable__Either_bifoldMap GHC.Base.id GHC.Base.id.
+    Bifoldable__pair_type_bifoldMap GHC.Base.id GHC.Base.id.
 
-Local Definition Bifoldable__Either_bifoldl
+Local Definition Bifoldable__pair_type_bifoldl
    : forall {c} {a} {b},
-     (c -> a -> c) -> (c -> b -> c) -> c -> Data.Either.Either a b -> c :=
+     (c -> a -> c) -> (c -> b -> c) -> c -> GHC.Tuple.pair_type a b -> c :=
   fun {c} {a} {b} =>
     fun f g z t =>
       Data.SemigroupInternal.appEndo (Data.SemigroupInternal.getDual
-                                      (Bifoldable__Either_bifoldMap (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
-                                                                     (Data.SemigroupInternal.Mk_Endo GHC.Base.∘
-                                                                      GHC.Base.flip f)) (Data.SemigroupInternal.Mk_Dual
-                                                                                         GHC.Base.∘
-                                                                                         (Data.SemigroupInternal.Mk_Endo
-                                                                                          GHC.Base.∘
-                                                                                          GHC.Base.flip g)) t)) z.
-
-Local Definition Bifoldable__Either_bifoldr
-   : forall {a} {c} {b},
-     (a -> c -> c) -> (b -> c -> c) -> c -> Data.Either.Either a b -> c :=
-  fun {a} {c} {b} =>
-    fun f g z t =>
-      Data.SemigroupInternal.appEndo (Bifoldable__Either_bifoldMap
-                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo f)
-                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo g) t) z.
-
-Program Instance Bifoldable__Either : Bifoldable Data.Either.Either :=
-  fun _ k__ =>
-    k__ {| bifold__ := fun {m} `{GHC.Base.Monoid m} => Bifoldable__Either_bifold ;
-           bifoldMap__ := fun {m} {a} {b} `{GHC.Base.Monoid m} =>
-             Bifoldable__Either_bifoldMap ;
-           bifoldl__ := fun {c} {a} {b} => Bifoldable__Either_bifoldl ;
-           bifoldr__ := fun {a} {c} {b} => Bifoldable__Either_bifoldr |}.
-
-Local Definition Bifoldable__sept_type_bifoldMap {inst_x} {inst_y} {inst_z}
-  {inst_w} {inst_v}
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monoid m},
-     (a -> m) ->
-     (b -> m) -> (GHC.Tuple.sept_type inst_x inst_y inst_z inst_w inst_v) a b -> m :=
-  fun {m} {a} {b} `{GHC.Base.Monoid m} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | f, g, pair (pair (pair (pair (pair (pair _ _) _) _) _) a) b =>
-          GHC.Base.mappend (f a) (g b)
-      end.
-
-Local Definition Bifoldable__sept_type_bifold {inst_x} {inst_y} {inst_z}
-  {inst_w} {inst_v}
-   : forall {m},
-     forall `{GHC.Base.Monoid m},
-     (GHC.Tuple.sept_type inst_x inst_y inst_z inst_w inst_v) m m -> m :=
-  fun {m} `{GHC.Base.Monoid m} =>
-    Bifoldable__sept_type_bifoldMap GHC.Base.id GHC.Base.id.
-
-Local Definition Bifoldable__sept_type_bifoldl {inst_x} {inst_y} {inst_z}
-  {inst_w} {inst_v}
-   : forall {c} {a} {b},
-     (c -> a -> c) ->
-     (c -> b -> c) ->
-     c -> (GHC.Tuple.sept_type inst_x inst_y inst_z inst_w inst_v) a b -> c :=
-  fun {c} {a} {b} =>
-    fun f g z t =>
-      Data.SemigroupInternal.appEndo (Data.SemigroupInternal.getDual
-                                      (Bifoldable__sept_type_bifoldMap (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
+                                      (Bifoldable__pair_type_bifoldMap (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
                                                                         (Data.SemigroupInternal.Mk_Endo GHC.Base.∘
                                                                          GHC.Base.flip f))
                                        (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
                                         (Data.SemigroupInternal.Mk_Endo GHC.Base.∘ GHC.Base.flip g)) t)) z.
 
-Local Definition Bifoldable__sept_type_bifoldr {inst_x} {inst_y} {inst_z}
-  {inst_w} {inst_v}
+Local Definition Bifoldable__pair_type_bifoldr
    : forall {a} {c} {b},
-     (a -> c -> c) ->
-     (b -> c -> c) ->
-     c -> (GHC.Tuple.sept_type inst_x inst_y inst_z inst_w inst_v) a b -> c :=
+     (a -> c -> c) -> (b -> c -> c) -> c -> GHC.Tuple.pair_type a b -> c :=
   fun {a} {c} {b} =>
     fun f g z t =>
-      Data.SemigroupInternal.appEndo (Bifoldable__sept_type_bifoldMap
+      Data.SemigroupInternal.appEndo (Bifoldable__pair_type_bifoldMap
                                       (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo f)
                                       (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo g) t) z.
 
-Program Instance Bifoldable__sept_type {x} {y} {z} {w} {v}
-   : Bifoldable (GHC.Tuple.sept_type x y z w v) :=
+Program Instance Bifoldable__pair_type : Bifoldable GHC.Tuple.pair_type :=
   fun _ k__ =>
     k__ {| bifold__ := fun {m} `{GHC.Base.Monoid m} =>
-             Bifoldable__sept_type_bifold ;
+             Bifoldable__pair_type_bifold ;
            bifoldMap__ := fun {m} {a} {b} `{GHC.Base.Monoid m} =>
-             Bifoldable__sept_type_bifoldMap ;
-           bifoldl__ := fun {c} {a} {b} => Bifoldable__sept_type_bifoldl ;
-           bifoldr__ := fun {a} {c} {b} => Bifoldable__sept_type_bifoldr |}.
+             Bifoldable__pair_type_bifoldMap ;
+           bifoldl__ := fun {c} {a} {b} => Bifoldable__pair_type_bifoldl ;
+           bifoldr__ := fun {a} {c} {b} => Bifoldable__pair_type_bifoldr |}.
+
+Local Definition Bifoldable__Const_bifoldMap
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monoid m},
+     (a -> m) -> (b -> m) -> Data.Functor.Const.Const a b -> m :=
+  fun {m} {a} {b} `{GHC.Base.Monoid m} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | f, _, Data.Functor.Const.Mk_Const a => f a
+      end.
+
+Local Definition Bifoldable__Const_bifold
+   : forall {m}, forall `{GHC.Base.Monoid m}, Data.Functor.Const.Const m m -> m :=
+  fun {m} `{GHC.Base.Monoid m} =>
+    Bifoldable__Const_bifoldMap GHC.Base.id GHC.Base.id.
+
+Local Definition Bifoldable__Const_bifoldl
+   : forall {c} {a} {b},
+     (c -> a -> c) -> (c -> b -> c) -> c -> Data.Functor.Const.Const a b -> c :=
+  fun {c} {a} {b} =>
+    fun f g z t =>
+      Data.SemigroupInternal.appEndo (Data.SemigroupInternal.getDual
+                                      (Bifoldable__Const_bifoldMap (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
+                                                                    (Data.SemigroupInternal.Mk_Endo GHC.Base.∘
+                                                                     GHC.Base.flip f)) (Data.SemigroupInternal.Mk_Dual
+                                                                                        GHC.Base.∘
+                                                                                        (Data.SemigroupInternal.Mk_Endo
+                                                                                         GHC.Base.∘
+                                                                                         GHC.Base.flip g)) t)) z.
+
+Local Definition Bifoldable__Const_bifoldr
+   : forall {a} {c} {b},
+     (a -> c -> c) -> (b -> c -> c) -> c -> Data.Functor.Const.Const a b -> c :=
+  fun {a} {c} {b} =>
+    fun f g z t =>
+      Data.SemigroupInternal.appEndo (Bifoldable__Const_bifoldMap
+                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo f)
+                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo g) t) z.
+
+Program Instance Bifoldable__Const : Bifoldable Data.Functor.Const.Const :=
+  fun _ k__ =>
+    k__ {| bifold__ := fun {m} `{GHC.Base.Monoid m} => Bifoldable__Const_bifold ;
+           bifoldMap__ := fun {m} {a} {b} `{GHC.Base.Monoid m} =>
+             Bifoldable__Const_bifoldMap ;
+           bifoldl__ := fun {c} {a} {b} => Bifoldable__Const_bifoldl ;
+           bifoldr__ := fun {a} {c} {b} => Bifoldable__Const_bifoldr |}.
+
+(* Skipping instance `Data.Bifoldable.Bifoldable__K1' of class
+   `Data.Bifoldable.Bifoldable' *)
+
+Local Definition Bifoldable__triple_type_bifoldMap {inst_x}
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monoid m},
+     (a -> m) -> (b -> m) -> (GHC.Tuple.triple_type inst_x) a b -> m :=
+  fun {m} {a} {b} `{GHC.Base.Monoid m} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | f, g, pair (pair _ a) b => GHC.Base.mappend (f a) (g b)
+      end.
+
+Local Definition Bifoldable__triple_type_bifold {inst_x}
+   : forall {m},
+     forall `{GHC.Base.Monoid m}, (GHC.Tuple.triple_type inst_x) m m -> m :=
+  fun {m} `{GHC.Base.Monoid m} =>
+    Bifoldable__triple_type_bifoldMap GHC.Base.id GHC.Base.id.
+
+Local Definition Bifoldable__triple_type_bifoldl {inst_x}
+   : forall {c} {a} {b},
+     (c -> a -> c) ->
+     (c -> b -> c) -> c -> (GHC.Tuple.triple_type inst_x) a b -> c :=
+  fun {c} {a} {b} =>
+    fun f g z t =>
+      Data.SemigroupInternal.appEndo (Data.SemigroupInternal.getDual
+                                      (Bifoldable__triple_type_bifoldMap (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
+                                                                          (Data.SemigroupInternal.Mk_Endo GHC.Base.∘
+                                                                           GHC.Base.flip f))
+                                       (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
+                                        (Data.SemigroupInternal.Mk_Endo GHC.Base.∘ GHC.Base.flip g)) t)) z.
+
+Local Definition Bifoldable__triple_type_bifoldr {inst_x}
+   : forall {a} {c} {b},
+     (a -> c -> c) ->
+     (b -> c -> c) -> c -> (GHC.Tuple.triple_type inst_x) a b -> c :=
+  fun {a} {c} {b} =>
+    fun f g z t =>
+      Data.SemigroupInternal.appEndo (Bifoldable__triple_type_bifoldMap
+                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo f)
+                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo g) t) z.
+
+Program Instance Bifoldable__triple_type {x}
+   : Bifoldable (GHC.Tuple.triple_type x) :=
+  fun _ k__ =>
+    k__ {| bifold__ := fun {m} `{GHC.Base.Monoid m} =>
+             Bifoldable__triple_type_bifold ;
+           bifoldMap__ := fun {m} {a} {b} `{GHC.Base.Monoid m} =>
+             Bifoldable__triple_type_bifoldMap ;
+           bifoldl__ := fun {c} {a} {b} => Bifoldable__triple_type_bifoldl ;
+           bifoldr__ := fun {a} {c} {b} => Bifoldable__triple_type_bifoldr |}.
+
+Local Definition Bifoldable__quad_type_bifoldMap {inst_x} {inst_y}
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monoid m},
+     (a -> m) -> (b -> m) -> (GHC.Tuple.quad_type inst_x inst_y) a b -> m :=
+  fun {m} {a} {b} `{GHC.Base.Monoid m} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | f, g, pair (pair (pair _ _) a) b => GHC.Base.mappend (f a) (g b)
+      end.
+
+Local Definition Bifoldable__quad_type_bifold {inst_x} {inst_y}
+   : forall {m},
+     forall `{GHC.Base.Monoid m}, (GHC.Tuple.quad_type inst_x inst_y) m m -> m :=
+  fun {m} `{GHC.Base.Monoid m} =>
+    Bifoldable__quad_type_bifoldMap GHC.Base.id GHC.Base.id.
+
+Local Definition Bifoldable__quad_type_bifoldl {inst_x} {inst_y}
+   : forall {c} {a} {b},
+     (c -> a -> c) ->
+     (c -> b -> c) -> c -> (GHC.Tuple.quad_type inst_x inst_y) a b -> c :=
+  fun {c} {a} {b} =>
+    fun f g z t =>
+      Data.SemigroupInternal.appEndo (Data.SemigroupInternal.getDual
+                                      (Bifoldable__quad_type_bifoldMap (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
+                                                                        (Data.SemigroupInternal.Mk_Endo GHC.Base.∘
+                                                                         GHC.Base.flip f))
+                                       (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
+                                        (Data.SemigroupInternal.Mk_Endo GHC.Base.∘ GHC.Base.flip g)) t)) z.
+
+Local Definition Bifoldable__quad_type_bifoldr {inst_x} {inst_y}
+   : forall {a} {c} {b},
+     (a -> c -> c) ->
+     (b -> c -> c) -> c -> (GHC.Tuple.quad_type inst_x inst_y) a b -> c :=
+  fun {a} {c} {b} =>
+    fun f g z t =>
+      Data.SemigroupInternal.appEndo (Bifoldable__quad_type_bifoldMap
+                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo f)
+                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo g) t) z.
+
+Program Instance Bifoldable__quad_type {x} {y}
+   : Bifoldable (GHC.Tuple.quad_type x y) :=
+  fun _ k__ =>
+    k__ {| bifold__ := fun {m} `{GHC.Base.Monoid m} =>
+             Bifoldable__quad_type_bifold ;
+           bifoldMap__ := fun {m} {a} {b} `{GHC.Base.Monoid m} =>
+             Bifoldable__quad_type_bifoldMap ;
+           bifoldl__ := fun {c} {a} {b} => Bifoldable__quad_type_bifoldl ;
+           bifoldr__ := fun {a} {c} {b} => Bifoldable__quad_type_bifoldr |}.
+
+Local Definition Bifoldable__quint_type_bifoldMap {inst_x} {inst_y} {inst_z}
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monoid m},
+     (a -> m) -> (b -> m) -> (GHC.Tuple.quint_type inst_x inst_y inst_z) a b -> m :=
+  fun {m} {a} {b} `{GHC.Base.Monoid m} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | f, g, pair (pair (pair (pair _ _) _) a) b => GHC.Base.mappend (f a) (g b)
+      end.
+
+Local Definition Bifoldable__quint_type_bifold {inst_x} {inst_y} {inst_z}
+   : forall {m},
+     forall `{GHC.Base.Monoid m},
+     (GHC.Tuple.quint_type inst_x inst_y inst_z) m m -> m :=
+  fun {m} `{GHC.Base.Monoid m} =>
+    Bifoldable__quint_type_bifoldMap GHC.Base.id GHC.Base.id.
+
+Local Definition Bifoldable__quint_type_bifoldl {inst_x} {inst_y} {inst_z}
+   : forall {c} {a} {b},
+     (c -> a -> c) ->
+     (c -> b -> c) -> c -> (GHC.Tuple.quint_type inst_x inst_y inst_z) a b -> c :=
+  fun {c} {a} {b} =>
+    fun f g z t =>
+      Data.SemigroupInternal.appEndo (Data.SemigroupInternal.getDual
+                                      (Bifoldable__quint_type_bifoldMap (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
+                                                                         (Data.SemigroupInternal.Mk_Endo GHC.Base.∘
+                                                                          GHC.Base.flip f))
+                                       (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
+                                        (Data.SemigroupInternal.Mk_Endo GHC.Base.∘ GHC.Base.flip g)) t)) z.
+
+Local Definition Bifoldable__quint_type_bifoldr {inst_x} {inst_y} {inst_z}
+   : forall {a} {c} {b},
+     (a -> c -> c) ->
+     (b -> c -> c) -> c -> (GHC.Tuple.quint_type inst_x inst_y inst_z) a b -> c :=
+  fun {a} {c} {b} =>
+    fun f g z t =>
+      Data.SemigroupInternal.appEndo (Bifoldable__quint_type_bifoldMap
+                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo f)
+                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo g) t) z.
+
+Program Instance Bifoldable__quint_type {x} {y} {z}
+   : Bifoldable (GHC.Tuple.quint_type x y z) :=
+  fun _ k__ =>
+    k__ {| bifold__ := fun {m} `{GHC.Base.Monoid m} =>
+             Bifoldable__quint_type_bifold ;
+           bifoldMap__ := fun {m} {a} {b} `{GHC.Base.Monoid m} =>
+             Bifoldable__quint_type_bifoldMap ;
+           bifoldl__ := fun {c} {a} {b} => Bifoldable__quint_type_bifoldl ;
+           bifoldr__ := fun {a} {c} {b} => Bifoldable__quint_type_bifoldr |}.
 
 Local Definition Bifoldable__sext_type_bifoldMap {inst_x} {inst_y} {inst_z}
   {inst_w}
@@ -363,247 +357,253 @@ Program Instance Bifoldable__sext_type {x} {y} {z} {w}
            bifoldl__ := fun {c} {a} {b} => Bifoldable__sext_type_bifoldl ;
            bifoldr__ := fun {a} {c} {b} => Bifoldable__sext_type_bifoldr |}.
 
-Local Definition Bifoldable__quint_type_bifoldMap {inst_x} {inst_y} {inst_z}
+Local Definition Bifoldable__sept_type_bifoldMap {inst_x} {inst_y} {inst_z}
+  {inst_w} {inst_v}
    : forall {m} {a} {b},
      forall `{GHC.Base.Monoid m},
-     (a -> m) -> (b -> m) -> (GHC.Tuple.quint_type inst_x inst_y inst_z) a b -> m :=
+     (a -> m) ->
+     (b -> m) -> (GHC.Tuple.sept_type inst_x inst_y inst_z inst_w inst_v) a b -> m :=
   fun {m} {a} {b} `{GHC.Base.Monoid m} =>
     fun arg_0__ arg_1__ arg_2__ =>
       match arg_0__, arg_1__, arg_2__ with
-      | f, g, pair (pair (pair (pair _ _) _) a) b => GHC.Base.mappend (f a) (g b)
+      | f, g, pair (pair (pair (pair (pair (pair _ _) _) _) _) a) b =>
+          GHC.Base.mappend (f a) (g b)
       end.
 
-Local Definition Bifoldable__quint_type_bifold {inst_x} {inst_y} {inst_z}
+Local Definition Bifoldable__sept_type_bifold {inst_x} {inst_y} {inst_z}
+  {inst_w} {inst_v}
    : forall {m},
      forall `{GHC.Base.Monoid m},
-     (GHC.Tuple.quint_type inst_x inst_y inst_z) m m -> m :=
+     (GHC.Tuple.sept_type inst_x inst_y inst_z inst_w inst_v) m m -> m :=
   fun {m} `{GHC.Base.Monoid m} =>
-    Bifoldable__quint_type_bifoldMap GHC.Base.id GHC.Base.id.
+    Bifoldable__sept_type_bifoldMap GHC.Base.id GHC.Base.id.
 
-Local Definition Bifoldable__quint_type_bifoldl {inst_x} {inst_y} {inst_z}
+Local Definition Bifoldable__sept_type_bifoldl {inst_x} {inst_y} {inst_z}
+  {inst_w} {inst_v}
    : forall {c} {a} {b},
      (c -> a -> c) ->
-     (c -> b -> c) -> c -> (GHC.Tuple.quint_type inst_x inst_y inst_z) a b -> c :=
+     (c -> b -> c) ->
+     c -> (GHC.Tuple.sept_type inst_x inst_y inst_z inst_w inst_v) a b -> c :=
   fun {c} {a} {b} =>
     fun f g z t =>
       Data.SemigroupInternal.appEndo (Data.SemigroupInternal.getDual
-                                      (Bifoldable__quint_type_bifoldMap (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
-                                                                         (Data.SemigroupInternal.Mk_Endo GHC.Base.∘
-                                                                          GHC.Base.flip f))
-                                       (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
-                                        (Data.SemigroupInternal.Mk_Endo GHC.Base.∘ GHC.Base.flip g)) t)) z.
-
-Local Definition Bifoldable__quint_type_bifoldr {inst_x} {inst_y} {inst_z}
-   : forall {a} {c} {b},
-     (a -> c -> c) ->
-     (b -> c -> c) -> c -> (GHC.Tuple.quint_type inst_x inst_y inst_z) a b -> c :=
-  fun {a} {c} {b} =>
-    fun f g z t =>
-      Data.SemigroupInternal.appEndo (Bifoldable__quint_type_bifoldMap
-                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo f)
-                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo g) t) z.
-
-Program Instance Bifoldable__quint_type {x} {y} {z}
-   : Bifoldable (GHC.Tuple.quint_type x y z) :=
-  fun _ k__ =>
-    k__ {| bifold__ := fun {m} `{GHC.Base.Monoid m} =>
-             Bifoldable__quint_type_bifold ;
-           bifoldMap__ := fun {m} {a} {b} `{GHC.Base.Monoid m} =>
-             Bifoldable__quint_type_bifoldMap ;
-           bifoldl__ := fun {c} {a} {b} => Bifoldable__quint_type_bifoldl ;
-           bifoldr__ := fun {a} {c} {b} => Bifoldable__quint_type_bifoldr |}.
-
-Local Definition Bifoldable__quad_type_bifoldMap {inst_x} {inst_y}
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monoid m},
-     (a -> m) -> (b -> m) -> (GHC.Tuple.quad_type inst_x inst_y) a b -> m :=
-  fun {m} {a} {b} `{GHC.Base.Monoid m} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | f, g, pair (pair (pair _ _) a) b => GHC.Base.mappend (f a) (g b)
-      end.
-
-Local Definition Bifoldable__quad_type_bifold {inst_x} {inst_y}
-   : forall {m},
-     forall `{GHC.Base.Monoid m}, (GHC.Tuple.quad_type inst_x inst_y) m m -> m :=
-  fun {m} `{GHC.Base.Monoid m} =>
-    Bifoldable__quad_type_bifoldMap GHC.Base.id GHC.Base.id.
-
-Local Definition Bifoldable__quad_type_bifoldl {inst_x} {inst_y}
-   : forall {c} {a} {b},
-     (c -> a -> c) ->
-     (c -> b -> c) -> c -> (GHC.Tuple.quad_type inst_x inst_y) a b -> c :=
-  fun {c} {a} {b} =>
-    fun f g z t =>
-      Data.SemigroupInternal.appEndo (Data.SemigroupInternal.getDual
-                                      (Bifoldable__quad_type_bifoldMap (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
+                                      (Bifoldable__sept_type_bifoldMap (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
                                                                         (Data.SemigroupInternal.Mk_Endo GHC.Base.∘
                                                                          GHC.Base.flip f))
                                        (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
                                         (Data.SemigroupInternal.Mk_Endo GHC.Base.∘ GHC.Base.flip g)) t)) z.
 
-Local Definition Bifoldable__quad_type_bifoldr {inst_x} {inst_y}
+Local Definition Bifoldable__sept_type_bifoldr {inst_x} {inst_y} {inst_z}
+  {inst_w} {inst_v}
    : forall {a} {c} {b},
      (a -> c -> c) ->
-     (b -> c -> c) -> c -> (GHC.Tuple.quad_type inst_x inst_y) a b -> c :=
+     (b -> c -> c) ->
+     c -> (GHC.Tuple.sept_type inst_x inst_y inst_z inst_w inst_v) a b -> c :=
   fun {a} {c} {b} =>
     fun f g z t =>
-      Data.SemigroupInternal.appEndo (Bifoldable__quad_type_bifoldMap
+      Data.SemigroupInternal.appEndo (Bifoldable__sept_type_bifoldMap
                                       (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo f)
                                       (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo g) t) z.
 
-Program Instance Bifoldable__quad_type {x} {y}
-   : Bifoldable (GHC.Tuple.quad_type x y) :=
+Program Instance Bifoldable__sept_type {x} {y} {z} {w} {v}
+   : Bifoldable (GHC.Tuple.sept_type x y z w v) :=
   fun _ k__ =>
     k__ {| bifold__ := fun {m} `{GHC.Base.Monoid m} =>
-             Bifoldable__quad_type_bifold ;
+             Bifoldable__sept_type_bifold ;
            bifoldMap__ := fun {m} {a} {b} `{GHC.Base.Monoid m} =>
-             Bifoldable__quad_type_bifoldMap ;
-           bifoldl__ := fun {c} {a} {b} => Bifoldable__quad_type_bifoldl ;
-           bifoldr__ := fun {a} {c} {b} => Bifoldable__quad_type_bifoldr |}.
+             Bifoldable__sept_type_bifoldMap ;
+           bifoldl__ := fun {c} {a} {b} => Bifoldable__sept_type_bifoldl ;
+           bifoldr__ := fun {a} {c} {b} => Bifoldable__sept_type_bifoldr |}.
 
-Local Definition Bifoldable__triple_type_bifoldMap {inst_x}
+Local Definition Bifoldable__Either_bifoldMap
    : forall {m} {a} {b},
      forall `{GHC.Base.Monoid m},
-     (a -> m) -> (b -> m) -> (GHC.Tuple.triple_type inst_x) a b -> m :=
+     (a -> m) -> (b -> m) -> Data.Either.Either a b -> m :=
   fun {m} {a} {b} `{GHC.Base.Monoid m} =>
     fun arg_0__ arg_1__ arg_2__ =>
       match arg_0__, arg_1__, arg_2__ with
-      | f, g, pair (pair _ a) b => GHC.Base.mappend (f a) (g b)
+      | f, _, Data.Either.Left a => f a
+      | _, g, Data.Either.Right b => g b
       end.
 
-Local Definition Bifoldable__triple_type_bifold {inst_x}
-   : forall {m},
-     forall `{GHC.Base.Monoid m}, (GHC.Tuple.triple_type inst_x) m m -> m :=
+Local Definition Bifoldable__Either_bifold
+   : forall {m}, forall `{GHC.Base.Monoid m}, Data.Either.Either m m -> m :=
   fun {m} `{GHC.Base.Monoid m} =>
-    Bifoldable__triple_type_bifoldMap GHC.Base.id GHC.Base.id.
+    Bifoldable__Either_bifoldMap GHC.Base.id GHC.Base.id.
 
-Local Definition Bifoldable__triple_type_bifoldl {inst_x}
+Local Definition Bifoldable__Either_bifoldl
    : forall {c} {a} {b},
-     (c -> a -> c) ->
-     (c -> b -> c) -> c -> (GHC.Tuple.triple_type inst_x) a b -> c :=
+     (c -> a -> c) -> (c -> b -> c) -> c -> Data.Either.Either a b -> c :=
   fun {c} {a} {b} =>
     fun f g z t =>
       Data.SemigroupInternal.appEndo (Data.SemigroupInternal.getDual
-                                      (Bifoldable__triple_type_bifoldMap (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
-                                                                          (Data.SemigroupInternal.Mk_Endo GHC.Base.∘
-                                                                           GHC.Base.flip f))
-                                       (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
-                                        (Data.SemigroupInternal.Mk_Endo GHC.Base.∘ GHC.Base.flip g)) t)) z.
-
-Local Definition Bifoldable__triple_type_bifoldr {inst_x}
-   : forall {a} {c} {b},
-     (a -> c -> c) ->
-     (b -> c -> c) -> c -> (GHC.Tuple.triple_type inst_x) a b -> c :=
-  fun {a} {c} {b} =>
-    fun f g z t =>
-      Data.SemigroupInternal.appEndo (Bifoldable__triple_type_bifoldMap
-                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo f)
-                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo g) t) z.
-
-Program Instance Bifoldable__triple_type {x}
-   : Bifoldable (GHC.Tuple.triple_type x) :=
-  fun _ k__ =>
-    k__ {| bifold__ := fun {m} `{GHC.Base.Monoid m} =>
-             Bifoldable__triple_type_bifold ;
-           bifoldMap__ := fun {m} {a} {b} `{GHC.Base.Monoid m} =>
-             Bifoldable__triple_type_bifoldMap ;
-           bifoldl__ := fun {c} {a} {b} => Bifoldable__triple_type_bifoldl ;
-           bifoldr__ := fun {a} {c} {b} => Bifoldable__triple_type_bifoldr |}.
-
-(* Skipping instance `Data.Bifoldable.Bifoldable__K1' of class
-   `Data.Bifoldable.Bifoldable' *)
-
-Local Definition Bifoldable__Const_bifoldMap
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monoid m},
-     (a -> m) -> (b -> m) -> Data.Functor.Const.Const a b -> m :=
-  fun {m} {a} {b} `{GHC.Base.Monoid m} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | f, _, Data.Functor.Const.Mk_Const a => f a
-      end.
-
-Local Definition Bifoldable__Const_bifold
-   : forall {m}, forall `{GHC.Base.Monoid m}, Data.Functor.Const.Const m m -> m :=
-  fun {m} `{GHC.Base.Monoid m} =>
-    Bifoldable__Const_bifoldMap GHC.Base.id GHC.Base.id.
-
-Local Definition Bifoldable__Const_bifoldl
-   : forall {c} {a} {b},
-     (c -> a -> c) -> (c -> b -> c) -> c -> Data.Functor.Const.Const a b -> c :=
-  fun {c} {a} {b} =>
-    fun f g z t =>
-      Data.SemigroupInternal.appEndo (Data.SemigroupInternal.getDual
-                                      (Bifoldable__Const_bifoldMap (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
-                                                                    (Data.SemigroupInternal.Mk_Endo GHC.Base.∘
-                                                                     GHC.Base.flip f)) (Data.SemigroupInternal.Mk_Dual
-                                                                                        GHC.Base.∘
-                                                                                        (Data.SemigroupInternal.Mk_Endo
+                                      (Bifoldable__Either_bifoldMap (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
+                                                                     (Data.SemigroupInternal.Mk_Endo GHC.Base.∘
+                                                                      GHC.Base.flip f)) (Data.SemigroupInternal.Mk_Dual
                                                                                          GHC.Base.∘
-                                                                                         GHC.Base.flip g)) t)) z.
+                                                                                         (Data.SemigroupInternal.Mk_Endo
+                                                                                          GHC.Base.∘
+                                                                                          GHC.Base.flip g)) t)) z.
 
-Local Definition Bifoldable__Const_bifoldr
+Local Definition Bifoldable__Either_bifoldr
    : forall {a} {c} {b},
-     (a -> c -> c) -> (b -> c -> c) -> c -> Data.Functor.Const.Const a b -> c :=
+     (a -> c -> c) -> (b -> c -> c) -> c -> Data.Either.Either a b -> c :=
   fun {a} {c} {b} =>
     fun f g z t =>
-      Data.SemigroupInternal.appEndo (Bifoldable__Const_bifoldMap
+      Data.SemigroupInternal.appEndo (Bifoldable__Either_bifoldMap
                                       (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo f)
                                       (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo g) t) z.
 
-Program Instance Bifoldable__Const : Bifoldable Data.Functor.Const.Const :=
+Program Instance Bifoldable__Either : Bifoldable Data.Either.Either :=
   fun _ k__ =>
-    k__ {| bifold__ := fun {m} `{GHC.Base.Monoid m} => Bifoldable__Const_bifold ;
+    k__ {| bifold__ := fun {m} `{GHC.Base.Monoid m} => Bifoldable__Either_bifold ;
            bifoldMap__ := fun {m} {a} {b} `{GHC.Base.Monoid m} =>
-             Bifoldable__Const_bifoldMap ;
-           bifoldl__ := fun {c} {a} {b} => Bifoldable__Const_bifoldl ;
-           bifoldr__ := fun {a} {c} {b} => Bifoldable__Const_bifoldr |}.
+             Bifoldable__Either_bifoldMap ;
+           bifoldl__ := fun {c} {a} {b} => Bifoldable__Either_bifoldl ;
+           bifoldr__ := fun {a} {c} {b} => Bifoldable__Either_bifoldr |}.
 
-Local Definition Bifoldable__pair_type_bifoldMap
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monoid m},
-     (a -> m) -> (b -> m) -> GHC.Tuple.pair_type a b -> m :=
-  fun {m} {a} {b} `{GHC.Base.Monoid m} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | f, g, pair a b => GHC.Base.mappend (f a) (g b)
-      end.
+Definition bifoldr' {t} {a} {c} {b} `{Bifoldable t}
+   : (a -> c -> c) -> (b -> c -> c) -> c -> t a b -> c :=
+  fun f g z0 xs =>
+    let g' := fun k x z => k (g x z) in
+    let f' := fun k x z => k (f x z) in bifoldl f' g' GHC.Base.id xs z0.
 
-Local Definition Bifoldable__pair_type_bifold
-   : forall {m}, forall `{GHC.Base.Monoid m}, GHC.Tuple.pair_type m m -> m :=
-  fun {m} `{GHC.Base.Monoid m} =>
-    Bifoldable__pair_type_bifoldMap GHC.Base.id GHC.Base.id.
+(* Skipping definition `Data.Bifoldable.bifoldr1' *)
 
-Local Definition Bifoldable__pair_type_bifoldl
-   : forall {c} {a} {b},
-     (c -> a -> c) -> (c -> b -> c) -> c -> GHC.Tuple.pair_type a b -> c :=
-  fun {c} {a} {b} =>
-    fun f g z t =>
-      Data.SemigroupInternal.appEndo (Data.SemigroupInternal.getDual
-                                      (Bifoldable__pair_type_bifoldMap (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
-                                                                        (Data.SemigroupInternal.Mk_Endo GHC.Base.∘
-                                                                         GHC.Base.flip f))
-                                       (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
-                                        (Data.SemigroupInternal.Mk_Endo GHC.Base.∘ GHC.Base.flip g)) t)) z.
+Definition bifoldrM {t} {m} {a} {c} {b} `{Bifoldable t} `{GHC.Base.Monad m}
+   : (a -> c -> m c) -> (b -> c -> m c) -> c -> t a b -> m c :=
+  fun f g z0 xs =>
+    let g' := fun k x z => g x z GHC.Base.>>= k in
+    let f' := fun k x z => f x z GHC.Base.>>= k in
+    bifoldl f' g' GHC.Base.return_ xs z0.
 
-Local Definition Bifoldable__pair_type_bifoldr
-   : forall {a} {c} {b},
-     (a -> c -> c) -> (b -> c -> c) -> c -> GHC.Tuple.pair_type a b -> c :=
-  fun {a} {c} {b} =>
-    fun f g z t =>
-      Data.SemigroupInternal.appEndo (Bifoldable__pair_type_bifoldMap
-                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo f)
-                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo g) t) z.
+Definition bifoldl' {t} {a} {b} {c} `{Bifoldable t}
+   : (a -> b -> a) -> (a -> c -> a) -> a -> t b c -> a :=
+  fun f g z0 xs =>
+    let g' := fun x k z => k (g z x) in
+    let f' := fun x k z => k (f z x) in bifoldr f' g' GHC.Base.id xs z0.
 
-Program Instance Bifoldable__pair_type : Bifoldable GHC.Tuple.pair_type :=
-  fun _ k__ =>
-    k__ {| bifold__ := fun {m} `{GHC.Base.Monoid m} =>
-             Bifoldable__pair_type_bifold ;
-           bifoldMap__ := fun {m} {a} {b} `{GHC.Base.Monoid m} =>
-             Bifoldable__pair_type_bifoldMap ;
-           bifoldl__ := fun {c} {a} {b} => Bifoldable__pair_type_bifoldl ;
-           bifoldr__ := fun {a} {c} {b} => Bifoldable__pair_type_bifoldr |}.
+(* Skipping definition `Data.Bifoldable.bifoldl1' *)
+
+Definition bifoldlM {t} {m} {a} {b} {c} `{Bifoldable t} `{GHC.Base.Monad m}
+   : (a -> b -> m a) -> (a -> c -> m a) -> a -> t b c -> m a :=
+  fun f g z0 xs =>
+    let g' := fun x k z => g z x GHC.Base.>>= k in
+    let f' := fun x k z => f z x GHC.Base.>>= k in
+    bifoldr f' g' GHC.Base.return_ xs z0.
+
+Definition bitraverse_ {t} {f} {a} {c} {b} {d} `{Bifoldable t}
+  `{GHC.Base.Applicative f}
+   : (a -> f c) -> (b -> f d) -> t a b -> f unit :=
+  fun f g =>
+    bifoldr (_GHC.Base.*>_ GHC.Base.∘ f) (_GHC.Base.*>_ GHC.Base.∘ g) (GHC.Base.pure
+                                                                       tt).
+
+Definition bifor_ {t} {f} {a} {b} {c} {d} `{Bifoldable t} `{GHC.Base.Applicative
+  f}
+   : t a b -> (a -> f c) -> (b -> f d) -> f unit :=
+  fun t f g => bitraverse_ f g t.
+
+Definition bimapM_ {t} {f} {a} {c} {b} {d} `{Bifoldable t}
+  `{GHC.Base.Applicative f}
+   : (a -> f c) -> (b -> f d) -> t a b -> f unit :=
+  bitraverse_.
+
+Definition biforM_ {t} {f} {a} {b} {c} {d} `{Bifoldable t}
+  `{GHC.Base.Applicative f}
+   : t a b -> (a -> f c) -> (b -> f d) -> f unit :=
+  bifor_.
+
+Definition bisequence_ {t} {f} {a} {b} `{Bifoldable t} `{GHC.Base.Applicative f}
+   : t (f a) (f b) -> f unit :=
+  bifoldr _GHC.Base.*>_ _GHC.Base.*>_ (GHC.Base.pure tt).
+
+Definition bisequenceA_ {t} {f} {a} {b} `{Bifoldable t} `{GHC.Base.Applicative
+  f}
+   : t (f a) (f b) -> f unit :=
+  bisequence_.
+
+(* Skipping definition `Data.Bifoldable.biasum' *)
+
+(* Skipping definition `Data.Bifoldable.bimsum' *)
+
+Definition biList {t} {a} `{Bifoldable t} : t a a -> list a :=
+  bifoldr cons cons nil.
+
+Definition binull {t} {a} {b} `{Bifoldable t} : t a b -> bool :=
+  bifoldr (fun arg_0__ arg_1__ => false) (fun arg_2__ arg_3__ => false) true.
+
+Definition bilength {t} {a} {b} `{Bifoldable t} : t a b -> GHC.Num.Int :=
+  bifoldl' (fun arg_0__ arg_1__ =>
+              match arg_0__, arg_1__ with
+              | c, _ => c GHC.Num.+ #1
+              end) (fun arg_4__ arg_5__ =>
+                      match arg_4__, arg_5__ with
+                      | c, _ => c GHC.Num.+ #1
+                      end) #0.
+
+Definition biany {t} {a} {b} `{Bifoldable t}
+   : (a -> bool) -> (b -> bool) -> t a b -> bool :=
+  fun p q =>
+    Coq.Program.Basics.compose Data.SemigroupInternal.getAny (bifoldMap
+                                (Data.SemigroupInternal.Mk_Any GHC.Base.∘ p) (Data.SemigroupInternal.Mk_Any
+                                 GHC.Base.∘
+                                 q)).
+
+Definition bielem {t} {a} `{Bifoldable t} `{GHC.Base.Eq_ a}
+   : a -> t a a -> bool :=
+  fun x =>
+    biany (fun arg_0__ => arg_0__ GHC.Base.== x) (fun arg_1__ =>
+                                                    arg_1__ GHC.Base.== x).
+
+Definition biconcat {t} {a} `{Bifoldable t} : t (list a) (list a) -> list a :=
+  bifold.
+
+(* Skipping definition `Data.Bifoldable.bimaximum' *)
+
+(* Skipping definition `Data.Bifoldable.biminimum' *)
+
+Definition bisum {t} {a} `{Bifoldable t} `{GHC.Num.Num a} : t a a -> a :=
+  Coq.Program.Basics.compose Data.SemigroupInternal.getSum (bifoldMap
+                              Data.SemigroupInternal.Mk_Sum Data.SemigroupInternal.Mk_Sum).
+
+Definition biproduct {t} {a} `{Bifoldable t} `{GHC.Num.Num a} : t a a -> a :=
+  Coq.Program.Basics.compose Data.SemigroupInternal.getProduct (bifoldMap
+                              Data.SemigroupInternal.Mk_Product Data.SemigroupInternal.Mk_Product).
+
+Definition biconcatMap {t} {a} {c} {b} `{Bifoldable t}
+   : (a -> list c) -> (b -> list c) -> t a b -> list c :=
+  bifoldMap.
+
+Definition biand {t} `{Bifoldable t} : t bool bool -> bool :=
+  Coq.Program.Basics.compose Data.SemigroupInternal.getAll (bifoldMap
+                              Data.SemigroupInternal.Mk_All Data.SemigroupInternal.Mk_All).
+
+Definition bior {t} `{Bifoldable t} : t bool bool -> bool :=
+  Coq.Program.Basics.compose Data.SemigroupInternal.getAny (bifoldMap
+                              Data.SemigroupInternal.Mk_Any Data.SemigroupInternal.Mk_Any).
+
+Definition biall {t} {a} {b} `{Bifoldable t}
+   : (a -> bool) -> (b -> bool) -> t a b -> bool :=
+  fun p q =>
+    Coq.Program.Basics.compose Data.SemigroupInternal.getAll (bifoldMap
+                                (Data.SemigroupInternal.Mk_All GHC.Base.∘ p) (Data.SemigroupInternal.Mk_All
+                                 GHC.Base.∘
+                                 q)).
+
+(* Skipping definition `Data.Bifoldable.bimaximumBy' *)
+
+(* Skipping definition `Data.Bifoldable.biminimumBy' *)
+
+Definition binotElem {t} {a} `{Bifoldable t} `{GHC.Base.Eq_ a}
+   : a -> t a a -> bool :=
+  fun x => negb GHC.Base.∘ bielem x.
+
+Definition bifind {t} {a} `{Bifoldable t} : (a -> bool) -> t a a -> option a :=
+  fun p =>
+    let finder :=
+      fun x => Data.Monoid.Mk_First (if p x : bool then Some x else None) in
+    Data.Monoid.getFirst GHC.Base.∘ bifoldMap finder finder.
 
 (* External variables:
      None Some bool cons false list negb nil option pair true tt unit

--- a/base/Data/Bifunctor.v
+++ b/base/Data/Bifunctor.v
@@ -42,97 +42,127 @@ Definition second `{g__0__ : Bifunctor p}
 
 (* Converted value declarations: *)
 
-(* Skipping instance `Data.Bifunctor.Bifunctor__K1' of class
-   `Data.Bifunctor.Bifunctor' *)
-
-Local Definition Bifunctor__Const_bimap
+Local Definition Bifunctor__pair_type_bimap
    : forall {a} {b} {c} {d},
-     (a -> b) ->
-     (c -> d) -> Data.Functor.Const.Const a c -> Data.Functor.Const.Const b d :=
+     (a -> b) -> (c -> d) -> GHC.Tuple.pair_type a c -> GHC.Tuple.pair_type b d :=
   fun {a} {b} {c} {d} =>
     fun arg_0__ arg_1__ arg_2__ =>
       match arg_0__, arg_1__, arg_2__ with
-      | f, _, Data.Functor.Const.Mk_Const a => Data.Functor.Const.Mk_Const (f a)
+      | f, g, pair a b => pair (f a) (g b)
       end.
 
-Local Definition Bifunctor__Const_first
+Local Definition Bifunctor__pair_type_first
    : forall {a} {b} {c},
-     (a -> b) -> Data.Functor.Const.Const a c -> Data.Functor.Const.Const b c :=
-  fun {a} {b} {c} => fun f => Bifunctor__Const_bimap f GHC.Base.id.
+     (a -> b) -> GHC.Tuple.pair_type a c -> GHC.Tuple.pair_type b c :=
+  fun {a} {b} {c} => fun f => Bifunctor__pair_type_bimap f GHC.Base.id.
 
-Local Definition Bifunctor__Const_second
+Local Definition Bifunctor__pair_type_second
    : forall {b} {c} {a},
-     (b -> c) -> Data.Functor.Const.Const a b -> Data.Functor.Const.Const a c :=
-  fun {b} {c} {a} => Bifunctor__Const_bimap GHC.Base.id.
+     (b -> c) -> GHC.Tuple.pair_type a b -> GHC.Tuple.pair_type a c :=
+  fun {b} {c} {a} => Bifunctor__pair_type_bimap GHC.Base.id.
 
-Program Instance Bifunctor__Const : Bifunctor Data.Functor.Const.Const :=
+Program Instance Bifunctor__pair_type : Bifunctor GHC.Tuple.pair_type :=
   fun _ k__ =>
-    k__ {| bimap__ := fun {a} {b} {c} {d} => Bifunctor__Const_bimap ;
-           first__ := fun {a} {b} {c} => Bifunctor__Const_first ;
-           second__ := fun {b} {c} {a} => Bifunctor__Const_second |}.
+    k__ {| bimap__ := fun {a} {b} {c} {d} => Bifunctor__pair_type_bimap ;
+           first__ := fun {a} {b} {c} => Bifunctor__pair_type_first ;
+           second__ := fun {b} {c} {a} => Bifunctor__pair_type_second |}.
 
-Local Definition Bifunctor__Either_bimap
-   : forall {a} {b} {c} {d},
-     (a -> b) -> (c -> d) -> Data.Either.Either a c -> Data.Either.Either b d :=
-  fun {a} {b} {c} {d} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | f, _, Data.Either.Left a => Data.Either.Left (f a)
-      | _, g, Data.Either.Right b => Data.Either.Right (g b)
-      end.
-
-Local Definition Bifunctor__Either_first
-   : forall {a} {b} {c},
-     (a -> b) -> Data.Either.Either a c -> Data.Either.Either b c :=
-  fun {a} {b} {c} => fun f => Bifunctor__Either_bimap f GHC.Base.id.
-
-Local Definition Bifunctor__Either_second
-   : forall {b} {c} {a},
-     (b -> c) -> Data.Either.Either a b -> Data.Either.Either a c :=
-  fun {b} {c} {a} => Bifunctor__Either_bimap GHC.Base.id.
-
-Program Instance Bifunctor__Either : Bifunctor Data.Either.Either :=
-  fun _ k__ =>
-    k__ {| bimap__ := fun {a} {b} {c} {d} => Bifunctor__Either_bimap ;
-           first__ := fun {a} {b} {c} => Bifunctor__Either_first ;
-           second__ := fun {b} {c} {a} => Bifunctor__Either_second |}.
-
-Local Definition Bifunctor__sept_type_bimap {inst_x1} {inst_x2} {inst_x3}
-  {inst_x4} {inst_x5}
+Local Definition Bifunctor__triple_type_bimap {inst_x1}
    : forall {a} {b} {c} {d},
      (a -> b) ->
      (c -> d) ->
-     (GHC.Tuple.sept_type inst_x1 inst_x2 inst_x3 inst_x4 inst_x5) a c ->
-     (GHC.Tuple.sept_type inst_x1 inst_x2 inst_x3 inst_x4 inst_x5) b d :=
+     (GHC.Tuple.triple_type inst_x1) a c -> (GHC.Tuple.triple_type inst_x1) b d :=
   fun {a} {b} {c} {d} =>
     fun arg_0__ arg_1__ arg_2__ =>
       match arg_0__, arg_1__, arg_2__ with
-      | f, g, pair (pair (pair (pair (pair (pair x1 x2) x3) x4) x5) a) b =>
-          pair (pair (pair (pair (pair (pair x1 x2) x3) x4) x5) (f a)) (g b)
+      | f, g, pair (pair x1 a) b => pair (pair x1 (f a)) (g b)
       end.
 
-Local Definition Bifunctor__sept_type_first {inst_x1} {inst_x2} {inst_x3}
-  {inst_x4} {inst_x5}
+Local Definition Bifunctor__triple_type_first {inst_x1}
    : forall {a} {b} {c},
      (a -> b) ->
-     (GHC.Tuple.sept_type inst_x1 inst_x2 inst_x3 inst_x4 inst_x5) a c ->
-     (GHC.Tuple.sept_type inst_x1 inst_x2 inst_x3 inst_x4 inst_x5) b c :=
-  fun {a} {b} {c} => fun f => Bifunctor__sept_type_bimap f GHC.Base.id.
+     (GHC.Tuple.triple_type inst_x1) a c -> (GHC.Tuple.triple_type inst_x1) b c :=
+  fun {a} {b} {c} => fun f => Bifunctor__triple_type_bimap f GHC.Base.id.
 
-Local Definition Bifunctor__sept_type_second {inst_x1} {inst_x2} {inst_x3}
-  {inst_x4} {inst_x5}
+Local Definition Bifunctor__triple_type_second {inst_x1}
    : forall {b} {c} {a},
      (b -> c) ->
-     (GHC.Tuple.sept_type inst_x1 inst_x2 inst_x3 inst_x4 inst_x5) a b ->
-     (GHC.Tuple.sept_type inst_x1 inst_x2 inst_x3 inst_x4 inst_x5) a c :=
-  fun {b} {c} {a} => Bifunctor__sept_type_bimap GHC.Base.id.
+     (GHC.Tuple.triple_type inst_x1) a b -> (GHC.Tuple.triple_type inst_x1) a c :=
+  fun {b} {c} {a} => Bifunctor__triple_type_bimap GHC.Base.id.
 
-Program Instance Bifunctor__sept_type {x1} {x2} {x3} {x4} {x5}
-   : Bifunctor (GHC.Tuple.sept_type x1 x2 x3 x4 x5) :=
+Program Instance Bifunctor__triple_type {x1}
+   : Bifunctor (GHC.Tuple.triple_type x1) :=
   fun _ k__ =>
-    k__ {| bimap__ := fun {a} {b} {c} {d} => Bifunctor__sept_type_bimap ;
-           first__ := fun {a} {b} {c} => Bifunctor__sept_type_first ;
-           second__ := fun {b} {c} {a} => Bifunctor__sept_type_second |}.
+    k__ {| bimap__ := fun {a} {b} {c} {d} => Bifunctor__triple_type_bimap ;
+           first__ := fun {a} {b} {c} => Bifunctor__triple_type_first ;
+           second__ := fun {b} {c} {a} => Bifunctor__triple_type_second |}.
+
+Local Definition Bifunctor__quad_type_bimap {inst_x1} {inst_x2}
+   : forall {a} {b} {c} {d},
+     (a -> b) ->
+     (c -> d) ->
+     (GHC.Tuple.quad_type inst_x1 inst_x2) a c ->
+     (GHC.Tuple.quad_type inst_x1 inst_x2) b d :=
+  fun {a} {b} {c} {d} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | f, g, pair (pair (pair x1 x2) a) b => pair (pair (pair x1 x2) (f a)) (g b)
+      end.
+
+Local Definition Bifunctor__quad_type_first {inst_x1} {inst_x2}
+   : forall {a} {b} {c},
+     (a -> b) ->
+     (GHC.Tuple.quad_type inst_x1 inst_x2) a c ->
+     (GHC.Tuple.quad_type inst_x1 inst_x2) b c :=
+  fun {a} {b} {c} => fun f => Bifunctor__quad_type_bimap f GHC.Base.id.
+
+Local Definition Bifunctor__quad_type_second {inst_x1} {inst_x2}
+   : forall {b} {c} {a},
+     (b -> c) ->
+     (GHC.Tuple.quad_type inst_x1 inst_x2) a b ->
+     (GHC.Tuple.quad_type inst_x1 inst_x2) a c :=
+  fun {b} {c} {a} => Bifunctor__quad_type_bimap GHC.Base.id.
+
+Program Instance Bifunctor__quad_type {x1} {x2}
+   : Bifunctor (GHC.Tuple.quad_type x1 x2) :=
+  fun _ k__ =>
+    k__ {| bimap__ := fun {a} {b} {c} {d} => Bifunctor__quad_type_bimap ;
+           first__ := fun {a} {b} {c} => Bifunctor__quad_type_first ;
+           second__ := fun {b} {c} {a} => Bifunctor__quad_type_second |}.
+
+Local Definition Bifunctor__quint_type_bimap {inst_x1} {inst_x2} {inst_x3}
+   : forall {a} {b} {c} {d},
+     (a -> b) ->
+     (c -> d) ->
+     (GHC.Tuple.quint_type inst_x1 inst_x2 inst_x3) a c ->
+     (GHC.Tuple.quint_type inst_x1 inst_x2 inst_x3) b d :=
+  fun {a} {b} {c} {d} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | f, g, pair (pair (pair (pair x1 x2) x3) a) b =>
+          pair (pair (pair (pair x1 x2) x3) (f a)) (g b)
+      end.
+
+Local Definition Bifunctor__quint_type_first {inst_x1} {inst_x2} {inst_x3}
+   : forall {a} {b} {c},
+     (a -> b) ->
+     (GHC.Tuple.quint_type inst_x1 inst_x2 inst_x3) a c ->
+     (GHC.Tuple.quint_type inst_x1 inst_x2 inst_x3) b c :=
+  fun {a} {b} {c} => fun f => Bifunctor__quint_type_bimap f GHC.Base.id.
+
+Local Definition Bifunctor__quint_type_second {inst_x1} {inst_x2} {inst_x3}
+   : forall {b} {c} {a},
+     (b -> c) ->
+     (GHC.Tuple.quint_type inst_x1 inst_x2 inst_x3) a b ->
+     (GHC.Tuple.quint_type inst_x1 inst_x2 inst_x3) a c :=
+  fun {b} {c} {a} => Bifunctor__quint_type_bimap GHC.Base.id.
+
+Program Instance Bifunctor__quint_type {x1} {x2} {x3}
+   : Bifunctor (GHC.Tuple.quint_type x1 x2 x3) :=
+  fun _ k__ =>
+    k__ {| bimap__ := fun {a} {b} {c} {d} => Bifunctor__quint_type_bimap ;
+           first__ := fun {a} {b} {c} => Bifunctor__quint_type_first ;
+           second__ := fun {b} {c} {a} => Bifunctor__quint_type_second |}.
 
 Local Definition Bifunctor__sext_type_bimap {inst_x1} {inst_x2} {inst_x3}
   {inst_x4}
@@ -171,127 +201,97 @@ Program Instance Bifunctor__sext_type {x1} {x2} {x3} {x4}
            first__ := fun {a} {b} {c} => Bifunctor__sext_type_first ;
            second__ := fun {b} {c} {a} => Bifunctor__sext_type_second |}.
 
-Local Definition Bifunctor__quint_type_bimap {inst_x1} {inst_x2} {inst_x3}
+Local Definition Bifunctor__sept_type_bimap {inst_x1} {inst_x2} {inst_x3}
+  {inst_x4} {inst_x5}
    : forall {a} {b} {c} {d},
      (a -> b) ->
      (c -> d) ->
-     (GHC.Tuple.quint_type inst_x1 inst_x2 inst_x3) a c ->
-     (GHC.Tuple.quint_type inst_x1 inst_x2 inst_x3) b d :=
+     (GHC.Tuple.sept_type inst_x1 inst_x2 inst_x3 inst_x4 inst_x5) a c ->
+     (GHC.Tuple.sept_type inst_x1 inst_x2 inst_x3 inst_x4 inst_x5) b d :=
   fun {a} {b} {c} {d} =>
     fun arg_0__ arg_1__ arg_2__ =>
       match arg_0__, arg_1__, arg_2__ with
-      | f, g, pair (pair (pair (pair x1 x2) x3) a) b =>
-          pair (pair (pair (pair x1 x2) x3) (f a)) (g b)
+      | f, g, pair (pair (pair (pair (pair (pair x1 x2) x3) x4) x5) a) b =>
+          pair (pair (pair (pair (pair (pair x1 x2) x3) x4) x5) (f a)) (g b)
       end.
 
-Local Definition Bifunctor__quint_type_first {inst_x1} {inst_x2} {inst_x3}
+Local Definition Bifunctor__sept_type_first {inst_x1} {inst_x2} {inst_x3}
+  {inst_x4} {inst_x5}
    : forall {a} {b} {c},
      (a -> b) ->
-     (GHC.Tuple.quint_type inst_x1 inst_x2 inst_x3) a c ->
-     (GHC.Tuple.quint_type inst_x1 inst_x2 inst_x3) b c :=
-  fun {a} {b} {c} => fun f => Bifunctor__quint_type_bimap f GHC.Base.id.
+     (GHC.Tuple.sept_type inst_x1 inst_x2 inst_x3 inst_x4 inst_x5) a c ->
+     (GHC.Tuple.sept_type inst_x1 inst_x2 inst_x3 inst_x4 inst_x5) b c :=
+  fun {a} {b} {c} => fun f => Bifunctor__sept_type_bimap f GHC.Base.id.
 
-Local Definition Bifunctor__quint_type_second {inst_x1} {inst_x2} {inst_x3}
+Local Definition Bifunctor__sept_type_second {inst_x1} {inst_x2} {inst_x3}
+  {inst_x4} {inst_x5}
    : forall {b} {c} {a},
      (b -> c) ->
-     (GHC.Tuple.quint_type inst_x1 inst_x2 inst_x3) a b ->
-     (GHC.Tuple.quint_type inst_x1 inst_x2 inst_x3) a c :=
-  fun {b} {c} {a} => Bifunctor__quint_type_bimap GHC.Base.id.
+     (GHC.Tuple.sept_type inst_x1 inst_x2 inst_x3 inst_x4 inst_x5) a b ->
+     (GHC.Tuple.sept_type inst_x1 inst_x2 inst_x3 inst_x4 inst_x5) a c :=
+  fun {b} {c} {a} => Bifunctor__sept_type_bimap GHC.Base.id.
 
-Program Instance Bifunctor__quint_type {x1} {x2} {x3}
-   : Bifunctor (GHC.Tuple.quint_type x1 x2 x3) :=
+Program Instance Bifunctor__sept_type {x1} {x2} {x3} {x4} {x5}
+   : Bifunctor (GHC.Tuple.sept_type x1 x2 x3 x4 x5) :=
   fun _ k__ =>
-    k__ {| bimap__ := fun {a} {b} {c} {d} => Bifunctor__quint_type_bimap ;
-           first__ := fun {a} {b} {c} => Bifunctor__quint_type_first ;
-           second__ := fun {b} {c} {a} => Bifunctor__quint_type_second |}.
+    k__ {| bimap__ := fun {a} {b} {c} {d} => Bifunctor__sept_type_bimap ;
+           first__ := fun {a} {b} {c} => Bifunctor__sept_type_first ;
+           second__ := fun {b} {c} {a} => Bifunctor__sept_type_second |}.
 
-Local Definition Bifunctor__quad_type_bimap {inst_x1} {inst_x2}
+Local Definition Bifunctor__Either_bimap
    : forall {a} {b} {c} {d},
-     (a -> b) ->
-     (c -> d) ->
-     (GHC.Tuple.quad_type inst_x1 inst_x2) a c ->
-     (GHC.Tuple.quad_type inst_x1 inst_x2) b d :=
+     (a -> b) -> (c -> d) -> Data.Either.Either a c -> Data.Either.Either b d :=
   fun {a} {b} {c} {d} =>
     fun arg_0__ arg_1__ arg_2__ =>
       match arg_0__, arg_1__, arg_2__ with
-      | f, g, pair (pair (pair x1 x2) a) b => pair (pair (pair x1 x2) (f a)) (g b)
+      | f, _, Data.Either.Left a => Data.Either.Left (f a)
+      | _, g, Data.Either.Right b => Data.Either.Right (g b)
       end.
 
-Local Definition Bifunctor__quad_type_first {inst_x1} {inst_x2}
+Local Definition Bifunctor__Either_first
    : forall {a} {b} {c},
-     (a -> b) ->
-     (GHC.Tuple.quad_type inst_x1 inst_x2) a c ->
-     (GHC.Tuple.quad_type inst_x1 inst_x2) b c :=
-  fun {a} {b} {c} => fun f => Bifunctor__quad_type_bimap f GHC.Base.id.
+     (a -> b) -> Data.Either.Either a c -> Data.Either.Either b c :=
+  fun {a} {b} {c} => fun f => Bifunctor__Either_bimap f GHC.Base.id.
 
-Local Definition Bifunctor__quad_type_second {inst_x1} {inst_x2}
+Local Definition Bifunctor__Either_second
    : forall {b} {c} {a},
-     (b -> c) ->
-     (GHC.Tuple.quad_type inst_x1 inst_x2) a b ->
-     (GHC.Tuple.quad_type inst_x1 inst_x2) a c :=
-  fun {b} {c} {a} => Bifunctor__quad_type_bimap GHC.Base.id.
+     (b -> c) -> Data.Either.Either a b -> Data.Either.Either a c :=
+  fun {b} {c} {a} => Bifunctor__Either_bimap GHC.Base.id.
 
-Program Instance Bifunctor__quad_type {x1} {x2}
-   : Bifunctor (GHC.Tuple.quad_type x1 x2) :=
+Program Instance Bifunctor__Either : Bifunctor Data.Either.Either :=
   fun _ k__ =>
-    k__ {| bimap__ := fun {a} {b} {c} {d} => Bifunctor__quad_type_bimap ;
-           first__ := fun {a} {b} {c} => Bifunctor__quad_type_first ;
-           second__ := fun {b} {c} {a} => Bifunctor__quad_type_second |}.
+    k__ {| bimap__ := fun {a} {b} {c} {d} => Bifunctor__Either_bimap ;
+           first__ := fun {a} {b} {c} => Bifunctor__Either_first ;
+           second__ := fun {b} {c} {a} => Bifunctor__Either_second |}.
 
-Local Definition Bifunctor__triple_type_bimap {inst_x1}
+Local Definition Bifunctor__Const_bimap
    : forall {a} {b} {c} {d},
      (a -> b) ->
-     (c -> d) ->
-     (GHC.Tuple.triple_type inst_x1) a c -> (GHC.Tuple.triple_type inst_x1) b d :=
+     (c -> d) -> Data.Functor.Const.Const a c -> Data.Functor.Const.Const b d :=
   fun {a} {b} {c} {d} =>
     fun arg_0__ arg_1__ arg_2__ =>
       match arg_0__, arg_1__, arg_2__ with
-      | f, g, pair (pair x1 a) b => pair (pair x1 (f a)) (g b)
+      | f, _, Data.Functor.Const.Mk_Const a => Data.Functor.Const.Mk_Const (f a)
       end.
 
-Local Definition Bifunctor__triple_type_first {inst_x1}
+Local Definition Bifunctor__Const_first
    : forall {a} {b} {c},
-     (a -> b) ->
-     (GHC.Tuple.triple_type inst_x1) a c -> (GHC.Tuple.triple_type inst_x1) b c :=
-  fun {a} {b} {c} => fun f => Bifunctor__triple_type_bimap f GHC.Base.id.
+     (a -> b) -> Data.Functor.Const.Const a c -> Data.Functor.Const.Const b c :=
+  fun {a} {b} {c} => fun f => Bifunctor__Const_bimap f GHC.Base.id.
 
-Local Definition Bifunctor__triple_type_second {inst_x1}
+Local Definition Bifunctor__Const_second
    : forall {b} {c} {a},
-     (b -> c) ->
-     (GHC.Tuple.triple_type inst_x1) a b -> (GHC.Tuple.triple_type inst_x1) a c :=
-  fun {b} {c} {a} => Bifunctor__triple_type_bimap GHC.Base.id.
+     (b -> c) -> Data.Functor.Const.Const a b -> Data.Functor.Const.Const a c :=
+  fun {b} {c} {a} => Bifunctor__Const_bimap GHC.Base.id.
 
-Program Instance Bifunctor__triple_type {x1}
-   : Bifunctor (GHC.Tuple.triple_type x1) :=
+Program Instance Bifunctor__Const : Bifunctor Data.Functor.Const.Const :=
   fun _ k__ =>
-    k__ {| bimap__ := fun {a} {b} {c} {d} => Bifunctor__triple_type_bimap ;
-           first__ := fun {a} {b} {c} => Bifunctor__triple_type_first ;
-           second__ := fun {b} {c} {a} => Bifunctor__triple_type_second |}.
+    k__ {| bimap__ := fun {a} {b} {c} {d} => Bifunctor__Const_bimap ;
+           first__ := fun {a} {b} {c} => Bifunctor__Const_first ;
+           second__ := fun {b} {c} {a} => Bifunctor__Const_second |}.
 
-Local Definition Bifunctor__pair_type_bimap
-   : forall {a} {b} {c} {d},
-     (a -> b) -> (c -> d) -> GHC.Tuple.pair_type a c -> GHC.Tuple.pair_type b d :=
-  fun {a} {b} {c} {d} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | f, g, pair a b => pair (f a) (g b)
-      end.
-
-Local Definition Bifunctor__pair_type_first
-   : forall {a} {b} {c},
-     (a -> b) -> GHC.Tuple.pair_type a c -> GHC.Tuple.pair_type b c :=
-  fun {a} {b} {c} => fun f => Bifunctor__pair_type_bimap f GHC.Base.id.
-
-Local Definition Bifunctor__pair_type_second
-   : forall {b} {c} {a},
-     (b -> c) -> GHC.Tuple.pair_type a b -> GHC.Tuple.pair_type a c :=
-  fun {b} {c} {a} => Bifunctor__pair_type_bimap GHC.Base.id.
-
-Program Instance Bifunctor__pair_type : Bifunctor GHC.Tuple.pair_type :=
-  fun _ k__ =>
-    k__ {| bimap__ := fun {a} {b} {c} {d} => Bifunctor__pair_type_bimap ;
-           first__ := fun {a} {b} {c} => Bifunctor__pair_type_first ;
-           second__ := fun {b} {c} {a} => Bifunctor__pair_type_second |}.
+(* Skipping instance `Data.Bifunctor.Bifunctor__K1' of class
+   `Data.Bifunctor.Bifunctor' *)
 
 (* External variables:
      pair Data.Either.Either Data.Either.Left Data.Either.Right

--- a/base/Data/Bitraversable.v
+++ b/base/Data/Bitraversable.v
@@ -45,121 +45,79 @@ Definition bitraverse `{g__0__ : Bitraversable t}
 
 (* Converted value declarations: *)
 
-Definition bisequence {t} {f} {a} {b} `{Bitraversable t} `{GHC.Base.Applicative
-  f}
-   : t (f a) (f b) -> f (t a b) :=
-  bitraverse GHC.Base.id GHC.Base.id.
+Local Definition Bitraversable__pair_type_bitraverse
+   : forall {f} {a} {c} {b} {d},
+     forall `{GHC.Base.Applicative f},
+     (a -> f c) ->
+     (b -> f d) -> GHC.Tuple.pair_type a b -> f (GHC.Tuple.pair_type c d) :=
+  fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | f, g, pair a b => GHC.Base.liftA2 GHC.Tuple.pair2 (f a) (g b)
+      end.
 
-Definition bisequenceA {t} {f} {a} {b} `{Bitraversable t} `{GHC.Base.Applicative
-  f}
-   : t (f a) (f b) -> f (t a b) :=
-  bisequence.
+Program Instance Bitraversable__pair_type : Bitraversable GHC.Tuple.pair_type :=
+  fun _ k__ =>
+    k__ {| bitraverse__ := fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
+             Bitraversable__pair_type_bitraverse |}.
 
-Definition bimapM {t} {f} {a} {c} {b} {d} `{Bitraversable t}
-  `{GHC.Base.Applicative f}
-   : (a -> f c) -> (b -> f d) -> t a b -> f (t c d) :=
-  bitraverse.
-
-Definition bimapDefault {t} {a} {b} {c} {d} `{Bitraversable t}
-   : (a -> b) -> (c -> d) -> t a c -> t b d :=
-  GHC.Prim.coerce (bitraverse : (a -> Data.Functor.Identity.Identity b) ->
-                   (c -> Data.Functor.Identity.Identity d) ->
-                   t a c -> Data.Functor.Identity.Identity (t b d)).
-
-Definition bimapAccumR {t} {a} {b} {c} {d} {e} `{Bitraversable t}
-   : (a -> b -> (a * c)%type) ->
-     (a -> d -> (a * e)%type) -> a -> t b d -> (a * t c e)%type :=
-  fun f g s t =>
-    Data.Functor.Utils.runStateR (bitraverse (Data.Functor.Utils.Mk_StateR
-                                              GHC.Base.∘
-                                              GHC.Base.flip f) (Data.Functor.Utils.Mk_StateR GHC.Base.∘ GHC.Base.flip g)
-                                  t) s.
-
-Definition bimapAccumL {t} {a} {b} {c} {d} {e} `{Bitraversable t}
-   : (a -> b -> (a * c)%type) ->
-     (a -> d -> (a * e)%type) -> a -> t b d -> (a * t c e)%type :=
-  fun f g s t =>
-    Data.Functor.Utils.runStateL (bitraverse (Data.Functor.Utils.Mk_StateL
-                                              GHC.Base.∘
-                                              GHC.Base.flip f) (Data.Functor.Utils.Mk_StateL GHC.Base.∘ GHC.Base.flip g)
-                                  t) s.
-
-Definition bifor {t} {f} {a} {b} {c} {d} `{Bitraversable t}
-  `{GHC.Base.Applicative f}
-   : t a b -> (a -> f c) -> (b -> f d) -> f (t c d) :=
-  fun t f g => bitraverse f g t.
-
-Definition biforM {t} {f} {a} {b} {c} {d} `{Bitraversable t}
-  `{GHC.Base.Applicative f}
-   : t a b -> (a -> f c) -> (b -> f d) -> f (t c d) :=
-  bifor.
-
-Definition bifoldMapDefault {t} {m} {a} {b} `{Bitraversable t} `{GHC.Base.Monoid
-  m}
-   : (a -> m) -> (b -> m) -> t a b -> m :=
-  GHC.Prim.coerce (bitraverse : (a -> Data.Functor.Const.Const m unit) ->
-                   (b -> Data.Functor.Const.Const m unit) ->
-                   t a b -> Data.Functor.Const.Const m (t unit unit)).
-
-(* Skipping instance `Data.Bitraversable.Bitraversable__K1' of class
-   `Data.Bitraversable.Bitraversable' *)
-
-Local Definition Bitraversable__Const_bitraverse
+Local Definition Bitraversable__triple_type_bitraverse {inst_x}
    : forall {f} {a} {c} {b} {d},
      forall `{GHC.Base.Applicative f},
      (a -> f c) ->
      (b -> f d) ->
-     Data.Functor.Const.Const a b -> f (Data.Functor.Const.Const c d) :=
+     (GHC.Tuple.triple_type inst_x) a b -> f ((GHC.Tuple.triple_type inst_x) c d) :=
   fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
     fun arg_0__ arg_1__ arg_2__ =>
       match arg_0__, arg_1__, arg_2__ with
-      | f, _, Data.Functor.Const.Mk_Const a =>
-          Data.Functor.Const.Mk_Const Data.Functor.<$> f a
+      | f, g, pair (pair x a) b => GHC.Base.liftA2 (GHC.Tuple.pair3 x) (f a) (g b)
       end.
 
-Program Instance Bitraversable__Const
-   : Bitraversable Data.Functor.Const.Const :=
+Program Instance Bitraversable__triple_type {x}
+   : Bitraversable (GHC.Tuple.triple_type x) :=
   fun _ k__ =>
     k__ {| bitraverse__ := fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
-             Bitraversable__Const_bitraverse |}.
+             Bitraversable__triple_type_bitraverse |}.
 
-Local Definition Bitraversable__Either_bitraverse
-   : forall {f} {a} {c} {b} {d},
-     forall `{GHC.Base.Applicative f},
-     (a -> f c) ->
-     (b -> f d) -> Data.Either.Either a b -> f (Data.Either.Either c d) :=
-  fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | f, _, Data.Either.Left a => Data.Either.Left Data.Functor.<$> f a
-      | _, g, Data.Either.Right b => Data.Either.Right Data.Functor.<$> g b
-      end.
-
-Program Instance Bitraversable__Either : Bitraversable Data.Either.Either :=
-  fun _ k__ =>
-    k__ {| bitraverse__ := fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
-             Bitraversable__Either_bitraverse |}.
-
-Local Definition Bitraversable__sept_type_bitraverse {inst_x} {inst_y} {inst_z}
-  {inst_w} {inst_v}
+Local Definition Bitraversable__quad_type_bitraverse {inst_x} {inst_y}
    : forall {f} {a} {c} {b} {d},
      forall `{GHC.Base.Applicative f},
      (a -> f c) ->
      (b -> f d) ->
-     (GHC.Tuple.sept_type inst_x inst_y inst_z inst_w inst_v) a b ->
-     f ((GHC.Tuple.sept_type inst_x inst_y inst_z inst_w inst_v) c d) :=
+     (GHC.Tuple.quad_type inst_x inst_y) a b ->
+     f ((GHC.Tuple.quad_type inst_x inst_y) c d) :=
   fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
     fun arg_0__ arg_1__ arg_2__ =>
       match arg_0__, arg_1__, arg_2__ with
-      | f, g, pair (pair (pair (pair (pair (pair x y) z) w) v) a) b =>
-          GHC.Base.liftA2 (GHC.Tuple.pair7 x y z w v) (f a) (g b)
+      | f, g, pair (pair (pair x y) a) b =>
+          GHC.Base.liftA2 (GHC.Tuple.pair4 x y) (f a) (g b)
       end.
 
-Program Instance Bitraversable__sept_type {x} {y} {z} {w} {v}
-   : Bitraversable (GHC.Tuple.sept_type x y z w v) :=
+Program Instance Bitraversable__quad_type {x} {y}
+   : Bitraversable (GHC.Tuple.quad_type x y) :=
   fun _ k__ =>
     k__ {| bitraverse__ := fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
-             Bitraversable__sept_type_bitraverse |}.
+             Bitraversable__quad_type_bitraverse |}.
+
+Local Definition Bitraversable__quint_type_bitraverse {inst_x} {inst_y} {inst_z}
+   : forall {f} {a} {c} {b} {d},
+     forall `{GHC.Base.Applicative f},
+     (a -> f c) ->
+     (b -> f d) ->
+     (GHC.Tuple.quint_type inst_x inst_y inst_z) a b ->
+     f ((GHC.Tuple.quint_type inst_x inst_y inst_z) c d) :=
+  fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | f, g, pair (pair (pair (pair x y) z) a) b =>
+          GHC.Base.liftA2 (GHC.Tuple.pair5 x y z) (f a) (g b)
+      end.
+
+Program Instance Bitraversable__quint_type {x} {y} {z}
+   : Bitraversable (GHC.Tuple.quint_type x y z) :=
+  fun _ k__ =>
+    k__ {| bitraverse__ := fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
+             Bitraversable__quint_type_bitraverse |}.
 
 Local Definition Bitraversable__sext_type_bitraverse {inst_x} {inst_y} {inst_z}
   {inst_w}
@@ -182,79 +140,121 @@ Program Instance Bitraversable__sext_type {x} {y} {z} {w}
     k__ {| bitraverse__ := fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
              Bitraversable__sext_type_bitraverse |}.
 
-Local Definition Bitraversable__quint_type_bitraverse {inst_x} {inst_y} {inst_z}
+Local Definition Bitraversable__sept_type_bitraverse {inst_x} {inst_y} {inst_z}
+  {inst_w} {inst_v}
    : forall {f} {a} {c} {b} {d},
      forall `{GHC.Base.Applicative f},
      (a -> f c) ->
      (b -> f d) ->
-     (GHC.Tuple.quint_type inst_x inst_y inst_z) a b ->
-     f ((GHC.Tuple.quint_type inst_x inst_y inst_z) c d) :=
+     (GHC.Tuple.sept_type inst_x inst_y inst_z inst_w inst_v) a b ->
+     f ((GHC.Tuple.sept_type inst_x inst_y inst_z inst_w inst_v) c d) :=
   fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
     fun arg_0__ arg_1__ arg_2__ =>
       match arg_0__, arg_1__, arg_2__ with
-      | f, g, pair (pair (pair (pair x y) z) a) b =>
-          GHC.Base.liftA2 (GHC.Tuple.pair5 x y z) (f a) (g b)
+      | f, g, pair (pair (pair (pair (pair (pair x y) z) w) v) a) b =>
+          GHC.Base.liftA2 (GHC.Tuple.pair7 x y z w v) (f a) (g b)
       end.
 
-Program Instance Bitraversable__quint_type {x} {y} {z}
-   : Bitraversable (GHC.Tuple.quint_type x y z) :=
+Program Instance Bitraversable__sept_type {x} {y} {z} {w} {v}
+   : Bitraversable (GHC.Tuple.sept_type x y z w v) :=
   fun _ k__ =>
     k__ {| bitraverse__ := fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
-             Bitraversable__quint_type_bitraverse |}.
+             Bitraversable__sept_type_bitraverse |}.
 
-Local Definition Bitraversable__quad_type_bitraverse {inst_x} {inst_y}
+Local Definition Bitraversable__Either_bitraverse
+   : forall {f} {a} {c} {b} {d},
+     forall `{GHC.Base.Applicative f},
+     (a -> f c) ->
+     (b -> f d) -> Data.Either.Either a b -> f (Data.Either.Either c d) :=
+  fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | f, _, Data.Either.Left a => Data.Either.Left Data.Functor.<$> f a
+      | _, g, Data.Either.Right b => Data.Either.Right Data.Functor.<$> g b
+      end.
+
+Program Instance Bitraversable__Either : Bitraversable Data.Either.Either :=
+  fun _ k__ =>
+    k__ {| bitraverse__ := fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
+             Bitraversable__Either_bitraverse |}.
+
+Local Definition Bitraversable__Const_bitraverse
    : forall {f} {a} {c} {b} {d},
      forall `{GHC.Base.Applicative f},
      (a -> f c) ->
      (b -> f d) ->
-     (GHC.Tuple.quad_type inst_x inst_y) a b ->
-     f ((GHC.Tuple.quad_type inst_x inst_y) c d) :=
+     Data.Functor.Const.Const a b -> f (Data.Functor.Const.Const c d) :=
   fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
     fun arg_0__ arg_1__ arg_2__ =>
       match arg_0__, arg_1__, arg_2__ with
-      | f, g, pair (pair (pair x y) a) b =>
-          GHC.Base.liftA2 (GHC.Tuple.pair4 x y) (f a) (g b)
+      | f, _, Data.Functor.Const.Mk_Const a =>
+          Data.Functor.Const.Mk_Const Data.Functor.<$> f a
       end.
 
-Program Instance Bitraversable__quad_type {x} {y}
-   : Bitraversable (GHC.Tuple.quad_type x y) :=
+Program Instance Bitraversable__Const
+   : Bitraversable Data.Functor.Const.Const :=
   fun _ k__ =>
     k__ {| bitraverse__ := fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
-             Bitraversable__quad_type_bitraverse |}.
+             Bitraversable__Const_bitraverse |}.
 
-Local Definition Bitraversable__triple_type_bitraverse {inst_x}
-   : forall {f} {a} {c} {b} {d},
-     forall `{GHC.Base.Applicative f},
-     (a -> f c) ->
-     (b -> f d) ->
-     (GHC.Tuple.triple_type inst_x) a b -> f ((GHC.Tuple.triple_type inst_x) c d) :=
-  fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | f, g, pair (pair x a) b => GHC.Base.liftA2 (GHC.Tuple.pair3 x) (f a) (g b)
-      end.
+(* Skipping instance `Data.Bitraversable.Bitraversable__K1' of class
+   `Data.Bitraversable.Bitraversable' *)
 
-Program Instance Bitraversable__triple_type {x}
-   : Bitraversable (GHC.Tuple.triple_type x) :=
-  fun _ k__ =>
-    k__ {| bitraverse__ := fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
-             Bitraversable__triple_type_bitraverse |}.
+Definition bisequence {t} {f} {a} {b} `{Bitraversable t} `{GHC.Base.Applicative
+  f}
+   : t (f a) (f b) -> f (t a b) :=
+  bitraverse GHC.Base.id GHC.Base.id.
 
-Local Definition Bitraversable__pair_type_bitraverse
-   : forall {f} {a} {c} {b} {d},
-     forall `{GHC.Base.Applicative f},
-     (a -> f c) ->
-     (b -> f d) -> GHC.Tuple.pair_type a b -> f (GHC.Tuple.pair_type c d) :=
-  fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | f, g, pair a b => GHC.Base.liftA2 GHC.Tuple.pair2 (f a) (g b)
-      end.
+Definition bisequenceA {t} {f} {a} {b} `{Bitraversable t} `{GHC.Base.Applicative
+  f}
+   : t (f a) (f b) -> f (t a b) :=
+  bisequence.
 
-Program Instance Bitraversable__pair_type : Bitraversable GHC.Tuple.pair_type :=
-  fun _ k__ =>
-    k__ {| bitraverse__ := fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
-             Bitraversable__pair_type_bitraverse |}.
+Definition bimapM {t} {f} {a} {c} {b} {d} `{Bitraversable t}
+  `{GHC.Base.Applicative f}
+   : (a -> f c) -> (b -> f d) -> t a b -> f (t c d) :=
+  bitraverse.
+
+Definition bifor {t} {f} {a} {b} {c} {d} `{Bitraversable t}
+  `{GHC.Base.Applicative f}
+   : t a b -> (a -> f c) -> (b -> f d) -> f (t c d) :=
+  fun t f g => bitraverse f g t.
+
+Definition biforM {t} {f} {a} {b} {c} {d} `{Bitraversable t}
+  `{GHC.Base.Applicative f}
+   : t a b -> (a -> f c) -> (b -> f d) -> f (t c d) :=
+  bifor.
+
+Definition bimapAccumL {t} {a} {b} {c} {d} {e} `{Bitraversable t}
+   : (a -> b -> (a * c)%type) ->
+     (a -> d -> (a * e)%type) -> a -> t b d -> (a * t c e)%type :=
+  fun f g s t =>
+    Data.Functor.Utils.runStateL (bitraverse (Data.Functor.Utils.Mk_StateL
+                                              GHC.Base.∘
+                                              GHC.Base.flip f) (Data.Functor.Utils.Mk_StateL GHC.Base.∘ GHC.Base.flip g)
+                                  t) s.
+
+Definition bimapAccumR {t} {a} {b} {c} {d} {e} `{Bitraversable t}
+   : (a -> b -> (a * c)%type) ->
+     (a -> d -> (a * e)%type) -> a -> t b d -> (a * t c e)%type :=
+  fun f g s t =>
+    Data.Functor.Utils.runStateR (bitraverse (Data.Functor.Utils.Mk_StateR
+                                              GHC.Base.∘
+                                              GHC.Base.flip f) (Data.Functor.Utils.Mk_StateR GHC.Base.∘ GHC.Base.flip g)
+                                  t) s.
+
+Definition bimapDefault {t} {a} {b} {c} {d} `{Bitraversable t}
+   : (a -> b) -> (c -> d) -> t a c -> t b d :=
+  GHC.Prim.coerce (bitraverse : (a -> Data.Functor.Identity.Identity b) ->
+                   (c -> Data.Functor.Identity.Identity d) ->
+                   t a c -> Data.Functor.Identity.Identity (t b d)).
+
+Definition bifoldMapDefault {t} {m} {a} {b} `{Bitraversable t} `{GHC.Base.Monoid
+  m}
+   : (a -> m) -> (b -> m) -> t a b -> m :=
+  GHC.Prim.coerce (bitraverse : (a -> Data.Functor.Const.Const m unit) ->
+                   (b -> Data.Functor.Const.Const m unit) ->
+                   t a b -> Data.Functor.Const.Const m (t unit unit)).
 
 (* External variables:
      op_zt__ pair unit Data.Bifoldable.Bifoldable Data.Bifunctor.Bifunctor

--- a/base/Data/Either.v
+++ b/base/Data/Either.v
@@ -28,65 +28,6 @@ Arguments Right {_} {_} _.
 
 (* Converted value declarations: *)
 
-Definition rights {a} {b} : list (Either a b) -> list b :=
-  fun x =>
-    let cont_0__ arg_1__ :=
-      match arg_1__ with
-      | Right a => cons a nil
-      | _ => nil
-      end in
-    Coq.Lists.List.flat_map cont_0__ x.
-
-Definition lefts {a} {b} : list (Either a b) -> list a :=
-  fun x =>
-    let cont_0__ arg_1__ :=
-      match arg_1__ with
-      | Left a => cons a nil
-      | _ => nil
-      end in
-    Coq.Lists.List.flat_map cont_0__ x.
-
-Definition isRight {a} {b} : Either a b -> bool :=
-  fun arg_0__ => match arg_0__ with | Left _ => false | Right _ => true end.
-
-Definition isLeft {a} {b} : Either a b -> bool :=
-  fun arg_0__ => match arg_0__ with | Left _ => true | Right _ => false end.
-
-Definition fromRight {b} {a} : b -> Either a b -> b :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | _, Right b => b
-    | b, _ => b
-    end.
-
-Definition fromLeft {a} {b} : a -> Either a b -> a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | _, Left a => a
-    | a, _ => a
-    end.
-
-Definition either {a} {c} {b} : (a -> c) -> (b -> c) -> Either a b -> c :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | f, _, Left x => f x
-    | _, g, Right y => g y
-    end.
-
-Definition partitionEithers {a} {b}
-   : list (Either a b) -> (list a * list b)%type :=
-  let right_ :=
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | a, pair l r => pair l (cons a r)
-      end in
-  let left_ :=
-    fun arg_4__ arg_5__ =>
-      match arg_4__, arg_5__ with
-      | a, pair l r => pair (cons a l) r
-      end in
-  GHC.Base.foldr (either left_ right_) (pair nil nil).
-
 Local Definition Eq___Either_op_zeze__ {inst_a} {inst_b} `{GHC.Base.Eq_ inst_a}
   `{GHC.Base.Eq_ inst_b}
    : Either inst_a inst_b -> Either inst_a inst_b -> bool :=
@@ -168,21 +109,6 @@ Program Instance Ord__Either {a} {b} `{GHC.Base.Ord a} `{GHC.Base.Ord b}
 (* Skipping all instances of class `GHC.Show.Show', including
    `Data.Either.Show__Either' *)
 
-Local Definition Monad__Either_op_zgzgze__ {inst_e}
-   : forall {a} {b},
-     (Either inst_e) a -> (a -> (Either inst_e) b) -> (Either inst_e) b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | Left l, _ => Left l
-      | Right r, k => k r
-      end.
-
-Local Definition Monad__Either_op_zgzg__ {inst_e}
-   : forall {a} {b},
-     (Either inst_e) a -> (Either inst_e) b -> (Either inst_e) b :=
-  fun {a} {b} => fun m k => Monad__Either_op_zgzgze__ m (fun arg_0__ => k).
-
 Local Definition Functor__Either_fmap {inst_a}
    : forall {a} {b}, (a -> b) -> (Either inst_a) a -> (Either inst_a) b :=
   fun {a} {b} =>
@@ -200,6 +126,18 @@ Program Instance Functor__Either {a} : GHC.Base.Functor (Either a) :=
   fun _ k__ =>
     k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Either_fmap ;
            GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Either_op_zlzd__ |}.
+
+Local Definition Semigroup__Either_op_zlzlzgzg__ {inst_a} {inst_b}
+   : (Either inst_a inst_b) -> (Either inst_a inst_b) -> (Either inst_a inst_b) :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Left _, b => b
+    | a, _ => a
+    end.
+
+Program Instance Semigroup__Either {a} {b} : GHC.Base.Semigroup (Either a b) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__Either_op_zlzlzgzg__ |}.
 
 Local Definition Applicative__Either_op_zlztzg__ {inst_e}
    : forall {a} {b},
@@ -234,6 +172,21 @@ Program Instance Applicative__Either {e} : GHC.Base.Applicative (Either e) :=
            GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Either_op_ztzg__ ;
            GHC.Base.pure__ := fun {a} => Applicative__Either_pure |}.
 
+Local Definition Monad__Either_op_zgzgze__ {inst_e}
+   : forall {a} {b},
+     (Either inst_e) a -> (a -> (Either inst_e) b) -> (Either inst_e) b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | Left l, _ => Left l
+      | Right r, k => k r
+      end.
+
+Local Definition Monad__Either_op_zgzg__ {inst_e}
+   : forall {a} {b},
+     (Either inst_e) a -> (Either inst_e) b -> (Either inst_e) b :=
+  fun {a} {b} => fun m k => Monad__Either_op_zgzgze__ m (fun arg_0__ => k).
+
 Local Definition Monad__Either_return_ {inst_e}
    : forall {a}, a -> (Either inst_e) a :=
   fun {a} => GHC.Base.pure.
@@ -244,17 +197,64 @@ Program Instance Monad__Either {e} : GHC.Base.Monad (Either e) :=
            GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Either_op_zgzgze__ ;
            GHC.Base.return___ := fun {a} => Monad__Either_return_ |}.
 
-Local Definition Semigroup__Either_op_zlzlzgzg__ {inst_a} {inst_b}
-   : (Either inst_a inst_b) -> (Either inst_a inst_b) -> (Either inst_a inst_b) :=
+Definition either {a} {c} {b} : (a -> c) -> (b -> c) -> Either a b -> c :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | f, _, Left x => f x
+    | _, g, Right y => g y
+    end.
+
+Definition lefts {a} {b} : list (Either a b) -> list a :=
+  fun x =>
+    let cont_0__ arg_1__ :=
+      match arg_1__ with
+      | Left a => cons a nil
+      | _ => nil
+      end in
+    Coq.Lists.List.flat_map cont_0__ x.
+
+Definition rights {a} {b} : list (Either a b) -> list b :=
+  fun x =>
+    let cont_0__ arg_1__ :=
+      match arg_1__ with
+      | Right a => cons a nil
+      | _ => nil
+      end in
+    Coq.Lists.List.flat_map cont_0__ x.
+
+Definition partitionEithers {a} {b}
+   : list (Either a b) -> (list a * list b)%type :=
+  let right_ :=
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | a, pair l r => pair l (cons a r)
+      end in
+  let left_ :=
+    fun arg_4__ arg_5__ =>
+      match arg_4__, arg_5__ with
+      | a, pair l r => pair (cons a l) r
+      end in
+  GHC.Base.foldr (either left_ right_) (pair nil nil).
+
+Definition isLeft {a} {b} : Either a b -> bool :=
+  fun arg_0__ => match arg_0__ with | Left _ => true | Right _ => false end.
+
+Definition isRight {a} {b} : Either a b -> bool :=
+  fun arg_0__ => match arg_0__ with | Left _ => false | Right _ => true end.
+
+Definition fromLeft {a} {b} : a -> Either a b -> a :=
   fun arg_0__ arg_1__ =>
     match arg_0__, arg_1__ with
-    | Left _, b => b
+    | _, Left a => a
     | a, _ => a
     end.
 
-Program Instance Semigroup__Either {a} {b} : GHC.Base.Semigroup (Either a b) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__Either_op_zlzlzgzg__ |}.
+Definition fromRight {b} {a} : b -> Either a b -> b :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | _, Right b => b
+    | b, _ => b
+    end.
 
 (* External variables:
      Gt Lt bool comparison cons false list negb nil op_zt__ pair true

--- a/base/Data/Foldable.v
+++ b/base/Data/Foldable.v
@@ -166,65 +166,126 @@ Definition default_foldable_foldr (f : Type -> Type)
 
 (* Converted value declarations: *)
 
-Definition traverse_ {t} {f} {a} {b} `{Foldable t} `{GHC.Base.Applicative f}
-   : (a -> f b) -> t a -> f unit :=
-  fun f => foldr (_GHC.Base.*>_ GHC.Base.∘ f) (GHC.Base.pure tt).
+(* Skipping instance `Data.Foldable.Foldable__URec__Word' of class
+   `Data.Foldable.Foldable' *)
 
-Definition sequence_ {t} {m} {a} `{Foldable t} `{GHC.Base.Monad m}
-   : t (m a) -> m unit :=
-  foldr _GHC.Base.>>_ (GHC.Base.return_ tt).
+(* Skipping instance `Data.Foldable.Foldable__URec__Int' of class
+   `Data.Foldable.Foldable' *)
 
-Definition sequenceA_ {t} {f} {a} `{Foldable t} `{GHC.Base.Applicative f}
-   : t (f a) -> f unit :=
-  foldr _GHC.Base.*>_ (GHC.Base.pure tt).
+(* Skipping instance `Data.Foldable.Foldable__URec__Float' of class
+   `Data.Foldable.Foldable' *)
 
-Definition or {t} `{Foldable t} : t bool -> bool :=
-  Coq.Program.Basics.compose Data.SemigroupInternal.getAny (foldMap
-                              Data.SemigroupInternal.Mk_Any).
+(* Skipping instance `Data.Foldable.Foldable__URec__Double' of class
+   `Data.Foldable.Foldable' *)
 
-Definition any {t} {a} `{Foldable t} : (a -> bool) -> t a -> bool :=
-  fun p =>
-    Coq.Program.Basics.compose Data.SemigroupInternal.getAny (foldMap
-                                (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Any p)).
+(* Skipping instance `Data.Foldable.Foldable__URec__Char' of class
+   `Data.Foldable.Foldable' *)
 
-Definition elem {f} `{Foldable f} {a} `{GHC.Base.Eq_ a} : a -> f a -> bool :=
-  fun x xs => any (fun y => x GHC.Base.== y) xs.
+(* Skipping instance `Data.Foldable.Foldable__URec__Ptr__unit' of class
+   `Data.Foldable.Foldable' *)
 
-Definition notElem {t} {a} `{Foldable t} `{GHC.Base.Eq_ a} : a -> t a -> bool :=
-  fun x => negb GHC.Base.∘ elem x.
+(* Skipping instance `Data.Foldable.Foldable__op_ZCziZC__' of class
+   `Data.Foldable.Foldable' *)
 
-(* Skipping definition `Data.Foldable.msum' *)
+(* Skipping instance `Data.Foldable.Foldable__op_ZCztZC__' of class
+   `Data.Foldable.Foldable' *)
 
-(* Skipping definition `Data.Foldable.minimumBy' *)
+(* Skipping instance `Data.Foldable.Foldable__op_ZCzpZC__' of class
+   `Data.Foldable.Foldable' *)
 
-(* Skipping definition `Data.Foldable.maximumBy' *)
+(* Skipping instance `Data.Foldable.Foldable__M1' of class
+   `Data.Foldable.Foldable' *)
 
-Definition mapM_ {t} {m} {a} {b} `{Foldable t} `{GHC.Base.Monad m}
-   : (a -> m b) -> t a -> m unit :=
-  fun f => foldr (_GHC.Base.>>_ GHC.Base.∘ f) (GHC.Base.return_ tt).
+(* Skipping instance `Data.Foldable.Foldable__K1' of class
+   `Data.Foldable.Foldable' *)
 
-Definition for__ {t} {f} {a} {b} `{Foldable t} `{GHC.Base.Applicative f}
-   : t a -> (a -> f b) -> f unit :=
-  GHC.Base.flip traverse_.
+(* Skipping instance `Data.Foldable.Foldable__Rec1' of class
+   `Data.Foldable.Foldable' *)
 
-Definition forM_ {t} {m} {a} {b} `{Foldable t} `{GHC.Base.Monad m}
-   : t a -> (a -> m b) -> m unit :=
-  GHC.Base.flip mapM_.
+(* Skipping instance `Data.Foldable.Foldable__Par1' of class
+   `Data.Foldable.Foldable' *)
 
-Definition foldrM {t} {m} {a} {b} `{Foldable t} `{GHC.Base.Monad m}
-   : (a -> b -> m b) -> b -> t a -> m b :=
-  fun f z0 xs =>
-    let f' := fun k x z => f x z GHC.Base.>>= k in foldl f' GHC.Base.return_ xs z0.
+(* Skipping instance `Data.Foldable.Foldable__V1' of class
+   `Data.Foldable.Foldable' *)
 
-Definition foldlM {t} {m} {b} {a} `{Foldable t} `{GHC.Base.Monad m}
-   : (b -> a -> m b) -> b -> t a -> m b :=
-  fun f z0 xs =>
-    let f' := fun x k z => f z x GHC.Base.>>= k in foldr f' GHC.Base.return_ xs z0.
+Local Definition Foldable__option_foldMap
+   : forall {m} {a}, forall `{GHC.Base.Monoid m}, (a -> m) -> option a -> m :=
+  fun {m} {a} `{GHC.Base.Monoid m} => Data.Maybe.maybe GHC.Base.mempty.
 
-Definition find {t} {a} `{Foldable t} : (a -> bool) -> t a -> option a :=
-  fun p =>
-    Data.Monoid.getFirst GHC.Base.∘
-    foldMap (fun x => Data.Monoid.Mk_First (if p x : bool then Some x else None)).
+Local Definition Foldable__option_fold
+   : forall {m}, forall `{GHC.Base.Monoid m}, option m -> m :=
+  fun {m} `{GHC.Base.Monoid m} => Foldable__option_foldMap GHC.Base.id.
+
+Local Definition Foldable__option_foldl
+   : forall {b} {a}, (b -> a -> b) -> b -> option a -> b :=
+  fun {b} {a} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | _, z, None => z
+      | f, z, Some x => f z x
+      end.
+
+Local Definition Foldable__option_foldr
+   : forall {a} {b}, (a -> b -> b) -> b -> option a -> b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | _, z, None => z
+      | f, z, Some x => f x z
+      end.
+
+Local Definition Foldable__option_foldl'
+   : forall {b} {a}, (b -> a -> b) -> b -> option a -> b :=
+  fun {b} {a} =>
+    fun f z0 xs =>
+      let f' := fun x k z => k (f z x) in Foldable__option_foldr f' GHC.Base.id xs z0.
+
+Local Definition Foldable__option_foldr'
+   : forall {a} {b}, (a -> b -> b) -> b -> option a -> b :=
+  fun {a} {b} =>
+    fun f z0 xs =>
+      let f' := fun k x z => k (f x z) in Foldable__option_foldl f' GHC.Base.id xs z0.
+
+Local Definition Foldable__option_length
+   : forall {a}, option a -> GHC.Num.Int :=
+  fun {a} =>
+    Foldable__option_foldl' (fun arg_0__ arg_1__ =>
+                               match arg_0__, arg_1__ with
+                               | c, _ => c GHC.Num.+ #1
+                               end) #0.
+
+Local Definition Foldable__option_null : forall {a}, option a -> bool :=
+  fun {a} => Foldable__option_foldr (fun arg_0__ arg_1__ => false) true.
+
+Local Definition Foldable__option_product
+   : forall {a}, forall `{GHC.Num.Num a}, option a -> a :=
+  fun {a} `{GHC.Num.Num a} =>
+    Coq.Program.Basics.compose Data.SemigroupInternal.getProduct
+                               (Foldable__option_foldMap Data.SemigroupInternal.Mk_Product).
+
+Local Definition Foldable__option_sum
+   : forall {a}, forall `{GHC.Num.Num a}, option a -> a :=
+  fun {a} `{GHC.Num.Num a} =>
+    Coq.Program.Basics.compose Data.SemigroupInternal.getSum
+                               (Foldable__option_foldMap Data.SemigroupInternal.Mk_Sum).
+
+Local Definition Foldable__option_toList : forall {a}, option a -> list a :=
+  fun {a} =>
+    fun t => GHC.Base.build' (fun _ => (fun c n => Foldable__option_foldr c n t)).
+
+Program Instance Foldable__option : Foldable option :=
+  fun _ k__ =>
+    k__ {| fold__ := fun {m} `{GHC.Base.Monoid m} => Foldable__option_fold ;
+           foldMap__ := fun {m} {a} `{GHC.Base.Monoid m} => Foldable__option_foldMap ;
+           foldl__ := fun {b} {a} => Foldable__option_foldl ;
+           foldl'__ := fun {b} {a} => Foldable__option_foldl' ;
+           foldr__ := fun {a} {b} => Foldable__option_foldr ;
+           foldr'__ := fun {a} {b} => Foldable__option_foldr' ;
+           length__ := fun {a} => Foldable__option_length ;
+           null__ := fun {a} => Foldable__option_null ;
+           product__ := fun {a} `{GHC.Num.Num a} => Foldable__option_product ;
+           sum__ := fun {a} `{GHC.Num.Num a} => Foldable__option_sum ;
+           toList__ := fun {a} => Foldable__option_toList |}.
 
 Local Definition Foldable__list_foldr
    : forall {a} {b}, (a -> b -> b) -> b -> list a -> b :=
@@ -284,434 +345,87 @@ Program Instance Foldable__list : Foldable list :=
            sum__ := fun {a} `{GHC.Num.Num a} => Foldable__list_sum ;
            toList__ := fun {a} => Foldable__list_toList |}.
 
-Definition concatMap {t} {a} {b} `{Foldable t}
-   : (a -> list b) -> t a -> list b :=
-  fun f xs =>
-    GHC.Base.build' (fun _ => (fun c n => foldr (fun x b => foldr c b (f x)) n xs)).
+Local Definition Foldable__NonEmpty_fold
+   : forall {m}, forall `{GHC.Base.Monoid m}, GHC.Base.NonEmpty m -> m :=
+  fun {m} `{GHC.Base.Monoid m} =>
+    fun '(GHC.Base.NEcons m ms) => GHC.Base.mappend m (fold ms).
 
-Definition concat {t} {a} `{Foldable t} : t (list a) -> list a :=
-  fun xs =>
-    GHC.Base.build' (fun _ =>
-                       fun c n => foldr (fun x y => (@foldr _ Foldable__list _ _ c y x)) n xs).
-
-(* Skipping definition `Data.Foldable.asum' *)
-
-Definition and {t} `{Foldable t} : t bool -> bool :=
-  Coq.Program.Basics.compose Data.SemigroupInternal.getAll (foldMap
-                              Data.SemigroupInternal.Mk_All).
-
-Definition all {t} {a} `{Foldable t} : (a -> bool) -> t a -> bool :=
-  fun p =>
-    Coq.Program.Basics.compose Data.SemigroupInternal.getAll (foldMap
-                                (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_All p)).
-
-(* Skipping instance `Data.Foldable.Foldable__URec__Word' of class
-   `Data.Foldable.Foldable' *)
-
-(* Skipping instance `Data.Foldable.Foldable__URec__Int' of class
-   `Data.Foldable.Foldable' *)
-
-(* Skipping instance `Data.Foldable.Foldable__URec__Float' of class
-   `Data.Foldable.Foldable' *)
-
-(* Skipping instance `Data.Foldable.Foldable__URec__Double' of class
-   `Data.Foldable.Foldable' *)
-
-(* Skipping instance `Data.Foldable.Foldable__URec__Char' of class
-   `Data.Foldable.Foldable' *)
-
-(* Skipping instance `Data.Foldable.Foldable__URec__Ptr__unit' of class
-   `Data.Foldable.Foldable' *)
-
-(* Skipping instance `Data.Foldable.Foldable__op_ZCziZC__' of class
-   `Data.Foldable.Foldable' *)
-
-(* Skipping instance `Data.Foldable.Foldable__op_ZCztZC__' of class
-   `Data.Foldable.Foldable' *)
-
-(* Skipping instance `Data.Foldable.Foldable__op_ZCzpZC__' of class
-   `Data.Foldable.Foldable' *)
-
-(* Skipping instance `Data.Foldable.Foldable__M1' of class
-   `Data.Foldable.Foldable' *)
-
-(* Skipping instance `Data.Foldable.Foldable__K1' of class
-   `Data.Foldable.Foldable' *)
-
-(* Skipping instance `Data.Foldable.Foldable__Rec1' of class
-   `Data.Foldable.Foldable' *)
-
-(* Skipping instance `Data.Foldable.Foldable__Par1' of class
-   `Data.Foldable.Foldable' *)
-
-(* Skipping instance `Data.Foldable.Foldable__V1' of class
-   `Data.Foldable.Foldable' *)
-
-(* Skipping instance `Data.Foldable.Foldable__U1' of class
-   `Data.Foldable.Foldable' *)
-
-(* Skipping instance `Data.Foldable.Foldable__Last' of class
-   `Data.Foldable.Foldable' *)
-
-(* Skipping instance `Data.Foldable.Foldable__First' of class
-   `Data.Foldable.Foldable' *)
-
-Local Definition Foldable__Product_foldMap
+Local Definition Foldable__NonEmpty_foldMap
    : forall {m} {a},
-     forall `{GHC.Base.Monoid m},
-     (a -> m) -> Data.SemigroupInternal.Product a -> m :=
-  fun {m} {a} `{GHC.Base.Monoid m} => GHC.Prim.coerce.
-
-Local Definition Foldable__Product_fold
-   : forall {m},
-     forall `{GHC.Base.Monoid m}, Data.SemigroupInternal.Product m -> m :=
-  fun {m} `{GHC.Base.Monoid m} => Foldable__Product_foldMap GHC.Base.id.
-
-Local Definition Foldable__Product_foldl
-   : forall {b} {a},
-     (b -> a -> b) -> b -> Data.SemigroupInternal.Product a -> b :=
-  fun {b} {a} => GHC.Prim.coerce.
-
-Local Definition Foldable__Product_foldl'
-   : forall {b} {a},
-     (b -> a -> b) -> b -> Data.SemigroupInternal.Product a -> b :=
-  fun {b} {a} => GHC.Prim.coerce.
-
-Local Definition Foldable__Product_foldr
-   : forall {a} {b},
-     (a -> b -> b) -> b -> Data.SemigroupInternal.Product a -> b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | f, z, Data.SemigroupInternal.Mk_Product x => f x z
-      end.
-
-Local Definition Foldable__Product_foldr'
-   : forall {a} {b},
-     (a -> b -> b) -> b -> Data.SemigroupInternal.Product a -> b :=
-  fun {a} {b} => Foldable__Product_foldr.
-
-Local Definition Foldable__Product_length
-   : forall {a}, Data.SemigroupInternal.Product a -> GHC.Num.Int :=
-  fun {a} => fun arg_0__ => #1.
-
-Local Definition Foldable__Product_null
-   : forall {a}, Data.SemigroupInternal.Product a -> bool :=
-  fun {a} => fun arg_0__ => false.
-
-Local Definition Foldable__Product_product
-   : forall {a}, forall `{GHC.Num.Num a}, Data.SemigroupInternal.Product a -> a :=
-  fun {a} `{GHC.Num.Num a} => Data.SemigroupInternal.getProduct.
-
-Local Definition Foldable__Product_sum
-   : forall {a}, forall `{GHC.Num.Num a}, Data.SemigroupInternal.Product a -> a :=
-  fun {a} `{GHC.Num.Num a} => Data.SemigroupInternal.getProduct.
-
-Local Definition Foldable__Product_toList
-   : forall {a}, Data.SemigroupInternal.Product a -> list a :=
-  fun {a} => fun '(Data.SemigroupInternal.Mk_Product x) => cons x nil.
-
-Program Instance Foldable__Product : Foldable Data.SemigroupInternal.Product :=
-  fun _ k__ =>
-    k__ {| fold__ := fun {m} `{GHC.Base.Monoid m} => Foldable__Product_fold ;
-           foldMap__ := fun {m} {a} `{GHC.Base.Monoid m} => Foldable__Product_foldMap ;
-           foldl__ := fun {b} {a} => Foldable__Product_foldl ;
-           foldl'__ := fun {b} {a} => Foldable__Product_foldl' ;
-           foldr__ := fun {a} {b} => Foldable__Product_foldr ;
-           foldr'__ := fun {a} {b} => Foldable__Product_foldr' ;
-           length__ := fun {a} => Foldable__Product_length ;
-           null__ := fun {a} => Foldable__Product_null ;
-           product__ := fun {a} `{GHC.Num.Num a} => Foldable__Product_product ;
-           sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Product_sum ;
-           toList__ := fun {a} => Foldable__Product_toList |}.
-
-Local Definition Foldable__Sum_foldMap
-   : forall {m} {a},
-     forall `{GHC.Base.Monoid m}, (a -> m) -> Data.SemigroupInternal.Sum a -> m :=
-  fun {m} {a} `{GHC.Base.Monoid m} => GHC.Prim.coerce.
-
-Local Definition Foldable__Sum_fold
-   : forall {m}, forall `{GHC.Base.Monoid m}, Data.SemigroupInternal.Sum m -> m :=
-  fun {m} `{GHC.Base.Monoid m} => Foldable__Sum_foldMap GHC.Base.id.
-
-Local Definition Foldable__Sum_foldl
-   : forall {b} {a}, (b -> a -> b) -> b -> Data.SemigroupInternal.Sum a -> b :=
-  fun {b} {a} => GHC.Prim.coerce.
-
-Local Definition Foldable__Sum_foldl'
-   : forall {b} {a}, (b -> a -> b) -> b -> Data.SemigroupInternal.Sum a -> b :=
-  fun {b} {a} => GHC.Prim.coerce.
-
-Local Definition Foldable__Sum_foldr
-   : forall {a} {b}, (a -> b -> b) -> b -> Data.SemigroupInternal.Sum a -> b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | f, z, Data.SemigroupInternal.Mk_Sum x => f x z
-      end.
-
-Local Definition Foldable__Sum_foldr'
-   : forall {a} {b}, (a -> b -> b) -> b -> Data.SemigroupInternal.Sum a -> b :=
-  fun {a} {b} => Foldable__Sum_foldr.
-
-Local Definition Foldable__Sum_length
-   : forall {a}, Data.SemigroupInternal.Sum a -> GHC.Num.Int :=
-  fun {a} => fun arg_0__ => #1.
-
-Local Definition Foldable__Sum_null
-   : forall {a}, Data.SemigroupInternal.Sum a -> bool :=
-  fun {a} => fun arg_0__ => false.
-
-Local Definition Foldable__Sum_product
-   : forall {a}, forall `{GHC.Num.Num a}, Data.SemigroupInternal.Sum a -> a :=
-  fun {a} `{GHC.Num.Num a} => Data.SemigroupInternal.getSum.
-
-Local Definition Foldable__Sum_sum
-   : forall {a}, forall `{GHC.Num.Num a}, Data.SemigroupInternal.Sum a -> a :=
-  fun {a} `{GHC.Num.Num a} => Data.SemigroupInternal.getSum.
-
-Local Definition Foldable__Sum_toList
-   : forall {a}, Data.SemigroupInternal.Sum a -> list a :=
-  fun {a} => fun '(Data.SemigroupInternal.Mk_Sum x) => cons x nil.
-
-Program Instance Foldable__Sum : Foldable Data.SemigroupInternal.Sum :=
-  fun _ k__ =>
-    k__ {| fold__ := fun {m} `{GHC.Base.Monoid m} => Foldable__Sum_fold ;
-           foldMap__ := fun {m} {a} `{GHC.Base.Monoid m} => Foldable__Sum_foldMap ;
-           foldl__ := fun {b} {a} => Foldable__Sum_foldl ;
-           foldl'__ := fun {b} {a} => Foldable__Sum_foldl' ;
-           foldr__ := fun {a} {b} => Foldable__Sum_foldr ;
-           foldr'__ := fun {a} {b} => Foldable__Sum_foldr' ;
-           length__ := fun {a} => Foldable__Sum_length ;
-           null__ := fun {a} => Foldable__Sum_null ;
-           product__ := fun {a} `{GHC.Num.Num a} => Foldable__Sum_product ;
-           sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Sum_sum ;
-           toList__ := fun {a} => Foldable__Sum_toList |}.
-
-Local Definition Foldable__Dual_foldMap
-   : forall {m} {a},
-     forall `{GHC.Base.Monoid m}, (a -> m) -> Data.SemigroupInternal.Dual a -> m :=
-  fun {m} {a} `{GHC.Base.Monoid m} => GHC.Prim.coerce.
-
-Local Definition Foldable__Dual_fold
-   : forall {m},
-     forall `{GHC.Base.Monoid m}, Data.SemigroupInternal.Dual m -> m :=
-  fun {m} `{GHC.Base.Monoid m} => Foldable__Dual_foldMap GHC.Base.id.
-
-Local Definition Foldable__Dual_foldl
-   : forall {b} {a}, (b -> a -> b) -> b -> Data.SemigroupInternal.Dual a -> b :=
-  fun {b} {a} => GHC.Prim.coerce.
-
-Local Definition Foldable__Dual_foldl'
-   : forall {b} {a}, (b -> a -> b) -> b -> Data.SemigroupInternal.Dual a -> b :=
-  fun {b} {a} => GHC.Prim.coerce.
-
-Local Definition Foldable__Dual_foldr
-   : forall {a} {b}, (a -> b -> b) -> b -> Data.SemigroupInternal.Dual a -> b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | f, z, Data.SemigroupInternal.Mk_Dual x => f x z
-      end.
-
-Local Definition Foldable__Dual_foldr'
-   : forall {a} {b}, (a -> b -> b) -> b -> Data.SemigroupInternal.Dual a -> b :=
-  fun {a} {b} => Foldable__Dual_foldr.
-
-Local Definition Foldable__Dual_length
-   : forall {a}, Data.SemigroupInternal.Dual a -> GHC.Num.Int :=
-  fun {a} => fun arg_0__ => #1.
-
-Local Definition Foldable__Dual_null
-   : forall {a}, Data.SemigroupInternal.Dual a -> bool :=
-  fun {a} => fun arg_0__ => false.
-
-Local Definition Foldable__Dual_product
-   : forall {a}, forall `{GHC.Num.Num a}, Data.SemigroupInternal.Dual a -> a :=
-  fun {a} `{GHC.Num.Num a} => Data.SemigroupInternal.getDual.
-
-Local Definition Foldable__Dual_sum
-   : forall {a}, forall `{GHC.Num.Num a}, Data.SemigroupInternal.Dual a -> a :=
-  fun {a} `{GHC.Num.Num a} => Data.SemigroupInternal.getDual.
-
-Local Definition Foldable__Dual_toList
-   : forall {a}, Data.SemigroupInternal.Dual a -> list a :=
-  fun {a} => fun '(Data.SemigroupInternal.Mk_Dual x) => cons x nil.
-
-Program Instance Foldable__Dual : Foldable Data.SemigroupInternal.Dual :=
-  fun _ k__ =>
-    k__ {| fold__ := fun {m} `{GHC.Base.Monoid m} => Foldable__Dual_fold ;
-           foldMap__ := fun {m} {a} `{GHC.Base.Monoid m} => Foldable__Dual_foldMap ;
-           foldl__ := fun {b} {a} => Foldable__Dual_foldl ;
-           foldl'__ := fun {b} {a} => Foldable__Dual_foldl' ;
-           foldr__ := fun {a} {b} => Foldable__Dual_foldr ;
-           foldr'__ := fun {a} {b} => Foldable__Dual_foldr' ;
-           length__ := fun {a} => Foldable__Dual_length ;
-           null__ := fun {a} => Foldable__Dual_null ;
-           product__ := fun {a} `{GHC.Num.Num a} => Foldable__Dual_product ;
-           sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Dual_sum ;
-           toList__ := fun {a} => Foldable__Dual_toList |}.
-
-Local Definition Foldable__Proxy_fold
-   : forall {m}, forall `{GHC.Base.Monoid m}, Data.Proxy.Proxy m -> m :=
-  fun {m} `{GHC.Base.Monoid m} => fun arg_0__ => GHC.Base.mempty.
-
-Local Definition Foldable__Proxy_foldMap
-   : forall {m} {a},
-     forall `{GHC.Base.Monoid m}, (a -> m) -> Data.Proxy.Proxy a -> m :=
-  fun {m} {a} `{GHC.Base.Monoid m} => fun arg_0__ arg_1__ => GHC.Base.mempty.
-
-Local Definition Foldable__Proxy_foldl
-   : forall {b} {a}, (b -> a -> b) -> b -> Data.Proxy.Proxy a -> b :=
-  fun {b} {a} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | _, z, _ => z
-      end.
-
-Local Definition Foldable__Proxy_foldr
-   : forall {a} {b}, (a -> b -> b) -> b -> Data.Proxy.Proxy a -> b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | _, z, _ => z
-      end.
-
-Local Definition Foldable__Proxy_foldl'
-   : forall {b} {a}, (b -> a -> b) -> b -> Data.Proxy.Proxy a -> b :=
-  fun {b} {a} =>
-    fun f z0 xs =>
-      let f' := fun x k z => k (f z x) in Foldable__Proxy_foldr f' GHC.Base.id xs z0.
-
-Local Definition Foldable__Proxy_foldr'
-   : forall {a} {b}, (a -> b -> b) -> b -> Data.Proxy.Proxy a -> b :=
-  fun {a} {b} =>
-    fun f z0 xs =>
-      let f' := fun k x z => k (f x z) in Foldable__Proxy_foldl f' GHC.Base.id xs z0.
-
-Local Definition Foldable__Proxy_length
-   : forall {a}, Data.Proxy.Proxy a -> GHC.Num.Int :=
-  fun {a} => fun arg_0__ => #0.
-
-Local Definition Foldable__Proxy_null
-   : forall {a}, Data.Proxy.Proxy a -> bool :=
-  fun {a} => fun arg_0__ => true.
-
-Local Definition Foldable__Proxy_product
-   : forall {a}, forall `{GHC.Num.Num a}, Data.Proxy.Proxy a -> a :=
-  fun {a} `{GHC.Num.Num a} => fun arg_0__ => #1.
-
-Local Definition Foldable__Proxy_sum
-   : forall {a}, forall `{GHC.Num.Num a}, Data.Proxy.Proxy a -> a :=
-  fun {a} `{GHC.Num.Num a} => fun arg_0__ => #0.
-
-Local Definition Foldable__Proxy_toList
-   : forall {a}, Data.Proxy.Proxy a -> list a :=
-  fun {a} =>
-    fun t => GHC.Base.build' (fun _ => (fun c n => Foldable__Proxy_foldr c n t)).
-
-Program Instance Foldable__Proxy : Foldable Data.Proxy.Proxy :=
-  fun _ k__ =>
-    k__ {| fold__ := fun {m} `{GHC.Base.Monoid m} => Foldable__Proxy_fold ;
-           foldMap__ := fun {m} {a} `{GHC.Base.Monoid m} => Foldable__Proxy_foldMap ;
-           foldl__ := fun {b} {a} => Foldable__Proxy_foldl ;
-           foldl'__ := fun {b} {a} => Foldable__Proxy_foldl' ;
-           foldr__ := fun {a} {b} => Foldable__Proxy_foldr ;
-           foldr'__ := fun {a} {b} => Foldable__Proxy_foldr' ;
-           length__ := fun {a} => Foldable__Proxy_length ;
-           null__ := fun {a} => Foldable__Proxy_null ;
-           product__ := fun {a} `{GHC.Num.Num a} => Foldable__Proxy_product ;
-           sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Proxy_sum ;
-           toList__ := fun {a} => Foldable__Proxy_toList |}.
-
-(* Skipping instance `Data.Foldable.Foldable__Array' of class
-   `Data.Foldable.Foldable' *)
-
-Local Definition Foldable__pair_type_foldMap {inst_a}
-   : forall {m} {a},
-     forall `{GHC.Base.Monoid m}, (a -> m) -> (GHC.Tuple.pair_type inst_a) a -> m :=
+     forall `{GHC.Base.Monoid m}, (a -> m) -> GHC.Base.NonEmpty a -> m :=
   fun {m} {a} `{GHC.Base.Monoid m} =>
-    fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | f, pair _ y => f y end.
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, GHC.Base.NEcons a as_ => GHC.Base.mappend (f a) (foldMap f as_)
+      end.
 
-Local Definition Foldable__pair_type_fold {inst_a}
-   : forall {m},
-     forall `{GHC.Base.Monoid m}, (GHC.Tuple.pair_type inst_a) m -> m :=
-  fun {m} `{GHC.Base.Monoid m} => Foldable__pair_type_foldMap GHC.Base.id.
-
-Local Definition Foldable__pair_type_foldl {inst_a}
-   : forall {b} {a}, (b -> a -> b) -> b -> (GHC.Tuple.pair_type inst_a) a -> b :=
+Local Definition Foldable__NonEmpty_foldl
+   : forall {b} {a}, (b -> a -> b) -> b -> GHC.Base.NonEmpty a -> b :=
   fun {b} {a} =>
-    fun f z t =>
-      Data.SemigroupInternal.appEndo (Data.SemigroupInternal.getDual
-                                      (Foldable__pair_type_foldMap (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
-                                                                    (Data.SemigroupInternal.Mk_Endo GHC.Base.∘
-                                                                     GHC.Base.flip f)) t)) z.
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | f, z, GHC.Base.NEcons a as_ => GHC.Base.foldl f (f z a) as_
+      end.
 
-Local Definition Foldable__pair_type_foldr {inst_a}
-   : forall {a} {b}, (a -> b -> b) -> b -> (GHC.Tuple.pair_type inst_a) a -> b :=
+Local Definition Foldable__NonEmpty_foldr
+   : forall {a} {b}, (a -> b -> b) -> b -> GHC.Base.NonEmpty a -> b :=
   fun {a} {b} =>
     fun arg_0__ arg_1__ arg_2__ =>
       match arg_0__, arg_1__, arg_2__ with
-      | f, z, pair _ y => f y z
+      | f, z, GHC.Base.NEcons a as_ => f a (GHC.Base.foldr f z as_)
       end.
 
-Local Definition Foldable__pair_type_foldl' {inst_a}
-   : forall {b} {a}, (b -> a -> b) -> b -> (GHC.Tuple.pair_type inst_a) a -> b :=
+Local Definition Foldable__NonEmpty_foldl'
+   : forall {b} {a}, (b -> a -> b) -> b -> GHC.Base.NonEmpty a -> b :=
   fun {b} {a} =>
     fun f z0 xs =>
       let f' := fun x k z => k (f z x) in
-      Foldable__pair_type_foldr f' GHC.Base.id xs z0.
+      Foldable__NonEmpty_foldr f' GHC.Base.id xs z0.
 
-Local Definition Foldable__pair_type_foldr' {inst_a}
-   : forall {a} {b}, (a -> b -> b) -> b -> (GHC.Tuple.pair_type inst_a) a -> b :=
+Local Definition Foldable__NonEmpty_foldr'
+   : forall {a} {b}, (a -> b -> b) -> b -> GHC.Base.NonEmpty a -> b :=
   fun {a} {b} =>
     fun f z0 xs =>
       let f' := fun k x z => k (f x z) in
-      Foldable__pair_type_foldl f' GHC.Base.id xs z0.
+      Foldable__NonEmpty_foldl f' GHC.Base.id xs z0.
 
-Local Definition Foldable__pair_type_length {inst_a}
-   : forall {a}, (GHC.Tuple.pair_type inst_a) a -> GHC.Num.Int :=
-  fun {a} =>
-    Foldable__pair_type_foldl' (fun arg_0__ arg_1__ =>
-                                  match arg_0__, arg_1__ with
-                                  | c, _ => c GHC.Num.+ #1
-                                  end) #0.
+Local Definition Foldable__NonEmpty_length
+   : forall {a}, GHC.Base.NonEmpty a -> GHC.Num.Int :=
+  fun {a} => fun '(GHC.Base.NEcons _ as_) => #1 GHC.Num.+ GHC.List.length as_.
 
-Local Definition Foldable__pair_type_null {inst_a}
-   : forall {a}, (GHC.Tuple.pair_type inst_a) a -> bool :=
-  fun {a} => Foldable__pair_type_foldr (fun arg_0__ arg_1__ => false) true.
+Local Definition Foldable__NonEmpty_null
+   : forall {a}, GHC.Base.NonEmpty a -> bool :=
+  fun {a} => Foldable__NonEmpty_foldr (fun arg_0__ arg_1__ => false) true.
 
-Local Definition Foldable__pair_type_product {inst_a}
-   : forall {a}, forall `{GHC.Num.Num a}, (GHC.Tuple.pair_type inst_a) a -> a :=
+Local Definition Foldable__NonEmpty_product
+   : forall {a}, forall `{GHC.Num.Num a}, GHC.Base.NonEmpty a -> a :=
   fun {a} `{GHC.Num.Num a} =>
     Coq.Program.Basics.compose Data.SemigroupInternal.getProduct
-                               (Foldable__pair_type_foldMap Data.SemigroupInternal.Mk_Product).
+                               (Foldable__NonEmpty_foldMap Data.SemigroupInternal.Mk_Product).
 
-Local Definition Foldable__pair_type_sum {inst_a}
-   : forall {a}, forall `{GHC.Num.Num a}, (GHC.Tuple.pair_type inst_a) a -> a :=
+Local Definition Foldable__NonEmpty_sum
+   : forall {a}, forall `{GHC.Num.Num a}, GHC.Base.NonEmpty a -> a :=
   fun {a} `{GHC.Num.Num a} =>
     Coq.Program.Basics.compose Data.SemigroupInternal.getSum
-                               (Foldable__pair_type_foldMap Data.SemigroupInternal.Mk_Sum).
+                               (Foldable__NonEmpty_foldMap Data.SemigroupInternal.Mk_Sum).
 
-Local Definition Foldable__pair_type_toList {inst_a}
-   : forall {a}, (GHC.Tuple.pair_type inst_a) a -> list a :=
-  fun {a} =>
-    fun t =>
-      GHC.Base.build' (fun _ => (fun c n => Foldable__pair_type_foldr c n t)).
+Local Definition Foldable__NonEmpty_toList
+   : forall {a}, GHC.Base.NonEmpty a -> list a :=
+  fun {a} => fun '(GHC.Base.NEcons a as_) => cons a as_.
 
-Program Instance Foldable__pair_type {a} : Foldable (GHC.Tuple.pair_type a) :=
+Program Instance Foldable__NonEmpty : Foldable GHC.Base.NonEmpty :=
   fun _ k__ =>
-    k__ {| fold__ := fun {m} `{GHC.Base.Monoid m} => Foldable__pair_type_fold ;
-           foldMap__ := fun {m} {a} `{GHC.Base.Monoid m} => Foldable__pair_type_foldMap ;
-           foldl__ := fun {b} {a} => Foldable__pair_type_foldl ;
-           foldl'__ := fun {b} {a} => Foldable__pair_type_foldl' ;
-           foldr__ := fun {a} {b} => Foldable__pair_type_foldr ;
-           foldr'__ := fun {a} {b} => Foldable__pair_type_foldr' ;
-           length__ := fun {a} => Foldable__pair_type_length ;
-           null__ := fun {a} => Foldable__pair_type_null ;
-           product__ := fun {a} `{GHC.Num.Num a} => Foldable__pair_type_product ;
-           sum__ := fun {a} `{GHC.Num.Num a} => Foldable__pair_type_sum ;
-           toList__ := fun {a} => Foldable__pair_type_toList |}.
+    k__ {| fold__ := fun {m} `{GHC.Base.Monoid m} => Foldable__NonEmpty_fold ;
+           foldMap__ := fun {m} {a} `{GHC.Base.Monoid m} => Foldable__NonEmpty_foldMap ;
+           foldl__ := fun {b} {a} => Foldable__NonEmpty_foldl ;
+           foldl'__ := fun {b} {a} => Foldable__NonEmpty_foldl' ;
+           foldr__ := fun {a} {b} => Foldable__NonEmpty_foldr ;
+           foldr'__ := fun {a} {b} => Foldable__NonEmpty_foldr' ;
+           length__ := fun {a} => Foldable__NonEmpty_length ;
+           null__ := fun {a} => Foldable__NonEmpty_null ;
+           product__ := fun {a} `{GHC.Num.Num a} => Foldable__NonEmpty_product ;
+           sum__ := fun {a} `{GHC.Num.Num a} => Foldable__NonEmpty_sum ;
+           toList__ := fun {a} => Foldable__NonEmpty_toList |}.
 
 Local Definition Foldable__Either_foldMap {inst_a}
    : forall {m} {a},
@@ -802,166 +516,452 @@ Program Instance Foldable__Either {a} : Foldable (Data.Either.Either a) :=
            sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Either_sum ;
            toList__ := fun {a} => Foldable__Either_toList |}.
 
-Local Definition Foldable__NonEmpty_fold
-   : forall {m}, forall `{GHC.Base.Monoid m}, GHC.Base.NonEmpty m -> m :=
-  fun {m} `{GHC.Base.Monoid m} =>
-    fun '(GHC.Base.NEcons m ms) => GHC.Base.mappend m (fold ms).
-
-Local Definition Foldable__NonEmpty_foldMap
+Local Definition Foldable__pair_type_foldMap {inst_a}
    : forall {m} {a},
-     forall `{GHC.Base.Monoid m}, (a -> m) -> GHC.Base.NonEmpty a -> m :=
+     forall `{GHC.Base.Monoid m}, (a -> m) -> (GHC.Tuple.pair_type inst_a) a -> m :=
   fun {m} {a} `{GHC.Base.Monoid m} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, GHC.Base.NEcons a as_ => GHC.Base.mappend (f a) (foldMap f as_)
-      end.
+    fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | f, pair _ y => f y end.
 
-Local Definition Foldable__NonEmpty_foldl
-   : forall {b} {a}, (b -> a -> b) -> b -> GHC.Base.NonEmpty a -> b :=
+Local Definition Foldable__pair_type_fold {inst_a}
+   : forall {m},
+     forall `{GHC.Base.Monoid m}, (GHC.Tuple.pair_type inst_a) m -> m :=
+  fun {m} `{GHC.Base.Monoid m} => Foldable__pair_type_foldMap GHC.Base.id.
+
+Local Definition Foldable__pair_type_foldl {inst_a}
+   : forall {b} {a}, (b -> a -> b) -> b -> (GHC.Tuple.pair_type inst_a) a -> b :=
   fun {b} {a} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | f, z, GHC.Base.NEcons a as_ => GHC.Base.foldl f (f z a) as_
-      end.
+    fun f z t =>
+      Data.SemigroupInternal.appEndo (Data.SemigroupInternal.getDual
+                                      (Foldable__pair_type_foldMap (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
+                                                                    (Data.SemigroupInternal.Mk_Endo GHC.Base.∘
+                                                                     GHC.Base.flip f)) t)) z.
 
-Local Definition Foldable__NonEmpty_foldr
-   : forall {a} {b}, (a -> b -> b) -> b -> GHC.Base.NonEmpty a -> b :=
+Local Definition Foldable__pair_type_foldr {inst_a}
+   : forall {a} {b}, (a -> b -> b) -> b -> (GHC.Tuple.pair_type inst_a) a -> b :=
   fun {a} {b} =>
     fun arg_0__ arg_1__ arg_2__ =>
       match arg_0__, arg_1__, arg_2__ with
-      | f, z, GHC.Base.NEcons a as_ => f a (GHC.Base.foldr f z as_)
+      | f, z, pair _ y => f y z
       end.
 
-Local Definition Foldable__NonEmpty_foldl'
-   : forall {b} {a}, (b -> a -> b) -> b -> GHC.Base.NonEmpty a -> b :=
+Local Definition Foldable__pair_type_foldl' {inst_a}
+   : forall {b} {a}, (b -> a -> b) -> b -> (GHC.Tuple.pair_type inst_a) a -> b :=
   fun {b} {a} =>
     fun f z0 xs =>
       let f' := fun x k z => k (f z x) in
-      Foldable__NonEmpty_foldr f' GHC.Base.id xs z0.
+      Foldable__pair_type_foldr f' GHC.Base.id xs z0.
 
-Local Definition Foldable__NonEmpty_foldr'
-   : forall {a} {b}, (a -> b -> b) -> b -> GHC.Base.NonEmpty a -> b :=
+Local Definition Foldable__pair_type_foldr' {inst_a}
+   : forall {a} {b}, (a -> b -> b) -> b -> (GHC.Tuple.pair_type inst_a) a -> b :=
   fun {a} {b} =>
     fun f z0 xs =>
       let f' := fun k x z => k (f x z) in
-      Foldable__NonEmpty_foldl f' GHC.Base.id xs z0.
+      Foldable__pair_type_foldl f' GHC.Base.id xs z0.
 
-Local Definition Foldable__NonEmpty_length
-   : forall {a}, GHC.Base.NonEmpty a -> GHC.Num.Int :=
-  fun {a} => fun '(GHC.Base.NEcons _ as_) => #1 GHC.Num.+ GHC.List.length as_.
+Local Definition Foldable__pair_type_length {inst_a}
+   : forall {a}, (GHC.Tuple.pair_type inst_a) a -> GHC.Num.Int :=
+  fun {a} =>
+    Foldable__pair_type_foldl' (fun arg_0__ arg_1__ =>
+                                  match arg_0__, arg_1__ with
+                                  | c, _ => c GHC.Num.+ #1
+                                  end) #0.
 
-Local Definition Foldable__NonEmpty_null
-   : forall {a}, GHC.Base.NonEmpty a -> bool :=
-  fun {a} => Foldable__NonEmpty_foldr (fun arg_0__ arg_1__ => false) true.
+Local Definition Foldable__pair_type_null {inst_a}
+   : forall {a}, (GHC.Tuple.pair_type inst_a) a -> bool :=
+  fun {a} => Foldable__pair_type_foldr (fun arg_0__ arg_1__ => false) true.
 
-Local Definition Foldable__NonEmpty_product
-   : forall {a}, forall `{GHC.Num.Num a}, GHC.Base.NonEmpty a -> a :=
+Local Definition Foldable__pair_type_product {inst_a}
+   : forall {a}, forall `{GHC.Num.Num a}, (GHC.Tuple.pair_type inst_a) a -> a :=
   fun {a} `{GHC.Num.Num a} =>
     Coq.Program.Basics.compose Data.SemigroupInternal.getProduct
-                               (Foldable__NonEmpty_foldMap Data.SemigroupInternal.Mk_Product).
+                               (Foldable__pair_type_foldMap Data.SemigroupInternal.Mk_Product).
 
-Local Definition Foldable__NonEmpty_sum
-   : forall {a}, forall `{GHC.Num.Num a}, GHC.Base.NonEmpty a -> a :=
+Local Definition Foldable__pair_type_sum {inst_a}
+   : forall {a}, forall `{GHC.Num.Num a}, (GHC.Tuple.pair_type inst_a) a -> a :=
   fun {a} `{GHC.Num.Num a} =>
     Coq.Program.Basics.compose Data.SemigroupInternal.getSum
-                               (Foldable__NonEmpty_foldMap Data.SemigroupInternal.Mk_Sum).
+                               (Foldable__pair_type_foldMap Data.SemigroupInternal.Mk_Sum).
 
-Local Definition Foldable__NonEmpty_toList
-   : forall {a}, GHC.Base.NonEmpty a -> list a :=
-  fun {a} => fun '(GHC.Base.NEcons a as_) => cons a as_.
+Local Definition Foldable__pair_type_toList {inst_a}
+   : forall {a}, (GHC.Tuple.pair_type inst_a) a -> list a :=
+  fun {a} =>
+    fun t =>
+      GHC.Base.build' (fun _ => (fun c n => Foldable__pair_type_foldr c n t)).
 
-Program Instance Foldable__NonEmpty : Foldable GHC.Base.NonEmpty :=
+Program Instance Foldable__pair_type {a} : Foldable (GHC.Tuple.pair_type a) :=
   fun _ k__ =>
-    k__ {| fold__ := fun {m} `{GHC.Base.Monoid m} => Foldable__NonEmpty_fold ;
-           foldMap__ := fun {m} {a} `{GHC.Base.Monoid m} => Foldable__NonEmpty_foldMap ;
-           foldl__ := fun {b} {a} => Foldable__NonEmpty_foldl ;
-           foldl'__ := fun {b} {a} => Foldable__NonEmpty_foldl' ;
-           foldr__ := fun {a} {b} => Foldable__NonEmpty_foldr ;
-           foldr'__ := fun {a} {b} => Foldable__NonEmpty_foldr' ;
-           length__ := fun {a} => Foldable__NonEmpty_length ;
-           null__ := fun {a} => Foldable__NonEmpty_null ;
-           product__ := fun {a} `{GHC.Num.Num a} => Foldable__NonEmpty_product ;
-           sum__ := fun {a} `{GHC.Num.Num a} => Foldable__NonEmpty_sum ;
-           toList__ := fun {a} => Foldable__NonEmpty_toList |}.
+    k__ {| fold__ := fun {m} `{GHC.Base.Monoid m} => Foldable__pair_type_fold ;
+           foldMap__ := fun {m} {a} `{GHC.Base.Monoid m} => Foldable__pair_type_foldMap ;
+           foldl__ := fun {b} {a} => Foldable__pair_type_foldl ;
+           foldl'__ := fun {b} {a} => Foldable__pair_type_foldl' ;
+           foldr__ := fun {a} {b} => Foldable__pair_type_foldr ;
+           foldr'__ := fun {a} {b} => Foldable__pair_type_foldr' ;
+           length__ := fun {a} => Foldable__pair_type_length ;
+           null__ := fun {a} => Foldable__pair_type_null ;
+           product__ := fun {a} `{GHC.Num.Num a} => Foldable__pair_type_product ;
+           sum__ := fun {a} `{GHC.Num.Num a} => Foldable__pair_type_sum ;
+           toList__ := fun {a} => Foldable__pair_type_toList |}.
 
-Local Definition Foldable__option_foldMap
-   : forall {m} {a}, forall `{GHC.Base.Monoid m}, (a -> m) -> option a -> m :=
-  fun {m} {a} `{GHC.Base.Monoid m} => Data.Maybe.maybe GHC.Base.mempty.
+(* Skipping instance `Data.Foldable.Foldable__Array' of class
+   `Data.Foldable.Foldable' *)
 
-Local Definition Foldable__option_fold
-   : forall {m}, forall `{GHC.Base.Monoid m}, option m -> m :=
-  fun {m} `{GHC.Base.Monoid m} => Foldable__option_foldMap GHC.Base.id.
+Local Definition Foldable__Proxy_fold
+   : forall {m}, forall `{GHC.Base.Monoid m}, Data.Proxy.Proxy m -> m :=
+  fun {m} `{GHC.Base.Monoid m} => fun arg_0__ => GHC.Base.mempty.
 
-Local Definition Foldable__option_foldl
-   : forall {b} {a}, (b -> a -> b) -> b -> option a -> b :=
+Local Definition Foldable__Proxy_foldMap
+   : forall {m} {a},
+     forall `{GHC.Base.Monoid m}, (a -> m) -> Data.Proxy.Proxy a -> m :=
+  fun {m} {a} `{GHC.Base.Monoid m} => fun arg_0__ arg_1__ => GHC.Base.mempty.
+
+Local Definition Foldable__Proxy_foldl
+   : forall {b} {a}, (b -> a -> b) -> b -> Data.Proxy.Proxy a -> b :=
   fun {b} {a} =>
     fun arg_0__ arg_1__ arg_2__ =>
       match arg_0__, arg_1__, arg_2__ with
-      | _, z, None => z
-      | f, z, Some x => f z x
+      | _, z, _ => z
       end.
 
-Local Definition Foldable__option_foldr
-   : forall {a} {b}, (a -> b -> b) -> b -> option a -> b :=
+Local Definition Foldable__Proxy_foldr
+   : forall {a} {b}, (a -> b -> b) -> b -> Data.Proxy.Proxy a -> b :=
   fun {a} {b} =>
     fun arg_0__ arg_1__ arg_2__ =>
       match arg_0__, arg_1__, arg_2__ with
-      | _, z, None => z
-      | f, z, Some x => f x z
+      | _, z, _ => z
       end.
 
-Local Definition Foldable__option_foldl'
-   : forall {b} {a}, (b -> a -> b) -> b -> option a -> b :=
+Local Definition Foldable__Proxy_foldl'
+   : forall {b} {a}, (b -> a -> b) -> b -> Data.Proxy.Proxy a -> b :=
   fun {b} {a} =>
     fun f z0 xs =>
-      let f' := fun x k z => k (f z x) in Foldable__option_foldr f' GHC.Base.id xs z0.
+      let f' := fun x k z => k (f z x) in Foldable__Proxy_foldr f' GHC.Base.id xs z0.
 
-Local Definition Foldable__option_foldr'
-   : forall {a} {b}, (a -> b -> b) -> b -> option a -> b :=
+Local Definition Foldable__Proxy_foldr'
+   : forall {a} {b}, (a -> b -> b) -> b -> Data.Proxy.Proxy a -> b :=
   fun {a} {b} =>
     fun f z0 xs =>
-      let f' := fun k x z => k (f x z) in Foldable__option_foldl f' GHC.Base.id xs z0.
+      let f' := fun k x z => k (f x z) in Foldable__Proxy_foldl f' GHC.Base.id xs z0.
 
-Local Definition Foldable__option_length
-   : forall {a}, option a -> GHC.Num.Int :=
+Local Definition Foldable__Proxy_length
+   : forall {a}, Data.Proxy.Proxy a -> GHC.Num.Int :=
+  fun {a} => fun arg_0__ => #0.
+
+Local Definition Foldable__Proxy_null
+   : forall {a}, Data.Proxy.Proxy a -> bool :=
+  fun {a} => fun arg_0__ => true.
+
+Local Definition Foldable__Proxy_product
+   : forall {a}, forall `{GHC.Num.Num a}, Data.Proxy.Proxy a -> a :=
+  fun {a} `{GHC.Num.Num a} => fun arg_0__ => #1.
+
+Local Definition Foldable__Proxy_sum
+   : forall {a}, forall `{GHC.Num.Num a}, Data.Proxy.Proxy a -> a :=
+  fun {a} `{GHC.Num.Num a} => fun arg_0__ => #0.
+
+Local Definition Foldable__Proxy_toList
+   : forall {a}, Data.Proxy.Proxy a -> list a :=
   fun {a} =>
-    Foldable__option_foldl' (fun arg_0__ arg_1__ =>
-                               match arg_0__, arg_1__ with
-                               | c, _ => c GHC.Num.+ #1
-                               end) #0.
+    fun t => GHC.Base.build' (fun _ => (fun c n => Foldable__Proxy_foldr c n t)).
 
-Local Definition Foldable__option_null : forall {a}, option a -> bool :=
-  fun {a} => Foldable__option_foldr (fun arg_0__ arg_1__ => false) true.
-
-Local Definition Foldable__option_product
-   : forall {a}, forall `{GHC.Num.Num a}, option a -> a :=
-  fun {a} `{GHC.Num.Num a} =>
-    Coq.Program.Basics.compose Data.SemigroupInternal.getProduct
-                               (Foldable__option_foldMap Data.SemigroupInternal.Mk_Product).
-
-Local Definition Foldable__option_sum
-   : forall {a}, forall `{GHC.Num.Num a}, option a -> a :=
-  fun {a} `{GHC.Num.Num a} =>
-    Coq.Program.Basics.compose Data.SemigroupInternal.getSum
-                               (Foldable__option_foldMap Data.SemigroupInternal.Mk_Sum).
-
-Local Definition Foldable__option_toList : forall {a}, option a -> list a :=
-  fun {a} =>
-    fun t => GHC.Base.build' (fun _ => (fun c n => Foldable__option_foldr c n t)).
-
-Program Instance Foldable__option : Foldable option :=
+Program Instance Foldable__Proxy : Foldable Data.Proxy.Proxy :=
   fun _ k__ =>
-    k__ {| fold__ := fun {m} `{GHC.Base.Monoid m} => Foldable__option_fold ;
-           foldMap__ := fun {m} {a} `{GHC.Base.Monoid m} => Foldable__option_foldMap ;
-           foldl__ := fun {b} {a} => Foldable__option_foldl ;
-           foldl'__ := fun {b} {a} => Foldable__option_foldl' ;
-           foldr__ := fun {a} {b} => Foldable__option_foldr ;
-           foldr'__ := fun {a} {b} => Foldable__option_foldr' ;
-           length__ := fun {a} => Foldable__option_length ;
-           null__ := fun {a} => Foldable__option_null ;
-           product__ := fun {a} `{GHC.Num.Num a} => Foldable__option_product ;
-           sum__ := fun {a} `{GHC.Num.Num a} => Foldable__option_sum ;
-           toList__ := fun {a} => Foldable__option_toList |}.
+    k__ {| fold__ := fun {m} `{GHC.Base.Monoid m} => Foldable__Proxy_fold ;
+           foldMap__ := fun {m} {a} `{GHC.Base.Monoid m} => Foldable__Proxy_foldMap ;
+           foldl__ := fun {b} {a} => Foldable__Proxy_foldl ;
+           foldl'__ := fun {b} {a} => Foldable__Proxy_foldl' ;
+           foldr__ := fun {a} {b} => Foldable__Proxy_foldr ;
+           foldr'__ := fun {a} {b} => Foldable__Proxy_foldr' ;
+           length__ := fun {a} => Foldable__Proxy_length ;
+           null__ := fun {a} => Foldable__Proxy_null ;
+           product__ := fun {a} `{GHC.Num.Num a} => Foldable__Proxy_product ;
+           sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Proxy_sum ;
+           toList__ := fun {a} => Foldable__Proxy_toList |}.
+
+Local Definition Foldable__Dual_foldMap
+   : forall {m} {a},
+     forall `{GHC.Base.Monoid m}, (a -> m) -> Data.SemigroupInternal.Dual a -> m :=
+  fun {m} {a} `{GHC.Base.Monoid m} => GHC.Prim.coerce.
+
+Local Definition Foldable__Dual_fold
+   : forall {m},
+     forall `{GHC.Base.Monoid m}, Data.SemigroupInternal.Dual m -> m :=
+  fun {m} `{GHC.Base.Monoid m} => Foldable__Dual_foldMap GHC.Base.id.
+
+Local Definition Foldable__Dual_foldl
+   : forall {b} {a}, (b -> a -> b) -> b -> Data.SemigroupInternal.Dual a -> b :=
+  fun {b} {a} => GHC.Prim.coerce.
+
+Local Definition Foldable__Dual_foldl'
+   : forall {b} {a}, (b -> a -> b) -> b -> Data.SemigroupInternal.Dual a -> b :=
+  fun {b} {a} => GHC.Prim.coerce.
+
+Local Definition Foldable__Dual_foldr
+   : forall {a} {b}, (a -> b -> b) -> b -> Data.SemigroupInternal.Dual a -> b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | f, z, Data.SemigroupInternal.Mk_Dual x => f x z
+      end.
+
+Local Definition Foldable__Dual_foldr'
+   : forall {a} {b}, (a -> b -> b) -> b -> Data.SemigroupInternal.Dual a -> b :=
+  fun {a} {b} => Foldable__Dual_foldr.
+
+Local Definition Foldable__Dual_length
+   : forall {a}, Data.SemigroupInternal.Dual a -> GHC.Num.Int :=
+  fun {a} => fun arg_0__ => #1.
+
+Local Definition Foldable__Dual_null
+   : forall {a}, Data.SemigroupInternal.Dual a -> bool :=
+  fun {a} => fun arg_0__ => false.
+
+Local Definition Foldable__Dual_product
+   : forall {a}, forall `{GHC.Num.Num a}, Data.SemigroupInternal.Dual a -> a :=
+  fun {a} `{GHC.Num.Num a} => Data.SemigroupInternal.getDual.
+
+Local Definition Foldable__Dual_sum
+   : forall {a}, forall `{GHC.Num.Num a}, Data.SemigroupInternal.Dual a -> a :=
+  fun {a} `{GHC.Num.Num a} => Data.SemigroupInternal.getDual.
+
+Local Definition Foldable__Dual_toList
+   : forall {a}, Data.SemigroupInternal.Dual a -> list a :=
+  fun {a} => fun '(Data.SemigroupInternal.Mk_Dual x) => cons x nil.
+
+Program Instance Foldable__Dual : Foldable Data.SemigroupInternal.Dual :=
+  fun _ k__ =>
+    k__ {| fold__ := fun {m} `{GHC.Base.Monoid m} => Foldable__Dual_fold ;
+           foldMap__ := fun {m} {a} `{GHC.Base.Monoid m} => Foldable__Dual_foldMap ;
+           foldl__ := fun {b} {a} => Foldable__Dual_foldl ;
+           foldl'__ := fun {b} {a} => Foldable__Dual_foldl' ;
+           foldr__ := fun {a} {b} => Foldable__Dual_foldr ;
+           foldr'__ := fun {a} {b} => Foldable__Dual_foldr' ;
+           length__ := fun {a} => Foldable__Dual_length ;
+           null__ := fun {a} => Foldable__Dual_null ;
+           product__ := fun {a} `{GHC.Num.Num a} => Foldable__Dual_product ;
+           sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Dual_sum ;
+           toList__ := fun {a} => Foldable__Dual_toList |}.
+
+Local Definition Foldable__Sum_foldMap
+   : forall {m} {a},
+     forall `{GHC.Base.Monoid m}, (a -> m) -> Data.SemigroupInternal.Sum a -> m :=
+  fun {m} {a} `{GHC.Base.Monoid m} => GHC.Prim.coerce.
+
+Local Definition Foldable__Sum_fold
+   : forall {m}, forall `{GHC.Base.Monoid m}, Data.SemigroupInternal.Sum m -> m :=
+  fun {m} `{GHC.Base.Monoid m} => Foldable__Sum_foldMap GHC.Base.id.
+
+Local Definition Foldable__Sum_foldl
+   : forall {b} {a}, (b -> a -> b) -> b -> Data.SemigroupInternal.Sum a -> b :=
+  fun {b} {a} => GHC.Prim.coerce.
+
+Local Definition Foldable__Sum_foldl'
+   : forall {b} {a}, (b -> a -> b) -> b -> Data.SemigroupInternal.Sum a -> b :=
+  fun {b} {a} => GHC.Prim.coerce.
+
+Local Definition Foldable__Sum_foldr
+   : forall {a} {b}, (a -> b -> b) -> b -> Data.SemigroupInternal.Sum a -> b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | f, z, Data.SemigroupInternal.Mk_Sum x => f x z
+      end.
+
+Local Definition Foldable__Sum_foldr'
+   : forall {a} {b}, (a -> b -> b) -> b -> Data.SemigroupInternal.Sum a -> b :=
+  fun {a} {b} => Foldable__Sum_foldr.
+
+Local Definition Foldable__Sum_length
+   : forall {a}, Data.SemigroupInternal.Sum a -> GHC.Num.Int :=
+  fun {a} => fun arg_0__ => #1.
+
+Local Definition Foldable__Sum_null
+   : forall {a}, Data.SemigroupInternal.Sum a -> bool :=
+  fun {a} => fun arg_0__ => false.
+
+Local Definition Foldable__Sum_product
+   : forall {a}, forall `{GHC.Num.Num a}, Data.SemigroupInternal.Sum a -> a :=
+  fun {a} `{GHC.Num.Num a} => Data.SemigroupInternal.getSum.
+
+Local Definition Foldable__Sum_sum
+   : forall {a}, forall `{GHC.Num.Num a}, Data.SemigroupInternal.Sum a -> a :=
+  fun {a} `{GHC.Num.Num a} => Data.SemigroupInternal.getSum.
+
+Local Definition Foldable__Sum_toList
+   : forall {a}, Data.SemigroupInternal.Sum a -> list a :=
+  fun {a} => fun '(Data.SemigroupInternal.Mk_Sum x) => cons x nil.
+
+Program Instance Foldable__Sum : Foldable Data.SemigroupInternal.Sum :=
+  fun _ k__ =>
+    k__ {| fold__ := fun {m} `{GHC.Base.Monoid m} => Foldable__Sum_fold ;
+           foldMap__ := fun {m} {a} `{GHC.Base.Monoid m} => Foldable__Sum_foldMap ;
+           foldl__ := fun {b} {a} => Foldable__Sum_foldl ;
+           foldl'__ := fun {b} {a} => Foldable__Sum_foldl' ;
+           foldr__ := fun {a} {b} => Foldable__Sum_foldr ;
+           foldr'__ := fun {a} {b} => Foldable__Sum_foldr' ;
+           length__ := fun {a} => Foldable__Sum_length ;
+           null__ := fun {a} => Foldable__Sum_null ;
+           product__ := fun {a} `{GHC.Num.Num a} => Foldable__Sum_product ;
+           sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Sum_sum ;
+           toList__ := fun {a} => Foldable__Sum_toList |}.
+
+Local Definition Foldable__Product_foldMap
+   : forall {m} {a},
+     forall `{GHC.Base.Monoid m},
+     (a -> m) -> Data.SemigroupInternal.Product a -> m :=
+  fun {m} {a} `{GHC.Base.Monoid m} => GHC.Prim.coerce.
+
+Local Definition Foldable__Product_fold
+   : forall {m},
+     forall `{GHC.Base.Monoid m}, Data.SemigroupInternal.Product m -> m :=
+  fun {m} `{GHC.Base.Monoid m} => Foldable__Product_foldMap GHC.Base.id.
+
+Local Definition Foldable__Product_foldl
+   : forall {b} {a},
+     (b -> a -> b) -> b -> Data.SemigroupInternal.Product a -> b :=
+  fun {b} {a} => GHC.Prim.coerce.
+
+Local Definition Foldable__Product_foldl'
+   : forall {b} {a},
+     (b -> a -> b) -> b -> Data.SemigroupInternal.Product a -> b :=
+  fun {b} {a} => GHC.Prim.coerce.
+
+Local Definition Foldable__Product_foldr
+   : forall {a} {b},
+     (a -> b -> b) -> b -> Data.SemigroupInternal.Product a -> b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | f, z, Data.SemigroupInternal.Mk_Product x => f x z
+      end.
+
+Local Definition Foldable__Product_foldr'
+   : forall {a} {b},
+     (a -> b -> b) -> b -> Data.SemigroupInternal.Product a -> b :=
+  fun {a} {b} => Foldable__Product_foldr.
+
+Local Definition Foldable__Product_length
+   : forall {a}, Data.SemigroupInternal.Product a -> GHC.Num.Int :=
+  fun {a} => fun arg_0__ => #1.
+
+Local Definition Foldable__Product_null
+   : forall {a}, Data.SemigroupInternal.Product a -> bool :=
+  fun {a} => fun arg_0__ => false.
+
+Local Definition Foldable__Product_product
+   : forall {a}, forall `{GHC.Num.Num a}, Data.SemigroupInternal.Product a -> a :=
+  fun {a} `{GHC.Num.Num a} => Data.SemigroupInternal.getProduct.
+
+Local Definition Foldable__Product_sum
+   : forall {a}, forall `{GHC.Num.Num a}, Data.SemigroupInternal.Product a -> a :=
+  fun {a} `{GHC.Num.Num a} => Data.SemigroupInternal.getProduct.
+
+Local Definition Foldable__Product_toList
+   : forall {a}, Data.SemigroupInternal.Product a -> list a :=
+  fun {a} => fun '(Data.SemigroupInternal.Mk_Product x) => cons x nil.
+
+Program Instance Foldable__Product : Foldable Data.SemigroupInternal.Product :=
+  fun _ k__ =>
+    k__ {| fold__ := fun {m} `{GHC.Base.Monoid m} => Foldable__Product_fold ;
+           foldMap__ := fun {m} {a} `{GHC.Base.Monoid m} => Foldable__Product_foldMap ;
+           foldl__ := fun {b} {a} => Foldable__Product_foldl ;
+           foldl'__ := fun {b} {a} => Foldable__Product_foldl' ;
+           foldr__ := fun {a} {b} => Foldable__Product_foldr ;
+           foldr'__ := fun {a} {b} => Foldable__Product_foldr' ;
+           length__ := fun {a} => Foldable__Product_length ;
+           null__ := fun {a} => Foldable__Product_null ;
+           product__ := fun {a} `{GHC.Num.Num a} => Foldable__Product_product ;
+           sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Product_sum ;
+           toList__ := fun {a} => Foldable__Product_toList |}.
+
+(* Skipping instance `Data.Foldable.Foldable__First' of class
+   `Data.Foldable.Foldable' *)
+
+(* Skipping instance `Data.Foldable.Foldable__Last' of class
+   `Data.Foldable.Foldable' *)
+
+(* Skipping instance `Data.Foldable.Foldable__U1' of class
+   `Data.Foldable.Foldable' *)
+
+Definition foldrM {t} {m} {a} {b} `{Foldable t} `{GHC.Base.Monad m}
+   : (a -> b -> m b) -> b -> t a -> m b :=
+  fun f z0 xs =>
+    let f' := fun k x z => f x z GHC.Base.>>= k in foldl f' GHC.Base.return_ xs z0.
+
+Definition foldlM {t} {m} {b} {a} `{Foldable t} `{GHC.Base.Monad m}
+   : (b -> a -> m b) -> b -> t a -> m b :=
+  fun f z0 xs =>
+    let f' := fun x k z => f z x GHC.Base.>>= k in foldr f' GHC.Base.return_ xs z0.
+
+Definition traverse_ {t} {f} {a} {b} `{Foldable t} `{GHC.Base.Applicative f}
+   : (a -> f b) -> t a -> f unit :=
+  fun f => foldr (_GHC.Base.*>_ GHC.Base.∘ f) (GHC.Base.pure tt).
+
+Definition for__ {t} {f} {a} {b} `{Foldable t} `{GHC.Base.Applicative f}
+   : t a -> (a -> f b) -> f unit :=
+  GHC.Base.flip traverse_.
+
+Definition mapM_ {t} {m} {a} {b} `{Foldable t} `{GHC.Base.Monad m}
+   : (a -> m b) -> t a -> m unit :=
+  fun f => foldr (_GHC.Base.>>_ GHC.Base.∘ f) (GHC.Base.return_ tt).
+
+Definition forM_ {t} {m} {a} {b} `{Foldable t} `{GHC.Base.Monad m}
+   : t a -> (a -> m b) -> m unit :=
+  GHC.Base.flip mapM_.
+
+Definition sequenceA_ {t} {f} {a} `{Foldable t} `{GHC.Base.Applicative f}
+   : t (f a) -> f unit :=
+  foldr _GHC.Base.*>_ (GHC.Base.pure tt).
+
+Definition sequence_ {t} {m} {a} `{Foldable t} `{GHC.Base.Monad m}
+   : t (m a) -> m unit :=
+  foldr _GHC.Base.>>_ (GHC.Base.return_ tt).
+
+(* Skipping definition `Data.Foldable.asum' *)
+
+(* Skipping definition `Data.Foldable.msum' *)
+
+Definition concatMap {t} {a} {b} `{Foldable t}
+   : (a -> list b) -> t a -> list b :=
+  fun f xs =>
+    GHC.Base.build' (fun _ => (fun c n => foldr (fun x b => foldr c b (f x)) n xs)).
+
+Definition concat {t} {a} `{Foldable t} : t (list a) -> list a :=
+  fun xs =>
+    GHC.Base.build' (fun _ =>
+                       fun c n => foldr (fun x y => (@foldr _ Foldable__list _ _ c y x)) n xs).
+
+Definition and {t} `{Foldable t} : t bool -> bool :=
+  Coq.Program.Basics.compose Data.SemigroupInternal.getAll (foldMap
+                              Data.SemigroupInternal.Mk_All).
+
+Definition or {t} `{Foldable t} : t bool -> bool :=
+  Coq.Program.Basics.compose Data.SemigroupInternal.getAny (foldMap
+                              Data.SemigroupInternal.Mk_Any).
+
+Definition any {t} {a} `{Foldable t} : (a -> bool) -> t a -> bool :=
+  fun p =>
+    Coq.Program.Basics.compose Data.SemigroupInternal.getAny (foldMap
+                                (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Any p)).
+
+Definition all {t} {a} `{Foldable t} : (a -> bool) -> t a -> bool :=
+  fun p =>
+    Coq.Program.Basics.compose Data.SemigroupInternal.getAll (foldMap
+                                (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_All p)).
+
+(* Skipping definition `Data.Foldable.maximumBy' *)
+
+(* Skipping definition `Data.Foldable.minimumBy' *)
+
+Definition elem {f} `{Foldable f} {a} `{GHC.Base.Eq_ a} : a -> f a -> bool :=
+  fun x xs => any (fun y => x GHC.Base.== y) xs.
+
+Definition notElem {t} {a} `{Foldable t} `{GHC.Base.Eq_ a} : a -> t a -> bool :=
+  fun x => negb GHC.Base.∘ elem x.
+
+Definition find {t} {a} `{Foldable t} : (a -> bool) -> t a -> option a :=
+  fun p =>
+    Data.Monoid.getFirst GHC.Base.∘
+    foldMap (fun x => Data.Monoid.Mk_First (if p x : bool then Some x else None)).
 
 (* External variables:
      None Some bool cons false list negb nil option pair true tt unit

--- a/base/Data/Function.v
+++ b/base/Data/Function.v
@@ -16,17 +16,17 @@ Require Coq.Program.Wf.
 
 (* Converted value declarations: *)
 
+(* Skipping definition `Data.Function.fix_' *)
+
+Definition on {b} {c} {a} : (b -> b -> c) -> (a -> b) -> a -> a -> c :=
+  fun lop_ziztzi__ f => fun x y => lop_ziztzi__ (f x) (f y).
+
 Definition op_za__ {a} {b} : a -> (a -> b) -> b :=
   fun x f => f x.
 
 Notation "'_&_'" := (op_za__).
 
 Infix "&" := (_&_) (at level 99).
-
-Definition on {b} {c} {a} : (b -> b -> c) -> (a -> b) -> a -> a -> c :=
-  fun lop_ziztzi__ f => fun x y => lop_ziztzi__ (f x) (f y).
-
-(* Skipping definition `Data.Function.fix_' *)
 
 Module Notations.
 Notation "'_Data.Function.&_'" := (op_za__).

--- a/base/Data/Functor.v
+++ b/base/Data/Functor.v
@@ -22,9 +22,6 @@ Import GHC.Base.Notations.
 
 (* Converted value declarations: *)
 
-Definition void {f} {a} `{GHC.Base.Functor f} : f a -> f unit :=
-  fun x => tt GHC.Base.<$ x.
-
 Definition op_zlzdzg__ {f} {a} {b} `{GHC.Base.Functor f}
    : (a -> b) -> f a -> f b :=
   GHC.Base.fmap.
@@ -47,6 +44,9 @@ Definition op_zdzg__ {f} {a} {b} `{GHC.Base.Functor f} : f a -> b -> f b :=
 Notation "'_$>_'" := (op_zdzg__).
 
 Infix "$>" := (_$>_) (at level 99).
+
+Definition void {f} {a} `{GHC.Base.Functor f} : f a -> f unit :=
+  fun x => tt GHC.Base.<$ x.
 
 Module Notations.
 Notation "'_Data.Functor.<$>_'" := (op_zlzdzg__).

--- a/base/Data/Functor/Classes.v
+++ b/base/Data/Functor/Classes.v
@@ -75,120 +75,6 @@ Definition liftCompare `{g__0__ : Ord1 f}
 
 (* Converted value declarations: *)
 
-(* Skipping definition `Data.Functor.Classes.showsUnaryWith' *)
-
-(* Skipping definition `Data.Functor.Classes.showsUnary1' *)
-
-(* Skipping definition `Data.Functor.Classes.showsUnary' *)
-
-(* Skipping definition `Data.Functor.Classes.showsPrec2' *)
-
-(* Skipping definition `Data.Functor.Classes.showsPrec1' *)
-
-(* Skipping definition `Data.Functor.Classes.showsBinaryWith' *)
-
-(* Skipping definition `Data.Functor.Classes.showsBinary1' *)
-
-(* Skipping definition `Data.Functor.Classes.readsUnaryWith' *)
-
-(* Skipping definition `Data.Functor.Classes.readsUnary1' *)
-
-(* Skipping definition `Data.Functor.Classes.readsUnary' *)
-
-(* Skipping definition `Data.Functor.Classes.readsPrec2' *)
-
-(* Skipping definition `Data.Functor.Classes.readsPrec1' *)
-
-(* Skipping definition `Data.Functor.Classes.readsData' *)
-
-(* Skipping definition `Data.Functor.Classes.readsBinaryWith' *)
-
-(* Skipping definition `Data.Functor.Classes.readsBinary1' *)
-
-(* Skipping definition `Data.Functor.Classes.readUnaryWith' *)
-
-(* Skipping definition `Data.Functor.Classes.readPrec2' *)
-
-(* Skipping definition `Data.Functor.Classes.readPrec1' *)
-
-(* Skipping definition `Data.Functor.Classes.readData' *)
-
-(* Skipping definition `Data.Functor.Classes.readBinaryWith' *)
-
-(* Skipping definition `Data.Functor.Classes.liftReadListPrecDefault' *)
-
-(* Skipping definition `Data.Functor.Classes.liftReadListPrec2Default' *)
-
-(* Skipping definition `Data.Functor.Classes.liftReadListDefault' *)
-
-(* Skipping definition `Data.Functor.Classes.liftReadList2Default' *)
-
-Definition eq2 {f} {a} {b} `{Eq2 f} `{GHC.Base.Eq_ a} `{GHC.Base.Eq_ b}
-   : f a b -> f a b -> bool :=
-  liftEq2 _GHC.Base.==_ _GHC.Base.==_.
-
-Definition eq1 {f} {a} `{Eq1 f} `{GHC.Base.Eq_ a} : f a -> f a -> bool :=
-  liftEq _GHC.Base.==_.
-
-Definition compare2 {f} {a} {b} `{Ord2 f} `{GHC.Base.Ord a} `{GHC.Base.Ord b}
-   : f a b -> f a b -> comparison :=
-  liftCompare2 GHC.Base.compare GHC.Base.compare.
-
-Definition compare1 {f} {a} `{Ord1 f} `{GHC.Base.Ord a}
-   : f a -> f a -> comparison :=
-  liftCompare GHC.Base.compare.
-
-Local Definition Eq1__Proxy_liftEq
-   : forall {a} {b},
-     (a -> b -> bool) -> Data.Proxy.Proxy a -> Data.Proxy.Proxy b -> bool :=
-  fun {a} {b} => fun arg_0__ arg_1__ arg_2__ => true.
-
-Program Instance Eq1__Proxy : Eq1 Data.Proxy.Proxy :=
-  fun _ k__ => k__ {| liftEq__ := fun {a} {b} => Eq1__Proxy_liftEq |}.
-
-Local Definition Eq1__Identity_liftEq
-   : forall {a} {b},
-     (a -> b -> bool) ->
-     Data.Functor.Identity.Identity a -> Data.Functor.Identity.Identity b -> bool :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | eq
-      , Data.Functor.Identity.Mk_Identity x
-      , Data.Functor.Identity.Mk_Identity y =>
-          eq x y
-      end.
-
-Program Instance Eq1__Identity : Eq1 Data.Functor.Identity.Identity :=
-  fun _ k__ => k__ {| liftEq__ := fun {a} {b} => Eq1__Identity_liftEq |}.
-
-Local Definition Eq1__list_liftEq
-   : forall {a} {b}, (a -> b -> bool) -> list a -> list b -> bool :=
-  fun {a} {b} =>
-    fix liftEq arg_69__ arg_70__ arg_71__
-          := match arg_69__, arg_70__, arg_71__ with
-             | _, nil, nil => true
-             | _, nil, cons _ _ => false
-             | _, cons _ _, nil => false
-             | eq, cons x xs, cons y ys => andb (eq x y) (liftEq eq xs ys)
-             end.
-
-Program Instance Eq1__list : Eq1 list :=
-  fun _ k__ => k__ {| liftEq__ := fun {a} {b} => Eq1__list_liftEq |}.
-
-Local Definition Eq1__NonEmpty_liftEq
-   : forall {a} {b},
-     (a -> b -> bool) -> GHC.Base.NonEmpty a -> GHC.Base.NonEmpty b -> bool :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | eq, GHC.Base.NEcons a as_, GHC.Base.NEcons b bs =>
-          andb (eq a b) (liftEq eq as_ bs)
-      end.
-
-Program Instance Eq1__NonEmpty : Eq1 GHC.Base.NonEmpty :=
-  fun _ k__ => k__ {| liftEq__ := fun {a} {b} => Eq1__NonEmpty_liftEq |}.
-
 Local Definition Eq1__option_liftEq
    : forall {a} {b}, (a -> b -> bool) -> option a -> option b -> bool :=
   fun {a} {b} =>
@@ -202,63 +88,6 @@ Local Definition Eq1__option_liftEq
 
 Program Instance Eq1__option : Eq1 option :=
   fun _ k__ => k__ {| liftEq__ := fun {a} {b} => Eq1__option_liftEq |}.
-
-Local Definition Ord1__Proxy_liftCompare
-   : forall {a} {b},
-     (a -> b -> comparison) ->
-     Data.Proxy.Proxy a -> Data.Proxy.Proxy b -> comparison :=
-  fun {a} {b} => fun arg_0__ arg_1__ arg_2__ => Eq.
-
-Program Instance Ord1__Proxy : Ord1 Data.Proxy.Proxy :=
-  fun _ k__ => k__ {| liftCompare__ := fun {a} {b} => Ord1__Proxy_liftCompare |}.
-
-Local Definition Ord1__Identity_liftCompare
-   : forall {a} {b},
-     (a -> b -> comparison) ->
-     Data.Functor.Identity.Identity a ->
-     Data.Functor.Identity.Identity b -> comparison :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | comp
-      , Data.Functor.Identity.Mk_Identity x
-      , Data.Functor.Identity.Mk_Identity y =>
-          comp x y
-      end.
-
-Program Instance Ord1__Identity : Ord1 Data.Functor.Identity.Identity :=
-  fun _ k__ =>
-    k__ {| liftCompare__ := fun {a} {b} => Ord1__Identity_liftCompare |}.
-
-Local Definition Ord1__list_liftCompare
-   : forall {a} {b}, (a -> b -> comparison) -> list a -> list b -> comparison :=
-  fun {a} {b} =>
-    fix liftCompare arg_69__ arg_70__ arg_71__
-          := match arg_69__, arg_70__, arg_71__ with
-             | _, nil, nil => Eq
-             | _, nil, cons _ _ => Lt
-             | _, cons _ _, nil => Gt
-             | comp, cons x xs, cons y ys =>
-                 GHC.Base.mappend (comp x y) (liftCompare comp xs ys)
-             end.
-
-Program Instance Ord1__list : Ord1 list :=
-  fun _ k__ => k__ {| liftCompare__ := fun {a} {b} => Ord1__list_liftCompare |}.
-
-Local Definition Ord1__NonEmpty_liftCompare
-   : forall {a} {b},
-     (a -> b -> comparison) ->
-     GHC.Base.NonEmpty a -> GHC.Base.NonEmpty b -> comparison :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | cmp, GHC.Base.NEcons a as_, GHC.Base.NEcons b bs =>
-          GHC.Base.mappend (cmp a b) (liftCompare cmp as_ bs)
-      end.
-
-Program Instance Ord1__NonEmpty : Ord1 GHC.Base.NonEmpty :=
-  fun _ k__ =>
-    k__ {| liftCompare__ := fun {a} {b} => Ord1__NonEmpty_liftCompare |}.
 
 Local Definition Ord1__option_liftCompare
    : forall {a} {b},
@@ -276,85 +105,79 @@ Program Instance Ord1__option : Ord1 option :=
   fun _ k__ => k__ {| liftCompare__ := fun {a} {b} => Ord1__option_liftCompare |}.
 
 (* Skipping all instances of class `Data.Functor.Classes.Read1', including
-   `Data.Functor.Classes.Read1__Proxy' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Read1', including
-   `Data.Functor.Classes.Read1__Identity' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Read1', including
-   `Data.Functor.Classes.Read1__NonEmpty' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Read1', including
-   `Data.Functor.Classes.Read1__list' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Read1', including
    `Data.Functor.Classes.Read1__option' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Show1', including
-   `Data.Functor.Classes.Show1__Proxy' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Show1', including
-   `Data.Functor.Classes.Show1__Identity' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Show1', including
-   `Data.Functor.Classes.Show1__NonEmpty' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Show1', including
-   `Data.Functor.Classes.Show1__list' *)
 
 (* Skipping all instances of class `Data.Functor.Classes.Show1', including
    `Data.Functor.Classes.Show1__option' *)
 
-Local Definition Eq2__Const_liftEq2
-   : forall {a} {b} {c} {d},
-     (a -> b -> bool) ->
-     (c -> d -> bool) ->
-     Data.Functor.Const.Const a c -> Data.Functor.Const.Const b d -> bool :=
-  fun {a} {b} {c} {d} =>
-    fun arg_0__ arg_1__ arg_2__ arg_3__ =>
-      match arg_0__, arg_1__, arg_2__, arg_3__ with
-      | eq, _, Data.Functor.Const.Mk_Const x, Data.Functor.Const.Mk_Const y => eq x y
+Local Definition Eq1__list_liftEq
+   : forall {a} {b}, (a -> b -> bool) -> list a -> list b -> bool :=
+  fun {a} {b} =>
+    fix liftEq arg_69__ arg_70__ arg_71__
+          := match arg_69__, arg_70__, arg_71__ with
+             | _, nil, nil => true
+             | _, nil, cons _ _ => false
+             | _, cons _ _, nil => false
+             | eq, cons x xs, cons y ys => andb (eq x y) (liftEq eq xs ys)
+             end.
+
+Program Instance Eq1__list : Eq1 list :=
+  fun _ k__ => k__ {| liftEq__ := fun {a} {b} => Eq1__list_liftEq |}.
+
+Local Definition Ord1__list_liftCompare
+   : forall {a} {b}, (a -> b -> comparison) -> list a -> list b -> comparison :=
+  fun {a} {b} =>
+    fix liftCompare arg_69__ arg_70__ arg_71__
+          := match arg_69__, arg_70__, arg_71__ with
+             | _, nil, nil => Eq
+             | _, nil, cons _ _ => Lt
+             | _, cons _ _, nil => Gt
+             | comp, cons x xs, cons y ys =>
+                 GHC.Base.mappend (comp x y) (liftCompare comp xs ys)
+             end.
+
+Program Instance Ord1__list : Ord1 list :=
+  fun _ k__ => k__ {| liftCompare__ := fun {a} {b} => Ord1__list_liftCompare |}.
+
+(* Skipping all instances of class `Data.Functor.Classes.Read1', including
+   `Data.Functor.Classes.Read1__list' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Show1', including
+   `Data.Functor.Classes.Show1__list' *)
+
+Local Definition Eq1__NonEmpty_liftEq
+   : forall {a} {b},
+     (a -> b -> bool) -> GHC.Base.NonEmpty a -> GHC.Base.NonEmpty b -> bool :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | eq, GHC.Base.NEcons a as_, GHC.Base.NEcons b bs =>
+          andb (eq a b) (liftEq eq as_ bs)
       end.
 
-Program Instance Eq2__Const : Eq2 Data.Functor.Const.Const :=
-  fun _ k__ => k__ {| liftEq2__ := fun {a} {b} {c} {d} => Eq2__Const_liftEq2 |}.
+Program Instance Eq1__NonEmpty : Eq1 GHC.Base.NonEmpty :=
+  fun _ k__ => k__ {| liftEq__ := fun {a} {b} => Eq1__NonEmpty_liftEq |}.
 
-Local Definition Eq1__Const_liftEq {inst_a} `{(GHC.Base.Eq_ inst_a)}
+Local Definition Ord1__NonEmpty_liftCompare
    : forall {a} {b},
-     (a -> b -> bool) ->
-     (Data.Functor.Const.Const inst_a) a ->
-     (Data.Functor.Const.Const inst_a) b -> bool :=
-  fun {a} {b} => liftEq2 _GHC.Base.==_.
-
-Program Instance Eq1__Const {a} `{(GHC.Base.Eq_ a)}
-   : Eq1 (Data.Functor.Const.Const a) :=
-  fun _ k__ => k__ {| liftEq__ := fun {a} {b} => Eq1__Const_liftEq |}.
-
-Local Definition Eq2__Either_liftEq2
-   : forall {a} {b} {c} {d},
-     (a -> b -> bool) ->
-     (c -> d -> bool) -> Data.Either.Either a c -> Data.Either.Either b d -> bool :=
-  fun {a} {b} {c} {d} =>
-    fun arg_0__ arg_1__ arg_2__ arg_3__ =>
-      match arg_0__, arg_1__, arg_2__, arg_3__ with
-      | e1, _, Data.Either.Left x, Data.Either.Left y => e1 x y
-      | _, _, Data.Either.Left _, Data.Either.Right _ => false
-      | _, _, Data.Either.Right _, Data.Either.Left _ => false
-      | _, e2, Data.Either.Right x, Data.Either.Right y => e2 x y
+     (a -> b -> comparison) ->
+     GHC.Base.NonEmpty a -> GHC.Base.NonEmpty b -> comparison :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | cmp, GHC.Base.NEcons a as_, GHC.Base.NEcons b bs =>
+          GHC.Base.mappend (cmp a b) (liftCompare cmp as_ bs)
       end.
 
-Program Instance Eq2__Either : Eq2 Data.Either.Either :=
-  fun _ k__ => k__ {| liftEq2__ := fun {a} {b} {c} {d} => Eq2__Either_liftEq2 |}.
+Program Instance Ord1__NonEmpty : Ord1 GHC.Base.NonEmpty :=
+  fun _ k__ =>
+    k__ {| liftCompare__ := fun {a} {b} => Ord1__NonEmpty_liftCompare |}.
 
-Local Definition Eq1__Either_liftEq {inst_a} `{(GHC.Base.Eq_ inst_a)}
-   : forall {a} {b},
-     (a -> b -> bool) ->
-     (Data.Either.Either inst_a) a -> (Data.Either.Either inst_a) b -> bool :=
-  fun {a} {b} => liftEq2 _GHC.Base.==_.
+(* Skipping all instances of class `Data.Functor.Classes.Read1', including
+   `Data.Functor.Classes.Read1__NonEmpty' *)
 
-Program Instance Eq1__Either {a} `{(GHC.Base.Eq_ a)}
-   : Eq1 (Data.Either.Either a) :=
-  fun _ k__ => k__ {| liftEq__ := fun {a} {b} => Eq1__Either_liftEq |}.
+(* Skipping all instances of class `Data.Functor.Classes.Show1', including
+   `Data.Functor.Classes.Show1__NonEmpty' *)
 
 Local Definition Eq2__pair_type_liftEq2
    : forall {a} {b} {c} {d},
@@ -371,6 +194,28 @@ Program Instance Eq2__pair_type : Eq2 GHC.Tuple.pair_type :=
   fun _ k__ =>
     k__ {| liftEq2__ := fun {a} {b} {c} {d} => Eq2__pair_type_liftEq2 |}.
 
+Local Definition Ord2__pair_type_liftCompare2
+   : forall {a} {b} {c} {d},
+     (a -> b -> comparison) ->
+     (c -> d -> comparison) ->
+     GHC.Tuple.pair_type a c -> GHC.Tuple.pair_type b d -> comparison :=
+  fun {a} {b} {c} {d} =>
+    fun arg_0__ arg_1__ arg_2__ arg_3__ =>
+      match arg_0__, arg_1__, arg_2__, arg_3__ with
+      | comp1, comp2, pair x1 y1, pair x2 y2 =>
+          GHC.Base.mappend (comp1 x1 x2) (comp2 y1 y2)
+      end.
+
+Program Instance Ord2__pair_type : Ord2 GHC.Tuple.pair_type :=
+  fun _ k__ =>
+    k__ {| liftCompare2__ := fun {a} {b} {c} {d} => Ord2__pair_type_liftCompare2 |}.
+
+(* Skipping all instances of class `Data.Functor.Classes.Read2', including
+   `Data.Functor.Classes.Read2__pair_type' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Show2', including
+   `Data.Functor.Classes.Show2__pair_type' *)
+
 Local Definition Eq1__pair_type_liftEq {inst_a} `{(GHC.Base.Eq_ inst_a)}
    : forall {a} {b},
      (a -> b -> bool) ->
@@ -381,32 +226,39 @@ Program Instance Eq1__pair_type {a} `{(GHC.Base.Eq_ a)}
    : Eq1 (GHC.Tuple.pair_type a) :=
   fun _ k__ => k__ {| liftEq__ := fun {a} {b} => Eq1__pair_type_liftEq |}.
 
-Local Definition Ord2__Const_liftCompare2
-   : forall {a} {b} {c} {d},
+Local Definition Ord1__pair_type_liftCompare {inst_a} `{(GHC.Base.Ord inst_a)}
+   : forall {a} {b},
      (a -> b -> comparison) ->
-     (c -> d -> comparison) ->
-     Data.Functor.Const.Const a c -> Data.Functor.Const.Const b d -> comparison :=
+     (GHC.Tuple.pair_type inst_a) a ->
+     (GHC.Tuple.pair_type inst_a) b -> comparison :=
+  fun {a} {b} => liftCompare2 GHC.Base.compare.
+
+Program Instance Ord1__pair_type {a} `{(GHC.Base.Ord a)}
+   : Ord1 (GHC.Tuple.pair_type a) :=
+  fun _ k__ =>
+    k__ {| liftCompare__ := fun {a} {b} => Ord1__pair_type_liftCompare |}.
+
+(* Skipping all instances of class `Data.Functor.Classes.Read1', including
+   `Data.Functor.Classes.Read1__pair_type' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Show1', including
+   `Data.Functor.Classes.Show1__pair_type' *)
+
+Local Definition Eq2__Either_liftEq2
+   : forall {a} {b} {c} {d},
+     (a -> b -> bool) ->
+     (c -> d -> bool) -> Data.Either.Either a c -> Data.Either.Either b d -> bool :=
   fun {a} {b} {c} {d} =>
     fun arg_0__ arg_1__ arg_2__ arg_3__ =>
       match arg_0__, arg_1__, arg_2__, arg_3__ with
-      | comp, _, Data.Functor.Const.Mk_Const x, Data.Functor.Const.Mk_Const y =>
-          comp x y
+      | e1, _, Data.Either.Left x, Data.Either.Left y => e1 x y
+      | _, _, Data.Either.Left _, Data.Either.Right _ => false
+      | _, _, Data.Either.Right _, Data.Either.Left _ => false
+      | _, e2, Data.Either.Right x, Data.Either.Right y => e2 x y
       end.
 
-Program Instance Ord2__Const : Ord2 Data.Functor.Const.Const :=
-  fun _ k__ =>
-    k__ {| liftCompare2__ := fun {a} {b} {c} {d} => Ord2__Const_liftCompare2 |}.
-
-Local Definition Ord1__Const_liftCompare {inst_a} `{(GHC.Base.Ord inst_a)}
-   : forall {a} {b},
-     (a -> b -> comparison) ->
-     (Data.Functor.Const.Const inst_a) a ->
-     (Data.Functor.Const.Const inst_a) b -> comparison :=
-  fun {a} {b} => liftCompare2 GHC.Base.compare.
-
-Program Instance Ord1__Const {a} `{(GHC.Base.Ord a)}
-   : Ord1 (Data.Functor.Const.Const a) :=
-  fun _ k__ => k__ {| liftCompare__ := fun {a} {b} => Ord1__Const_liftCompare |}.
+Program Instance Eq2__Either : Eq2 Data.Either.Either :=
+  fun _ k__ => k__ {| liftEq2__ := fun {a} {b} {c} {d} => Eq2__Either_liftEq2 |}.
 
 Local Definition Ord2__Either_liftCompare2
    : forall {a} {b} {c} {d},
@@ -426,6 +278,22 @@ Program Instance Ord2__Either : Ord2 Data.Either.Either :=
   fun _ k__ =>
     k__ {| liftCompare2__ := fun {a} {b} {c} {d} => Ord2__Either_liftCompare2 |}.
 
+(* Skipping all instances of class `Data.Functor.Classes.Read2', including
+   `Data.Functor.Classes.Read2__Either' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Show2', including
+   `Data.Functor.Classes.Show2__Either' *)
+
+Local Definition Eq1__Either_liftEq {inst_a} `{(GHC.Base.Eq_ inst_a)}
+   : forall {a} {b},
+     (a -> b -> bool) ->
+     (Data.Either.Either inst_a) a -> (Data.Either.Either inst_a) b -> bool :=
+  fun {a} {b} => liftEq2 _GHC.Base.==_.
+
+Program Instance Eq1__Either {a} `{(GHC.Base.Eq_ a)}
+   : Eq1 (Data.Either.Either a) :=
+  fun _ k__ => k__ {| liftEq__ := fun {a} {b} => Eq1__Either_liftEq |}.
+
 Local Definition Ord1__Either_liftCompare {inst_a} `{(GHC.Base.Ord inst_a)}
    : forall {a} {b},
      (a -> b -> comparison) ->
@@ -436,69 +304,201 @@ Program Instance Ord1__Either {a} `{(GHC.Base.Ord a)}
    : Ord1 (Data.Either.Either a) :=
   fun _ k__ => k__ {| liftCompare__ := fun {a} {b} => Ord1__Either_liftCompare |}.
 
-Local Definition Ord2__pair_type_liftCompare2
-   : forall {a} {b} {c} {d},
-     (a -> b -> comparison) ->
-     (c -> d -> comparison) ->
-     GHC.Tuple.pair_type a c -> GHC.Tuple.pair_type b d -> comparison :=
-  fun {a} {b} {c} {d} =>
-    fun arg_0__ arg_1__ arg_2__ arg_3__ =>
-      match arg_0__, arg_1__, arg_2__, arg_3__ with
-      | comp1, comp2, pair x1 y1, pair x2 y2 =>
-          GHC.Base.mappend (comp1 x1 x2) (comp2 y1 y2)
-      end.
-
-Program Instance Ord2__pair_type : Ord2 GHC.Tuple.pair_type :=
-  fun _ k__ =>
-    k__ {| liftCompare2__ := fun {a} {b} {c} {d} => Ord2__pair_type_liftCompare2 |}.
-
-Local Definition Ord1__pair_type_liftCompare {inst_a} `{(GHC.Base.Ord inst_a)}
-   : forall {a} {b},
-     (a -> b -> comparison) ->
-     (GHC.Tuple.pair_type inst_a) a ->
-     (GHC.Tuple.pair_type inst_a) b -> comparison :=
-  fun {a} {b} => liftCompare2 GHC.Base.compare.
-
-Program Instance Ord1__pair_type {a} `{(GHC.Base.Ord a)}
-   : Ord1 (GHC.Tuple.pair_type a) :=
-  fun _ k__ =>
-    k__ {| liftCompare__ := fun {a} {b} => Ord1__pair_type_liftCompare |}.
-
-(* Skipping all instances of class `Data.Functor.Classes.Read1', including
-   `Data.Functor.Classes.Read1__Const' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Read2', including
-   `Data.Functor.Classes.Read2__Const' *)
-
 (* Skipping all instances of class `Data.Functor.Classes.Read1', including
    `Data.Functor.Classes.Read1__Either' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Read2', including
-   `Data.Functor.Classes.Read2__Either' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Read1', including
-   `Data.Functor.Classes.Read1__pair_type' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Read2', including
-   `Data.Functor.Classes.Read2__pair_type' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Show1', including
-   `Data.Functor.Classes.Show1__Const' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Show2', including
-   `Data.Functor.Classes.Show2__Const' *)
 
 (* Skipping all instances of class `Data.Functor.Classes.Show1', including
    `Data.Functor.Classes.Show1__Either' *)
 
-(* Skipping all instances of class `Data.Functor.Classes.Show2', including
-   `Data.Functor.Classes.Show2__Either' *)
+Local Definition Eq1__Identity_liftEq
+   : forall {a} {b},
+     (a -> b -> bool) ->
+     Data.Functor.Identity.Identity a -> Data.Functor.Identity.Identity b -> bool :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | eq
+      , Data.Functor.Identity.Mk_Identity x
+      , Data.Functor.Identity.Mk_Identity y =>
+          eq x y
+      end.
+
+Program Instance Eq1__Identity : Eq1 Data.Functor.Identity.Identity :=
+  fun _ k__ => k__ {| liftEq__ := fun {a} {b} => Eq1__Identity_liftEq |}.
+
+Local Definition Ord1__Identity_liftCompare
+   : forall {a} {b},
+     (a -> b -> comparison) ->
+     Data.Functor.Identity.Identity a ->
+     Data.Functor.Identity.Identity b -> comparison :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | comp
+      , Data.Functor.Identity.Mk_Identity x
+      , Data.Functor.Identity.Mk_Identity y =>
+          comp x y
+      end.
+
+Program Instance Ord1__Identity : Ord1 Data.Functor.Identity.Identity :=
+  fun _ k__ =>
+    k__ {| liftCompare__ := fun {a} {b} => Ord1__Identity_liftCompare |}.
+
+(* Skipping all instances of class `Data.Functor.Classes.Read1', including
+   `Data.Functor.Classes.Read1__Identity' *)
 
 (* Skipping all instances of class `Data.Functor.Classes.Show1', including
-   `Data.Functor.Classes.Show1__pair_type' *)
+   `Data.Functor.Classes.Show1__Identity' *)
+
+Local Definition Eq2__Const_liftEq2
+   : forall {a} {b} {c} {d},
+     (a -> b -> bool) ->
+     (c -> d -> bool) ->
+     Data.Functor.Const.Const a c -> Data.Functor.Const.Const b d -> bool :=
+  fun {a} {b} {c} {d} =>
+    fun arg_0__ arg_1__ arg_2__ arg_3__ =>
+      match arg_0__, arg_1__, arg_2__, arg_3__ with
+      | eq, _, Data.Functor.Const.Mk_Const x, Data.Functor.Const.Mk_Const y => eq x y
+      end.
+
+Program Instance Eq2__Const : Eq2 Data.Functor.Const.Const :=
+  fun _ k__ => k__ {| liftEq2__ := fun {a} {b} {c} {d} => Eq2__Const_liftEq2 |}.
+
+Local Definition Ord2__Const_liftCompare2
+   : forall {a} {b} {c} {d},
+     (a -> b -> comparison) ->
+     (c -> d -> comparison) ->
+     Data.Functor.Const.Const a c -> Data.Functor.Const.Const b d -> comparison :=
+  fun {a} {b} {c} {d} =>
+    fun arg_0__ arg_1__ arg_2__ arg_3__ =>
+      match arg_0__, arg_1__, arg_2__, arg_3__ with
+      | comp, _, Data.Functor.Const.Mk_Const x, Data.Functor.Const.Mk_Const y =>
+          comp x y
+      end.
+
+Program Instance Ord2__Const : Ord2 Data.Functor.Const.Const :=
+  fun _ k__ =>
+    k__ {| liftCompare2__ := fun {a} {b} {c} {d} => Ord2__Const_liftCompare2 |}.
+
+(* Skipping all instances of class `Data.Functor.Classes.Read2', including
+   `Data.Functor.Classes.Read2__Const' *)
 
 (* Skipping all instances of class `Data.Functor.Classes.Show2', including
-   `Data.Functor.Classes.Show2__pair_type' *)
+   `Data.Functor.Classes.Show2__Const' *)
+
+Local Definition Eq1__Const_liftEq {inst_a} `{(GHC.Base.Eq_ inst_a)}
+   : forall {a} {b},
+     (a -> b -> bool) ->
+     (Data.Functor.Const.Const inst_a) a ->
+     (Data.Functor.Const.Const inst_a) b -> bool :=
+  fun {a} {b} => liftEq2 _GHC.Base.==_.
+
+Program Instance Eq1__Const {a} `{(GHC.Base.Eq_ a)}
+   : Eq1 (Data.Functor.Const.Const a) :=
+  fun _ k__ => k__ {| liftEq__ := fun {a} {b} => Eq1__Const_liftEq |}.
+
+Local Definition Ord1__Const_liftCompare {inst_a} `{(GHC.Base.Ord inst_a)}
+   : forall {a} {b},
+     (a -> b -> comparison) ->
+     (Data.Functor.Const.Const inst_a) a ->
+     (Data.Functor.Const.Const inst_a) b -> comparison :=
+  fun {a} {b} => liftCompare2 GHC.Base.compare.
+
+Program Instance Ord1__Const {a} `{(GHC.Base.Ord a)}
+   : Ord1 (Data.Functor.Const.Const a) :=
+  fun _ k__ => k__ {| liftCompare__ := fun {a} {b} => Ord1__Const_liftCompare |}.
+
+(* Skipping all instances of class `Data.Functor.Classes.Read1', including
+   `Data.Functor.Classes.Read1__Const' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Show1', including
+   `Data.Functor.Classes.Show1__Const' *)
+
+Local Definition Eq1__Proxy_liftEq
+   : forall {a} {b},
+     (a -> b -> bool) -> Data.Proxy.Proxy a -> Data.Proxy.Proxy b -> bool :=
+  fun {a} {b} => fun arg_0__ arg_1__ arg_2__ => true.
+
+Program Instance Eq1__Proxy : Eq1 Data.Proxy.Proxy :=
+  fun _ k__ => k__ {| liftEq__ := fun {a} {b} => Eq1__Proxy_liftEq |}.
+
+Local Definition Ord1__Proxy_liftCompare
+   : forall {a} {b},
+     (a -> b -> comparison) ->
+     Data.Proxy.Proxy a -> Data.Proxy.Proxy b -> comparison :=
+  fun {a} {b} => fun arg_0__ arg_1__ arg_2__ => Eq.
+
+Program Instance Ord1__Proxy : Ord1 Data.Proxy.Proxy :=
+  fun _ k__ => k__ {| liftCompare__ := fun {a} {b} => Ord1__Proxy_liftCompare |}.
+
+(* Skipping all instances of class `Data.Functor.Classes.Show1', including
+   `Data.Functor.Classes.Show1__Proxy' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Read1', including
+   `Data.Functor.Classes.Read1__Proxy' *)
+
+Definition eq1 {f} {a} `{Eq1 f} `{GHC.Base.Eq_ a} : f a -> f a -> bool :=
+  liftEq _GHC.Base.==_.
+
+Definition compare1 {f} {a} `{Ord1 f} `{GHC.Base.Ord a}
+   : f a -> f a -> comparison :=
+  liftCompare GHC.Base.compare.
+
+(* Skipping definition `Data.Functor.Classes.readsPrec1' *)
+
+(* Skipping definition `Data.Functor.Classes.readPrec1' *)
+
+(* Skipping definition `Data.Functor.Classes.liftReadListDefault' *)
+
+(* Skipping definition `Data.Functor.Classes.liftReadListPrecDefault' *)
+
+(* Skipping definition `Data.Functor.Classes.showsPrec1' *)
+
+Definition eq2 {f} {a} {b} `{Eq2 f} `{GHC.Base.Eq_ a} `{GHC.Base.Eq_ b}
+   : f a b -> f a b -> bool :=
+  liftEq2 _GHC.Base.==_ _GHC.Base.==_.
+
+Definition compare2 {f} {a} {b} `{Ord2 f} `{GHC.Base.Ord a} `{GHC.Base.Ord b}
+   : f a b -> f a b -> comparison :=
+  liftCompare2 GHC.Base.compare GHC.Base.compare.
+
+(* Skipping definition `Data.Functor.Classes.readsPrec2' *)
+
+(* Skipping definition `Data.Functor.Classes.readPrec2' *)
+
+(* Skipping definition `Data.Functor.Classes.liftReadList2Default' *)
+
+(* Skipping definition `Data.Functor.Classes.liftReadListPrec2Default' *)
+
+(* Skipping definition `Data.Functor.Classes.showsPrec2' *)
+
+(* Skipping definition `Data.Functor.Classes.readsData' *)
+
+(* Skipping definition `Data.Functor.Classes.readData' *)
+
+(* Skipping definition `Data.Functor.Classes.readsUnaryWith' *)
+
+(* Skipping definition `Data.Functor.Classes.readUnaryWith' *)
+
+(* Skipping definition `Data.Functor.Classes.readsBinaryWith' *)
+
+(* Skipping definition `Data.Functor.Classes.readBinaryWith' *)
+
+(* Skipping definition `Data.Functor.Classes.showsUnaryWith' *)
+
+(* Skipping definition `Data.Functor.Classes.showsBinaryWith' *)
+
+(* Skipping definition `Data.Functor.Classes.readsUnary' *)
+
+(* Skipping definition `Data.Functor.Classes.readsUnary1' *)
+
+(* Skipping definition `Data.Functor.Classes.readsBinary1' *)
+
+(* Skipping definition `Data.Functor.Classes.showsUnary' *)
+
+(* Skipping definition `Data.Functor.Classes.showsUnary1' *)
+
+(* Skipping definition `Data.Functor.Classes.showsBinary1' *)
 
 (* External variables:
      Eq Gt Lt None Some andb bool comparison cons false list option pair true

--- a/base/Data/Functor/Compose.v
+++ b/base/Data/Functor/Compose.v
@@ -47,32 +47,130 @@ Definition getCompose {f : Type -> Type} {g : Type -> Type} {a : Type} (arg_0__
 (* Skipping all instances of class `GHC.Generics.Generic1', including
    `Data.Functor.Compose.Generic1__Compose__5' *)
 
-(* Skipping all instances of class `GHC.Base.Alternative', including
-   `Data.Functor.Compose.Alternative__Compose' *)
-
-Local Definition Applicative__Compose_liftA2 {inst_f} {inst_g}
-  `{GHC.Base.Applicative inst_f} `{GHC.Base.Applicative inst_g}
-   : forall {a} {b} {c},
-     (a -> b -> c) ->
-     (Compose inst_f inst_g) a ->
-     (Compose inst_f inst_g) b -> (Compose inst_f inst_g) c :=
-  fun {a} {b} {c} =>
+Local Definition Eq1__Compose_liftEq {inst_f} {inst_g}
+  `{Data.Functor.Classes.Eq1 inst_f} `{Data.Functor.Classes.Eq1 inst_g}
+   : forall {a} {b},
+     (a -> b -> bool) ->
+     (Compose inst_f inst_g) a -> (Compose inst_f inst_g) b -> bool :=
+  fun {a} {b} =>
     fun arg_0__ arg_1__ arg_2__ =>
       match arg_0__, arg_1__, arg_2__ with
-      | f, Mk_Compose x, Mk_Compose y =>
-          Mk_Compose (GHC.Base.liftA2 (GHC.Base.liftA2 f) x y)
+      | eq, Mk_Compose x, Mk_Compose y =>
+          Data.Functor.Classes.liftEq (Data.Functor.Classes.liftEq eq) x y
       end.
 
-Local Definition Applicative__Compose_op_zlztzg__ {inst_f} {inst_g}
-  `{GHC.Base.Applicative inst_f} `{GHC.Base.Applicative inst_g}
+Program Instance Eq1__Compose {f} {g} `{Data.Functor.Classes.Eq1 f}
+  `{Data.Functor.Classes.Eq1 g}
+   : Data.Functor.Classes.Eq1 (Compose f g) :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__Compose_liftEq |}.
+
+Local Definition Ord1__Compose_liftCompare {inst_f} {inst_g}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
    : forall {a} {b},
-     (Compose inst_f inst_g) (a -> b) ->
-     (Compose inst_f inst_g) a -> (Compose inst_f inst_g) b :=
+     (a -> b -> comparison) ->
+     (Compose inst_f inst_g) a -> (Compose inst_f inst_g) b -> comparison :=
   fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | Mk_Compose f, Mk_Compose x => Mk_Compose (GHC.Base.liftA2 _GHC.Base.<*>_ f x)
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | comp, Mk_Compose x, Mk_Compose y =>
+          Data.Functor.Classes.liftCompare (Data.Functor.Classes.liftCompare comp) x y
       end.
+
+Program Instance Ord1__Compose {f} {g} `{Data.Functor.Classes.Ord1 f}
+  `{Data.Functor.Classes.Ord1 g}
+   : Data.Functor.Classes.Ord1 (Compose f g) :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
+             Ord1__Compose_liftCompare |}.
+
+(* Skipping all instances of class `Data.Functor.Classes.Read1', including
+   `Data.Functor.Compose.Read1__Compose' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Show1', including
+   `Data.Functor.Compose.Show1__Compose' *)
+
+Local Definition Eq___Compose_op_zeze__ {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Eq1 inst_f} `{Data.Functor.Classes.Eq1 inst_g}
+  `{GHC.Base.Eq_ inst_a}
+   : (Compose inst_f inst_g inst_a) -> (Compose inst_f inst_g inst_a) -> bool :=
+  Data.Functor.Classes.eq1.
+
+Local Definition Eq___Compose_op_zsze__ {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Eq1 inst_f} `{Data.Functor.Classes.Eq1 inst_g}
+  `{GHC.Base.Eq_ inst_a}
+   : (Compose inst_f inst_g inst_a) -> (Compose inst_f inst_g inst_a) -> bool :=
+  fun x y => negb (Eq___Compose_op_zeze__ x y).
+
+Program Instance Eq___Compose {f} {g} {a} `{Data.Functor.Classes.Eq1 f}
+  `{Data.Functor.Classes.Eq1 g} `{GHC.Base.Eq_ a}
+   : GHC.Base.Eq_ (Compose f g a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___Compose_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___Compose_op_zsze__ |}.
+
+Local Definition Ord__Compose_compare {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
+  `{GHC.Base.Ord inst_a}
+   : (Compose inst_f inst_g inst_a) ->
+     (Compose inst_f inst_g inst_a) -> comparison :=
+  Data.Functor.Classes.compare1.
+
+Local Definition Ord__Compose_op_zl__ {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
+  `{GHC.Base.Ord inst_a}
+   : (Compose inst_f inst_g inst_a) -> (Compose inst_f inst_g inst_a) -> bool :=
+  fun x y => Ord__Compose_compare x y GHC.Base.== Lt.
+
+Local Definition Ord__Compose_op_zlze__ {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
+  `{GHC.Base.Ord inst_a}
+   : (Compose inst_f inst_g inst_a) -> (Compose inst_f inst_g inst_a) -> bool :=
+  fun x y => Ord__Compose_compare x y GHC.Base./= Gt.
+
+Local Definition Ord__Compose_op_zg__ {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
+  `{GHC.Base.Ord inst_a}
+   : (Compose inst_f inst_g inst_a) -> (Compose inst_f inst_g inst_a) -> bool :=
+  fun x y => Ord__Compose_compare x y GHC.Base.== Gt.
+
+Local Definition Ord__Compose_op_zgze__ {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
+  `{GHC.Base.Ord inst_a}
+   : (Compose inst_f inst_g inst_a) -> (Compose inst_f inst_g inst_a) -> bool :=
+  fun x y => Ord__Compose_compare x y GHC.Base./= Lt.
+
+Local Definition Ord__Compose_max {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
+  `{GHC.Base.Ord inst_a}
+   : (Compose inst_f inst_g inst_a) ->
+     (Compose inst_f inst_g inst_a) -> (Compose inst_f inst_g inst_a) :=
+  fun x y => if Ord__Compose_op_zlze__ x y : bool then y else x.
+
+Local Definition Ord__Compose_min {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
+  `{GHC.Base.Ord inst_a}
+   : (Compose inst_f inst_g inst_a) ->
+     (Compose inst_f inst_g inst_a) -> (Compose inst_f inst_g inst_a) :=
+  fun x y => if Ord__Compose_op_zlze__ x y : bool then x else y.
+
+Program Instance Ord__Compose {f} {g} {a} `{Data.Functor.Classes.Ord1 f}
+  `{Data.Functor.Classes.Ord1 g} `{GHC.Base.Ord a}
+   : GHC.Base.Ord (Compose f g a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zl____ := Ord__Compose_op_zl__ ;
+           GHC.Base.op_zlze____ := Ord__Compose_op_zlze__ ;
+           GHC.Base.op_zg____ := Ord__Compose_op_zg__ ;
+           GHC.Base.op_zgze____ := Ord__Compose_op_zgze__ ;
+           GHC.Base.compare__ := Ord__Compose_compare ;
+           GHC.Base.max__ := Ord__Compose_max ;
+           GHC.Base.min__ := Ord__Compose_min |}.
+
+(* Skipping all instances of class `GHC.Read.Read', including
+   `Data.Functor.Compose.Read__Compose' *)
+
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Data.Functor.Compose.Show__Compose' *)
 
 Local Definition Functor__Compose_fmap {inst_f} {inst_g} `{GHC.Base.Functor
   inst_f} `{GHC.Base.Functor inst_g}
@@ -96,63 +194,6 @@ Program Instance Functor__Compose {f} {g} `{GHC.Base.Functor f}
   fun _ k__ =>
     k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Compose_fmap ;
            GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Compose_op_zlzd__ |}.
-
-Local Definition Applicative__Compose_op_ztzg__ {inst_f} {inst_g}
-  `{GHC.Base.Applicative inst_f} `{GHC.Base.Applicative inst_g}
-   : forall {a} {b},
-     (Compose inst_f inst_g) a ->
-     (Compose inst_f inst_g) b -> (Compose inst_f inst_g) b :=
-  fun {a} {b} =>
-    fun a1 a2 => Applicative__Compose_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
-
-Local Definition Applicative__Compose_pure {inst_f} {inst_g}
-  `{GHC.Base.Applicative inst_f} `{GHC.Base.Applicative inst_g}
-   : forall {a}, a -> (Compose inst_f inst_g) a :=
-  fun {a} => fun x => Mk_Compose (GHC.Base.pure (GHC.Base.pure x)).
-
-Program Instance Applicative__Compose {f} {g} `{GHC.Base.Applicative f}
-  `{GHC.Base.Applicative g}
-   : GHC.Base.Applicative (Compose f g) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Compose_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Compose_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Compose_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__Compose_pure |}.
-
-Local Definition Traversable__Compose_traverse {inst_f} {inst_g}
-  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f},
-     (a -> f b) -> (Compose inst_f inst_g) a -> f ((Compose inst_f inst_g) b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, Mk_Compose t =>
-          Mk_Compose Data.Functor.<$>
-          Data.Traversable.traverse (Data.Traversable.traverse f) t
-      end.
-
-Local Definition Traversable__Compose_mapM {inst_f} {inst_g}
-  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m},
-     (a -> m b) -> (Compose inst_f inst_g) a -> m ((Compose inst_f inst_g) b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Compose_traverse.
-
-Local Definition Traversable__Compose_sequenceA {inst_f} {inst_g}
-  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
-   : forall {f} {a},
-     forall `{GHC.Base.Applicative f},
-     (Compose inst_f inst_g) (f a) -> f ((Compose inst_f inst_g) a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} =>
-    Traversable__Compose_traverse GHC.Base.id.
-
-Local Definition Traversable__Compose_sequence {inst_f} {inst_g}
-  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
-   : forall {m} {a},
-     forall `{GHC.Base.Monad m},
-     (Compose inst_f inst_g) (m a) -> m ((Compose inst_f inst_g) a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Compose_sequenceA.
 
 Local Definition Foldable__Compose_foldMap {inst_f} {inst_g}
   `{Data.Foldable.Foldable inst_f} `{Data.Foldable.Foldable inst_g}
@@ -256,6 +297,41 @@ Program Instance Foldable__Compose {f} {g} `{Data.Foldable.Foldable f}
            Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Compose_sum ;
            Data.Foldable.toList__ := fun {a} => Foldable__Compose_toList |}.
 
+Local Definition Traversable__Compose_traverse {inst_f} {inst_g}
+  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f},
+     (a -> f b) -> (Compose inst_f inst_g) a -> f ((Compose inst_f inst_g) b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, Mk_Compose t =>
+          Mk_Compose Data.Functor.<$>
+          Data.Traversable.traverse (Data.Traversable.traverse f) t
+      end.
+
+Local Definition Traversable__Compose_mapM {inst_f} {inst_g}
+  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m},
+     (a -> m b) -> (Compose inst_f inst_g) a -> m ((Compose inst_f inst_g) b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Compose_traverse.
+
+Local Definition Traversable__Compose_sequenceA {inst_f} {inst_g}
+  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
+   : forall {f} {a},
+     forall `{GHC.Base.Applicative f},
+     (Compose inst_f inst_g) (f a) -> f ((Compose inst_f inst_g) a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} =>
+    Traversable__Compose_traverse GHC.Base.id.
+
+Local Definition Traversable__Compose_sequence {inst_f} {inst_g}
+  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
+   : forall {m} {a},
+     forall `{GHC.Base.Monad m},
+     (Compose inst_f inst_g) (m a) -> m ((Compose inst_f inst_g) a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Compose_sequenceA.
+
 Program Instance Traversable__Compose {f} {g} `{Data.Traversable.Traversable f}
   `{Data.Traversable.Traversable g}
    : Data.Traversable.Traversable (Compose f g) :=
@@ -269,130 +345,54 @@ Program Instance Traversable__Compose {f} {g} `{Data.Traversable.Traversable f}
            Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
              Traversable__Compose_traverse |}.
 
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Data.Functor.Compose.Show__Compose' *)
-
-(* Skipping all instances of class `GHC.Read.Read', including
-   `Data.Functor.Compose.Read__Compose' *)
-
-Local Definition Ord1__Compose_liftCompare {inst_f} {inst_g}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-   : forall {a} {b},
-     (a -> b -> comparison) ->
-     (Compose inst_f inst_g) a -> (Compose inst_f inst_g) b -> comparison :=
-  fun {a} {b} =>
+Local Definition Applicative__Compose_liftA2 {inst_f} {inst_g}
+  `{GHC.Base.Applicative inst_f} `{GHC.Base.Applicative inst_g}
+   : forall {a} {b} {c},
+     (a -> b -> c) ->
+     (Compose inst_f inst_g) a ->
+     (Compose inst_f inst_g) b -> (Compose inst_f inst_g) c :=
+  fun {a} {b} {c} =>
     fun arg_0__ arg_1__ arg_2__ =>
       match arg_0__, arg_1__, arg_2__ with
-      | comp, Mk_Compose x, Mk_Compose y =>
-          Data.Functor.Classes.liftCompare (Data.Functor.Classes.liftCompare comp) x y
+      | f, Mk_Compose x, Mk_Compose y =>
+          Mk_Compose (GHC.Base.liftA2 (GHC.Base.liftA2 f) x y)
       end.
 
-Local Definition Eq1__Compose_liftEq {inst_f} {inst_g}
-  `{Data.Functor.Classes.Eq1 inst_f} `{Data.Functor.Classes.Eq1 inst_g}
+Local Definition Applicative__Compose_op_zlztzg__ {inst_f} {inst_g}
+  `{GHC.Base.Applicative inst_f} `{GHC.Base.Applicative inst_g}
    : forall {a} {b},
-     (a -> b -> bool) ->
-     (Compose inst_f inst_g) a -> (Compose inst_f inst_g) b -> bool :=
+     (Compose inst_f inst_g) (a -> b) ->
+     (Compose inst_f inst_g) a -> (Compose inst_f inst_g) b :=
   fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | eq, Mk_Compose x, Mk_Compose y =>
-          Data.Functor.Classes.liftEq (Data.Functor.Classes.liftEq eq) x y
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | Mk_Compose f, Mk_Compose x => Mk_Compose (GHC.Base.liftA2 _GHC.Base.<*>_ f x)
       end.
 
-Program Instance Eq1__Compose {f} {g} `{Data.Functor.Classes.Eq1 f}
-  `{Data.Functor.Classes.Eq1 g}
-   : Data.Functor.Classes.Eq1 (Compose f g) :=
+Local Definition Applicative__Compose_op_ztzg__ {inst_f} {inst_g}
+  `{GHC.Base.Applicative inst_f} `{GHC.Base.Applicative inst_g}
+   : forall {a} {b},
+     (Compose inst_f inst_g) a ->
+     (Compose inst_f inst_g) b -> (Compose inst_f inst_g) b :=
+  fun {a} {b} =>
+    fun a1 a2 => Applicative__Compose_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
+
+Local Definition Applicative__Compose_pure {inst_f} {inst_g}
+  `{GHC.Base.Applicative inst_f} `{GHC.Base.Applicative inst_g}
+   : forall {a}, a -> (Compose inst_f inst_g) a :=
+  fun {a} => fun x => Mk_Compose (GHC.Base.pure (GHC.Base.pure x)).
+
+Program Instance Applicative__Compose {f} {g} `{GHC.Base.Applicative f}
+  `{GHC.Base.Applicative g}
+   : GHC.Base.Applicative (Compose f g) :=
   fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__Compose_liftEq |}.
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Compose_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Compose_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Compose_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__Compose_pure |}.
 
-Program Instance Ord1__Compose {f} {g} `{Data.Functor.Classes.Ord1 f}
-  `{Data.Functor.Classes.Ord1 g}
-   : Data.Functor.Classes.Ord1 (Compose f g) :=
-  fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
-             Ord1__Compose_liftCompare |}.
-
-Local Definition Ord__Compose_compare {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-  `{GHC.Base.Ord inst_a}
-   : (Compose inst_f inst_g inst_a) ->
-     (Compose inst_f inst_g inst_a) -> comparison :=
-  Data.Functor.Classes.compare1.
-
-Local Definition Ord__Compose_op_zl__ {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-  `{GHC.Base.Ord inst_a}
-   : (Compose inst_f inst_g inst_a) -> (Compose inst_f inst_g inst_a) -> bool :=
-  fun x y => Ord__Compose_compare x y GHC.Base.== Lt.
-
-Local Definition Ord__Compose_op_zlze__ {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-  `{GHC.Base.Ord inst_a}
-   : (Compose inst_f inst_g inst_a) -> (Compose inst_f inst_g inst_a) -> bool :=
-  fun x y => Ord__Compose_compare x y GHC.Base./= Gt.
-
-Local Definition Ord__Compose_op_zg__ {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-  `{GHC.Base.Ord inst_a}
-   : (Compose inst_f inst_g inst_a) -> (Compose inst_f inst_g inst_a) -> bool :=
-  fun x y => Ord__Compose_compare x y GHC.Base.== Gt.
-
-Local Definition Ord__Compose_op_zgze__ {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-  `{GHC.Base.Ord inst_a}
-   : (Compose inst_f inst_g inst_a) -> (Compose inst_f inst_g inst_a) -> bool :=
-  fun x y => Ord__Compose_compare x y GHC.Base./= Lt.
-
-Local Definition Ord__Compose_max {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-  `{GHC.Base.Ord inst_a}
-   : (Compose inst_f inst_g inst_a) ->
-     (Compose inst_f inst_g inst_a) -> (Compose inst_f inst_g inst_a) :=
-  fun x y => if Ord__Compose_op_zlze__ x y : bool then y else x.
-
-Local Definition Ord__Compose_min {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-  `{GHC.Base.Ord inst_a}
-   : (Compose inst_f inst_g inst_a) ->
-     (Compose inst_f inst_g inst_a) -> (Compose inst_f inst_g inst_a) :=
-  fun x y => if Ord__Compose_op_zlze__ x y : bool then x else y.
-
-Local Definition Eq___Compose_op_zeze__ {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Eq1 inst_f} `{Data.Functor.Classes.Eq1 inst_g}
-  `{GHC.Base.Eq_ inst_a}
-   : (Compose inst_f inst_g inst_a) -> (Compose inst_f inst_g inst_a) -> bool :=
-  Data.Functor.Classes.eq1.
-
-Local Definition Eq___Compose_op_zsze__ {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Eq1 inst_f} `{Data.Functor.Classes.Eq1 inst_g}
-  `{GHC.Base.Eq_ inst_a}
-   : (Compose inst_f inst_g inst_a) -> (Compose inst_f inst_g inst_a) -> bool :=
-  fun x y => negb (Eq___Compose_op_zeze__ x y).
-
-Program Instance Eq___Compose {f} {g} {a} `{Data.Functor.Classes.Eq1 f}
-  `{Data.Functor.Classes.Eq1 g} `{GHC.Base.Eq_ a}
-   : GHC.Base.Eq_ (Compose f g a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___Compose_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___Compose_op_zsze__ |}.
-
-Program Instance Ord__Compose {f} {g} {a} `{Data.Functor.Classes.Ord1 f}
-  `{Data.Functor.Classes.Ord1 g} `{GHC.Base.Ord a}
-   : GHC.Base.Ord (Compose f g a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zl____ := Ord__Compose_op_zl__ ;
-           GHC.Base.op_zlze____ := Ord__Compose_op_zlze__ ;
-           GHC.Base.op_zg____ := Ord__Compose_op_zg__ ;
-           GHC.Base.op_zgze____ := Ord__Compose_op_zgze__ ;
-           GHC.Base.compare__ := Ord__Compose_compare ;
-           GHC.Base.max__ := Ord__Compose_max ;
-           GHC.Base.min__ := Ord__Compose_min |}.
-
-(* Skipping all instances of class `Data.Functor.Classes.Show1', including
-   `Data.Functor.Compose.Show1__Compose' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Read1', including
-   `Data.Functor.Compose.Read1__Compose' *)
+(* Skipping all instances of class `GHC.Base.Alternative', including
+   `Data.Functor.Compose.Alternative__Compose' *)
 
 (* External variables:
      Gt Lt Type bool comparison false list negb true Coq.Program.Basics.compose

--- a/base/Data/Functor/Const.v
+++ b/base/Data/Functor/Const.v
@@ -192,53 +192,11 @@ Program Instance Ord__Const {a} {b} `{GHC.Base.Ord a}
 (* Skipping all instances of class `Foreign.Storable.Storable', including
    `Data.Functor.Const.Storable__Const' *)
 
-Local Definition Applicative__Const_liftA2 {inst_m} `{GHC.Base.Monoid inst_m}
-   : forall {a} {b} {c},
-     (a -> b -> c) -> (Const inst_m) a -> (Const inst_m) b -> (Const inst_m) c :=
-  fun {a} {b} {c} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | _, Mk_Const x, Mk_Const y => Mk_Const (GHC.Base.mappend x y)
-      end.
+(* Skipping all instances of class `GHC.Read.Read', including
+   `Data.Functor.Const.Read__Const' *)
 
-Local Definition Applicative__Const_op_zlztzg__ {inst_m} `{GHC.Base.Monoid
-  inst_m}
-   : forall {a} {b}, Const inst_m (a -> b) -> Const inst_m a -> Const inst_m b :=
-  fun {a} {b} => GHC.Prim.coerce GHC.Base.mappend.
-
-Local Definition Functor__Const_fmap {inst_m}
-   : forall {a} {b}, (a -> b) -> (Const inst_m) a -> (Const inst_m) b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | _, Mk_Const v => Mk_Const v
-      end.
-
-Local Definition Functor__Const_op_zlzd__ {inst_m}
-   : forall {a} {b}, a -> (Const inst_m) b -> (Const inst_m) a :=
-  fun {a} {b} => Functor__Const_fmap GHC.Base.∘ GHC.Base.const.
-
-Program Instance Functor__Const {m} : GHC.Base.Functor (Const m) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Const_fmap ;
-           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Const_op_zlzd__ |}.
-
-Local Definition Applicative__Const_op_ztzg__ {inst_m} `{GHC.Base.Monoid inst_m}
-   : forall {a} {b}, (Const inst_m) a -> (Const inst_m) b -> (Const inst_m) b :=
-  fun {a} {b} =>
-    fun a1 a2 => Applicative__Const_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
-
-Local Definition Applicative__Const_pure {inst_m} `{GHC.Base.Monoid inst_m}
-   : forall {a}, a -> (Const inst_m) a :=
-  fun {a} => fun arg_0__ => Mk_Const GHC.Base.mempty.
-
-Program Instance Applicative__Const {m} `{GHC.Base.Monoid m}
-   : GHC.Base.Applicative (Const m) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Const_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Const_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Const_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__Const_pure |}.
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Data.Functor.Const.Show__Const' *)
 
 Local Definition Foldable__Const_foldMap {inst_m}
    : forall {m} {a},
@@ -322,11 +280,53 @@ Program Instance Foldable__Const {m} : Data.Foldable.Foldable (Const m) :=
            Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Const_sum ;
            Data.Foldable.toList__ := fun {a} => Foldable__Const_toList |}.
 
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Data.Functor.Const.Show__Const' *)
+Local Definition Functor__Const_fmap {inst_m}
+   : forall {a} {b}, (a -> b) -> (Const inst_m) a -> (Const inst_m) b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | _, Mk_Const v => Mk_Const v
+      end.
 
-(* Skipping all instances of class `GHC.Read.Read', including
-   `Data.Functor.Const.Read__Const' *)
+Local Definition Functor__Const_op_zlzd__ {inst_m}
+   : forall {a} {b}, a -> (Const inst_m) b -> (Const inst_m) a :=
+  fun {a} {b} => Functor__Const_fmap GHC.Base.∘ GHC.Base.const.
+
+Program Instance Functor__Const {m} : GHC.Base.Functor (Const m) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Const_fmap ;
+           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Const_op_zlzd__ |}.
+
+Local Definition Applicative__Const_liftA2 {inst_m} `{GHC.Base.Monoid inst_m}
+   : forall {a} {b} {c},
+     (a -> b -> c) -> (Const inst_m) a -> (Const inst_m) b -> (Const inst_m) c :=
+  fun {a} {b} {c} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | _, Mk_Const x, Mk_Const y => Mk_Const (GHC.Base.mappend x y)
+      end.
+
+Local Definition Applicative__Const_op_zlztzg__ {inst_m} `{GHC.Base.Monoid
+  inst_m}
+   : forall {a} {b}, Const inst_m (a -> b) -> Const inst_m a -> Const inst_m b :=
+  fun {a} {b} => GHC.Prim.coerce GHC.Base.mappend.
+
+Local Definition Applicative__Const_op_ztzg__ {inst_m} `{GHC.Base.Monoid inst_m}
+   : forall {a} {b}, (Const inst_m) a -> (Const inst_m) b -> (Const inst_m) b :=
+  fun {a} {b} =>
+    fun a1 a2 => Applicative__Const_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
+
+Local Definition Applicative__Const_pure {inst_m} `{GHC.Base.Monoid inst_m}
+   : forall {a}, a -> (Const inst_m) a :=
+  fun {a} => fun arg_0__ => Mk_Const GHC.Base.mempty.
+
+Program Instance Applicative__Const {m} `{GHC.Base.Monoid m}
+   : GHC.Base.Applicative (Const m) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Const_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Const_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Const_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__Const_pure |}.
 
 (* External variables:
      bool comparison false list true Coq.Program.Basics.compose

--- a/base/Data/Functor/Identity.v
+++ b/base/Data/Functor/Identity.v
@@ -163,62 +163,11 @@ Program Instance Ord__Identity {a} `{GHC.Base.Ord a}
 (* Skipping all instances of class `Foreign.Storable.Storable', including
    `Data.Functor.Identity.Storable__Identity' *)
 
-(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
-   `Data.Functor.Identity.MonadFix__Identity' *)
+(* Skipping all instances of class `GHC.Read.Read', including
+   `Data.Functor.Identity.Read__Identity' *)
 
-Local Definition Monad__Identity_op_zgzgze__
-   : forall {a} {b}, Identity a -> (a -> Identity b) -> Identity b :=
-  fun {a} {b} => fun m k => k (runIdentity m).
-
-Local Definition Monad__Identity_op_zgzg__
-   : forall {a} {b}, Identity a -> Identity b -> Identity b :=
-  fun {a} {b} => fun m k => Monad__Identity_op_zgzgze__ m (fun arg_0__ => k).
-
-Local Definition Applicative__Identity_liftA2
-   : forall {a} {b} {c},
-     (a -> b -> c) -> Identity a -> Identity b -> Identity c :=
-  fun {a} {b} {c} => GHC.Prim.coerce.
-
-Local Definition Applicative__Identity_op_zlztzg__
-   : forall {a} {b}, Identity (a -> b) -> Identity a -> Identity b :=
-  fun {a} {b} => GHC.Prim.coerce.
-
-Local Definition Functor__Identity_fmap
-   : forall {a} {b}, (a -> b) -> Identity a -> Identity b :=
-  fun {a} {b} => GHC.Prim.coerce.
-
-Local Definition Functor__Identity_op_zlzd__
-   : forall {a} {b}, a -> Identity b -> Identity a :=
-  fun {a} {b} => Functor__Identity_fmap GHC.Base.∘ GHC.Base.const.
-
-Program Instance Functor__Identity : GHC.Base.Functor Identity :=
-  fun _ k__ =>
-    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Identity_fmap ;
-           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Identity_op_zlzd__ |}.
-
-Local Definition Applicative__Identity_op_ztzg__
-   : forall {a} {b}, Identity a -> Identity b -> Identity b :=
-  fun {a} {b} =>
-    fun a1 a2 => Applicative__Identity_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
-
-Local Definition Applicative__Identity_pure : forall {a}, a -> Identity a :=
-  fun {a} => Mk_Identity.
-
-Program Instance Applicative__Identity : GHC.Base.Applicative Identity :=
-  fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Identity_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Identity_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Identity_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__Identity_pure |}.
-
-Local Definition Monad__Identity_return_ : forall {a}, a -> Identity a :=
-  fun {a} => GHC.Base.pure.
-
-Program Instance Monad__Identity : GHC.Base.Monad Identity :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Identity_op_zgzg__ ;
-           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Identity_op_zgzgze__ ;
-           GHC.Base.return___ := fun {a} => Monad__Identity_return_ |}.
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Data.Functor.Identity.Show__Identity' *)
 
 Local Definition Foldable__Identity_foldMap
    : forall {m} {a}, forall `{GHC.Base.Monoid m}, (a -> m) -> Identity a -> m :=
@@ -283,11 +232,62 @@ Program Instance Foldable__Identity : Data.Foldable.Foldable Identity :=
            Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Identity_sum ;
            Data.Foldable.toList__ := fun {a} => Foldable__Identity_toList |}.
 
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Data.Functor.Identity.Show__Identity' *)
+Local Definition Functor__Identity_fmap
+   : forall {a} {b}, (a -> b) -> Identity a -> Identity b :=
+  fun {a} {b} => GHC.Prim.coerce.
 
-(* Skipping all instances of class `GHC.Read.Read', including
-   `Data.Functor.Identity.Read__Identity' *)
+Local Definition Functor__Identity_op_zlzd__
+   : forall {a} {b}, a -> Identity b -> Identity a :=
+  fun {a} {b} => Functor__Identity_fmap GHC.Base.∘ GHC.Base.const.
+
+Program Instance Functor__Identity : GHC.Base.Functor Identity :=
+  fun _ k__ =>
+    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Identity_fmap ;
+           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Identity_op_zlzd__ |}.
+
+Local Definition Applicative__Identity_liftA2
+   : forall {a} {b} {c},
+     (a -> b -> c) -> Identity a -> Identity b -> Identity c :=
+  fun {a} {b} {c} => GHC.Prim.coerce.
+
+Local Definition Applicative__Identity_op_zlztzg__
+   : forall {a} {b}, Identity (a -> b) -> Identity a -> Identity b :=
+  fun {a} {b} => GHC.Prim.coerce.
+
+Local Definition Applicative__Identity_op_ztzg__
+   : forall {a} {b}, Identity a -> Identity b -> Identity b :=
+  fun {a} {b} =>
+    fun a1 a2 => Applicative__Identity_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
+
+Local Definition Applicative__Identity_pure : forall {a}, a -> Identity a :=
+  fun {a} => Mk_Identity.
+
+Program Instance Applicative__Identity : GHC.Base.Applicative Identity :=
+  fun _ k__ =>
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Identity_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Identity_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Identity_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__Identity_pure |}.
+
+Local Definition Monad__Identity_op_zgzgze__
+   : forall {a} {b}, Identity a -> (a -> Identity b) -> Identity b :=
+  fun {a} {b} => fun m k => k (runIdentity m).
+
+Local Definition Monad__Identity_op_zgzg__
+   : forall {a} {b}, Identity a -> Identity b -> Identity b :=
+  fun {a} {b} => fun m k => Monad__Identity_op_zgzgze__ m (fun arg_0__ => k).
+
+Local Definition Monad__Identity_return_ : forall {a}, a -> Identity a :=
+  fun {a} => GHC.Base.pure.
+
+Program Instance Monad__Identity : GHC.Base.Monad Identity :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Identity_op_zgzg__ ;
+           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Identity_op_zgzgze__ ;
+           GHC.Base.return___ := fun {a} => Monad__Identity_return_ |}.
+
+(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
+   `Data.Functor.Identity.MonadFix__Identity' *)
 
 (* External variables:
      bool comparison cons false list nil Data.Foldable.Foldable

--- a/base/Data/Functor/Product.v
+++ b/base/Data/Functor/Product.v
@@ -43,49 +43,132 @@ Arguments Pair {_} {_} {_} _ _.
 (* Skipping all instances of class `GHC.Generics.Generic1', including
    `Data.Functor.Product.Generic1__Product__5' *)
 
-Local Definition Monad__Product_op_zgzgze__ {inst_f} {inst_g} `{GHC.Base.Monad
-  inst_f} `{GHC.Base.Monad inst_g}
+Local Definition Eq1__Product_liftEq {inst_f} {inst_g}
+  `{Data.Functor.Classes.Eq1 inst_f} `{Data.Functor.Classes.Eq1 inst_g}
    : forall {a} {b},
-     (Product inst_f inst_g) a ->
-     (a -> (Product inst_f inst_g) b) -> (Product inst_f inst_g) b :=
+     (a -> b -> bool) ->
+     (Product inst_f inst_g) a -> (Product inst_f inst_g) b -> bool :=
   fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | Pair m n, f =>
-          let sndP := fun '(Pair _ b) => b in
-          let fstP := fun '(Pair a _) => a in
-          Pair (m GHC.Base.>>= (fstP GHC.Base.∘ f)) (n GHC.Base.>>= (sndP GHC.Base.∘ f))
-      end.
-
-Local Definition Monad__Product_op_zgzg__ {inst_f} {inst_g} `{GHC.Base.Monad
-  inst_f} `{GHC.Base.Monad inst_g}
-   : forall {a} {b},
-     (Product inst_f inst_g) a ->
-     (Product inst_f inst_g) b -> (Product inst_f inst_g) b :=
-  fun {a} {b} => fun m k => Monad__Product_op_zgzgze__ m (fun arg_0__ => k).
-
-Local Definition Applicative__Product_liftA2 {inst_f} {inst_g}
-  `{GHC.Base.Applicative inst_f} `{GHC.Base.Applicative inst_g}
-   : forall {a} {b} {c},
-     (a -> b -> c) ->
-     (Product inst_f inst_g) a ->
-     (Product inst_f inst_g) b -> (Product inst_f inst_g) c :=
-  fun {a} {b} {c} =>
     fun arg_0__ arg_1__ arg_2__ =>
       match arg_0__, arg_1__, arg_2__ with
-      | f, Pair a b, Pair x y => Pair (GHC.Base.liftA2 f a x) (GHC.Base.liftA2 f b y)
+      | eq, Pair x1 y1, Pair x2 y2 =>
+          andb (Data.Functor.Classes.liftEq eq x1 x2) (Data.Functor.Classes.liftEq eq y1
+                y2)
       end.
 
-Local Definition Applicative__Product_op_zlztzg__ {inst_f} {inst_g}
-  `{GHC.Base.Applicative inst_f} `{GHC.Base.Applicative inst_g}
+Program Instance Eq1__Product {f} {g} `{Data.Functor.Classes.Eq1 f}
+  `{Data.Functor.Classes.Eq1 g}
+   : Data.Functor.Classes.Eq1 (Product f g) :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__Product_liftEq |}.
+
+Local Definition Ord1__Product_liftCompare {inst_f} {inst_g}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
    : forall {a} {b},
-     (Product inst_f inst_g) (a -> b) ->
-     (Product inst_f inst_g) a -> (Product inst_f inst_g) b :=
+     (a -> b -> comparison) ->
+     (Product inst_f inst_g) a -> (Product inst_f inst_g) b -> comparison :=
   fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | Pair f g, Pair x y => Pair (f GHC.Base.<*> x) (g GHC.Base.<*> y)
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | comp, Pair x1 y1, Pair x2 y2 =>
+          GHC.Base.mappend (Data.Functor.Classes.liftCompare comp x1 x2)
+                           (Data.Functor.Classes.liftCompare comp y1 y2)
       end.
+
+Program Instance Ord1__Product {f} {g} `{Data.Functor.Classes.Ord1 f}
+  `{Data.Functor.Classes.Ord1 g}
+   : Data.Functor.Classes.Ord1 (Product f g) :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
+             Ord1__Product_liftCompare |}.
+
+(* Skipping all instances of class `Data.Functor.Classes.Read1', including
+   `Data.Functor.Product.Read1__Product' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Show1', including
+   `Data.Functor.Product.Show1__Product' *)
+
+Local Definition Eq___Product_op_zeze__ {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Eq1 inst_f} `{Data.Functor.Classes.Eq1 inst_g}
+  `{GHC.Base.Eq_ inst_a}
+   : (Product inst_f inst_g inst_a) -> (Product inst_f inst_g inst_a) -> bool :=
+  Data.Functor.Classes.eq1.
+
+Local Definition Eq___Product_op_zsze__ {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Eq1 inst_f} `{Data.Functor.Classes.Eq1 inst_g}
+  `{GHC.Base.Eq_ inst_a}
+   : (Product inst_f inst_g inst_a) -> (Product inst_f inst_g inst_a) -> bool :=
+  fun x y => negb (Eq___Product_op_zeze__ x y).
+
+Program Instance Eq___Product {f} {g} {a} `{Data.Functor.Classes.Eq1 f}
+  `{Data.Functor.Classes.Eq1 g} `{GHC.Base.Eq_ a}
+   : GHC.Base.Eq_ (Product f g a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___Product_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___Product_op_zsze__ |}.
+
+Local Definition Ord__Product_compare {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
+  `{GHC.Base.Ord inst_a}
+   : (Product inst_f inst_g inst_a) ->
+     (Product inst_f inst_g inst_a) -> comparison :=
+  Data.Functor.Classes.compare1.
+
+Local Definition Ord__Product_op_zl__ {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
+  `{GHC.Base.Ord inst_a}
+   : (Product inst_f inst_g inst_a) -> (Product inst_f inst_g inst_a) -> bool :=
+  fun x y => Ord__Product_compare x y GHC.Base.== Lt.
+
+Local Definition Ord__Product_op_zlze__ {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
+  `{GHC.Base.Ord inst_a}
+   : (Product inst_f inst_g inst_a) -> (Product inst_f inst_g inst_a) -> bool :=
+  fun x y => Ord__Product_compare x y GHC.Base./= Gt.
+
+Local Definition Ord__Product_op_zg__ {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
+  `{GHC.Base.Ord inst_a}
+   : (Product inst_f inst_g inst_a) -> (Product inst_f inst_g inst_a) -> bool :=
+  fun x y => Ord__Product_compare x y GHC.Base.== Gt.
+
+Local Definition Ord__Product_op_zgze__ {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
+  `{GHC.Base.Ord inst_a}
+   : (Product inst_f inst_g inst_a) -> (Product inst_f inst_g inst_a) -> bool :=
+  fun x y => Ord__Product_compare x y GHC.Base./= Lt.
+
+Local Definition Ord__Product_max {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
+  `{GHC.Base.Ord inst_a}
+   : (Product inst_f inst_g inst_a) ->
+     (Product inst_f inst_g inst_a) -> (Product inst_f inst_g inst_a) :=
+  fun x y => if Ord__Product_op_zlze__ x y : bool then y else x.
+
+Local Definition Ord__Product_min {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
+  `{GHC.Base.Ord inst_a}
+   : (Product inst_f inst_g inst_a) ->
+     (Product inst_f inst_g inst_a) -> (Product inst_f inst_g inst_a) :=
+  fun x y => if Ord__Product_op_zlze__ x y : bool then x else y.
+
+Program Instance Ord__Product {f} {g} {a} `{Data.Functor.Classes.Ord1 f}
+  `{Data.Functor.Classes.Ord1 g} `{GHC.Base.Ord a}
+   : GHC.Base.Ord (Product f g a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zl____ := Ord__Product_op_zl__ ;
+           GHC.Base.op_zlze____ := Ord__Product_op_zlze__ ;
+           GHC.Base.op_zg____ := Ord__Product_op_zg__ ;
+           GHC.Base.op_zgze____ := Ord__Product_op_zgze__ ;
+           GHC.Base.compare__ := Ord__Product_compare ;
+           GHC.Base.max__ := Ord__Product_max ;
+           GHC.Base.min__ := Ord__Product_min |}.
+
+(* Skipping all instances of class `GHC.Read.Read', including
+   `Data.Functor.Product.Read__Product' *)
+
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Data.Functor.Product.Show__Product' *)
 
 Local Definition Functor__Product_fmap {inst_f} {inst_g} `{GHC.Base.Functor
   inst_f} `{GHC.Base.Functor inst_g}
@@ -109,122 +192,6 @@ Program Instance Functor__Product {f} {g} `{GHC.Base.Functor f}
   fun _ k__ =>
     k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Product_fmap ;
            GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Product_op_zlzd__ |}.
-
-Local Definition Applicative__Product_op_ztzg__ {inst_f} {inst_g}
-  `{GHC.Base.Applicative inst_f} `{GHC.Base.Applicative inst_g}
-   : forall {a} {b},
-     (Product inst_f inst_g) a ->
-     (Product inst_f inst_g) b -> (Product inst_f inst_g) b :=
-  fun {a} {b} =>
-    fun a1 a2 => Applicative__Product_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
-
-Local Definition Applicative__Product_pure {inst_f} {inst_g}
-  `{GHC.Base.Applicative inst_f} `{GHC.Base.Applicative inst_g}
-   : forall {a}, a -> (Product inst_f inst_g) a :=
-  fun {a} => fun x => Pair (GHC.Base.pure x) (GHC.Base.pure x).
-
-Program Instance Applicative__Product {f} {g} `{GHC.Base.Applicative f}
-  `{GHC.Base.Applicative g}
-   : GHC.Base.Applicative (Product f g) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Product_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Product_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Product_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__Product_pure |}.
-
-Local Definition Monad__Product_return_ {inst_f} {inst_g} `{GHC.Base.Monad
-  inst_f} `{GHC.Base.Monad inst_g}
-   : forall {a}, a -> (Product inst_f inst_g) a :=
-  fun {a} => GHC.Base.pure.
-
-Program Instance Monad__Product {f} {g} `{GHC.Base.Monad f} `{GHC.Base.Monad g}
-   : GHC.Base.Monad (Product f g) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Product_op_zgzg__ ;
-           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Product_op_zgzgze__ ;
-           GHC.Base.return___ := fun {a} => Monad__Product_return_ |}.
-
-Local Definition MonadZip__Product_munzip {inst_f} {inst_g}
-  `{Control.Monad.Zip.MonadZip inst_f} `{Control.Monad.Zip.MonadZip inst_g}
-   : forall {a} {b},
-     (Product inst_f inst_g) (a * b)%type ->
-     ((Product inst_f inst_g) a * (Product inst_f inst_g) b)%type :=
-  fun {a} {b} =>
-    fun mab =>
-      pair (GHC.Base.liftM Data.Tuple.fst mab) (GHC.Base.liftM Data.Tuple.snd mab).
-
-Local Definition MonadZip__Product_mzipWith {inst_f} {inst_g}
-  `{Control.Monad.Zip.MonadZip inst_f} `{Control.Monad.Zip.MonadZip inst_g}
-   : forall {a} {b} {c},
-     (a -> b -> c) ->
-     (Product inst_f inst_g) a ->
-     (Product inst_f inst_g) b -> (Product inst_f inst_g) c :=
-  fun {a} {b} {c} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | f, Pair x1 y1, Pair x2 y2 =>
-          Pair (Control.Monad.Zip.mzipWith f x1 x2) (Control.Monad.Zip.mzipWith f y1 y2)
-      end.
-
-Local Definition MonadZip__Product_mzip {inst_f} {inst_g}
-  `{Control.Monad.Zip.MonadZip inst_f} `{Control.Monad.Zip.MonadZip inst_g}
-   : forall {a} {b},
-     (Product inst_f inst_g) a ->
-     (Product inst_f inst_g) b -> (Product inst_f inst_g) (a * b)%type :=
-  fun {a} {b} => MonadZip__Product_mzipWith GHC.Tuple.pair2.
-
-Program Instance MonadZip__Product {f} {g} `{Control.Monad.Zip.MonadZip f}
-  `{Control.Monad.Zip.MonadZip g}
-   : Control.Monad.Zip.MonadZip (Product f g) :=
-  fun _ k__ =>
-    k__ {| Control.Monad.Zip.munzip__ := fun {a} {b} => MonadZip__Product_munzip ;
-           Control.Monad.Zip.mzip__ := fun {a} {b} => MonadZip__Product_mzip ;
-           Control.Monad.Zip.mzipWith__ := fun {a} {b} {c} =>
-             MonadZip__Product_mzipWith |}.
-
-(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
-   `Data.Functor.Product.MonadFix__Product' *)
-
-(* Skipping all instances of class `GHC.Base.MonadPlus', including
-   `Data.Functor.Product.MonadPlus__Product' *)
-
-(* Skipping all instances of class `GHC.Base.Alternative', including
-   `Data.Functor.Product.Alternative__Product' *)
-
-Local Definition Traversable__Product_traverse {inst_f} {inst_g}
-  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f},
-     (a -> f b) -> (Product inst_f inst_g) a -> f ((Product inst_f inst_g) b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, Pair x y =>
-          GHC.Base.liftA2 Pair (Data.Traversable.traverse f x) (Data.Traversable.traverse
-                                                                f y)
-      end.
-
-Local Definition Traversable__Product_mapM {inst_f} {inst_g}
-  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m},
-     (a -> m b) -> (Product inst_f inst_g) a -> m ((Product inst_f inst_g) b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Product_traverse.
-
-Local Definition Traversable__Product_sequenceA {inst_f} {inst_g}
-  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
-   : forall {f} {a},
-     forall `{GHC.Base.Applicative f},
-     (Product inst_f inst_g) (f a) -> f ((Product inst_f inst_g) a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} =>
-    Traversable__Product_traverse GHC.Base.id.
-
-Local Definition Traversable__Product_sequence {inst_f} {inst_g}
-  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
-   : forall {m} {a},
-     forall `{GHC.Base.Monad m},
-     (Product inst_f inst_g) (m a) -> m ((Product inst_f inst_g) a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Product_sequenceA.
 
 Local Definition Foldable__Product_foldMap {inst_f} {inst_g}
   `{Data.Foldable.Foldable inst_f} `{Data.Foldable.Foldable inst_g}
@@ -329,6 +296,41 @@ Program Instance Foldable__Product {f} {g} `{Data.Foldable.Foldable f}
            Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Product_sum ;
            Data.Foldable.toList__ := fun {a} => Foldable__Product_toList |}.
 
+Local Definition Traversable__Product_traverse {inst_f} {inst_g}
+  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f},
+     (a -> f b) -> (Product inst_f inst_g) a -> f ((Product inst_f inst_g) b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, Pair x y =>
+          GHC.Base.liftA2 Pair (Data.Traversable.traverse f x) (Data.Traversable.traverse
+                                                                f y)
+      end.
+
+Local Definition Traversable__Product_mapM {inst_f} {inst_g}
+  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m},
+     (a -> m b) -> (Product inst_f inst_g) a -> m ((Product inst_f inst_g) b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Product_traverse.
+
+Local Definition Traversable__Product_sequenceA {inst_f} {inst_g}
+  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
+   : forall {f} {a},
+     forall `{GHC.Base.Applicative f},
+     (Product inst_f inst_g) (f a) -> f ((Product inst_f inst_g) a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} =>
+    Traversable__Product_traverse GHC.Base.id.
+
+Local Definition Traversable__Product_sequence {inst_f} {inst_g}
+  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
+   : forall {m} {a},
+     forall `{GHC.Base.Monad m},
+     (Product inst_f inst_g) (m a) -> m ((Product inst_f inst_g) a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Product_sequenceA.
+
 Program Instance Traversable__Product {f} {g} `{Data.Traversable.Traversable f}
   `{Data.Traversable.Traversable g}
    : Data.Traversable.Traversable (Product f g) :=
@@ -342,132 +344,130 @@ Program Instance Traversable__Product {f} {g} `{Data.Traversable.Traversable f}
            Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
              Traversable__Product_traverse |}.
 
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Data.Functor.Product.Show__Product' *)
-
-(* Skipping all instances of class `GHC.Read.Read', including
-   `Data.Functor.Product.Read__Product' *)
-
-Local Definition Ord1__Product_liftCompare {inst_f} {inst_g}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-   : forall {a} {b},
-     (a -> b -> comparison) ->
-     (Product inst_f inst_g) a -> (Product inst_f inst_g) b -> comparison :=
-  fun {a} {b} =>
+Local Definition Applicative__Product_liftA2 {inst_f} {inst_g}
+  `{GHC.Base.Applicative inst_f} `{GHC.Base.Applicative inst_g}
+   : forall {a} {b} {c},
+     (a -> b -> c) ->
+     (Product inst_f inst_g) a ->
+     (Product inst_f inst_g) b -> (Product inst_f inst_g) c :=
+  fun {a} {b} {c} =>
     fun arg_0__ arg_1__ arg_2__ =>
       match arg_0__, arg_1__, arg_2__ with
-      | comp, Pair x1 y1, Pair x2 y2 =>
-          GHC.Base.mappend (Data.Functor.Classes.liftCompare comp x1 x2)
-                           (Data.Functor.Classes.liftCompare comp y1 y2)
+      | f, Pair a b, Pair x y => Pair (GHC.Base.liftA2 f a x) (GHC.Base.liftA2 f b y)
       end.
 
-Local Definition Eq1__Product_liftEq {inst_f} {inst_g}
-  `{Data.Functor.Classes.Eq1 inst_f} `{Data.Functor.Classes.Eq1 inst_g}
+Local Definition Applicative__Product_op_zlztzg__ {inst_f} {inst_g}
+  `{GHC.Base.Applicative inst_f} `{GHC.Base.Applicative inst_g}
    : forall {a} {b},
-     (a -> b -> bool) ->
-     (Product inst_f inst_g) a -> (Product inst_f inst_g) b -> bool :=
+     (Product inst_f inst_g) (a -> b) ->
+     (Product inst_f inst_g) a -> (Product inst_f inst_g) b :=
   fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | Pair f g, Pair x y => Pair (f GHC.Base.<*> x) (g GHC.Base.<*> y)
+      end.
+
+Local Definition Applicative__Product_op_ztzg__ {inst_f} {inst_g}
+  `{GHC.Base.Applicative inst_f} `{GHC.Base.Applicative inst_g}
+   : forall {a} {b},
+     (Product inst_f inst_g) a ->
+     (Product inst_f inst_g) b -> (Product inst_f inst_g) b :=
+  fun {a} {b} =>
+    fun a1 a2 => Applicative__Product_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
+
+Local Definition Applicative__Product_pure {inst_f} {inst_g}
+  `{GHC.Base.Applicative inst_f} `{GHC.Base.Applicative inst_g}
+   : forall {a}, a -> (Product inst_f inst_g) a :=
+  fun {a} => fun x => Pair (GHC.Base.pure x) (GHC.Base.pure x).
+
+Program Instance Applicative__Product {f} {g} `{GHC.Base.Applicative f}
+  `{GHC.Base.Applicative g}
+   : GHC.Base.Applicative (Product f g) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Product_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Product_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Product_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__Product_pure |}.
+
+(* Skipping all instances of class `GHC.Base.Alternative', including
+   `Data.Functor.Product.Alternative__Product' *)
+
+Local Definition Monad__Product_op_zgzgze__ {inst_f} {inst_g} `{GHC.Base.Monad
+  inst_f} `{GHC.Base.Monad inst_g}
+   : forall {a} {b},
+     (Product inst_f inst_g) a ->
+     (a -> (Product inst_f inst_g) b) -> (Product inst_f inst_g) b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | Pair m n, f =>
+          let sndP := fun '(Pair _ b) => b in
+          let fstP := fun '(Pair a _) => a in
+          Pair (m GHC.Base.>>= (fstP GHC.Base.∘ f)) (n GHC.Base.>>= (sndP GHC.Base.∘ f))
+      end.
+
+Local Definition Monad__Product_op_zgzg__ {inst_f} {inst_g} `{GHC.Base.Monad
+  inst_f} `{GHC.Base.Monad inst_g}
+   : forall {a} {b},
+     (Product inst_f inst_g) a ->
+     (Product inst_f inst_g) b -> (Product inst_f inst_g) b :=
+  fun {a} {b} => fun m k => Monad__Product_op_zgzgze__ m (fun arg_0__ => k).
+
+Local Definition Monad__Product_return_ {inst_f} {inst_g} `{GHC.Base.Monad
+  inst_f} `{GHC.Base.Monad inst_g}
+   : forall {a}, a -> (Product inst_f inst_g) a :=
+  fun {a} => GHC.Base.pure.
+
+Program Instance Monad__Product {f} {g} `{GHC.Base.Monad f} `{GHC.Base.Monad g}
+   : GHC.Base.Monad (Product f g) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Product_op_zgzg__ ;
+           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Product_op_zgzgze__ ;
+           GHC.Base.return___ := fun {a} => Monad__Product_return_ |}.
+
+(* Skipping all instances of class `GHC.Base.MonadPlus', including
+   `Data.Functor.Product.MonadPlus__Product' *)
+
+(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
+   `Data.Functor.Product.MonadFix__Product' *)
+
+Local Definition MonadZip__Product_munzip {inst_f} {inst_g}
+  `{Control.Monad.Zip.MonadZip inst_f} `{Control.Monad.Zip.MonadZip inst_g}
+   : forall {a} {b},
+     (Product inst_f inst_g) (a * b)%type ->
+     ((Product inst_f inst_g) a * (Product inst_f inst_g) b)%type :=
+  fun {a} {b} =>
+    fun mab =>
+      pair (GHC.Base.liftM Data.Tuple.fst mab) (GHC.Base.liftM Data.Tuple.snd mab).
+
+Local Definition MonadZip__Product_mzipWith {inst_f} {inst_g}
+  `{Control.Monad.Zip.MonadZip inst_f} `{Control.Monad.Zip.MonadZip inst_g}
+   : forall {a} {b} {c},
+     (a -> b -> c) ->
+     (Product inst_f inst_g) a ->
+     (Product inst_f inst_g) b -> (Product inst_f inst_g) c :=
+  fun {a} {b} {c} =>
     fun arg_0__ arg_1__ arg_2__ =>
       match arg_0__, arg_1__, arg_2__ with
-      | eq, Pair x1 y1, Pair x2 y2 =>
-          andb (Data.Functor.Classes.liftEq eq x1 x2) (Data.Functor.Classes.liftEq eq y1
-                y2)
+      | f, Pair x1 y1, Pair x2 y2 =>
+          Pair (Control.Monad.Zip.mzipWith f x1 x2) (Control.Monad.Zip.mzipWith f y1 y2)
       end.
 
-Program Instance Eq1__Product {f} {g} `{Data.Functor.Classes.Eq1 f}
-  `{Data.Functor.Classes.Eq1 g}
-   : Data.Functor.Classes.Eq1 (Product f g) :=
+Local Definition MonadZip__Product_mzip {inst_f} {inst_g}
+  `{Control.Monad.Zip.MonadZip inst_f} `{Control.Monad.Zip.MonadZip inst_g}
+   : forall {a} {b},
+     (Product inst_f inst_g) a ->
+     (Product inst_f inst_g) b -> (Product inst_f inst_g) (a * b)%type :=
+  fun {a} {b} => MonadZip__Product_mzipWith GHC.Tuple.pair2.
+
+Program Instance MonadZip__Product {f} {g} `{Control.Monad.Zip.MonadZip f}
+  `{Control.Monad.Zip.MonadZip g}
+   : Control.Monad.Zip.MonadZip (Product f g) :=
   fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__Product_liftEq |}.
-
-Program Instance Ord1__Product {f} {g} `{Data.Functor.Classes.Ord1 f}
-  `{Data.Functor.Classes.Ord1 g}
-   : Data.Functor.Classes.Ord1 (Product f g) :=
-  fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
-             Ord1__Product_liftCompare |}.
-
-Local Definition Ord__Product_compare {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-  `{GHC.Base.Ord inst_a}
-   : (Product inst_f inst_g inst_a) ->
-     (Product inst_f inst_g inst_a) -> comparison :=
-  Data.Functor.Classes.compare1.
-
-Local Definition Ord__Product_op_zl__ {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-  `{GHC.Base.Ord inst_a}
-   : (Product inst_f inst_g inst_a) -> (Product inst_f inst_g inst_a) -> bool :=
-  fun x y => Ord__Product_compare x y GHC.Base.== Lt.
-
-Local Definition Ord__Product_op_zlze__ {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-  `{GHC.Base.Ord inst_a}
-   : (Product inst_f inst_g inst_a) -> (Product inst_f inst_g inst_a) -> bool :=
-  fun x y => Ord__Product_compare x y GHC.Base./= Gt.
-
-Local Definition Ord__Product_op_zg__ {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-  `{GHC.Base.Ord inst_a}
-   : (Product inst_f inst_g inst_a) -> (Product inst_f inst_g inst_a) -> bool :=
-  fun x y => Ord__Product_compare x y GHC.Base.== Gt.
-
-Local Definition Ord__Product_op_zgze__ {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-  `{GHC.Base.Ord inst_a}
-   : (Product inst_f inst_g inst_a) -> (Product inst_f inst_g inst_a) -> bool :=
-  fun x y => Ord__Product_compare x y GHC.Base./= Lt.
-
-Local Definition Ord__Product_max {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-  `{GHC.Base.Ord inst_a}
-   : (Product inst_f inst_g inst_a) ->
-     (Product inst_f inst_g inst_a) -> (Product inst_f inst_g inst_a) :=
-  fun x y => if Ord__Product_op_zlze__ x y : bool then y else x.
-
-Local Definition Ord__Product_min {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-  `{GHC.Base.Ord inst_a}
-   : (Product inst_f inst_g inst_a) ->
-     (Product inst_f inst_g inst_a) -> (Product inst_f inst_g inst_a) :=
-  fun x y => if Ord__Product_op_zlze__ x y : bool then x else y.
-
-Local Definition Eq___Product_op_zeze__ {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Eq1 inst_f} `{Data.Functor.Classes.Eq1 inst_g}
-  `{GHC.Base.Eq_ inst_a}
-   : (Product inst_f inst_g inst_a) -> (Product inst_f inst_g inst_a) -> bool :=
-  Data.Functor.Classes.eq1.
-
-Local Definition Eq___Product_op_zsze__ {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Eq1 inst_f} `{Data.Functor.Classes.Eq1 inst_g}
-  `{GHC.Base.Eq_ inst_a}
-   : (Product inst_f inst_g inst_a) -> (Product inst_f inst_g inst_a) -> bool :=
-  fun x y => negb (Eq___Product_op_zeze__ x y).
-
-Program Instance Eq___Product {f} {g} {a} `{Data.Functor.Classes.Eq1 f}
-  `{Data.Functor.Classes.Eq1 g} `{GHC.Base.Eq_ a}
-   : GHC.Base.Eq_ (Product f g a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___Product_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___Product_op_zsze__ |}.
-
-Program Instance Ord__Product {f} {g} {a} `{Data.Functor.Classes.Ord1 f}
-  `{Data.Functor.Classes.Ord1 g} `{GHC.Base.Ord a}
-   : GHC.Base.Ord (Product f g a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zl____ := Ord__Product_op_zl__ ;
-           GHC.Base.op_zlze____ := Ord__Product_op_zlze__ ;
-           GHC.Base.op_zg____ := Ord__Product_op_zg__ ;
-           GHC.Base.op_zgze____ := Ord__Product_op_zgze__ ;
-           GHC.Base.compare__ := Ord__Product_compare ;
-           GHC.Base.max__ := Ord__Product_max ;
-           GHC.Base.min__ := Ord__Product_min |}.
-
-(* Skipping all instances of class `Data.Functor.Classes.Show1', including
-   `Data.Functor.Product.Show1__Product' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Read1', including
-   `Data.Functor.Product.Read1__Product' *)
+    k__ {| Control.Monad.Zip.munzip__ := fun {a} {b} => MonadZip__Product_munzip ;
+           Control.Monad.Zip.mzip__ := fun {a} {b} => MonadZip__Product_mzip ;
+           Control.Monad.Zip.mzipWith__ := fun {a} {b} {c} =>
+             MonadZip__Product_mzipWith |}.
 
 (* External variables:
      Gt Lt Type andb bool comparison false list negb op_zt__ pair true

--- a/base/Data/Functor/Sum.v
+++ b/base/Data/Functor/Sum.v
@@ -45,38 +45,154 @@ Arguments InR {_} {_} {_} _.
 (* Skipping all instances of class `GHC.Generics.Generic1', including
    `Data.Functor.Sum.Generic1__Sum__5' *)
 
-Local Definition Traversable__Sum_traverse {inst_f} {inst_g}
-  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f},
-     (a -> f b) -> (Sum inst_f inst_g) a -> f ((Sum inst_f inst_g) b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, InL x => InL Data.Functor.<$> Data.Traversable.traverse f x
-      | f, InR y => InR Data.Functor.<$> Data.Traversable.traverse f y
+Local Definition Eq1__Sum_liftEq {inst_f} {inst_g} `{Data.Functor.Classes.Eq1
+  inst_f} `{Data.Functor.Classes.Eq1 inst_g}
+   : forall {a} {b},
+     (a -> b -> bool) -> (Sum inst_f inst_g) a -> (Sum inst_f inst_g) b -> bool :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | eq, InL x1, InL x2 => Data.Functor.Classes.liftEq eq x1 x2
+      | _, InL _, InR _ => false
+      | _, InR _, InL _ => false
+      | eq, InR y1, InR y2 => Data.Functor.Classes.liftEq eq y1 y2
       end.
 
-Local Definition Traversable__Sum_mapM {inst_f} {inst_g}
-  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m},
-     (a -> m b) -> (Sum inst_f inst_g) a -> m ((Sum inst_f inst_g) b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Sum_traverse.
+Program Instance Eq1__Sum {f} {g} `{Data.Functor.Classes.Eq1 f}
+  `{Data.Functor.Classes.Eq1 g}
+   : Data.Functor.Classes.Eq1 (Sum f g) :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__Sum_liftEq |}.
 
-Local Definition Traversable__Sum_sequenceA {inst_f} {inst_g}
-  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
-   : forall {f} {a},
-     forall `{GHC.Base.Applicative f},
-     (Sum inst_f inst_g) (f a) -> f ((Sum inst_f inst_g) a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} => Traversable__Sum_traverse GHC.Base.id.
+Local Definition Ord1__Sum_liftCompare {inst_f} {inst_g}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
+   : forall {a} {b},
+     (a -> b -> comparison) ->
+     (Sum inst_f inst_g) a -> (Sum inst_f inst_g) b -> comparison :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | comp, InL x1, InL x2 => Data.Functor.Classes.liftCompare comp x1 x2
+      | _, InL _, InR _ => Lt
+      | _, InR _, InL _ => Gt
+      | comp, InR y1, InR y2 => Data.Functor.Classes.liftCompare comp y1 y2
+      end.
 
-Local Definition Traversable__Sum_sequence {inst_f} {inst_g}
-  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
-   : forall {m} {a},
-     forall `{GHC.Base.Monad m},
-     (Sum inst_f inst_g) (m a) -> m ((Sum inst_f inst_g) a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Sum_sequenceA.
+Program Instance Ord1__Sum {f} {g} `{Data.Functor.Classes.Ord1 f}
+  `{Data.Functor.Classes.Ord1 g}
+   : Data.Functor.Classes.Ord1 (Sum f g) :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
+             Ord1__Sum_liftCompare |}.
+
+(* Skipping all instances of class `Data.Functor.Classes.Read1', including
+   `Data.Functor.Sum.Read1__Sum' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Show1', including
+   `Data.Functor.Sum.Show1__Sum' *)
+
+Local Definition Eq___Sum_op_zeze__ {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Eq1 inst_f} `{Data.Functor.Classes.Eq1 inst_g}
+  `{GHC.Base.Eq_ inst_a}
+   : (Sum inst_f inst_g inst_a) -> (Sum inst_f inst_g inst_a) -> bool :=
+  Data.Functor.Classes.eq1.
+
+Local Definition Eq___Sum_op_zsze__ {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Eq1 inst_f} `{Data.Functor.Classes.Eq1 inst_g}
+  `{GHC.Base.Eq_ inst_a}
+   : (Sum inst_f inst_g inst_a) -> (Sum inst_f inst_g inst_a) -> bool :=
+  fun x y => negb (Eq___Sum_op_zeze__ x y).
+
+Program Instance Eq___Sum {f} {g} {a} `{Data.Functor.Classes.Eq1 f}
+  `{Data.Functor.Classes.Eq1 g} `{GHC.Base.Eq_ a}
+   : GHC.Base.Eq_ (Sum f g a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___Sum_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___Sum_op_zsze__ |}.
+
+Local Definition Ord__Sum_compare {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
+  `{GHC.Base.Ord inst_a}
+   : (Sum inst_f inst_g inst_a) -> (Sum inst_f inst_g inst_a) -> comparison :=
+  Data.Functor.Classes.compare1.
+
+Local Definition Ord__Sum_op_zl__ {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
+  `{GHC.Base.Ord inst_a}
+   : (Sum inst_f inst_g inst_a) -> (Sum inst_f inst_g inst_a) -> bool :=
+  fun x y => Ord__Sum_compare x y GHC.Base.== Lt.
+
+Local Definition Ord__Sum_op_zlze__ {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
+  `{GHC.Base.Ord inst_a}
+   : (Sum inst_f inst_g inst_a) -> (Sum inst_f inst_g inst_a) -> bool :=
+  fun x y => Ord__Sum_compare x y GHC.Base./= Gt.
+
+Local Definition Ord__Sum_op_zg__ {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
+  `{GHC.Base.Ord inst_a}
+   : (Sum inst_f inst_g inst_a) -> (Sum inst_f inst_g inst_a) -> bool :=
+  fun x y => Ord__Sum_compare x y GHC.Base.== Gt.
+
+Local Definition Ord__Sum_op_zgze__ {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
+  `{GHC.Base.Ord inst_a}
+   : (Sum inst_f inst_g inst_a) -> (Sum inst_f inst_g inst_a) -> bool :=
+  fun x y => Ord__Sum_compare x y GHC.Base./= Lt.
+
+Local Definition Ord__Sum_max {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
+  `{GHC.Base.Ord inst_a}
+   : (Sum inst_f inst_g inst_a) ->
+     (Sum inst_f inst_g inst_a) -> (Sum inst_f inst_g inst_a) :=
+  fun x y => if Ord__Sum_op_zlze__ x y : bool then y else x.
+
+Local Definition Ord__Sum_min {inst_f} {inst_g} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
+  `{GHC.Base.Ord inst_a}
+   : (Sum inst_f inst_g inst_a) ->
+     (Sum inst_f inst_g inst_a) -> (Sum inst_f inst_g inst_a) :=
+  fun x y => if Ord__Sum_op_zlze__ x y : bool then x else y.
+
+Program Instance Ord__Sum {f} {g} {a} `{Data.Functor.Classes.Ord1 f}
+  `{Data.Functor.Classes.Ord1 g} `{GHC.Base.Ord a}
+   : GHC.Base.Ord (Sum f g a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zl____ := Ord__Sum_op_zl__ ;
+           GHC.Base.op_zlze____ := Ord__Sum_op_zlze__ ;
+           GHC.Base.op_zg____ := Ord__Sum_op_zg__ ;
+           GHC.Base.op_zgze____ := Ord__Sum_op_zgze__ ;
+           GHC.Base.compare__ := Ord__Sum_compare ;
+           GHC.Base.max__ := Ord__Sum_max ;
+           GHC.Base.min__ := Ord__Sum_min |}.
+
+(* Skipping all instances of class `GHC.Read.Read', including
+   `Data.Functor.Sum.Read__Sum' *)
+
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Data.Functor.Sum.Show__Sum' *)
+
+Local Definition Functor__Sum_fmap {inst_f} {inst_g} `{GHC.Base.Functor inst_f}
+  `{GHC.Base.Functor inst_g}
+   : forall {a} {b}, (a -> b) -> (Sum inst_f inst_g) a -> (Sum inst_f inst_g) b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, InL x => InL (GHC.Base.fmap f x)
+      | f, InR y => InR (GHC.Base.fmap f y)
+      end.
+
+Local Definition Functor__Sum_op_zlzd__ {inst_f} {inst_g} `{GHC.Base.Functor
+  inst_f} `{GHC.Base.Functor inst_g}
+   : forall {a} {b}, a -> (Sum inst_f inst_g) b -> (Sum inst_f inst_g) a :=
+  fun {a} {b} => Functor__Sum_fmap GHC.Base.∘ GHC.Base.const.
+
+Program Instance Functor__Sum {f} {g} `{GHC.Base.Functor f} `{GHC.Base.Functor
+  g}
+   : GHC.Base.Functor (Sum f g) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Sum_fmap ;
+           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Sum_op_zlzd__ |}.
 
 Local Definition Foldable__Sum_foldMap {inst_f} {inst_g}
   `{Data.Foldable.Foldable inst_f} `{Data.Foldable.Foldable inst_g}
@@ -178,27 +294,38 @@ Program Instance Foldable__Sum {f} {g} `{Data.Foldable.Foldable f}
            Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Sum_sum ;
            Data.Foldable.toList__ := fun {a} => Foldable__Sum_toList |}.
 
-Local Definition Functor__Sum_fmap {inst_f} {inst_g} `{GHC.Base.Functor inst_f}
-  `{GHC.Base.Functor inst_g}
-   : forall {a} {b}, (a -> b) -> (Sum inst_f inst_g) a -> (Sum inst_f inst_g) b :=
-  fun {a} {b} =>
+Local Definition Traversable__Sum_traverse {inst_f} {inst_g}
+  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f},
+     (a -> f b) -> (Sum inst_f inst_g) a -> f ((Sum inst_f inst_g) b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
     fun arg_0__ arg_1__ =>
       match arg_0__, arg_1__ with
-      | f, InL x => InL (GHC.Base.fmap f x)
-      | f, InR y => InR (GHC.Base.fmap f y)
+      | f, InL x => InL Data.Functor.<$> Data.Traversable.traverse f x
+      | f, InR y => InR Data.Functor.<$> Data.Traversable.traverse f y
       end.
 
-Local Definition Functor__Sum_op_zlzd__ {inst_f} {inst_g} `{GHC.Base.Functor
-  inst_f} `{GHC.Base.Functor inst_g}
-   : forall {a} {b}, a -> (Sum inst_f inst_g) b -> (Sum inst_f inst_g) a :=
-  fun {a} {b} => Functor__Sum_fmap GHC.Base.∘ GHC.Base.const.
+Local Definition Traversable__Sum_mapM {inst_f} {inst_g}
+  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m},
+     (a -> m b) -> (Sum inst_f inst_g) a -> m ((Sum inst_f inst_g) b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Sum_traverse.
 
-Program Instance Functor__Sum {f} {g} `{GHC.Base.Functor f} `{GHC.Base.Functor
-  g}
-   : GHC.Base.Functor (Sum f g) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Sum_fmap ;
-           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Sum_op_zlzd__ |}.
+Local Definition Traversable__Sum_sequenceA {inst_f} {inst_g}
+  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
+   : forall {f} {a},
+     forall `{GHC.Base.Applicative f},
+     (Sum inst_f inst_g) (f a) -> f ((Sum inst_f inst_g) a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} => Traversable__Sum_traverse GHC.Base.id.
+
+Local Definition Traversable__Sum_sequence {inst_f} {inst_g}
+  `{Data.Traversable.Traversable inst_f} `{Data.Traversable.Traversable inst_g}
+   : forall {m} {a},
+     forall `{GHC.Base.Monad m},
+     (Sum inst_f inst_g) (m a) -> m ((Sum inst_f inst_g) a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Sum_sequenceA.
 
 Program Instance Traversable__Sum {f} {g} `{Data.Traversable.Traversable f}
   `{Data.Traversable.Traversable g}
@@ -212,133 +339,6 @@ Program Instance Traversable__Sum {f} {g} `{Data.Traversable.Traversable f}
              Traversable__Sum_sequenceA ;
            Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
              Traversable__Sum_traverse |}.
-
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Data.Functor.Sum.Show__Sum' *)
-
-(* Skipping all instances of class `GHC.Read.Read', including
-   `Data.Functor.Sum.Read__Sum' *)
-
-Local Definition Ord1__Sum_liftCompare {inst_f} {inst_g}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-   : forall {a} {b},
-     (a -> b -> comparison) ->
-     (Sum inst_f inst_g) a -> (Sum inst_f inst_g) b -> comparison :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | comp, InL x1, InL x2 => Data.Functor.Classes.liftCompare comp x1 x2
-      | _, InL _, InR _ => Lt
-      | _, InR _, InL _ => Gt
-      | comp, InR y1, InR y2 => Data.Functor.Classes.liftCompare comp y1 y2
-      end.
-
-Local Definition Eq1__Sum_liftEq {inst_f} {inst_g} `{Data.Functor.Classes.Eq1
-  inst_f} `{Data.Functor.Classes.Eq1 inst_g}
-   : forall {a} {b},
-     (a -> b -> bool) -> (Sum inst_f inst_g) a -> (Sum inst_f inst_g) b -> bool :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | eq, InL x1, InL x2 => Data.Functor.Classes.liftEq eq x1 x2
-      | _, InL _, InR _ => false
-      | _, InR _, InL _ => false
-      | eq, InR y1, InR y2 => Data.Functor.Classes.liftEq eq y1 y2
-      end.
-
-Program Instance Eq1__Sum {f} {g} `{Data.Functor.Classes.Eq1 f}
-  `{Data.Functor.Classes.Eq1 g}
-   : Data.Functor.Classes.Eq1 (Sum f g) :=
-  fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__Sum_liftEq |}.
-
-Program Instance Ord1__Sum {f} {g} `{Data.Functor.Classes.Ord1 f}
-  `{Data.Functor.Classes.Ord1 g}
-   : Data.Functor.Classes.Ord1 (Sum f g) :=
-  fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
-             Ord1__Sum_liftCompare |}.
-
-Local Definition Ord__Sum_compare {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-  `{GHC.Base.Ord inst_a}
-   : (Sum inst_f inst_g inst_a) -> (Sum inst_f inst_g inst_a) -> comparison :=
-  Data.Functor.Classes.compare1.
-
-Local Definition Ord__Sum_op_zl__ {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-  `{GHC.Base.Ord inst_a}
-   : (Sum inst_f inst_g inst_a) -> (Sum inst_f inst_g inst_a) -> bool :=
-  fun x y => Ord__Sum_compare x y GHC.Base.== Lt.
-
-Local Definition Ord__Sum_op_zlze__ {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-  `{GHC.Base.Ord inst_a}
-   : (Sum inst_f inst_g inst_a) -> (Sum inst_f inst_g inst_a) -> bool :=
-  fun x y => Ord__Sum_compare x y GHC.Base./= Gt.
-
-Local Definition Ord__Sum_op_zg__ {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-  `{GHC.Base.Ord inst_a}
-   : (Sum inst_f inst_g inst_a) -> (Sum inst_f inst_g inst_a) -> bool :=
-  fun x y => Ord__Sum_compare x y GHC.Base.== Gt.
-
-Local Definition Ord__Sum_op_zgze__ {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-  `{GHC.Base.Ord inst_a}
-   : (Sum inst_f inst_g inst_a) -> (Sum inst_f inst_g inst_a) -> bool :=
-  fun x y => Ord__Sum_compare x y GHC.Base./= Lt.
-
-Local Definition Ord__Sum_max {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-  `{GHC.Base.Ord inst_a}
-   : (Sum inst_f inst_g inst_a) ->
-     (Sum inst_f inst_g inst_a) -> (Sum inst_f inst_g inst_a) :=
-  fun x y => if Ord__Sum_op_zlze__ x y : bool then y else x.
-
-Local Definition Ord__Sum_min {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{Data.Functor.Classes.Ord1 inst_g}
-  `{GHC.Base.Ord inst_a}
-   : (Sum inst_f inst_g inst_a) ->
-     (Sum inst_f inst_g inst_a) -> (Sum inst_f inst_g inst_a) :=
-  fun x y => if Ord__Sum_op_zlze__ x y : bool then x else y.
-
-Local Definition Eq___Sum_op_zeze__ {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Eq1 inst_f} `{Data.Functor.Classes.Eq1 inst_g}
-  `{GHC.Base.Eq_ inst_a}
-   : (Sum inst_f inst_g inst_a) -> (Sum inst_f inst_g inst_a) -> bool :=
-  Data.Functor.Classes.eq1.
-
-Local Definition Eq___Sum_op_zsze__ {inst_f} {inst_g} {inst_a}
-  `{Data.Functor.Classes.Eq1 inst_f} `{Data.Functor.Classes.Eq1 inst_g}
-  `{GHC.Base.Eq_ inst_a}
-   : (Sum inst_f inst_g inst_a) -> (Sum inst_f inst_g inst_a) -> bool :=
-  fun x y => negb (Eq___Sum_op_zeze__ x y).
-
-Program Instance Eq___Sum {f} {g} {a} `{Data.Functor.Classes.Eq1 f}
-  `{Data.Functor.Classes.Eq1 g} `{GHC.Base.Eq_ a}
-   : GHC.Base.Eq_ (Sum f g a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___Sum_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___Sum_op_zsze__ |}.
-
-Program Instance Ord__Sum {f} {g} {a} `{Data.Functor.Classes.Ord1 f}
-  `{Data.Functor.Classes.Ord1 g} `{GHC.Base.Ord a}
-   : GHC.Base.Ord (Sum f g a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zl____ := Ord__Sum_op_zl__ ;
-           GHC.Base.op_zlze____ := Ord__Sum_op_zlze__ ;
-           GHC.Base.op_zg____ := Ord__Sum_op_zg__ ;
-           GHC.Base.op_zgze____ := Ord__Sum_op_zgze__ ;
-           GHC.Base.compare__ := Ord__Sum_compare ;
-           GHC.Base.max__ := Ord__Sum_max ;
-           GHC.Base.min__ := Ord__Sum_min |}.
-
-(* Skipping all instances of class `Data.Functor.Classes.Show1', including
-   `Data.Functor.Sum.Show1__Sum' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Read1', including
-   `Data.Functor.Sum.Read1__Sum' *)
 
 (* External variables:
      Gt Lt Type bool comparison false list negb true Coq.Program.Basics.compose

--- a/base/Data/Functor/Utils.v
+++ b/base/Data/Functor/Utils.v
@@ -66,8 +66,6 @@ Instance Unpeel_Max {a} : Prim.Unpeel (Max a) (option a)
 
 (* Converted value declarations: *)
 
-(* Skipping definition `Data.Functor.Utils.hash_compose' *)
-
 Local Definition Semigroup__Max_op_zlzlzgzg__ {inst_a} `{GHC.Base.Ord inst_a}
    : (Max inst_a) -> (Max inst_a) -> (Max inst_a) :=
   fun arg_0__ arg_1__ =>
@@ -134,6 +132,23 @@ Program Instance Monoid__Min {a} `{GHC.Base.Ord a} : GHC.Base.Monoid (Min a) :=
            GHC.Base.mconcat__ := Monoid__Min_mconcat ;
            GHC.Base.mempty__ := Monoid__Min_mempty |}.
 
+Local Definition Functor__StateL_fmap {inst_s}
+   : forall {a} {b}, (a -> b) -> (StateL inst_s) a -> (StateL inst_s) b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, Mk_StateL k => Mk_StateL (fun s => let 'pair s' v := k s in pair s' (f v))
+      end.
+
+Local Definition Functor__StateL_op_zlzd__ {inst_s}
+   : forall {a} {b}, a -> (StateL inst_s) b -> (StateL inst_s) a :=
+  fun {a} {b} => Functor__StateL_fmap GHC.Base.∘ GHC.Base.const.
+
+Program Instance Functor__StateL {s} : GHC.Base.Functor (StateL s) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__StateL_fmap ;
+           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__StateL_op_zlzd__ |}.
+
 Local Definition Applicative__StateL_liftA2 {inst_s}
    : forall {a} {b} {c},
      (a -> b -> c) -> (StateL inst_s) a -> (StateL inst_s) b -> (StateL inst_s) c :=
@@ -160,23 +175,6 @@ Local Definition Applicative__StateL_op_zlztzg__ {inst_s}
                        pair s'' (f v))
       end.
 
-Local Definition Functor__StateL_fmap {inst_s}
-   : forall {a} {b}, (a -> b) -> (StateL inst_s) a -> (StateL inst_s) b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, Mk_StateL k => Mk_StateL (fun s => let 'pair s' v := k s in pair s' (f v))
-      end.
-
-Local Definition Functor__StateL_op_zlzd__ {inst_s}
-   : forall {a} {b}, a -> (StateL inst_s) b -> (StateL inst_s) a :=
-  fun {a} {b} => Functor__StateL_fmap GHC.Base.∘ GHC.Base.const.
-
-Program Instance Functor__StateL {s} : GHC.Base.Functor (StateL s) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__StateL_fmap ;
-           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__StateL_op_zlzd__ |}.
-
 Local Definition Applicative__StateL_op_ztzg__ {inst_s}
    : forall {a} {b},
      (StateL inst_s) a -> (StateL inst_s) b -> (StateL inst_s) b :=
@@ -193,6 +191,23 @@ Program Instance Applicative__StateL {s} : GHC.Base.Applicative (StateL s) :=
            GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__StateL_op_zlztzg__ ;
            GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__StateL_op_ztzg__ ;
            GHC.Base.pure__ := fun {a} => Applicative__StateL_pure |}.
+
+Local Definition Functor__StateR_fmap {inst_s}
+   : forall {a} {b}, (a -> b) -> (StateR inst_s) a -> (StateR inst_s) b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, Mk_StateR k => Mk_StateR (fun s => let 'pair s' v := k s in pair s' (f v))
+      end.
+
+Local Definition Functor__StateR_op_zlzd__ {inst_s}
+   : forall {a} {b}, a -> (StateR inst_s) b -> (StateR inst_s) a :=
+  fun {a} {b} => Functor__StateR_fmap GHC.Base.∘ GHC.Base.const.
+
+Program Instance Functor__StateR {s} : GHC.Base.Functor (StateR s) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__StateR_fmap ;
+           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__StateR_op_zlzd__ |}.
 
 Local Definition Applicative__StateR_liftA2 {inst_s}
    : forall {a} {b} {c},
@@ -220,23 +235,6 @@ Local Definition Applicative__StateR_op_zlztzg__ {inst_s}
                        pair s'' (f v))
       end.
 
-Local Definition Functor__StateR_fmap {inst_s}
-   : forall {a} {b}, (a -> b) -> (StateR inst_s) a -> (StateR inst_s) b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, Mk_StateR k => Mk_StateR (fun s => let 'pair s' v := k s in pair s' (f v))
-      end.
-
-Local Definition Functor__StateR_op_zlzd__ {inst_s}
-   : forall {a} {b}, a -> (StateR inst_s) b -> (StateR inst_s) a :=
-  fun {a} {b} => Functor__StateR_fmap GHC.Base.∘ GHC.Base.const.
-
-Program Instance Functor__StateR {s} : GHC.Base.Functor (StateR s) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__StateR_fmap ;
-           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__StateR_op_zlzd__ |}.
-
 Local Definition Applicative__StateR_op_ztzg__ {inst_s}
    : forall {a} {b},
      (StateR inst_s) a -> (StateR inst_s) b -> (StateR inst_s) b :=
@@ -253,6 +251,8 @@ Program Instance Applicative__StateR {s} : GHC.Base.Applicative (StateR s) :=
            GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__StateR_op_zlztzg__ ;
            GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__StateR_op_ztzg__ ;
            GHC.Base.pure__ := fun {a} => Applicative__StateR_pure |}.
+
+(* Skipping definition `Data.Functor.Utils.hash_compose' *)
 
 (* External variables:
      None Some bool list op_zt__ option pair GHC.Base.Applicative GHC.Base.Functor

--- a/base/Data/List/NonEmpty.v
+++ b/base/Data/List/NonEmpty.v
@@ -88,23 +88,8 @@ Definition sort {a} `{GHC.Base.Ord a} : GHC.Base.NonEmpty a -> GHC.Base.NonEmpty
 
 (* Converted value declarations: *)
 
-Definition zipWith {a} {b} {c}
-   : (a -> b -> c) ->
-     GHC.Base.NonEmpty a -> GHC.Base.NonEmpty b -> GHC.Base.NonEmpty c :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | f, GHC.Base.NEcons x xs, GHC.Base.NEcons y ys =>
-        GHC.Base.NEcons (f x y) (GHC.List.zipWith f xs ys)
-    end.
-
-Definition zip {a} {b}
-   : GHC.Base.NonEmpty a ->
-     GHC.Base.NonEmpty b -> GHC.Base.NonEmpty (a * b)%type :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | GHC.Base.NEcons x xs, GHC.Base.NEcons y ys =>
-        GHC.Base.NEcons (pair x y) (GHC.List.zip xs ys)
-    end.
+Definition length {a} : GHC.Base.NonEmpty a -> GHC.Num.Int :=
+  fun '(GHC.Base.NEcons _ xs) => #1 GHC.Num.+ Data.Foldable.length xs.
 
 Definition xor : GHC.Base.NonEmpty bool -> bool :=
   fun '(GHC.Base.NEcons x xs) =>
@@ -116,65 +101,30 @@ Definition xor : GHC.Base.NonEmpty bool -> bool :=
         end in
     Data.Foldable.foldr xor' x xs.
 
-Definition unzip {f} {a} {b} `{GHC.Base.Functor f}
-   : f (a * b)%type -> (f a * f b)%type :=
-  fun xs =>
-    pair (Data.Tuple.fst Data.Functor.<$> xs) (Data.Tuple.snd Data.Functor.<$> xs).
+(* Skipping definition `Data.List.NonEmpty.unfold' *)
+
+Definition nonEmpty {a} : list a -> option (GHC.Base.NonEmpty a) :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | nil => None
+    | cons a as_ => Some (GHC.Base.NEcons a as_)
+    end.
+
+Definition uncons {a}
+   : GHC.Base.NonEmpty a -> (a * option (GHC.Base.NonEmpty a))%type :=
+  fun '(GHC.Base.NEcons a as_) => pair a (nonEmpty as_).
 
 (* Skipping definition `Data.List.NonEmpty.unfoldr' *)
 
-(* Skipping definition `Data.List.NonEmpty.unfold' *)
-
-(* Skipping definition `Data.List.NonEmpty.transpose' *)
-
-(* Skipping definition `Data.List.NonEmpty.toList' *)
-
-Definition takeWhile {a} : (a -> bool) -> GHC.Base.NonEmpty a -> list a :=
-  fun p => GHC.List.takeWhile p GHC.Base.∘ toList.
-
-Definition take {a} : GHC.Num.Int -> GHC.Base.NonEmpty a -> list a :=
-  fun n => GHC.List.take n GHC.Base.∘ toList.
-
-(* Skipping definition `Data.List.NonEmpty.tails' *)
+Definition head {a} : GHC.Base.NonEmpty a -> a :=
+  fun '(GHC.Base.NEcons a _) => a.
 
 Definition tail {a} : GHC.Base.NonEmpty a -> list a :=
   fun '(GHC.Base.NEcons _ as_) => as_.
 
-Definition splitAt {a}
-   : GHC.Num.Int -> GHC.Base.NonEmpty a -> (list a * list a)%type :=
-  fun n => GHC.List.splitAt n GHC.Base.∘ toList.
+(* Skipping definition `Data.List.NonEmpty.last' *)
 
-Definition span {a}
-   : (a -> bool) -> GHC.Base.NonEmpty a -> (list a * list a)%type :=
-  fun p => GHC.List.span p GHC.Base.∘ toList.
-
-(* Skipping definition `Data.List.NonEmpty.sortBy' *)
-
-Definition sortWith {o} {a} `{GHC.Base.Ord o}
-   : (a -> o) -> GHC.Base.NonEmpty a -> GHC.Base.NonEmpty a :=
-  sortBy GHC.Base.∘ Data.Ord.comparing.
-
-(* Skipping definition `Data.List.NonEmpty.sort' *)
-
-(* Skipping definition `Data.List.NonEmpty.some1' *)
-
-(* Skipping definition `Data.List.NonEmpty.scanr1' *)
-
-(* Skipping definition `Data.List.NonEmpty.scanr' *)
-
-(* Skipping definition `Data.List.NonEmpty.scanl1' *)
-
-(* Skipping definition `Data.List.NonEmpty.scanl' *)
-
-(* Skipping definition `Data.List.NonEmpty.reverse' *)
-
-(* Skipping definition `Data.List.NonEmpty.repeat' *)
-
-Definition partition {a}
-   : (a -> bool) -> GHC.Base.NonEmpty a -> (list a * list a)%type :=
-  fun p => Data.OldList.partition p GHC.Base.∘ toList.
-
-(* Skipping definition `Data.List.NonEmpty.op_znzn__' *)
+(* Skipping definition `Data.List.NonEmpty.init' *)
 
 Definition op_zlzb__ {a} : a -> GHC.Base.NonEmpty a -> GHC.Base.NonEmpty a :=
   fun arg_0__ arg_1__ =>
@@ -185,6 +135,131 @@ Definition op_zlzb__ {a} : a -> GHC.Base.NonEmpty a -> GHC.Base.NonEmpty a :=
 Notation "'_<|_'" := (op_zlzb__).
 
 Infix "<|" := (_<|_) (at level 99).
+
+Definition cons_ {a} : a -> GHC.Base.NonEmpty a -> GHC.Base.NonEmpty a :=
+  _<|_.
+
+(* Skipping definition `Data.List.NonEmpty.sort' *)
+
+(* Skipping definition `Data.List.NonEmpty.fromList' *)
+
+(* Skipping definition `Data.List.NonEmpty.toList' *)
+
+(* Skipping definition `Data.List.NonEmpty.lift' *)
+
+Definition map {a} {b}
+   : (a -> b) -> GHC.Base.NonEmpty a -> GHC.Base.NonEmpty b :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, GHC.Base.NEcons a as_ => GHC.Base.NEcons (f a) (GHC.Base.fmap f as_)
+    end.
+
+(* Skipping definition `Data.List.NonEmpty.inits' *)
+
+(* Skipping definition `Data.List.NonEmpty.tails' *)
+
+(* Skipping definition `Data.List.NonEmpty.insert' *)
+
+(* Skipping definition `Data.List.NonEmpty.some1' *)
+
+(* Skipping definition `Data.List.NonEmpty.scanl' *)
+
+(* Skipping definition `Data.List.NonEmpty.scanr' *)
+
+(* Skipping definition `Data.List.NonEmpty.scanl1' *)
+
+(* Skipping definition `Data.List.NonEmpty.scanr1' *)
+
+(* Skipping definition `Data.List.NonEmpty.intersperse' *)
+
+(* Skipping definition `Data.List.NonEmpty.iterate' *)
+
+(* Skipping definition `Data.List.NonEmpty.cycle' *)
+
+(* Skipping definition `Data.List.NonEmpty.reverse' *)
+
+(* Skipping definition `Data.List.NonEmpty.repeat' *)
+
+Definition take {a} : GHC.Num.Int -> GHC.Base.NonEmpty a -> list a :=
+  fun n => GHC.List.take n GHC.Base.∘ toList.
+
+Definition drop {a} : GHC.Num.Int -> GHC.Base.NonEmpty a -> list a :=
+  fun n => GHC.List.drop n GHC.Base.∘ toList.
+
+Definition splitAt {a}
+   : GHC.Num.Int -> GHC.Base.NonEmpty a -> (list a * list a)%type :=
+  fun n => GHC.List.splitAt n GHC.Base.∘ toList.
+
+Definition takeWhile {a} : (a -> bool) -> GHC.Base.NonEmpty a -> list a :=
+  fun p => GHC.List.takeWhile p GHC.Base.∘ toList.
+
+Definition dropWhile {a} : (a -> bool) -> GHC.Base.NonEmpty a -> list a :=
+  fun p => GHC.List.dropWhile p GHC.Base.∘ toList.
+
+Definition span {a}
+   : (a -> bool) -> GHC.Base.NonEmpty a -> (list a * list a)%type :=
+  fun p => GHC.List.span p GHC.Base.∘ toList.
+
+Definition break {a}
+   : (a -> bool) -> GHC.Base.NonEmpty a -> (list a * list a)%type :=
+  fun p => span (negb GHC.Base.∘ p).
+
+Definition filter {a} : (a -> bool) -> GHC.Base.NonEmpty a -> list a :=
+  fun p => GHC.List.filter p GHC.Base.∘ toList.
+
+Definition partition {a}
+   : (a -> bool) -> GHC.Base.NonEmpty a -> (list a * list a)%type :=
+  fun p => Data.OldList.partition p GHC.Base.∘ toList.
+
+(* Skipping definition `Data.List.NonEmpty.group' *)
+
+(* Skipping definition `Data.List.NonEmpty.groupBy' *)
+
+(* Skipping definition `Data.List.NonEmpty.groupWith' *)
+
+(* Skipping definition `Data.List.NonEmpty.groupAllWith' *)
+
+(* Skipping definition `Data.List.NonEmpty.group1' *)
+
+(* Skipping definition `Data.List.NonEmpty.groupBy1' *)
+
+(* Skipping definition `Data.List.NonEmpty.groupWith1' *)
+
+(* Skipping definition `Data.List.NonEmpty.groupAllWith1' *)
+
+Definition isPrefixOf {a} `{GHC.Base.Eq_ a}
+   : list a -> GHC.Base.NonEmpty a -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | nil, _ => true
+    | cons y ys, GHC.Base.NEcons x xs =>
+        andb (y GHC.Base.== x) (Data.OldList.isPrefixOf ys xs)
+    end.
+
+(* Skipping definition `Data.List.NonEmpty.op_znzn__' *)
+
+Definition zip {a} {b}
+   : GHC.Base.NonEmpty a ->
+     GHC.Base.NonEmpty b -> GHC.Base.NonEmpty (a * b)%type :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | GHC.Base.NEcons x xs, GHC.Base.NEcons y ys =>
+        GHC.Base.NEcons (pair x y) (GHC.List.zip xs ys)
+    end.
+
+Definition zipWith {a} {b} {c}
+   : (a -> b -> c) ->
+     GHC.Base.NonEmpty a -> GHC.Base.NonEmpty b -> GHC.Base.NonEmpty c :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | f, GHC.Base.NEcons x xs, GHC.Base.NEcons y ys =>
+        GHC.Base.NEcons (f x y) (GHC.List.zipWith f xs ys)
+    end.
+
+Definition unzip {f} {a} {b} `{GHC.Base.Functor f}
+   : f (a * b)%type -> (f a * f b)%type :=
+  fun xs =>
+    pair (Data.Tuple.fst Data.Functor.<$> xs) (Data.Tuple.snd Data.Functor.<$> xs).
 
 Definition nubBy {a}
    : (a -> a -> bool) -> GHC.Base.NonEmpty a -> GHC.Base.NonEmpty a :=
@@ -199,88 +274,13 @@ Definition nub {a} `{GHC.Base.Eq_ a}
    : GHC.Base.NonEmpty a -> GHC.Base.NonEmpty a :=
   nubBy _GHC.Base.==_.
 
-Definition nonEmpty {a} : list a -> option (GHC.Base.NonEmpty a) :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | nil => None
-    | cons a as_ => Some (GHC.Base.NEcons a as_)
-    end.
+(* Skipping definition `Data.List.NonEmpty.transpose' *)
 
-Definition uncons {a}
-   : GHC.Base.NonEmpty a -> (a * option (GHC.Base.NonEmpty a))%type :=
-  fun '(GHC.Base.NEcons a as_) => pair a (nonEmpty as_).
+(* Skipping definition `Data.List.NonEmpty.sortBy' *)
 
-Definition map {a} {b}
-   : (a -> b) -> GHC.Base.NonEmpty a -> GHC.Base.NonEmpty b :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, GHC.Base.NEcons a as_ => GHC.Base.NEcons (f a) (GHC.Base.fmap f as_)
-    end.
-
-(* Skipping definition `Data.List.NonEmpty.lift' *)
-
-Definition length {a} : GHC.Base.NonEmpty a -> GHC.Num.Int :=
-  fun '(GHC.Base.NEcons _ xs) => #1 GHC.Num.+ Data.Foldable.length xs.
-
-(* Skipping definition `Data.List.NonEmpty.last' *)
-
-(* Skipping definition `Data.List.NonEmpty.iterate' *)
-
-Definition isPrefixOf {a} `{GHC.Base.Eq_ a}
-   : list a -> GHC.Base.NonEmpty a -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | nil, _ => true
-    | cons y ys, GHC.Base.NEcons x xs =>
-        andb (y GHC.Base.== x) (Data.OldList.isPrefixOf ys xs)
-    end.
-
-(* Skipping definition `Data.List.NonEmpty.intersperse' *)
-
-(* Skipping definition `Data.List.NonEmpty.insert' *)
-
-(* Skipping definition `Data.List.NonEmpty.inits' *)
-
-(* Skipping definition `Data.List.NonEmpty.init' *)
-
-Definition head {a} : GHC.Base.NonEmpty a -> a :=
-  fun '(GHC.Base.NEcons a _) => a.
-
-(* Skipping definition `Data.List.NonEmpty.groupWith1' *)
-
-(* Skipping definition `Data.List.NonEmpty.groupWith' *)
-
-(* Skipping definition `Data.List.NonEmpty.groupBy1' *)
-
-(* Skipping definition `Data.List.NonEmpty.groupBy' *)
-
-(* Skipping definition `Data.List.NonEmpty.groupAllWith1' *)
-
-(* Skipping definition `Data.List.NonEmpty.groupAllWith' *)
-
-(* Skipping definition `Data.List.NonEmpty.group1' *)
-
-(* Skipping definition `Data.List.NonEmpty.group' *)
-
-(* Skipping definition `Data.List.NonEmpty.fromList' *)
-
-Definition filter {a} : (a -> bool) -> GHC.Base.NonEmpty a -> list a :=
-  fun p => GHC.List.filter p GHC.Base.∘ toList.
-
-Definition dropWhile {a} : (a -> bool) -> GHC.Base.NonEmpty a -> list a :=
-  fun p => GHC.List.dropWhile p GHC.Base.∘ toList.
-
-Definition drop {a} : GHC.Num.Int -> GHC.Base.NonEmpty a -> list a :=
-  fun n => GHC.List.drop n GHC.Base.∘ toList.
-
-(* Skipping definition `Data.List.NonEmpty.cycle' *)
-
-Definition cons_ {a} : a -> GHC.Base.NonEmpty a -> GHC.Base.NonEmpty a :=
-  _<|_.
-
-Definition break {a}
-   : (a -> bool) -> GHC.Base.NonEmpty a -> (list a * list a)%type :=
-  fun p => span (negb GHC.Base.∘ p).
+Definition sortWith {o} {a} `{GHC.Base.Ord o}
+   : (a -> o) -> GHC.Base.NonEmpty a -> GHC.Base.NonEmpty a :=
+  sortBy GHC.Base.∘ Data.Ord.comparing.
 
 Module Notations.
 Notation "'_Data.List.NonEmpty.<|_'" := (op_zlzb__).

--- a/base/Data/Maybe.v
+++ b/base/Data/Maybe.v
@@ -23,9 +23,6 @@ Import GHC.Base.Notations.
 
 (* Converted value declarations: *)
 
-Definition maybeToList {a} : option a -> list a :=
-  fun arg_0__ => match arg_0__ with | None => nil | Some x => cons x nil end.
-
 Definition maybe {b} {a} : b -> (a -> b) -> option a -> b :=
   fun arg_0__ arg_1__ arg_2__ =>
     match arg_0__, arg_1__, arg_2__ with
@@ -33,35 +30,22 @@ Definition maybe {b} {a} : b -> (a -> b) -> option a -> b :=
     | _, f, Some x => f x
     end.
 
-Definition mapMaybeFB {b} {r} {a}
-   : (b -> r -> r) -> (a -> option b) -> a -> r -> r :=
-  fun cons_ f x next =>
-    match f x with
-    | None => next
-    | Some r => cons_ r next
-    end.
-
-Fixpoint mapMaybe {a} {b} (arg_0__ : (a -> option b)) (arg_1__ : list a) : list
-                                                                           b
-           := match arg_0__, arg_1__ with
-              | _, nil => nil
-              | f, cons x xs =>
-                  let rs := mapMaybe f xs in match f x with | None => rs | Some r => cons r rs end
-              end.
-
-Definition listToMaybe {a} : list a -> option a :=
-  GHC.Base.foldr (GHC.Base.const GHC.Base.∘ Some) None.
+Definition isJust {a} : option a -> bool :=
+  fun arg_0__ => match arg_0__ with | None => false | _ => true end.
 
 Definition isNothing {a} : option a -> bool :=
   fun arg_0__ => match arg_0__ with | None => true | _ => false end.
 
-Definition isJust {a} : option a -> bool :=
-  fun arg_0__ => match arg_0__ with | None => false | _ => true end.
+(* Skipping definition `Data.Maybe.fromJust' *)
 
 Definition fromMaybe {a} : a -> option a -> a :=
   fun d x => match x with | None => d | Some v => v end.
 
-(* Skipping definition `Data.Maybe.fromJust' *)
+Definition maybeToList {a} : option a -> list a :=
+  fun arg_0__ => match arg_0__ with | None => nil | Some x => cons x nil end.
+
+Definition listToMaybe {a} : list a -> option a :=
+  GHC.Base.foldr (GHC.Base.const GHC.Base.∘ Some) None.
 
 Definition catMaybes {a} : list (option a) -> list a :=
   fun ls =>
@@ -71,6 +55,22 @@ Definition catMaybes {a} : list (option a) -> list a :=
       | _ => nil
       end in
     Coq.Lists.List.flat_map cont_0__ ls.
+
+Fixpoint mapMaybe {a} {b} (arg_0__ : (a -> option b)) (arg_1__ : list a) : list
+                                                                           b
+           := match arg_0__, arg_1__ with
+              | _, nil => nil
+              | f, cons x xs =>
+                  let rs := mapMaybe f xs in match f x with | None => rs | Some r => cons r rs end
+              end.
+
+Definition mapMaybeFB {b} {r} {a}
+   : (b -> r -> r) -> (a -> option b) -> a -> r -> r :=
+  fun cons_ f x next =>
+    match f x with
+    | None => next
+    | Some r => cons_ r next
+    end.
 
 (* External variables:
      None Some bool cons false list nil option true Coq.Lists.List.flat_map

--- a/base/Data/OldList.v
+++ b/base/Data/OldList.v
@@ -226,6 +226,311 @@ Defined.
 
 (* Converted value declarations: *)
 
+Definition dropWhileEnd {a} : (a -> bool) -> list a -> list a :=
+  fun p =>
+    foldr (fun x xs =>
+             if andb (p x) (GHC.List.null xs) : bool
+             then nil
+             else cons x xs) nil.
+
+Fixpoint stripPrefix {a} `{Eq_ a} (arg_0__ arg_1__ : list a) : option (list a)
+           := match arg_0__, arg_1__ with
+              | nil, ys => Some ys
+              | cons x xs, cons y ys => if x == y : bool then stripPrefix xs ys else None
+              | _, _ => None
+              end.
+
+(* Skipping definition `Data.OldList.elemIndex' *)
+
+(* Skipping definition `Data.OldList.elemIndices' *)
+
+Definition find {a} : (a -> bool) -> list a -> option a :=
+  fun p => Data.Maybe.listToMaybe ∘ GHC.List.filter p.
+
+(* Skipping definition `Data.OldList.findIndex' *)
+
+(* Skipping definition `Data.OldList.findIndices' *)
+
+Fixpoint isPrefixOf {a} `{(Eq_ a)} (arg_0__ arg_1__ : list a) : bool
+           := match arg_0__, arg_1__ with
+              | nil, _ => true
+              | _, nil => false
+              | cons x xs, cons y ys => andb (x == y) (isPrefixOf xs ys)
+              end.
+
+Fixpoint dropLength {a} {b} (arg_0__ : list a) (arg_1__ : list b) : list b
+           := match arg_0__, arg_1__ with
+              | nil, y => y
+              | _, nil => nil
+              | cons _ x', cons _ y' => dropLength x' y'
+              end.
+
+Fixpoint dropLengthMaybe {a} {b} (arg_0__ : list a) (arg_1__ : list b) : option
+                                                                         (list b)
+           := match arg_0__, arg_1__ with
+              | nil, y => Some y
+              | _, nil => None
+              | cons _ x', cons _ y' => dropLengthMaybe x' y'
+              end.
+
+Definition isSuffixOf {a} `{(Eq_ a)} : list a -> list a -> bool :=
+  fun ns hs =>
+    Data.Maybe.maybe false id (dropLengthMaybe ns hs >>=
+                               (fun delta => return_ (ns == dropLength delta hs))).
+
+(* Skipping definition `Data.OldList.isInfixOf' *)
+
+Fixpoint elem_by {a} (arg_0__ : (a -> a -> bool)) (arg_1__ : a) (arg_2__
+                   : list a) : bool
+           := match arg_0__, arg_1__, arg_2__ with
+              | _, _, nil => false
+              | eq, y, cons x xs => orb (eq x y) (elem_by eq y xs)
+              end.
+
+Definition nubBy {a} : (a -> a -> bool) -> list a -> list a :=
+  fun eq l =>
+    let fix nubBy' arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | nil, _ => nil
+                 | cons y ys, xs =>
+                     if elem_by eq y xs : bool then nubBy' ys xs else
+                     cons y (nubBy' ys (cons y xs))
+                 end in
+    nubBy' l nil.
+
+Definition nub {a} `{(Eq_ a)} : list a -> list a :=
+  nubBy _==_.
+
+Fixpoint deleteBy {a} (arg_0__ : (a -> a -> bool)) (arg_1__ : a) (arg_2__
+                    : list a) : list a
+           := match arg_0__, arg_1__, arg_2__ with
+              | _, _, nil => nil
+              | eq, x, cons y ys => if eq x y : bool then ys else cons y (deleteBy eq x ys)
+              end.
+
+Definition delete {a} `{(Eq_ a)} : a -> list a -> list a :=
+  deleteBy _==_.
+
+Definition op_zrzr__ {a} `{(Eq_ a)} : list a -> list a -> list a :=
+  foldl (flip delete).
+
+Notation "'_\\_'" := (op_zrzr__).
+
+Infix "\\" := (_\\_) (at level 99).
+
+Definition unionBy {a} : (a -> a -> bool) -> list a -> list a -> list a :=
+  fun eq xs ys =>
+    Coq.Init.Datatypes.app xs (foldl (flip (deleteBy eq)) (nubBy eq ys) xs).
+
+Definition union {a} `{(Eq_ a)} : list a -> list a -> list a :=
+  unionBy _==_.
+
+Definition intersectBy {a} : (a -> a -> bool) -> list a -> list a -> list a :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | _, nil, _ => nil
+    | _, _, nil => nil
+    | eq, xs, ys =>
+        Coq.Lists.List.flat_map (fun x =>
+                                   if GHC.List.any (eq x) ys : bool then cons x nil else
+                                   nil) xs
+    end.
+
+Definition intersect {a} `{(Eq_ a)} : list a -> list a -> list a :=
+  intersectBy _==_.
+
+(* Skipping definition `Data.OldList.intersperse' *)
+
+Fixpoint prependToAll {a} (arg_0__ : a) (arg_1__ : list a) : list a
+           := match arg_0__, arg_1__ with
+              | _, nil => nil
+              | sep, cons x xs => cons sep (cons x (prependToAll sep xs))
+              end.
+
+(* Skipping definition `Data.OldList.intercalate' *)
+
+(* Skipping definition `Data.OldList.transpose' *)
+
+Definition select {a}
+   : (a -> bool) -> a -> (list a * list a)%type -> (list a * list a)%type :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | p, x, pair ts fs =>
+        if p x : bool then pair (cons x ts) fs else
+        pair ts (cons x fs)
+    end.
+
+Definition partition {a} : (a -> bool) -> list a -> (list a * list a)%type :=
+  fun p xs => foldr (select p) (pair nil nil) xs.
+
+Fixpoint mapAccumL {acc} {x} {y} (arg_0__ : (acc -> x -> (acc * y)%type))
+                   (arg_1__ : acc) (arg_2__ : list x) : (acc * list y)%type
+           := match arg_0__, arg_1__, arg_2__ with
+              | _, s, nil => pair s nil
+              | f, s, cons x xs =>
+                  let 'pair s' y := f s x in
+                  let 'pair s'' ys := mapAccumL f s' xs in
+                  pair s'' (cons y ys)
+              end.
+
+Definition pairWithNil {acc} {y} : acc -> (acc * list y)%type :=
+  fun x => pair x nil.
+
+Definition mapAccumLF {acc} {x} {y}
+   : (acc -> x -> (acc * y)%type) ->
+     x -> (acc -> (acc * list y)%type) -> acc -> (acc * list y)%type :=
+  fun f =>
+    fun x r =>
+      (fun s =>
+         let 'pair s' y := f s x in
+         let 'pair s'' ys := r s' in
+         pair s'' (cons y ys)).
+
+Fixpoint mapAccumR {acc} {x} {y} (arg_0__ : (acc -> x -> (acc * y)%type))
+                   (arg_1__ : acc) (arg_2__ : list x) : (acc * list y)%type
+           := match arg_0__, arg_1__, arg_2__ with
+              | _, s, nil => pair s nil
+              | f, s, cons x xs =>
+                  let 'pair s' ys := mapAccumR f s xs in
+                  let 'pair s'' y := f s' x in
+                  pair s'' (cons y ys)
+              end.
+
+Fixpoint insertBy {a} (arg_0__ : (a -> a -> comparison)) (arg_1__ : a) (arg_2__
+                    : list a) : list a
+           := match arg_0__, arg_1__, arg_2__ with
+              | _, x, nil => cons x nil
+              | cmp, x, (cons y ys' as ys) =>
+                  match cmp x y with
+                  | Gt => cons y (insertBy cmp x ys')
+                  | _ => cons x ys
+                  end
+              end.
+
+Definition insert {a} `{Ord a} : a -> list a -> list a :=
+  fun e ls => insertBy (compare) e ls.
+
+Definition maximumBy {a} {_ : GHC.Err.Default a} {_ : Eq_ a} {_ : Ord a}
+   : (a -> a -> comparison) -> list a -> a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | _, nil =>
+        GHC.Err.errorWithoutStackTrace (GHC.Base.hs_string__
+                                        "List.maximumBy: empty list")
+    | cmp, xs =>
+        let maxBy := fun x y => match cmp x y with | Gt => x | _ => y end in
+        GHC.List.foldl1 maxBy xs
+    end.
+
+Definition minimumBy {a} {_ : GHC.Err.Default a} {_ : Eq_ a} {_ : Ord a}
+   : (a -> a -> comparison) -> list a -> a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | _, nil =>
+        GHC.Err.errorWithoutStackTrace (GHC.Base.hs_string__
+                                        "List.minimumBy: empty list")
+    | cmp, xs =>
+        let minBy := fun x y => match cmp x y with | Gt => y | _ => x end in
+        GHC.List.foldl1 minBy xs
+    end.
+
+Fixpoint genericLength {i} {a} `{(GHC.Num.Num i)} (arg_0__ : list a) : i
+           := match arg_0__ with
+              | nil => #0
+              | cons _ l => #1 GHC.Num.+ genericLength l
+              end.
+
+Definition strictGenericLength {i} {b} `{(GHC.Num.Num i)} : list b -> i :=
+  fun l =>
+    let fix gl arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | nil, a => a
+                 | cons _ xs, a => let a' := a GHC.Num.+ #1 in GHC.Prim.seq a' (gl xs a')
+                 end in
+    gl l #0.
+
+Fixpoint genericTake {i} {a} `{(GHC.Real.Integral i)} (arg_0__ : i) (arg_1__
+                       : list a) : list a
+           := match arg_0__, arg_1__ with
+              | n, _ =>
+                  if n <= #0 : bool then nil else
+                  match arg_0__, arg_1__ with
+                  | _, nil => nil
+                  | n, cons x xs => cons x (genericTake (n GHC.Num.- #1) xs)
+                  end
+              end.
+
+Fixpoint genericDrop {i} {a} `{(GHC.Real.Integral i)} (arg_0__ : i) (arg_1__
+                       : list a) : list a
+           := match arg_0__, arg_1__ with
+              | n, xs =>
+                  if n <= #0 : bool then xs else
+                  match arg_0__, arg_1__ with
+                  | _, nil => nil
+                  | n, cons _ xs => genericDrop (n GHC.Num.- #1) xs
+                  end
+              end.
+
+Fixpoint genericSplitAt {i} {a} `{(GHC.Real.Integral i)} (arg_0__ : i) (arg_1__
+                          : list a) : (list a * list a)%type
+           := match arg_0__, arg_1__ with
+              | n, xs =>
+                  if n <= #0 : bool then pair nil xs else
+                  match arg_0__, arg_1__ with
+                  | _, nil => pair nil nil
+                  | n, cons x xs =>
+                      let 'pair xs' xs'' := genericSplitAt (n GHC.Num.- #1) xs in
+                      pair (cons x xs') xs''
+                  end
+              end.
+
+(* Skipping definition `Data.OldList.genericIndex' *)
+
+(* Skipping definition `Data.OldList.genericReplicate' *)
+
+Fixpoint zipWith4 {a} {b} {c} {d} {e} (arg_0__ : (a -> b -> c -> d -> e))
+                  (arg_1__ : list a) (arg_2__ : list b) (arg_3__ : list c) (arg_4__ : list d)
+           : list e
+           := match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__ with
+              | z, cons a as_, cons b bs, cons c cs, cons d ds =>
+                  cons (z a b c d) (zipWith4 z as_ bs cs ds)
+              | _, _, _, _, _ => nil
+              end.
+
+Definition zip4 {a} {b} {c} {d}
+   : list a -> list b -> list c -> list d -> list (a * b * c * d)%type :=
+  zipWith4 GHC.Tuple.pair4.
+
+Fixpoint zipWith5 {a} {b} {c} {d} {e} {f} (arg_0__
+                    : (a -> b -> c -> d -> e -> f)) (arg_1__ : list a) (arg_2__ : list b) (arg_3__
+                    : list c) (arg_4__ : list d) (arg_5__ : list e) : list f
+           := match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__, arg_5__ with
+              | z, cons a as_, cons b bs, cons c cs, cons d ds, cons e es =>
+                  cons (z a b c d e) (zipWith5 z as_ bs cs ds es)
+              | _, _, _, _, _, _ => nil
+              end.
+
+Definition zip5 {a} {b} {c} {d} {e}
+   : list a ->
+     list b -> list c -> list d -> list e -> list (a * b * c * d * e)%type :=
+  zipWith5 GHC.Tuple.pair5.
+
+Fixpoint zipWith6 {a} {b} {c} {d} {e} {f} {g} (arg_0__
+                    : (a -> b -> c -> d -> e -> f -> g)) (arg_1__ : list a) (arg_2__ : list b)
+                  (arg_3__ : list c) (arg_4__ : list d) (arg_5__ : list e) (arg_6__ : list f)
+           : list g
+           := match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__, arg_5__, arg_6__ with
+              | z, cons a as_, cons b bs, cons c cs, cons d ds, cons e es, cons f fs =>
+                  cons (z a b c d e f) (zipWith6 z as_ bs cs ds es fs)
+              | _, _, _, _, _, _, _ => nil
+              end.
+
+Definition zip6 {a} {b} {c} {d} {e} {f}
+   : list a ->
+     list b ->
+     list c -> list d -> list e -> list f -> list (a * b * c * d * e * f)%type :=
+  zipWith6 GHC.Tuple.pair6.
+
 Fixpoint zipWith7 {a} {b} {c} {d} {e} {f} {g} {h} (arg_0__
                     : (a -> b -> c -> d -> e -> f -> g -> h)) (arg_1__ : list a) (arg_2__ : list b)
                   (arg_3__ : list c) (arg_4__ : list d) (arg_5__ : list e) (arg_6__ : list f)
@@ -250,34 +555,6 @@ Fixpoint zipWith7 {a} {b} {c} {d} {e} {f} {g} {h} (arg_0__
               | _, _, _, _, _, _, _, _ => nil
               end.
 
-Fixpoint zipWith6 {a} {b} {c} {d} {e} {f} {g} (arg_0__
-                    : (a -> b -> c -> d -> e -> f -> g)) (arg_1__ : list a) (arg_2__ : list b)
-                  (arg_3__ : list c) (arg_4__ : list d) (arg_5__ : list e) (arg_6__ : list f)
-           : list g
-           := match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__, arg_5__, arg_6__ with
-              | z, cons a as_, cons b bs, cons c cs, cons d ds, cons e es, cons f fs =>
-                  cons (z a b c d e f) (zipWith6 z as_ bs cs ds es fs)
-              | _, _, _, _, _, _, _ => nil
-              end.
-
-Fixpoint zipWith5 {a} {b} {c} {d} {e} {f} (arg_0__
-                    : (a -> b -> c -> d -> e -> f)) (arg_1__ : list a) (arg_2__ : list b) (arg_3__
-                    : list c) (arg_4__ : list d) (arg_5__ : list e) : list f
-           := match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__, arg_5__ with
-              | z, cons a as_, cons b bs, cons c cs, cons d ds, cons e es =>
-                  cons (z a b c d e) (zipWith5 z as_ bs cs ds es)
-              | _, _, _, _, _, _ => nil
-              end.
-
-Fixpoint zipWith4 {a} {b} {c} {d} {e} (arg_0__ : (a -> b -> c -> d -> e))
-                  (arg_1__ : list a) (arg_2__ : list b) (arg_3__ : list c) (arg_4__ : list d)
-           : list e
-           := match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__ with
-              | z, cons a as_, cons b bs, cons c cs, cons d ds =>
-                  cons (z a b c d) (zipWith4 z as_ bs cs ds)
-              | _, _, _, _, _ => nil
-              end.
-
 Definition zip7 {a} {b} {c} {d} {e} {f} {g}
    : list a ->
      list b ->
@@ -285,46 +562,13 @@ Definition zip7 {a} {b} {c} {d} {e} {f} {g}
      list d -> list e -> list f -> list g -> list (a * b * c * d * e * f * g)%type :=
   zipWith7 GHC.Tuple.pair7.
 
-Definition zip6 {a} {b} {c} {d} {e} {f}
-   : list a ->
-     list b ->
-     list c -> list d -> list e -> list f -> list (a * b * c * d * e * f)%type :=
-  zipWith6 GHC.Tuple.pair6.
-
-Definition zip5 {a} {b} {c} {d} {e}
-   : list a ->
-     list b -> list c -> list d -> list e -> list (a * b * c * d * e)%type :=
-  zipWith5 GHC.Tuple.pair5.
-
-Definition zip4 {a} {b} {c} {d}
-   : list a -> list b -> list c -> list d -> list (a * b * c * d)%type :=
-  zipWith4 GHC.Tuple.pair4.
-
-(* Skipping definition `Data.OldList.wordsFB' *)
-
-(* Skipping definition `Data.OldList.words' *)
-
-Definition unzip7 {a} {b} {c} {d} {e} {f} {g}
-   : list (a * b * c * d * e * f * g)%type ->
-     (list a * list b * list c * list d * list e * list f * list g)%type :=
+Definition unzip4 {a} {b} {c} {d}
+   : list (a * b * c * d)%type -> (list a * list b * list c * list d)%type :=
   foldr (fun arg_0__ arg_1__ =>
            match arg_0__, arg_1__ with
-           | pair (pair (pair (pair (pair (pair a b) c) d) e) f) g
-           , pair (pair (pair (pair (pair (pair as_ bs) cs) ds) es) fs) gs =>
-               pair (pair (pair (pair (pair (pair (cons a as_) (cons b bs)) (cons c cs)) (cons
-                                       d ds)) (cons e es)) (cons f fs)) (cons g gs)
-           end) (pair (pair (pair (pair (pair (pair nil nil) nil) nil) nil) nil) nil).
-
-Definition unzip6 {a} {b} {c} {d} {e} {f}
-   : list (a * b * c * d * e * f)%type ->
-     (list a * list b * list c * list d * list e * list f)%type :=
-  foldr (fun arg_0__ arg_1__ =>
-           match arg_0__, arg_1__ with
-           | pair (pair (pair (pair (pair a b) c) d) e) f
-           , pair (pair (pair (pair (pair as_ bs) cs) ds) es) fs =>
-               pair (pair (pair (pair (pair (cons a as_) (cons b bs)) (cons c cs)) (cons d ds))
-                          (cons e es)) (cons f fs)
-           end) (pair (pair (pair (pair (pair nil nil) nil) nil) nil) nil).
+           | pair (pair (pair a b) c) d, pair (pair (pair as_ bs) cs) ds =>
+               pair (pair (pair (cons a as_) (cons b bs)) (cons c cs)) (cons d ds)
+           end) (pair (pair (pair nil nil) nil) nil).
 
 Definition unzip5 {a} {b} {c} {d} {e}
    : list (a * b * c * d * e)%type ->
@@ -337,16 +581,78 @@ Definition unzip5 {a} {b} {c} {d} {e}
                      e es)
            end) (pair (pair (pair (pair nil nil) nil) nil) nil).
 
-Definition unzip4 {a} {b} {c} {d}
-   : list (a * b * c * d)%type -> (list a * list b * list c * list d)%type :=
+Definition unzip6 {a} {b} {c} {d} {e} {f}
+   : list (a * b * c * d * e * f)%type ->
+     (list a * list b * list c * list d * list e * list f)%type :=
   foldr (fun arg_0__ arg_1__ =>
            match arg_0__, arg_1__ with
-           | pair (pair (pair a b) c) d, pair (pair (pair as_ bs) cs) ds =>
-               pair (pair (pair (cons a as_) (cons b bs)) (cons c cs)) (cons d ds)
-           end) (pair (pair (pair nil nil) nil) nil).
+           | pair (pair (pair (pair (pair a b) c) d) e) f
+           , pair (pair (pair (pair (pair as_ bs) cs) ds) es) fs =>
+               pair (pair (pair (pair (pair (cons a as_) (cons b bs)) (cons c cs)) (cons d ds))
+                          (cons e es)) (cons f fs)
+           end) (pair (pair (pair (pair (pair nil nil) nil) nil) nil) nil).
 
-Definition unwordsFB : String -> String -> String :=
-  fun w r => cons (GHC.Char.hs_char__ " ") (Coq.Init.Datatypes.app w r).
+Definition unzip7 {a} {b} {c} {d} {e} {f} {g}
+   : list (a * b * c * d * e * f * g)%type ->
+     (list a * list b * list c * list d * list e * list f * list g)%type :=
+  foldr (fun arg_0__ arg_1__ =>
+           match arg_0__, arg_1__ with
+           | pair (pair (pair (pair (pair (pair a b) c) d) e) f) g
+           , pair (pair (pair (pair (pair (pair as_ bs) cs) ds) es) fs) gs =>
+               pair (pair (pair (pair (pair (pair (cons a as_) (cons b bs)) (cons c cs)) (cons
+                                       d ds)) (cons e es)) (cons f fs)) (cons g gs)
+           end) (pair (pair (pair (pair (pair (pair nil nil) nil) nil) nil) nil) nil).
+
+Definition deleteFirstsBy {a}
+   : (a -> a -> bool) -> list a -> list a -> list a :=
+  fun eq => foldl (flip (deleteBy eq)).
+
+(* Skipping definition `Data.OldList.group' *)
+
+(* Skipping definition `Data.OldList.groupBy' *)
+
+(* Skipping definition `Data.OldList.inits' *)
+
+Definition tails {a} : list a -> list (list a) :=
+  fun lst =>
+    build' (fun _ =>
+              (fun c n =>
+                 let fix tailsGo xs
+                           := c xs (match xs with | nil => n | cons _ xs' => tailsGo xs' end) in
+                 tailsGo lst)).
+
+(* Skipping definition `Data.OldList.subsequences' *)
+
+Fixpoint nonEmptySubsequences {a} (arg_0__ : list a) : list (list a)
+           := match arg_0__ with
+              | nil => nil
+              | cons x xs =>
+                  let f := fun ys r => cons ys (cons (cons x ys) r) in
+                  cons (cons x nil) (foldr f nil (nonEmptySubsequences xs))
+              end.
+
+(* Skipping definition `Data.OldList.permutations' *)
+
+(* Skipping definition `Data.OldList.sortBy' *)
+
+Definition sort {a} `{(Ord a)} : list a -> list a :=
+  sortBy compare.
+
+Definition sortOn {b} {a} `{Ord b} : (a -> b) -> list a -> list a :=
+  fun f =>
+    map Data.Tuple.snd ∘
+    (sortBy (Data.Ord.comparing Data.Tuple.fst) ∘
+     map (fun x => let y := f x in GHC.Prim.seq y (pair y x))).
+
+(* Skipping definition `Data.OldList.unfoldr' *)
+
+(* Skipping definition `Data.OldList.lines' *)
+
+Axiom unlines : list String -> String.
+
+(* Skipping definition `Data.OldList.words' *)
+
+(* Skipping definition `Data.OldList.wordsFB' *)
 
 Definition unwords : list String -> String :=
   fun arg_0__ =>
@@ -361,327 +667,21 @@ Definition unwords : list String -> String :=
         Coq.Init.Datatypes.app w (go ws)
     end.
 
-Axiom unlines : list String -> String.
-
-(* Skipping definition `Data.OldList.unfoldr' *)
-
-(* Skipping definition `Data.OldList.transpose' *)
-
-Definition toListSB {a} : SnocBuilder a -> list a :=
-  fun '(Mk_SnocBuilder _ f r) => Coq.Init.Datatypes.app f (GHC.List.reverse r).
-
-Definition tails {a} : list a -> list (list a) :=
-  fun lst =>
-    build' (fun _ =>
-              (fun c n =>
-                 let fix tailsGo xs
-                           := c xs (match xs with | nil => n | cons _ xs' => tailsGo xs' end) in
-                 tailsGo lst)).
-
 Definition tailUnwords : String -> String :=
   fun arg_0__ => match arg_0__ with | nil => nil | cons _ xs => xs end.
 
-(* Skipping definition `Data.OldList.subsequences' *)
-
-Fixpoint stripPrefix {a} `{Eq_ a} (arg_0__ arg_1__ : list a) : option (list a)
-           := match arg_0__, arg_1__ with
-              | nil, ys => Some ys
-              | cons x xs, cons y ys => if x == y : bool then stripPrefix xs ys else None
-              | _, _ => None
-              end.
-
-Definition strictGenericLength {i} {b} `{(GHC.Num.Num i)} : list b -> i :=
-  fun l =>
-    let fix gl arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | nil, a => a
-                 | cons _ xs, a => let a' := a GHC.Num.+ #1 in GHC.Prim.seq a' (gl xs a')
-                 end in
-    gl l #0.
-
-(* Skipping definition `Data.OldList.sortBy' *)
-
-Definition sortOn {b} {a} `{Ord b} : (a -> b) -> list a -> list a :=
-  fun f =>
-    map Data.Tuple.snd ∘
-    (sortBy (Data.Ord.comparing Data.Tuple.fst) ∘
-     map (fun x => let y := f x in GHC.Prim.seq y (pair y x))).
-
-Definition sort {a} `{(Ord a)} : list a -> list a :=
-  sortBy compare.
-
-(* Skipping definition `Data.OldList.snocSB' *)
-
-Definition select {a}
-   : (a -> bool) -> a -> (list a * list a)%type -> (list a * list a)%type :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | p, x, pair ts fs =>
-        if p x : bool then pair (cons x ts) fs else
-        pair ts (cons x fs)
-    end.
+Definition unwordsFB : String -> String -> String :=
+  fun w r => cons (GHC.Char.hs_char__ " ") (Coq.Init.Datatypes.app w r).
 
 (* Skipping definition `Data.OldList.sb' *)
-
-Fixpoint prependToAll {a} (arg_0__ : a) (arg_1__ : list a) : list a
-           := match arg_0__, arg_1__ with
-              | _, nil => nil
-              | sep, cons x xs => cons sep (cons x (prependToAll sep xs))
-              end.
-
-(* Skipping definition `Data.OldList.permutations' *)
-
-Definition partition {a} : (a -> bool) -> list a -> (list a * list a)%type :=
-  fun p xs => foldr (select p) (pair nil nil) xs.
-
-Definition pairWithNil {acc} {y} : acc -> (acc * list y)%type :=
-  fun x => pair x nil.
-
-Fixpoint nonEmptySubsequences {a} (arg_0__ : list a) : list (list a)
-           := match arg_0__ with
-              | nil => nil
-              | cons x xs =>
-                  let f := fun ys r => cons ys (cons (cons x ys) r) in
-                  cons (cons x nil) (foldr f nil (nonEmptySubsequences xs))
-              end.
-
-Definition minimumBy {a} {_ : GHC.Err.Default a} {_ : Eq_ a} {_ : Ord a}
-   : (a -> a -> comparison) -> list a -> a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | _, nil =>
-        GHC.Err.errorWithoutStackTrace (GHC.Base.hs_string__
-                                        "List.minimumBy: empty list")
-    | cmp, xs =>
-        let minBy := fun x y => match cmp x y with | Gt => y | _ => x end in
-        GHC.List.foldl1 minBy xs
-    end.
-
-Definition maximumBy {a} {_ : GHC.Err.Default a} {_ : Eq_ a} {_ : Ord a}
-   : (a -> a -> comparison) -> list a -> a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | _, nil =>
-        GHC.Err.errorWithoutStackTrace (GHC.Base.hs_string__
-                                        "List.maximumBy: empty list")
-    | cmp, xs =>
-        let maxBy := fun x y => match cmp x y with | Gt => x | _ => y end in
-        GHC.List.foldl1 maxBy xs
-    end.
-
-Fixpoint mapAccumR {acc} {x} {y} (arg_0__ : (acc -> x -> (acc * y)%type))
-                   (arg_1__ : acc) (arg_2__ : list x) : (acc * list y)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, s, nil => pair s nil
-              | f, s, cons x xs =>
-                  let 'pair s' ys := mapAccumR f s xs in
-                  let 'pair s'' y := f s' x in
-                  pair s'' (cons y ys)
-              end.
-
-Definition mapAccumLF {acc} {x} {y}
-   : (acc -> x -> (acc * y)%type) ->
-     x -> (acc -> (acc * list y)%type) -> acc -> (acc * list y)%type :=
-  fun f =>
-    fun x r =>
-      (fun s =>
-         let 'pair s' y := f s x in
-         let 'pair s'' ys := r s' in
-         pair s'' (cons y ys)).
-
-Fixpoint mapAccumL {acc} {x} {y} (arg_0__ : (acc -> x -> (acc * y)%type))
-                   (arg_1__ : acc) (arg_2__ : list x) : (acc * list y)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, s, nil => pair s nil
-              | f, s, cons x xs =>
-                  let 'pair s' y := f s x in
-                  let 'pair s'' ys := mapAccumL f s' xs in
-                  pair s'' (cons y ys)
-              end.
-
-(* Skipping definition `Data.OldList.lines' *)
-
-Fixpoint isPrefixOf {a} `{(Eq_ a)} (arg_0__ arg_1__ : list a) : bool
-           := match arg_0__, arg_1__ with
-              | nil, _ => true
-              | _, nil => false
-              | cons x xs, cons y ys => andb (x == y) (isPrefixOf xs ys)
-              end.
-
-(* Skipping definition `Data.OldList.isInfixOf' *)
-
-(* Skipping definition `Data.OldList.intersperse' *)
-
-Definition intersectBy {a} : (a -> a -> bool) -> list a -> list a -> list a :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | _, nil, _ => nil
-    | _, _, nil => nil
-    | eq, xs, ys =>
-        Coq.Lists.List.flat_map (fun x =>
-                                   if GHC.List.any (eq x) ys : bool then cons x nil else
-                                   nil) xs
-    end.
-
-Definition intersect {a} `{(Eq_ a)} : list a -> list a -> list a :=
-  intersectBy _==_.
-
-(* Skipping definition `Data.OldList.intercalate' *)
-
-Fixpoint insertBy {a} (arg_0__ : (a -> a -> comparison)) (arg_1__ : a) (arg_2__
-                    : list a) : list a
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, x, nil => cons x nil
-              | cmp, x, (cons y ys' as ys) =>
-                  match cmp x y with
-                  | Gt => cons y (insertBy cmp x ys')
-                  | _ => cons x ys
-                  end
-              end.
-
-Definition insert {a} `{Ord a} : a -> list a -> list a :=
-  fun e ls => insertBy (compare) e ls.
-
-(* Skipping definition `Data.OldList.inits' *)
-
-(* Skipping definition `Data.OldList.groupBy' *)
-
-(* Skipping definition `Data.OldList.group' *)
-
-Fixpoint genericTake {i} {a} `{(GHC.Real.Integral i)} (arg_0__ : i) (arg_1__
-                       : list a) : list a
-           := match arg_0__, arg_1__ with
-              | n, _ =>
-                  if n <= #0 : bool then nil else
-                  match arg_0__, arg_1__ with
-                  | _, nil => nil
-                  | n, cons x xs => cons x (genericTake (n GHC.Num.- #1) xs)
-                  end
-              end.
-
-Fixpoint genericSplitAt {i} {a} `{(GHC.Real.Integral i)} (arg_0__ : i) (arg_1__
-                          : list a) : (list a * list a)%type
-           := match arg_0__, arg_1__ with
-              | n, xs =>
-                  if n <= #0 : bool then pair nil xs else
-                  match arg_0__, arg_1__ with
-                  | _, nil => pair nil nil
-                  | n, cons x xs =>
-                      let 'pair xs' xs'' := genericSplitAt (n GHC.Num.- #1) xs in
-                      pair (cons x xs') xs''
-                  end
-              end.
-
-(* Skipping definition `Data.OldList.genericReplicate' *)
-
-Fixpoint genericLength {i} {a} `{(GHC.Num.Num i)} (arg_0__ : list a) : i
-           := match arg_0__ with
-              | nil => #0
-              | cons _ l => #1 GHC.Num.+ genericLength l
-              end.
-
-(* Skipping definition `Data.OldList.genericIndex' *)
-
-Fixpoint genericDrop {i} {a} `{(GHC.Real.Integral i)} (arg_0__ : i) (arg_1__
-                       : list a) : list a
-           := match arg_0__, arg_1__ with
-              | n, xs =>
-                  if n <= #0 : bool then xs else
-                  match arg_0__, arg_1__ with
-                  | _, nil => nil
-                  | n, cons _ xs => genericDrop (n GHC.Num.- #1) xs
-                  end
-              end.
-
-(* Skipping definition `Data.OldList.findIndices' *)
-
-(* Skipping definition `Data.OldList.findIndex' *)
-
-Definition find {a} : (a -> bool) -> list a -> option a :=
-  fun p => Data.Maybe.listToMaybe ∘ GHC.List.filter p.
 
 Definition emptySB {a} : SnocBuilder a :=
   Mk_SnocBuilder #0 nil nil.
 
-Fixpoint elem_by {a} (arg_0__ : (a -> a -> bool)) (arg_1__ : a) (arg_2__
-                   : list a) : bool
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, _, nil => false
-              | eq, y, cons x xs => orb (eq x y) (elem_by eq y xs)
-              end.
+(* Skipping definition `Data.OldList.snocSB' *)
 
-Definition nubBy {a} : (a -> a -> bool) -> list a -> list a :=
-  fun eq l =>
-    let fix nubBy' arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | nil, _ => nil
-                 | cons y ys, xs =>
-                     if elem_by eq y xs : bool then nubBy' ys xs else
-                     cons y (nubBy' ys (cons y xs))
-                 end in
-    nubBy' l nil.
-
-Definition nub {a} `{(Eq_ a)} : list a -> list a :=
-  nubBy _==_.
-
-(* Skipping definition `Data.OldList.elemIndices' *)
-
-(* Skipping definition `Data.OldList.elemIndex' *)
-
-Definition dropWhileEnd {a} : (a -> bool) -> list a -> list a :=
-  fun p =>
-    foldr (fun x xs =>
-             if andb (p x) (GHC.List.null xs) : bool
-             then nil
-             else cons x xs) nil.
-
-Fixpoint dropLengthMaybe {a} {b} (arg_0__ : list a) (arg_1__ : list b) : option
-                                                                         (list b)
-           := match arg_0__, arg_1__ with
-              | nil, y => Some y
-              | _, nil => None
-              | cons _ x', cons _ y' => dropLengthMaybe x' y'
-              end.
-
-Fixpoint dropLength {a} {b} (arg_0__ : list a) (arg_1__ : list b) : list b
-           := match arg_0__, arg_1__ with
-              | nil, y => y
-              | _, nil => nil
-              | cons _ x', cons _ y' => dropLength x' y'
-              end.
-
-Definition isSuffixOf {a} `{(Eq_ a)} : list a -> list a -> bool :=
-  fun ns hs =>
-    Data.Maybe.maybe false id (dropLengthMaybe ns hs >>=
-                               (fun delta => return_ (ns == dropLength delta hs))).
-
-Fixpoint deleteBy {a} (arg_0__ : (a -> a -> bool)) (arg_1__ : a) (arg_2__
-                    : list a) : list a
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, _, nil => nil
-              | eq, x, cons y ys => if eq x y : bool then ys else cons y (deleteBy eq x ys)
-              end.
-
-Definition deleteFirstsBy {a}
-   : (a -> a -> bool) -> list a -> list a -> list a :=
-  fun eq => foldl (flip (deleteBy eq)).
-
-Definition unionBy {a} : (a -> a -> bool) -> list a -> list a -> list a :=
-  fun eq xs ys =>
-    Coq.Init.Datatypes.app xs (foldl (flip (deleteBy eq)) (nubBy eq ys) xs).
-
-Definition union {a} `{(Eq_ a)} : list a -> list a -> list a :=
-  unionBy _==_.
-
-Definition delete {a} `{(Eq_ a)} : a -> list a -> list a :=
-  deleteBy _==_.
-
-Definition op_zrzr__ {a} `{(Eq_ a)} : list a -> list a -> list a :=
-  foldl (flip delete).
-
-Notation "'_\\_'" := (op_zrzr__).
-
-Infix "\\" := (_\\_) (at level 99).
+Definition toListSB {a} : SnocBuilder a -> list a :=
+  fun '(Mk_SnocBuilder _ f r) => Coq.Init.Datatypes.app f (GHC.List.reverse r).
 
 Module Notations.
 Notation "'_Data.OldList.\\_'" := (op_zrzr__).

--- a/base/Data/Ord.v
+++ b/base/Data/Ord.v
@@ -24,10 +24,6 @@ Arguments Mk_Down {_} _.
 
 (* Converted value declarations: *)
 
-Definition comparing {a} {b} `{(GHC.Base.Ord a)}
-   : (b -> a) -> b -> b -> comparison :=
-  fun p x y => GHC.Base.compare (p x) (p y).
-
 Instance Unpeel_Down a : GHC.Prim.Unpeel (Down a) a :=
   GHC.Prim.Build_Unpeel _ _ (fun '(Mk_Down x) => x) Mk_Down.
 
@@ -82,60 +78,6 @@ Program Instance Monoid__Down {a} `{GHC.Base.Monoid a}
            GHC.Base.mconcat__ := Monoid__Down_mconcat ;
            GHC.Base.mempty__ := Monoid__Down_mempty |}.
 
-Local Definition Monad__Down_op_zgzgze__
-   : forall {a} {b}, Down a -> (a -> Down b) -> Down b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | Mk_Down a, k => k a end.
-
-Local Definition Monad__Down_op_zgzg__
-   : forall {a} {b}, Down a -> Down b -> Down b :=
-  fun {a} {b} => fun m k => Monad__Down_op_zgzgze__ m (fun arg_0__ => k).
-
-Local Definition Applicative__Down_op_zlztzg__
-   : forall {a} {b}, Down (a -> b) -> Down a -> Down b :=
-  fun {a} {b} => GHC.Prim.coerce.
-
-Local Definition Functor__Down_fmap
-   : forall {a} {b}, (a -> b) -> Down a -> Down b :=
-  fun {a} {b} => GHC.Prim.coerce.
-
-Local Definition Functor__Down_op_zlzd__
-   : forall {a} {b}, a -> Down b -> Down a :=
-  fun {a} {b} => Functor__Down_fmap GHC.Base.∘ GHC.Base.const.
-
-Program Instance Functor__Down : GHC.Base.Functor Down :=
-  fun _ k__ =>
-    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Down_fmap ;
-           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Down_op_zlzd__ |}.
-
-Local Definition Applicative__Down_liftA2
-   : forall {a} {b} {c}, (a -> b -> c) -> Down a -> Down b -> Down c :=
-  fun {a} {b} {c} => fun f x => Applicative__Down_op_zlztzg__ (GHC.Base.fmap f x).
-
-Local Definition Applicative__Down_op_ztzg__
-   : forall {a} {b}, Down a -> Down b -> Down b :=
-  fun {a} {b} =>
-    fun a1 a2 => Applicative__Down_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
-
-Local Definition Applicative__Down_pure : forall {a}, a -> Down a :=
-  fun {a} => Mk_Down.
-
-Program Instance Applicative__Down : GHC.Base.Applicative Down :=
-  fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Down_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Down_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Down_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__Down_pure |}.
-
-Local Definition Monad__Down_return_ : forall {a}, a -> Down a :=
-  fun {a} => GHC.Base.pure.
-
-Program Instance Monad__Down : GHC.Base.Monad Down :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Down_op_zgzg__ ;
-           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Down_op_zgzgze__ ;
-           GHC.Base.return___ := fun {a} => Monad__Down_return_ |}.
-
 Local Definition Ord__Down_compare {inst_a} `{GHC.Base.Ord inst_a}
    : (Down inst_a) -> (Down inst_a) -> comparison :=
   fun arg_0__ arg_1__ =>
@@ -176,6 +118,64 @@ Program Instance Ord__Down {a} `{GHC.Base.Ord a} : GHC.Base.Ord (Down a) :=
            GHC.Base.compare__ := Ord__Down_compare ;
            GHC.Base.max__ := Ord__Down_max ;
            GHC.Base.min__ := Ord__Down_min |}.
+
+Local Definition Functor__Down_fmap
+   : forall {a} {b}, (a -> b) -> Down a -> Down b :=
+  fun {a} {b} => GHC.Prim.coerce.
+
+Local Definition Functor__Down_op_zlzd__
+   : forall {a} {b}, a -> Down b -> Down a :=
+  fun {a} {b} => Functor__Down_fmap GHC.Base.∘ GHC.Base.const.
+
+Program Instance Functor__Down : GHC.Base.Functor Down :=
+  fun _ k__ =>
+    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Down_fmap ;
+           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Down_op_zlzd__ |}.
+
+Local Definition Applicative__Down_op_zlztzg__
+   : forall {a} {b}, Down (a -> b) -> Down a -> Down b :=
+  fun {a} {b} => GHC.Prim.coerce.
+
+Local Definition Applicative__Down_liftA2
+   : forall {a} {b} {c}, (a -> b -> c) -> Down a -> Down b -> Down c :=
+  fun {a} {b} {c} => fun f x => Applicative__Down_op_zlztzg__ (GHC.Base.fmap f x).
+
+Local Definition Applicative__Down_op_ztzg__
+   : forall {a} {b}, Down a -> Down b -> Down b :=
+  fun {a} {b} =>
+    fun a1 a2 => Applicative__Down_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
+
+Local Definition Applicative__Down_pure : forall {a}, a -> Down a :=
+  fun {a} => Mk_Down.
+
+Program Instance Applicative__Down : GHC.Base.Applicative Down :=
+  fun _ k__ =>
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Down_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Down_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Down_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__Down_pure |}.
+
+Local Definition Monad__Down_op_zgzgze__
+   : forall {a} {b}, Down a -> (a -> Down b) -> Down b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | Mk_Down a, k => k a end.
+
+Local Definition Monad__Down_op_zgzg__
+   : forall {a} {b}, Down a -> Down b -> Down b :=
+  fun {a} {b} => fun m k => Monad__Down_op_zgzgze__ m (fun arg_0__ => k).
+
+Local Definition Monad__Down_return_ : forall {a}, a -> Down a :=
+  fun {a} => GHC.Base.pure.
+
+Program Instance Monad__Down : GHC.Base.Monad Down :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Down_op_zgzg__ ;
+           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Down_op_zgzgze__ ;
+           GHC.Base.return___ := fun {a} => Monad__Down_return_ |}.
+
+Definition comparing {a} {b} `{(GHC.Base.Ord a)}
+   : (b -> a) -> b -> b -> comparison :=
+  fun p x y => GHC.Base.compare (p x) (p y).
 
 (* External variables:
      Gt Lt bool comparison list GHC.Base.Applicative GHC.Base.Eq_ GHC.Base.Functor

--- a/base/Data/Proxy.v
+++ b/base/Data/Proxy.v
@@ -31,108 +31,24 @@ Arguments Mk_KProxy {_}.
 
 (* Converted value declarations: *)
 
-Definition asProxyTypeOf {a} {proxy} : a -> proxy a -> a :=
-  GHC.Base.const.
-
 (* Skipping all instances of class `GHC.Enum.Bounded', including
    `Data.Proxy.Bounded__Proxy' *)
 
 (* Skipping all instances of class `GHC.Read.Read', including
    `Data.Proxy.Read__Proxy' *)
 
-(* Skipping all instances of class `GHC.Base.MonadPlus', including
-   `Data.Proxy.MonadPlus__Proxy' *)
+Local Definition Eq___Proxy_op_zeze__ {inst_s}
+   : (Proxy inst_s) -> (Proxy inst_s) -> bool :=
+  fun arg_0__ arg_1__ => true.
 
-Local Definition Monad__Proxy_op_zgzgze__
-   : forall {a} {b}, Proxy a -> (a -> Proxy b) -> Proxy b :=
-  fun {a} {b} => fun arg_0__ arg_1__ => Mk_Proxy.
+Local Definition Eq___Proxy_op_zsze__ {inst_s}
+   : (Proxy inst_s) -> (Proxy inst_s) -> bool :=
+  fun x y => negb (Eq___Proxy_op_zeze__ x y).
 
-Local Definition Monad__Proxy_op_zgzg__
-   : forall {a} {b}, Proxy a -> Proxy b -> Proxy b :=
-  fun {a} {b} => fun m k => Monad__Proxy_op_zgzgze__ m (fun arg_0__ => k).
-
-Local Definition Applicative__Proxy_op_zlztzg__
-   : forall {a} {b}, Proxy (a -> b) -> Proxy a -> Proxy b :=
-  fun {a} {b} => fun arg_0__ arg_1__ => Mk_Proxy.
-
-Local Definition Functor__Proxy_fmap
-   : forall {a} {b}, (a -> b) -> Proxy a -> Proxy b :=
-  fun {a} {b} => fun arg_0__ arg_1__ => Mk_Proxy.
-
-Local Definition Functor__Proxy_op_zlzd__
-   : forall {a} {b}, a -> Proxy b -> Proxy a :=
-  fun {a} {b} => Functor__Proxy_fmap GHC.Base.∘ GHC.Base.const.
-
-Program Instance Functor__Proxy : GHC.Base.Functor Proxy :=
+Program Instance Eq___Proxy {s} : GHC.Base.Eq_ (Proxy s) :=
   fun _ k__ =>
-    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Proxy_fmap ;
-           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Proxy_op_zlzd__ |}.
-
-Local Definition Applicative__Proxy_liftA2
-   : forall {a} {b} {c}, (a -> b -> c) -> Proxy a -> Proxy b -> Proxy c :=
-  fun {a} {b} {c} =>
-    fun f x => Applicative__Proxy_op_zlztzg__ (GHC.Base.fmap f x).
-
-Local Definition Applicative__Proxy_op_ztzg__
-   : forall {a} {b}, Proxy a -> Proxy b -> Proxy b :=
-  fun {a} {b} =>
-    fun a1 a2 => Applicative__Proxy_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
-
-Local Definition Applicative__Proxy_pure : forall {a}, a -> Proxy a :=
-  fun {a} => fun arg_0__ => Mk_Proxy.
-
-Program Instance Applicative__Proxy : GHC.Base.Applicative Proxy :=
-  fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Proxy_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Proxy_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Proxy_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__Proxy_pure |}.
-
-Local Definition Monad__Proxy_return_ : forall {a}, a -> Proxy a :=
-  fun {a} => GHC.Base.pure.
-
-Program Instance Monad__Proxy : GHC.Base.Monad Proxy :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Proxy_op_zgzg__ ;
-           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Proxy_op_zgzgze__ ;
-           GHC.Base.return___ := fun {a} => Monad__Proxy_return_ |}.
-
-(* Skipping all instances of class `GHC.Base.Alternative', including
-   `Data.Proxy.Alternative__Proxy' *)
-
-Local Definition Semigroup__Proxy_op_zlzlzgzg__ {inst_s}
-   : (Proxy inst_s) -> (Proxy inst_s) -> (Proxy inst_s) :=
-  fun arg_0__ arg_1__ => Mk_Proxy.
-
-Program Instance Semigroup__Proxy {s} : GHC.Base.Semigroup (Proxy s) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__Proxy_op_zlzlzgzg__ |}.
-
-Local Definition Monoid__Proxy_mappend {inst_s}
-   : (Proxy inst_s) -> (Proxy inst_s) -> (Proxy inst_s) :=
-  _GHC.Base.<<>>_.
-
-Local Definition Monoid__Proxy_mconcat {inst_s}
-   : list (Proxy inst_s) -> (Proxy inst_s) :=
-  fun arg_0__ => Mk_Proxy.
-
-Local Definition Monoid__Proxy_mempty {inst_s} : (Proxy inst_s) :=
-  Mk_Proxy.
-
-Program Instance Monoid__Proxy {s} : GHC.Base.Monoid (Proxy s) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.mappend__ := Monoid__Proxy_mappend ;
-           GHC.Base.mconcat__ := Monoid__Proxy_mconcat ;
-           GHC.Base.mempty__ := Monoid__Proxy_mempty |}.
-
-(* Skipping all instances of class `GHC.Arr.Ix', including
-   `Data.Proxy.Ix__Proxy' *)
-
-(* Skipping all instances of class `GHC.Enum.Enum', including
-   `Data.Proxy.Enum__Proxy' *)
-
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Data.Proxy.Show__Proxy' *)
+    k__ {| GHC.Base.op_zeze____ := Eq___Proxy_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___Proxy_op_zsze__ |}.
 
 Local Definition Ord__Proxy_compare {inst_s}
    : (Proxy inst_s) -> (Proxy inst_s) -> comparison :=
@@ -162,19 +78,6 @@ Local Definition Ord__Proxy_min {inst_s}
    : (Proxy inst_s) -> (Proxy inst_s) -> (Proxy inst_s) :=
   fun x y => if Ord__Proxy_op_zlze__ x y : bool then x else y.
 
-Local Definition Eq___Proxy_op_zeze__ {inst_s}
-   : (Proxy inst_s) -> (Proxy inst_s) -> bool :=
-  fun arg_0__ arg_1__ => true.
-
-Local Definition Eq___Proxy_op_zsze__ {inst_s}
-   : (Proxy inst_s) -> (Proxy inst_s) -> bool :=
-  fun x y => negb (Eq___Proxy_op_zeze__ x y).
-
-Program Instance Eq___Proxy {s} : GHC.Base.Eq_ (Proxy s) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___Proxy_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___Proxy_op_zsze__ |}.
-
 Program Instance Ord__Proxy {s} : GHC.Base.Ord (Proxy s) :=
   fun _ k__ =>
     k__ {| GHC.Base.op_zl____ := Ord__Proxy_op_zl__ ;
@@ -184,6 +87,103 @@ Program Instance Ord__Proxy {s} : GHC.Base.Ord (Proxy s) :=
            GHC.Base.compare__ := Ord__Proxy_compare ;
            GHC.Base.max__ := Ord__Proxy_max ;
            GHC.Base.min__ := Ord__Proxy_min |}.
+
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Data.Proxy.Show__Proxy' *)
+
+(* Skipping all instances of class `GHC.Enum.Enum', including
+   `Data.Proxy.Enum__Proxy' *)
+
+(* Skipping all instances of class `GHC.Arr.Ix', including
+   `Data.Proxy.Ix__Proxy' *)
+
+Local Definition Semigroup__Proxy_op_zlzlzgzg__ {inst_s}
+   : (Proxy inst_s) -> (Proxy inst_s) -> (Proxy inst_s) :=
+  fun arg_0__ arg_1__ => Mk_Proxy.
+
+Program Instance Semigroup__Proxy {s} : GHC.Base.Semigroup (Proxy s) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__Proxy_op_zlzlzgzg__ |}.
+
+Local Definition Monoid__Proxy_mappend {inst_s}
+   : (Proxy inst_s) -> (Proxy inst_s) -> (Proxy inst_s) :=
+  _GHC.Base.<<>>_.
+
+Local Definition Monoid__Proxy_mconcat {inst_s}
+   : list (Proxy inst_s) -> (Proxy inst_s) :=
+  fun arg_0__ => Mk_Proxy.
+
+Local Definition Monoid__Proxy_mempty {inst_s} : (Proxy inst_s) :=
+  Mk_Proxy.
+
+Program Instance Monoid__Proxy {s} : GHC.Base.Monoid (Proxy s) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.mappend__ := Monoid__Proxy_mappend ;
+           GHC.Base.mconcat__ := Monoid__Proxy_mconcat ;
+           GHC.Base.mempty__ := Monoid__Proxy_mempty |}.
+
+Local Definition Functor__Proxy_fmap
+   : forall {a} {b}, (a -> b) -> Proxy a -> Proxy b :=
+  fun {a} {b} => fun arg_0__ arg_1__ => Mk_Proxy.
+
+Local Definition Functor__Proxy_op_zlzd__
+   : forall {a} {b}, a -> Proxy b -> Proxy a :=
+  fun {a} {b} => Functor__Proxy_fmap GHC.Base.∘ GHC.Base.const.
+
+Program Instance Functor__Proxy : GHC.Base.Functor Proxy :=
+  fun _ k__ =>
+    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Proxy_fmap ;
+           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Proxy_op_zlzd__ |}.
+
+Local Definition Applicative__Proxy_op_zlztzg__
+   : forall {a} {b}, Proxy (a -> b) -> Proxy a -> Proxy b :=
+  fun {a} {b} => fun arg_0__ arg_1__ => Mk_Proxy.
+
+Local Definition Applicative__Proxy_liftA2
+   : forall {a} {b} {c}, (a -> b -> c) -> Proxy a -> Proxy b -> Proxy c :=
+  fun {a} {b} {c} =>
+    fun f x => Applicative__Proxy_op_zlztzg__ (GHC.Base.fmap f x).
+
+Local Definition Applicative__Proxy_op_ztzg__
+   : forall {a} {b}, Proxy a -> Proxy b -> Proxy b :=
+  fun {a} {b} =>
+    fun a1 a2 => Applicative__Proxy_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
+
+Local Definition Applicative__Proxy_pure : forall {a}, a -> Proxy a :=
+  fun {a} => fun arg_0__ => Mk_Proxy.
+
+Program Instance Applicative__Proxy : GHC.Base.Applicative Proxy :=
+  fun _ k__ =>
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Proxy_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Proxy_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Proxy_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__Proxy_pure |}.
+
+(* Skipping all instances of class `GHC.Base.Alternative', including
+   `Data.Proxy.Alternative__Proxy' *)
+
+Local Definition Monad__Proxy_op_zgzgze__
+   : forall {a} {b}, Proxy a -> (a -> Proxy b) -> Proxy b :=
+  fun {a} {b} => fun arg_0__ arg_1__ => Mk_Proxy.
+
+Local Definition Monad__Proxy_op_zgzg__
+   : forall {a} {b}, Proxy a -> Proxy b -> Proxy b :=
+  fun {a} {b} => fun m k => Monad__Proxy_op_zgzgze__ m (fun arg_0__ => k).
+
+Local Definition Monad__Proxy_return_ : forall {a}, a -> Proxy a :=
+  fun {a} => GHC.Base.pure.
+
+Program Instance Monad__Proxy : GHC.Base.Monad Proxy :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Proxy_op_zgzg__ ;
+           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Proxy_op_zgzgze__ ;
+           GHC.Base.return___ := fun {a} => Monad__Proxy_return_ |}.
+
+(* Skipping all instances of class `GHC.Base.MonadPlus', including
+   `Data.Proxy.MonadPlus__Proxy' *)
+
+Definition asProxyTypeOf {a} {proxy} : a -> proxy a -> a :=
+  GHC.Base.const.
 
 (* External variables:
      Eq Gt Lt Type bool comparison list negb true GHC.Base.Applicative GHC.Base.Eq_

--- a/base/Data/Semigroup.v
+++ b/base/Data/Semigroup.v
@@ -148,20 +148,6 @@ Program Instance Semigroup__SLast {a} : GHC.Base.Semigroup (Last a) := fun _ k =
 
 (* Converted value declarations: *)
 
-(* Skipping definition `Data.Semigroup.mtimesDefault' *)
-
-Definition diff {m} `{GHC.Base.Semigroup m}
-   : m -> Data.SemigroupInternal.Endo m :=
-  Data.SemigroupInternal.Mk_Endo GHC.Base.∘ _GHC.Base.<<>>_.
-
-Definition destruct_option {b} {a} : b -> (a -> b) -> Option a -> b :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | n, j, Mk_Option m => Data.Maybe.maybe n j m
-    end.
-
-(* Skipping definition `Data.Semigroup.cycle1' *)
-
 (* Skipping all instances of class `GHC.Enum.Bounded', including
    `Data.Semigroup.Bounded__Min' *)
 
@@ -608,27 +594,19 @@ Program Instance Ord__Option {a} `{GHC.Base.Ord a} : GHC.Base.Ord (Option a) :=
 (* Skipping all instances of class `GHC.Generics.Generic1', including
    `Data.Semigroup.Generic1__TYPE__Option__LiftedRep' *)
 
-(* Skipping all instances of class `GHC.Num.Num', including
-   `Data.Semigroup.Num__Min' *)
+(* Skipping all instances of class `GHC.Enum.Enum', including
+   `Data.Semigroup.Enum__Min' *)
 
-(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
-   `Data.Semigroup.MonadFix__Min' *)
+Local Definition Semigroup__Min_op_zlzlzgzg__ {inst_a} `{_
+   : GHC.Base.Ord inst_a}
+   : Min inst_a -> Min inst_a -> Min inst_a :=
+  GHC.Prim.coerce (@GHC.Base.min inst_a _ _).
 
-Local Definition Applicative__Min_liftA2
-   : forall {a} {b} {c}, (a -> b -> c) -> Min a -> Min b -> Min c :=
-  fun {a} {b} {c} => GHC.Prim.coerce.
+Program Instance Semigroup__Min {a} `{GHC.Base.Ord a}
+   : GHC.Base.Semigroup (Min a) :=
+  fun _ k__ => k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__Min_op_zlzlzgzg__ |}.
 
-Local Definition Applicative__Min_op_zlztzg__
-   : forall {a} {b}, Min (a -> b) -> Min a -> Min b :=
-  fun {a} {b} => GHC.Prim.coerce.
-
-Local Definition Applicative__Min_op_ztzg__
-   : forall {a} {b}, Min a -> Min b -> Min b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | _, a => a end.
-
-Local Definition Applicative__Min_pure : forall {a}, a -> Min a :=
-  fun {a} => Mk_Min.
+(* Skipping instance `Data.Semigroup.Monoid__Min' of class `GHC.Base.Monoid' *)
 
 Local Definition Functor__Min_fmap
    : forall {a} {b}, (a -> b) -> Min a -> Min b :=
@@ -645,53 +623,6 @@ Program Instance Functor__Min : GHC.Base.Functor Min :=
   fun _ k__ =>
     k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Min_fmap ;
            GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Min_op_zlzd__ |}.
-
-Program Instance Applicative__Min : GHC.Base.Applicative Min :=
-  fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Min_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Min_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Min_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__Min_pure |}.
-
-Local Definition Monad__Min_op_zgzg__
-   : forall {a} {b}, Min a -> Min b -> Min b :=
-  fun {a} {b} => _GHC.Base.*>_.
-
-Local Definition Monad__Min_op_zgzgze__
-   : forall {a} {b}, Min a -> (a -> Min b) -> Min b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | Mk_Min a, f => f a end.
-
-Local Definition Monad__Min_return_ : forall {a}, a -> Min a :=
-  fun {a} => GHC.Base.pure.
-
-Program Instance Monad__Min : GHC.Base.Monad Min :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Min_op_zgzg__ ;
-           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Min_op_zgzgze__ ;
-           GHC.Base.return___ := fun {a} => Monad__Min_return_ |}.
-
-Local Definition Traversable__Min_traverse
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f}, (a -> f b) -> Min a -> f (Min b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, Mk_Min a => Mk_Min Data.Functor.<$> f a
-      end.
-
-Local Definition Traversable__Min_mapM
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m}, (a -> m b) -> Min a -> m (Min b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Min_traverse.
-
-Local Definition Traversable__Min_sequenceA
-   : forall {f} {a}, forall `{GHC.Base.Applicative f}, Min (f a) -> f (Min a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} => Traversable__Min_traverse GHC.Base.id.
-
-Local Definition Traversable__Min_sequence
-   : forall {m} {a}, forall `{GHC.Base.Monad m}, Min (m a) -> m (Min a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Min_sequenceA.
 
 Local Definition Foldable__Min_foldMap
    : forall {m} {a}, forall `{GHC.Base.Monoid m}, (a -> m) -> Min a -> m :=
@@ -772,6 +703,28 @@ Program Instance Foldable__Min : Data.Foldable.Foldable Min :=
            Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Min_sum ;
            Data.Foldable.toList__ := fun {a} => Foldable__Min_toList |}.
 
+Local Definition Traversable__Min_traverse
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f}, (a -> f b) -> Min a -> f (Min b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, Mk_Min a => Mk_Min Data.Functor.<$> f a
+      end.
+
+Local Definition Traversable__Min_mapM
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m}, (a -> m b) -> Min a -> m (Min b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Min_traverse.
+
+Local Definition Traversable__Min_sequenceA
+   : forall {f} {a}, forall `{GHC.Base.Applicative f}, Min (f a) -> f (Min a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} => Traversable__Min_traverse GHC.Base.id.
+
+Local Definition Traversable__Min_sequence
+   : forall {m} {a}, forall `{GHC.Base.Monad m}, Min (m a) -> m (Min a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Min_sequenceA.
+
 Program Instance Traversable__Min : Data.Traversable.Traversable Min :=
   fun _ k__ =>
     k__ {| Data.Traversable.mapM__ := fun {m} {a} {b} `{GHC.Base.Monad m} =>
@@ -783,41 +736,66 @@ Program Instance Traversable__Min : Data.Traversable.Traversable Min :=
            Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
              Traversable__Min_traverse |}.
 
-(* Skipping instance `Data.Semigroup.Monoid__Min' of class `GHC.Base.Monoid' *)
-
-Local Definition Semigroup__Min_op_zlzlzgzg__ {inst_a} `{_
-   : GHC.Base.Ord inst_a}
-   : Min inst_a -> Min inst_a -> Min inst_a :=
-  GHC.Prim.coerce (@GHC.Base.min inst_a _ _).
-
-Program Instance Semigroup__Min {a} `{GHC.Base.Ord a}
-   : GHC.Base.Semigroup (Min a) :=
-  fun _ k__ => k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__Min_op_zlzlzgzg__ |}.
-
-(* Skipping all instances of class `GHC.Enum.Enum', including
-   `Data.Semigroup.Enum__Min' *)
-
-(* Skipping all instances of class `GHC.Num.Num', including
-   `Data.Semigroup.Num__Max' *)
-
-(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
-   `Data.Semigroup.MonadFix__Max' *)
-
-Local Definition Applicative__Max_liftA2
-   : forall {a} {b} {c}, (a -> b -> c) -> Max a -> Max b -> Max c :=
+Local Definition Applicative__Min_liftA2
+   : forall {a} {b} {c}, (a -> b -> c) -> Min a -> Min b -> Min c :=
   fun {a} {b} {c} => GHC.Prim.coerce.
 
-Local Definition Applicative__Max_op_zlztzg__
-   : forall {a} {b}, Max (a -> b) -> Max a -> Max b :=
+Local Definition Applicative__Min_op_zlztzg__
+   : forall {a} {b}, Min (a -> b) -> Min a -> Min b :=
   fun {a} {b} => GHC.Prim.coerce.
 
-Local Definition Applicative__Max_op_ztzg__
-   : forall {a} {b}, Max a -> Max b -> Max b :=
+Local Definition Applicative__Min_op_ztzg__
+   : forall {a} {b}, Min a -> Min b -> Min b :=
   fun {a} {b} =>
     fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | _, a => a end.
 
-Local Definition Applicative__Max_pure : forall {a}, a -> Max a :=
-  fun {a} => Mk_Max.
+Local Definition Applicative__Min_pure : forall {a}, a -> Min a :=
+  fun {a} => Mk_Min.
+
+Program Instance Applicative__Min : GHC.Base.Applicative Min :=
+  fun _ k__ =>
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Min_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Min_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Min_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__Min_pure |}.
+
+Local Definition Monad__Min_op_zgzg__
+   : forall {a} {b}, Min a -> Min b -> Min b :=
+  fun {a} {b} => _GHC.Base.*>_.
+
+Local Definition Monad__Min_op_zgzgze__
+   : forall {a} {b}, Min a -> (a -> Min b) -> Min b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | Mk_Min a, f => f a end.
+
+Local Definition Monad__Min_return_ : forall {a}, a -> Min a :=
+  fun {a} => GHC.Base.pure.
+
+Program Instance Monad__Min : GHC.Base.Monad Min :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Min_op_zgzg__ ;
+           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Min_op_zgzgze__ ;
+           GHC.Base.return___ := fun {a} => Monad__Min_return_ |}.
+
+(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
+   `Data.Semigroup.MonadFix__Min' *)
+
+(* Skipping all instances of class `GHC.Num.Num', including
+   `Data.Semigroup.Num__Min' *)
+
+(* Skipping all instances of class `GHC.Enum.Enum', including
+   `Data.Semigroup.Enum__Max' *)
+
+Local Definition Semigroup__Max_op_zlzlzgzg__ {inst_a} `{_
+   : GHC.Base.Ord inst_a}
+   : Max inst_a -> Max inst_a -> Max inst_a :=
+  GHC.Prim.coerce (@GHC.Base.max inst_a _ _).
+
+Program Instance Semigroup__Max {a} `{GHC.Base.Ord a}
+   : GHC.Base.Semigroup (Max a) :=
+  fun _ k__ => k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__Max_op_zlzlzgzg__ |}.
+
+(* Skipping instance `Data.Semigroup.Monoid__Max' of class `GHC.Base.Monoid' *)
 
 Local Definition Functor__Max_fmap
    : forall {a} {b}, (a -> b) -> Max a -> Max b :=
@@ -834,53 +812,6 @@ Program Instance Functor__Max : GHC.Base.Functor Max :=
   fun _ k__ =>
     k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Max_fmap ;
            GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Max_op_zlzd__ |}.
-
-Program Instance Applicative__Max : GHC.Base.Applicative Max :=
-  fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Max_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Max_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Max_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__Max_pure |}.
-
-Local Definition Monad__Max_op_zgzg__
-   : forall {a} {b}, Max a -> Max b -> Max b :=
-  fun {a} {b} => _GHC.Base.*>_.
-
-Local Definition Monad__Max_op_zgzgze__
-   : forall {a} {b}, Max a -> (a -> Max b) -> Max b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | Mk_Max a, f => f a end.
-
-Local Definition Monad__Max_return_ : forall {a}, a -> Max a :=
-  fun {a} => GHC.Base.pure.
-
-Program Instance Monad__Max : GHC.Base.Monad Max :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Max_op_zgzg__ ;
-           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Max_op_zgzgze__ ;
-           GHC.Base.return___ := fun {a} => Monad__Max_return_ |}.
-
-Local Definition Traversable__Max_traverse
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f}, (a -> f b) -> Max a -> f (Max b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, Mk_Max a => Mk_Max Data.Functor.<$> f a
-      end.
-
-Local Definition Traversable__Max_mapM
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m}, (a -> m b) -> Max a -> m (Max b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Max_traverse.
-
-Local Definition Traversable__Max_sequenceA
-   : forall {f} {a}, forall `{GHC.Base.Applicative f}, Max (f a) -> f (Max a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} => Traversable__Max_traverse GHC.Base.id.
-
-Local Definition Traversable__Max_sequence
-   : forall {m} {a}, forall `{GHC.Base.Monad m}, Max (m a) -> m (Max a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Max_sequenceA.
 
 Local Definition Foldable__Max_foldMap
    : forall {m} {a}, forall `{GHC.Base.Monoid m}, (a -> m) -> Max a -> m :=
@@ -961,6 +892,28 @@ Program Instance Foldable__Max : Data.Foldable.Foldable Max :=
            Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Max_sum ;
            Data.Foldable.toList__ := fun {a} => Foldable__Max_toList |}.
 
+Local Definition Traversable__Max_traverse
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f}, (a -> f b) -> Max a -> f (Max b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, Mk_Max a => Mk_Max Data.Functor.<$> f a
+      end.
+
+Local Definition Traversable__Max_mapM
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m}, (a -> m b) -> Max a -> m (Max b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Max_traverse.
+
+Local Definition Traversable__Max_sequenceA
+   : forall {f} {a}, forall `{GHC.Base.Applicative f}, Max (f a) -> f (Max a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} => Traversable__Max_traverse GHC.Base.id.
+
+Local Definition Traversable__Max_sequence
+   : forall {m} {a}, forall `{GHC.Base.Monad m}, Max (m a) -> m (Max a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Max_sequenceA.
+
 Program Instance Traversable__Max : Data.Traversable.Traversable Max :=
   fun _ k__ =>
     k__ {| Data.Traversable.mapM__ := fun {m} {a} {b} `{GHC.Base.Monad m} =>
@@ -972,149 +925,69 @@ Program Instance Traversable__Max : Data.Traversable.Traversable Max :=
            Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
              Traversable__Max_traverse |}.
 
-(* Skipping instance `Data.Semigroup.Monoid__Max' of class `GHC.Base.Monoid' *)
+Local Definition Applicative__Max_liftA2
+   : forall {a} {b} {c}, (a -> b -> c) -> Max a -> Max b -> Max c :=
+  fun {a} {b} {c} => GHC.Prim.coerce.
 
-Local Definition Semigroup__Max_op_zlzlzgzg__ {inst_a} `{_
-   : GHC.Base.Ord inst_a}
-   : Max inst_a -> Max inst_a -> Max inst_a :=
-  GHC.Prim.coerce (@GHC.Base.max inst_a _ _).
+Local Definition Applicative__Max_op_zlztzg__
+   : forall {a} {b}, Max (a -> b) -> Max a -> Max b :=
+  fun {a} {b} => GHC.Prim.coerce.
 
-Program Instance Semigroup__Max {a} `{GHC.Base.Ord a}
-   : GHC.Base.Semigroup (Max a) :=
-  fun _ k__ => k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__Max_op_zlzlzgzg__ |}.
+Local Definition Applicative__Max_op_ztzg__
+   : forall {a} {b}, Max a -> Max b -> Max b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | _, a => a end.
 
-(* Skipping all instances of class `GHC.Enum.Enum', including
-   `Data.Semigroup.Enum__Max' *)
+Local Definition Applicative__Max_pure : forall {a}, a -> Max a :=
+  fun {a} => Mk_Max.
 
-Local Definition Bitraversable__Arg_bitraverse
-   : forall {f} {a} {c} {b} {d},
-     forall `{GHC.Base.Applicative f},
-     (a -> f c) -> (b -> f d) -> Arg a b -> f (Arg c d) :=
-  fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | f, g, Mk_Arg a b => (Mk_Arg Data.Functor.<$> f a) GHC.Base.<*> g b
-      end.
-
-Local Definition Bifoldable__Arg_bifoldMap
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monoid m}, (a -> m) -> (b -> m) -> Arg a b -> m :=
-  fun {m} {a} {b} `{GHC.Base.Monoid m} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | f, g, Mk_Arg a b => f a GHC.Base.<<>> g b
-      end.
-
-Local Definition Bifoldable__Arg_bifold
-   : forall {m}, forall `{GHC.Base.Monoid m}, Arg m m -> m :=
-  fun {m} `{GHC.Base.Monoid m} =>
-    Bifoldable__Arg_bifoldMap GHC.Base.id GHC.Base.id.
-
-Local Definition Bifoldable__Arg_bifoldl
-   : forall {c} {a} {b}, (c -> a -> c) -> (c -> b -> c) -> c -> Arg a b -> c :=
-  fun {c} {a} {b} =>
-    fun f g z t =>
-      Data.SemigroupInternal.appEndo (Data.SemigroupInternal.getDual
-                                      (Bifoldable__Arg_bifoldMap (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
-                                                                  (Data.SemigroupInternal.Mk_Endo GHC.Base.∘
-                                                                   GHC.Base.flip f)) (Data.SemigroupInternal.Mk_Dual
-                                                                                      GHC.Base.∘
-                                                                                      (Data.SemigroupInternal.Mk_Endo
-                                                                                       GHC.Base.∘
-                                                                                       GHC.Base.flip g)) t)) z.
-
-Local Definition Bifoldable__Arg_bifoldr
-   : forall {a} {c} {b}, (a -> c -> c) -> (b -> c -> c) -> c -> Arg a b -> c :=
-  fun {a} {c} {b} =>
-    fun f g z t =>
-      Data.SemigroupInternal.appEndo (Bifoldable__Arg_bifoldMap
-                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo f)
-                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo g) t) z.
-
-Program Instance Bifoldable__Arg : Data.Bifoldable.Bifoldable Arg :=
+Program Instance Applicative__Max : GHC.Base.Applicative Max :=
   fun _ k__ =>
-    k__ {| Data.Bifoldable.bifold__ := fun {m} `{GHC.Base.Monoid m} =>
-             Bifoldable__Arg_bifold ;
-           Data.Bifoldable.bifoldMap__ := fun {m} {a} {b} `{GHC.Base.Monoid m} =>
-             Bifoldable__Arg_bifoldMap ;
-           Data.Bifoldable.bifoldl__ := fun {c} {a} {b} => Bifoldable__Arg_bifoldl ;
-           Data.Bifoldable.bifoldr__ := fun {a} {c} {b} => Bifoldable__Arg_bifoldr |}.
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Max_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Max_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Max_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__Max_pure |}.
 
-Local Definition Bifunctor__Arg_bimap
-   : forall {a} {b} {c} {d}, (a -> b) -> (c -> d) -> Arg a c -> Arg b d :=
-  fun {a} {b} {c} {d} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | f, g, Mk_Arg a b => Mk_Arg (f a) (g b)
-      end.
+Local Definition Monad__Max_op_zgzg__
+   : forall {a} {b}, Max a -> Max b -> Max b :=
+  fun {a} {b} => _GHC.Base.*>_.
 
-Local Definition Bifunctor__Arg_first
-   : forall {a} {b} {c}, (a -> b) -> Arg a c -> Arg b c :=
-  fun {a} {b} {c} => fun f => Bifunctor__Arg_bimap f GHC.Base.id.
+Local Definition Monad__Max_op_zgzgze__
+   : forall {a} {b}, Max a -> (a -> Max b) -> Max b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | Mk_Max a, f => f a end.
 
-Local Definition Bifunctor__Arg_second
-   : forall {b} {c} {a}, (b -> c) -> Arg a b -> Arg a c :=
-  fun {b} {c} {a} => Bifunctor__Arg_bimap GHC.Base.id.
+Local Definition Monad__Max_return_ : forall {a}, a -> Max a :=
+  fun {a} => GHC.Base.pure.
 
-Program Instance Bifunctor__Arg : Data.Bifunctor.Bifunctor Arg :=
+Program Instance Monad__Max : GHC.Base.Monad Max :=
   fun _ k__ =>
-    k__ {| Data.Bifunctor.bimap__ := fun {a} {b} {c} {d} => Bifunctor__Arg_bimap ;
-           Data.Bifunctor.first__ := fun {a} {b} {c} => Bifunctor__Arg_first ;
-           Data.Bifunctor.second__ := fun {b} {c} {a} => Bifunctor__Arg_second |}.
+    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Max_op_zgzg__ ;
+           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Max_op_zgzgze__ ;
+           GHC.Base.return___ := fun {a} => Monad__Max_return_ |}.
 
-Program Instance Bitraversable__Arg : Data.Bitraversable.Bitraversable Arg :=
-  fun _ k__ =>
-    k__ {| Data.Bitraversable.bitraverse__ := fun {f}
-           {a}
-           {c}
-           {b}
-           {d}
-           `{GHC.Base.Applicative f} =>
-             Bitraversable__Arg_bitraverse |}.
+(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
+   `Data.Semigroup.MonadFix__Max' *)
 
-(* Skipping instance `Data.Semigroup.Ord__Arg' of class `GHC.Base.Ord' *)
+(* Skipping all instances of class `GHC.Num.Num', including
+   `Data.Semigroup.Num__Max' *)
 
-Local Definition Eq___Arg_op_zeze__ {inst_a} {inst_b} `{GHC.Base.Eq_ inst_a}
-   : (Arg inst_a inst_b) -> (Arg inst_a inst_b) -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_Arg a _, Mk_Arg b _ => a GHC.Base.== b
-    end.
-
-Local Definition Eq___Arg_op_zsze__ {inst_a} {inst_b} `{GHC.Base.Eq_ inst_a}
-   : (Arg inst_a inst_b) -> (Arg inst_a inst_b) -> bool :=
-  fun x y => negb (Eq___Arg_op_zeze__ x y).
-
-Program Instance Eq___Arg {a} {b} `{GHC.Base.Eq_ a} : GHC.Base.Eq_ (Arg a b) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___Arg_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___Arg_op_zsze__ |}.
-
-Local Definition Traversable__Arg_traverse {inst_a}
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f},
-     (a -> f b) -> (Arg inst_a) a -> f ((Arg inst_a) b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+Local Definition Functor__Arg_fmap {inst_a}
+   : forall {a} {b}, (a -> b) -> (Arg inst_a) a -> (Arg inst_a) b :=
+  fun {a} {b} =>
     fun arg_0__ arg_1__ =>
       match arg_0__, arg_1__ with
-      | f, Mk_Arg x a => Mk_Arg x Data.Functor.<$> f a
+      | f, Mk_Arg x a => Mk_Arg x (f a)
       end.
 
-Local Definition Traversable__Arg_mapM {inst_a}
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m},
-     (a -> m b) -> (Arg inst_a) a -> m ((Arg inst_a) b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Arg_traverse.
+Local Definition Functor__Arg_op_zlzd__ {inst_a}
+   : forall {a} {b}, a -> (Arg inst_a) b -> (Arg inst_a) a :=
+  fun {a} {b} => Functor__Arg_fmap GHC.Base.∘ GHC.Base.const.
 
-Local Definition Traversable__Arg_sequenceA {inst_a}
-   : forall {f} {a},
-     forall `{GHC.Base.Applicative f}, (Arg inst_a) (f a) -> f ((Arg inst_a) a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} => Traversable__Arg_traverse GHC.Base.id.
-
-Local Definition Traversable__Arg_sequence {inst_a}
-   : forall {m} {a},
-     forall `{GHC.Base.Monad m}, (Arg inst_a) (m a) -> m ((Arg inst_a) a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Arg_sequenceA.
+Program Instance Functor__Arg {a} : GHC.Base.Functor (Arg a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Arg_fmap ;
+           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Arg_op_zlzd__ |}.
 
 Local Definition Foldable__Arg_foldMap {inst_a}
    : forall {m} {a},
@@ -1199,22 +1072,31 @@ Program Instance Foldable__Arg {a} : Data.Foldable.Foldable (Arg a) :=
            Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Arg_sum ;
            Data.Foldable.toList__ := fun {a} => Foldable__Arg_toList |}.
 
-Local Definition Functor__Arg_fmap {inst_a}
-   : forall {a} {b}, (a -> b) -> (Arg inst_a) a -> (Arg inst_a) b :=
-  fun {a} {b} =>
+Local Definition Traversable__Arg_traverse {inst_a}
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f},
+     (a -> f b) -> (Arg inst_a) a -> f ((Arg inst_a) b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
     fun arg_0__ arg_1__ =>
       match arg_0__, arg_1__ with
-      | f, Mk_Arg x a => Mk_Arg x (f a)
+      | f, Mk_Arg x a => Mk_Arg x Data.Functor.<$> f a
       end.
 
-Local Definition Functor__Arg_op_zlzd__ {inst_a}
-   : forall {a} {b}, a -> (Arg inst_a) b -> (Arg inst_a) a :=
-  fun {a} {b} => Functor__Arg_fmap GHC.Base.∘ GHC.Base.const.
+Local Definition Traversable__Arg_mapM {inst_a}
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m},
+     (a -> m b) -> (Arg inst_a) a -> m ((Arg inst_a) b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Arg_traverse.
 
-Program Instance Functor__Arg {a} : GHC.Base.Functor (Arg a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Arg_fmap ;
-           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Arg_op_zlzd__ |}.
+Local Definition Traversable__Arg_sequenceA {inst_a}
+   : forall {f} {a},
+     forall `{GHC.Base.Applicative f}, (Arg inst_a) (f a) -> f ((Arg inst_a) a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} => Traversable__Arg_traverse GHC.Base.id.
+
+Local Definition Traversable__Arg_sequence {inst_a}
+   : forall {m} {a},
+     forall `{GHC.Base.Monad m}, (Arg inst_a) (m a) -> m ((Arg inst_a) a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Arg_sequenceA.
 
 Program Instance Traversable__Arg {a} : Data.Traversable.Traversable (Arg a) :=
   fun _ k__ =>
@@ -1227,24 +1109,120 @@ Program Instance Traversable__Arg {a} : Data.Traversable.Traversable (Arg a) :=
            Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
              Traversable__Arg_traverse |}.
 
-(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
-   `Data.Semigroup.MonadFix__First' *)
+Local Definition Eq___Arg_op_zeze__ {inst_a} {inst_b} `{GHC.Base.Eq_ inst_a}
+   : (Arg inst_a inst_b) -> (Arg inst_a inst_b) -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_Arg a _, Mk_Arg b _ => a GHC.Base.== b
+    end.
 
-Local Definition Applicative__First_liftA2
-   : forall {a} {b} {c}, (a -> b -> c) -> First a -> First b -> First c :=
-  fun {a} {b} {c} => GHC.Prim.coerce.
+Local Definition Eq___Arg_op_zsze__ {inst_a} {inst_b} `{GHC.Base.Eq_ inst_a}
+   : (Arg inst_a inst_b) -> (Arg inst_a inst_b) -> bool :=
+  fun x y => negb (Eq___Arg_op_zeze__ x y).
 
-Local Definition Applicative__First_op_zlztzg__
-   : forall {a} {b}, First (a -> b) -> First a -> First b :=
-  fun {a} {b} => GHC.Prim.coerce.
+Program Instance Eq___Arg {a} {b} `{GHC.Base.Eq_ a} : GHC.Base.Eq_ (Arg a b) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___Arg_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___Arg_op_zsze__ |}.
 
-Local Definition Applicative__First_op_ztzg__
-   : forall {a} {b}, First a -> First b -> First b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | _, a => a end.
+(* Skipping instance `Data.Semigroup.Ord__Arg' of class `GHC.Base.Ord' *)
 
-Local Definition Applicative__First_pure : forall {a}, a -> First a :=
-  fun {a} => fun x => Mk_First x.
+Local Definition Bifunctor__Arg_bimap
+   : forall {a} {b} {c} {d}, (a -> b) -> (c -> d) -> Arg a c -> Arg b d :=
+  fun {a} {b} {c} {d} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | f, g, Mk_Arg a b => Mk_Arg (f a) (g b)
+      end.
+
+Local Definition Bifunctor__Arg_first
+   : forall {a} {b} {c}, (a -> b) -> Arg a c -> Arg b c :=
+  fun {a} {b} {c} => fun f => Bifunctor__Arg_bimap f GHC.Base.id.
+
+Local Definition Bifunctor__Arg_second
+   : forall {b} {c} {a}, (b -> c) -> Arg a b -> Arg a c :=
+  fun {b} {c} {a} => Bifunctor__Arg_bimap GHC.Base.id.
+
+Program Instance Bifunctor__Arg : Data.Bifunctor.Bifunctor Arg :=
+  fun _ k__ =>
+    k__ {| Data.Bifunctor.bimap__ := fun {a} {b} {c} {d} => Bifunctor__Arg_bimap ;
+           Data.Bifunctor.first__ := fun {a} {b} {c} => Bifunctor__Arg_first ;
+           Data.Bifunctor.second__ := fun {b} {c} {a} => Bifunctor__Arg_second |}.
+
+Local Definition Bifoldable__Arg_bifoldMap
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monoid m}, (a -> m) -> (b -> m) -> Arg a b -> m :=
+  fun {m} {a} {b} `{GHC.Base.Monoid m} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | f, g, Mk_Arg a b => f a GHC.Base.<<>> g b
+      end.
+
+Local Definition Bifoldable__Arg_bifold
+   : forall {m}, forall `{GHC.Base.Monoid m}, Arg m m -> m :=
+  fun {m} `{GHC.Base.Monoid m} =>
+    Bifoldable__Arg_bifoldMap GHC.Base.id GHC.Base.id.
+
+Local Definition Bifoldable__Arg_bifoldl
+   : forall {c} {a} {b}, (c -> a -> c) -> (c -> b -> c) -> c -> Arg a b -> c :=
+  fun {c} {a} {b} =>
+    fun f g z t =>
+      Data.SemigroupInternal.appEndo (Data.SemigroupInternal.getDual
+                                      (Bifoldable__Arg_bifoldMap (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
+                                                                  (Data.SemigroupInternal.Mk_Endo GHC.Base.∘
+                                                                   GHC.Base.flip f)) (Data.SemigroupInternal.Mk_Dual
+                                                                                      GHC.Base.∘
+                                                                                      (Data.SemigroupInternal.Mk_Endo
+                                                                                       GHC.Base.∘
+                                                                                       GHC.Base.flip g)) t)) z.
+
+Local Definition Bifoldable__Arg_bifoldr
+   : forall {a} {c} {b}, (a -> c -> c) -> (b -> c -> c) -> c -> Arg a b -> c :=
+  fun {a} {c} {b} =>
+    fun f g z t =>
+      Data.SemigroupInternal.appEndo (Bifoldable__Arg_bifoldMap
+                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo f)
+                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo g) t) z.
+
+Program Instance Bifoldable__Arg : Data.Bifoldable.Bifoldable Arg :=
+  fun _ k__ =>
+    k__ {| Data.Bifoldable.bifold__ := fun {m} `{GHC.Base.Monoid m} =>
+             Bifoldable__Arg_bifold ;
+           Data.Bifoldable.bifoldMap__ := fun {m} {a} {b} `{GHC.Base.Monoid m} =>
+             Bifoldable__Arg_bifoldMap ;
+           Data.Bifoldable.bifoldl__ := fun {c} {a} {b} => Bifoldable__Arg_bifoldl ;
+           Data.Bifoldable.bifoldr__ := fun {a} {c} {b} => Bifoldable__Arg_bifoldr |}.
+
+Local Definition Bitraversable__Arg_bitraverse
+   : forall {f} {a} {c} {b} {d},
+     forall `{GHC.Base.Applicative f},
+     (a -> f c) -> (b -> f d) -> Arg a b -> f (Arg c d) :=
+  fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | f, g, Mk_Arg a b => (Mk_Arg Data.Functor.<$> f a) GHC.Base.<*> g b
+      end.
+
+Program Instance Bitraversable__Arg : Data.Bitraversable.Bitraversable Arg :=
+  fun _ k__ =>
+    k__ {| Data.Bitraversable.bitraverse__ := fun {f}
+           {a}
+           {c}
+           {b}
+           {d}
+           `{GHC.Base.Applicative f} =>
+             Bitraversable__Arg_bitraverse |}.
+
+(* Skipping all instances of class `GHC.Enum.Enum', including
+   `Data.Semigroup.Enum__First' *)
+
+Local Definition Semigroup__First_op_zlzlzgzg__ {inst_a}
+   : (First inst_a) -> (First inst_a) -> (First inst_a) :=
+  fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | a, _ => a end.
+
+Program Instance Semigroup__First {a} : GHC.Base.Semigroup (First a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__First_op_zlzlzgzg__ |}.
 
 Local Definition Functor__First_fmap
    : forall {a} {b}, (a -> b) -> First a -> First b :=
@@ -1262,55 +1240,6 @@ Program Instance Functor__First : GHC.Base.Functor First :=
   fun _ k__ =>
     k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__First_fmap ;
            GHC.Base.op_zlzd____ := fun {a} {b} => Functor__First_op_zlzd__ |}.
-
-Program Instance Applicative__First : GHC.Base.Applicative First :=
-  fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__First_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__First_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__First_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__First_pure |}.
-
-Local Definition Monad__First_op_zgzg__
-   : forall {a} {b}, First a -> First b -> First b :=
-  fun {a} {b} => _GHC.Base.*>_.
-
-Local Definition Monad__First_op_zgzgze__
-   : forall {a} {b}, First a -> (a -> First b) -> First b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | Mk_First a, f => f a end.
-
-Local Definition Monad__First_return_ : forall {a}, a -> First a :=
-  fun {a} => GHC.Base.pure.
-
-Program Instance Monad__First : GHC.Base.Monad First :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__First_op_zgzg__ ;
-           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__First_op_zgzgze__ ;
-           GHC.Base.return___ := fun {a} => Monad__First_return_ |}.
-
-Local Definition Traversable__First_traverse
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f}, (a -> f b) -> First a -> f (First b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, Mk_First a => Mk_First Data.Functor.<$> f a
-      end.
-
-Local Definition Traversable__First_mapM
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m}, (a -> m b) -> First a -> m (First b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__First_traverse.
-
-Local Definition Traversable__First_sequenceA
-   : forall {f} {a},
-     forall `{GHC.Base.Applicative f}, First (f a) -> f (First a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} =>
-    Traversable__First_traverse GHC.Base.id.
-
-Local Definition Traversable__First_sequence
-   : forall {m} {a}, forall `{GHC.Base.Monad m}, First (m a) -> m (First a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__First_sequenceA.
 
 Local Definition Foldable__First_foldMap
    : forall {m} {a}, forall `{GHC.Base.Monoid m}, (a -> m) -> First a -> m :=
@@ -1391,6 +1320,30 @@ Program Instance Foldable__First : Data.Foldable.Foldable First :=
            Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__First_sum ;
            Data.Foldable.toList__ := fun {a} => Foldable__First_toList |}.
 
+Local Definition Traversable__First_traverse
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f}, (a -> f b) -> First a -> f (First b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, Mk_First a => Mk_First Data.Functor.<$> f a
+      end.
+
+Local Definition Traversable__First_mapM
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m}, (a -> m b) -> First a -> m (First b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__First_traverse.
+
+Local Definition Traversable__First_sequenceA
+   : forall {f} {a},
+     forall `{GHC.Base.Applicative f}, First (f a) -> f (First a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} =>
+    Traversable__First_traverse GHC.Base.id.
+
+Local Definition Traversable__First_sequence
+   : forall {m} {a}, forall `{GHC.Base.Monad m}, First (m a) -> m (First a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__First_sequenceA.
+
 Program Instance Traversable__First : Data.Traversable.Traversable First :=
   fun _ k__ =>
     k__ {| Data.Traversable.mapM__ := fun {m} {a} {b} `{GHC.Base.Monad m} =>
@@ -1402,35 +1355,60 @@ Program Instance Traversable__First : Data.Traversable.Traversable First :=
            Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
              Traversable__First_traverse |}.
 
-Local Definition Semigroup__First_op_zlzlzgzg__ {inst_a}
-   : (First inst_a) -> (First inst_a) -> (First inst_a) :=
-  fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | a, _ => a end.
-
-Program Instance Semigroup__First {a} : GHC.Base.Semigroup (First a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__First_op_zlzlzgzg__ |}.
-
-(* Skipping all instances of class `GHC.Enum.Enum', including
-   `Data.Semigroup.Enum__First' *)
-
-(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
-   `Data.Semigroup.MonadFix__Last' *)
-
-Local Definition Applicative__Last_liftA2
-   : forall {a} {b} {c}, (a -> b -> c) -> Last a -> Last b -> Last c :=
+Local Definition Applicative__First_liftA2
+   : forall {a} {b} {c}, (a -> b -> c) -> First a -> First b -> First c :=
   fun {a} {b} {c} => GHC.Prim.coerce.
 
-Local Definition Applicative__Last_op_zlztzg__
-   : forall {a} {b}, Last (a -> b) -> Last a -> Last b :=
+Local Definition Applicative__First_op_zlztzg__
+   : forall {a} {b}, First (a -> b) -> First a -> First b :=
   fun {a} {b} => GHC.Prim.coerce.
 
-Local Definition Applicative__Last_op_ztzg__
-   : forall {a} {b}, Last a -> Last b -> Last b :=
+Local Definition Applicative__First_op_ztzg__
+   : forall {a} {b}, First a -> First b -> First b :=
   fun {a} {b} =>
     fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | _, a => a end.
 
-Local Definition Applicative__Last_pure : forall {a}, a -> Last a :=
-  fun {a} => Mk_Last.
+Local Definition Applicative__First_pure : forall {a}, a -> First a :=
+  fun {a} => fun x => Mk_First x.
+
+Program Instance Applicative__First : GHC.Base.Applicative First :=
+  fun _ k__ =>
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__First_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__First_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__First_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__First_pure |}.
+
+Local Definition Monad__First_op_zgzg__
+   : forall {a} {b}, First a -> First b -> First b :=
+  fun {a} {b} => _GHC.Base.*>_.
+
+Local Definition Monad__First_op_zgzgze__
+   : forall {a} {b}, First a -> (a -> First b) -> First b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | Mk_First a, f => f a end.
+
+Local Definition Monad__First_return_ : forall {a}, a -> First a :=
+  fun {a} => GHC.Base.pure.
+
+Program Instance Monad__First : GHC.Base.Monad First :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__First_op_zgzg__ ;
+           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__First_op_zgzgze__ ;
+           GHC.Base.return___ := fun {a} => Monad__First_return_ |}.
+
+(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
+   `Data.Semigroup.MonadFix__First' *)
+
+(* Skipping all instances of class `GHC.Enum.Enum', including
+   `Data.Semigroup.Enum__Last' *)
+
+Local Definition Semigroup__Last_op_zlzlzgzg__ {inst_a}
+   : (Last inst_a) -> (Last inst_a) -> (Last inst_a) :=
+  fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | _, b => b end.
+
+Program Instance Semigroup__Last {a} : GHC.Base.Semigroup (Last a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__Last_op_zlzlzgzg__ |}.
 
 Local Definition Functor__Last_fmap
    : forall {a} {b}, (a -> b) -> Last a -> Last b :=
@@ -1449,53 +1427,6 @@ Program Instance Functor__Last : GHC.Base.Functor Last :=
   fun _ k__ =>
     k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Last_fmap ;
            GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Last_op_zlzd__ |}.
-
-Program Instance Applicative__Last : GHC.Base.Applicative Last :=
-  fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Last_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Last_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Last_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__Last_pure |}.
-
-Local Definition Monad__Last_op_zgzg__
-   : forall {a} {b}, Last a -> Last b -> Last b :=
-  fun {a} {b} => _GHC.Base.*>_.
-
-Local Definition Monad__Last_op_zgzgze__
-   : forall {a} {b}, Last a -> (a -> Last b) -> Last b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | Mk_Last a, f => f a end.
-
-Local Definition Monad__Last_return_ : forall {a}, a -> Last a :=
-  fun {a} => GHC.Base.pure.
-
-Program Instance Monad__Last : GHC.Base.Monad Last :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Last_op_zgzg__ ;
-           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Last_op_zgzgze__ ;
-           GHC.Base.return___ := fun {a} => Monad__Last_return_ |}.
-
-Local Definition Traversable__Last_traverse
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f}, (a -> f b) -> Last a -> f (Last b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, Mk_Last a => Mk_Last Data.Functor.<$> f a
-      end.
-
-Local Definition Traversable__Last_mapM
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m}, (a -> m b) -> Last a -> m (Last b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Last_traverse.
-
-Local Definition Traversable__Last_sequenceA
-   : forall {f} {a}, forall `{GHC.Base.Applicative f}, Last (f a) -> f (Last a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} => Traversable__Last_traverse GHC.Base.id.
-
-Local Definition Traversable__Last_sequence
-   : forall {m} {a}, forall `{GHC.Base.Monad m}, Last (m a) -> m (Last a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Last_sequenceA.
 
 Local Definition Foldable__Last_foldMap
    : forall {m} {a}, forall `{GHC.Base.Monoid m}, (a -> m) -> Last a -> m :=
@@ -1576,6 +1507,28 @@ Program Instance Foldable__Last : Data.Foldable.Foldable Last :=
            Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Last_sum ;
            Data.Foldable.toList__ := fun {a} => Foldable__Last_toList |}.
 
+Local Definition Traversable__Last_traverse
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f}, (a -> f b) -> Last a -> f (Last b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, Mk_Last a => Mk_Last Data.Functor.<$> f a
+      end.
+
+Local Definition Traversable__Last_mapM
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m}, (a -> m b) -> Last a -> m (Last b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Last_traverse.
+
+Local Definition Traversable__Last_sequenceA
+   : forall {f} {a}, forall `{GHC.Base.Applicative f}, Last (f a) -> f (Last a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} => Traversable__Last_traverse GHC.Base.id.
+
+Local Definition Traversable__Last_sequence
+   : forall {m} {a}, forall `{GHC.Base.Monad m}, Last (m a) -> m (Last a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Last_sequenceA.
+
 Program Instance Traversable__Last : Data.Traversable.Traversable Last :=
   fun _ k__ =>
     k__ {| Data.Traversable.mapM__ := fun {m} {a} {b} `{GHC.Base.Monad m} =>
@@ -1587,19 +1540,49 @@ Program Instance Traversable__Last : Data.Traversable.Traversable Last :=
            Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
              Traversable__Last_traverse |}.
 
-Local Definition Semigroup__Last_op_zlzlzgzg__ {inst_a}
-   : (Last inst_a) -> (Last inst_a) -> (Last inst_a) :=
-  fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | _, b => b end.
+Local Definition Applicative__Last_liftA2
+   : forall {a} {b} {c}, (a -> b -> c) -> Last a -> Last b -> Last c :=
+  fun {a} {b} {c} => GHC.Prim.coerce.
 
-Program Instance Semigroup__Last {a} : GHC.Base.Semigroup (Last a) :=
+Local Definition Applicative__Last_op_zlztzg__
+   : forall {a} {b}, Last (a -> b) -> Last a -> Last b :=
+  fun {a} {b} => GHC.Prim.coerce.
+
+Local Definition Applicative__Last_op_ztzg__
+   : forall {a} {b}, Last a -> Last b -> Last b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | _, a => a end.
+
+Local Definition Applicative__Last_pure : forall {a}, a -> Last a :=
+  fun {a} => Mk_Last.
+
+Program Instance Applicative__Last : GHC.Base.Applicative Last :=
   fun _ k__ =>
-    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__Last_op_zlzlzgzg__ |}.
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Last_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Last_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Last_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__Last_pure |}.
 
-(* Skipping all instances of class `GHC.Enum.Enum', including
-   `Data.Semigroup.Enum__Last' *)
+Local Definition Monad__Last_op_zgzg__
+   : forall {a} {b}, Last a -> Last b -> Last b :=
+  fun {a} {b} => _GHC.Base.*>_.
 
-(* Skipping all instances of class `GHC.Enum.Enum', including
-   `Data.Semigroup.Enum__WrappedMonoid' *)
+Local Definition Monad__Last_op_zgzgze__
+   : forall {a} {b}, Last a -> (a -> Last b) -> Last b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | Mk_Last a, f => f a end.
+
+Local Definition Monad__Last_return_ : forall {a}, a -> Last a :=
+  fun {a} => GHC.Base.pure.
+
+Program Instance Monad__Last : GHC.Base.Monad Last :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Last_op_zgzg__ ;
+           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Last_op_zgzgze__ ;
+           GHC.Base.return___ := fun {a} => Monad__Last_return_ |}.
+
+(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
+   `Data.Semigroup.MonadFix__Last' *)
 
 Local Definition Semigroup__WrappedMonoid_op_zlzlzgzg__ {inst_m} `{_
    : GHC.Base.Monoid inst_m}
@@ -1632,59 +1615,91 @@ Program Instance Monoid__WrappedMonoid {m} `{GHC.Base.Monoid m}
            GHC.Base.mconcat__ := Monoid__WrappedMonoid_mconcat ;
            GHC.Base.mempty__ := Monoid__WrappedMonoid_mempty |}.
 
-Local Definition Semigroup__Option_op_zlzlzgzg__ {inst_a} `{_
-   : GHC.Base.Semigroup inst_a}
-   : Option inst_a -> Option inst_a -> Option inst_a :=
-  GHC.Prim.coerce (@GHC.Base.op_zlzlzgzg__ (option inst_a) _).
+(* Skipping all instances of class `GHC.Enum.Enum', including
+   `Data.Semigroup.Enum__WrappedMonoid' *)
 
-Program Instance Semigroup__Option {a} `{GHC.Base.Semigroup a}
-   : GHC.Base.Semigroup (Option a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__Option_op_zlzlzgzg__ |}.
-
-Local Definition Monoid__Option_mappend {inst_a} `{GHC.Base.Semigroup inst_a}
-   : (Option inst_a) -> (Option inst_a) -> (Option inst_a) :=
-  _GHC.Base.<<>>_.
-
-Local Definition Monoid__Option_mempty {inst_a} `{GHC.Base.Semigroup inst_a}
-   : (Option inst_a) :=
-  Mk_Option None.
-
-Local Definition Monoid__Option_mconcat {inst_a} `{GHC.Base.Semigroup inst_a}
-   : list (Option inst_a) -> (Option inst_a) :=
-  GHC.Base.foldr Monoid__Option_mappend Monoid__Option_mempty.
-
-Program Instance Monoid__Option {a} `{GHC.Base.Semigroup a}
-   : GHC.Base.Monoid (Option a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.mappend__ := Monoid__Option_mappend ;
-           GHC.Base.mconcat__ := Monoid__Option_mconcat ;
-           GHC.Base.mempty__ := Monoid__Option_mempty |}.
-
-Local Definition Traversable__Option_traverse
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f}, (a -> f b) -> Option a -> f (Option b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+Local Definition Functor__Option_fmap
+   : forall {a} {b}, (a -> b) -> Option a -> Option b :=
+  fun {a} {b} =>
     fun arg_0__ arg_1__ =>
       match arg_0__, arg_1__ with
-      | f, Mk_Option (Some a) => (Mk_Option GHC.Base.∘ Some) Data.Functor.<$> f a
-      | _, Mk_Option None => GHC.Base.pure (Mk_Option None)
+      | f, Mk_Option a => Mk_Option (GHC.Base.fmap f a)
       end.
 
-Local Definition Traversable__Option_mapM
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m}, (a -> m b) -> Option a -> m (Option b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Option_traverse.
+Local Definition Functor__Option_op_zlzd__
+   : forall {a} {b}, a -> Option b -> Option a :=
+  fun {a} {b} => Functor__Option_fmap GHC.Base.∘ GHC.Base.const.
 
-Local Definition Traversable__Option_sequenceA
-   : forall {f} {a},
-     forall `{GHC.Base.Applicative f}, Option (f a) -> f (Option a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} =>
-    Traversable__Option_traverse GHC.Base.id.
+Program Instance Functor__Option : GHC.Base.Functor Option :=
+  fun _ k__ =>
+    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Option_fmap ;
+           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Option_op_zlzd__ |}.
 
-Local Definition Traversable__Option_sequence
-   : forall {m} {a}, forall `{GHC.Base.Monad m}, Option (m a) -> m (Option a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Option_sequenceA.
+Local Definition Applicative__Option_liftA2
+   : forall {a} {b} {c}, (a -> b -> c) -> Option a -> Option b -> Option c :=
+  fun {a} {b} {c} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | f, Mk_Option x, Mk_Option y => Mk_Option (GHC.Base.liftA2 f x y)
+      end.
+
+Local Definition Applicative__Option_op_zlztzg__
+   : forall {a} {b}, Option (a -> b) -> Option a -> Option b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | Mk_Option a, Mk_Option b => Mk_Option (a GHC.Base.<*> b)
+      end.
+
+Local Definition Applicative__Option_op_ztzg__
+   : forall {a} {b}, Option a -> Option b -> Option b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | Mk_Option None, _ => Mk_Option None
+      | _, b => b
+      end.
+
+Local Definition Applicative__Option_pure : forall {a}, a -> Option a :=
+  fun {a} => fun a => Mk_Option (Some a).
+
+Program Instance Applicative__Option : GHC.Base.Applicative Option :=
+  fun _ k__ =>
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Option_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Option_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Option_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__Option_pure |}.
+
+Local Definition Monad__Option_op_zgzg__
+   : forall {a} {b}, Option a -> Option b -> Option b :=
+  fun {a} {b} => _GHC.Base.*>_.
+
+Local Definition Monad__Option_op_zgzgze__
+   : forall {a} {b}, Option a -> (a -> Option b) -> Option b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | Mk_Option (Some a), k => k a
+      | _, _ => Mk_Option None
+      end.
+
+Local Definition Monad__Option_return_ : forall {a}, a -> Option a :=
+  fun {a} => GHC.Base.pure.
+
+Program Instance Monad__Option : GHC.Base.Monad Option :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Option_op_zgzg__ ;
+           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Option_op_zgzgze__ ;
+           GHC.Base.return___ := fun {a} => Monad__Option_return_ |}.
+
+(* Skipping all instances of class `GHC.Base.Alternative', including
+   `Data.Semigroup.Alternative__Option' *)
+
+(* Skipping all instances of class `GHC.Base.MonadPlus', including
+   `Data.Semigroup.MonadPlus__Option' *)
+
+(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
+   `Data.Semigroup.MonadFix__Option' *)
 
 Local Definition Foldable__Option_foldMap
    : forall {m} {a}, forall `{GHC.Base.Monoid m}, (a -> m) -> Option a -> m :=
@@ -1771,22 +1786,30 @@ Program Instance Foldable__Option : Data.Foldable.Foldable Option :=
            Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Option_sum ;
            Data.Foldable.toList__ := fun {a} => Foldable__Option_toList |}.
 
-Local Definition Functor__Option_fmap
-   : forall {a} {b}, (a -> b) -> Option a -> Option b :=
-  fun {a} {b} =>
+Local Definition Traversable__Option_traverse
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f}, (a -> f b) -> Option a -> f (Option b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
     fun arg_0__ arg_1__ =>
       match arg_0__, arg_1__ with
-      | f, Mk_Option a => Mk_Option (GHC.Base.fmap f a)
+      | f, Mk_Option (Some a) => (Mk_Option GHC.Base.∘ Some) Data.Functor.<$> f a
+      | _, Mk_Option None => GHC.Base.pure (Mk_Option None)
       end.
 
-Local Definition Functor__Option_op_zlzd__
-   : forall {a} {b}, a -> Option b -> Option a :=
-  fun {a} {b} => Functor__Option_fmap GHC.Base.∘ GHC.Base.const.
+Local Definition Traversable__Option_mapM
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m}, (a -> m b) -> Option a -> m (Option b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Option_traverse.
 
-Program Instance Functor__Option : GHC.Base.Functor Option :=
-  fun _ k__ =>
-    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Option_fmap ;
-           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Option_op_zlzd__ |}.
+Local Definition Traversable__Option_sequenceA
+   : forall {f} {a},
+     forall `{GHC.Base.Applicative f}, Option (f a) -> f (Option a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} =>
+    Traversable__Option_traverse GHC.Base.id.
+
+Local Definition Traversable__Option_sequence
+   : forall {m} {a}, forall `{GHC.Base.Monad m}, Option (m a) -> m (Option a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Option_sequenceA.
 
 Program Instance Traversable__Option : Data.Traversable.Traversable Option :=
   fun _ k__ =>
@@ -1799,71 +1822,48 @@ Program Instance Traversable__Option : Data.Traversable.Traversable Option :=
            Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
              Traversable__Option_traverse |}.
 
-(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
-   `Data.Semigroup.MonadFix__Option' *)
+Local Definition Semigroup__Option_op_zlzlzgzg__ {inst_a} `{_
+   : GHC.Base.Semigroup inst_a}
+   : Option inst_a -> Option inst_a -> Option inst_a :=
+  GHC.Prim.coerce (@GHC.Base.op_zlzlzgzg__ (option inst_a) _).
 
-(* Skipping all instances of class `GHC.Base.MonadPlus', including
-   `Data.Semigroup.MonadPlus__Option' *)
-
-(* Skipping all instances of class `GHC.Base.Alternative', including
-   `Data.Semigroup.Alternative__Option' *)
-
-Local Definition Applicative__Option_liftA2
-   : forall {a} {b} {c}, (a -> b -> c) -> Option a -> Option b -> Option c :=
-  fun {a} {b} {c} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | f, Mk_Option x, Mk_Option y => Mk_Option (GHC.Base.liftA2 f x y)
-      end.
-
-Local Definition Applicative__Option_op_zlztzg__
-   : forall {a} {b}, Option (a -> b) -> Option a -> Option b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | Mk_Option a, Mk_Option b => Mk_Option (a GHC.Base.<*> b)
-      end.
-
-Local Definition Applicative__Option_op_ztzg__
-   : forall {a} {b}, Option a -> Option b -> Option b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | Mk_Option None, _ => Mk_Option None
-      | _, b => b
-      end.
-
-Local Definition Applicative__Option_pure : forall {a}, a -> Option a :=
-  fun {a} => fun a => Mk_Option (Some a).
-
-Program Instance Applicative__Option : GHC.Base.Applicative Option :=
+Program Instance Semigroup__Option {a} `{GHC.Base.Semigroup a}
+   : GHC.Base.Semigroup (Option a) :=
   fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Option_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Option_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Option_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__Option_pure |}.
+    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__Option_op_zlzlzgzg__ |}.
 
-Local Definition Monad__Option_op_zgzg__
-   : forall {a} {b}, Option a -> Option b -> Option b :=
-  fun {a} {b} => _GHC.Base.*>_.
+Local Definition Monoid__Option_mappend {inst_a} `{GHC.Base.Semigroup inst_a}
+   : (Option inst_a) -> (Option inst_a) -> (Option inst_a) :=
+  _GHC.Base.<<>>_.
 
-Local Definition Monad__Option_op_zgzgze__
-   : forall {a} {b}, Option a -> (a -> Option b) -> Option b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | Mk_Option (Some a), k => k a
-      | _, _ => Mk_Option None
-      end.
+Local Definition Monoid__Option_mempty {inst_a} `{GHC.Base.Semigroup inst_a}
+   : (Option inst_a) :=
+  Mk_Option None.
 
-Local Definition Monad__Option_return_ : forall {a}, a -> Option a :=
-  fun {a} => GHC.Base.pure.
+Local Definition Monoid__Option_mconcat {inst_a} `{GHC.Base.Semigroup inst_a}
+   : list (Option inst_a) -> (Option inst_a) :=
+  GHC.Base.foldr Monoid__Option_mappend Monoid__Option_mempty.
 
-Program Instance Monad__Option : GHC.Base.Monad Option :=
+Program Instance Monoid__Option {a} `{GHC.Base.Semigroup a}
+   : GHC.Base.Monoid (Option a) :=
   fun _ k__ =>
-    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Option_op_zgzg__ ;
-           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Option_op_zgzgze__ ;
-           GHC.Base.return___ := fun {a} => Monad__Option_return_ |}.
+    k__ {| GHC.Base.mappend__ := Monoid__Option_mappend ;
+           GHC.Base.mconcat__ := Monoid__Option_mconcat ;
+           GHC.Base.mempty__ := Monoid__Option_mempty |}.
+
+(* Skipping definition `Data.Semigroup.cycle1' *)
+
+Definition diff {m} `{GHC.Base.Semigroup m}
+   : m -> Data.SemigroupInternal.Endo m :=
+  Data.SemigroupInternal.Mk_Endo GHC.Base.∘ _GHC.Base.<<>>_.
+
+(* Skipping definition `Data.Semigroup.mtimesDefault' *)
+
+Definition destruct_option {b} {a} : b -> (a -> b) -> Option a -> b :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | n, j, Mk_Option m => Data.Maybe.maybe n j m
+    end.
 
 (* External variables:
      None Some bool comparison false list negb option true Coq.Program.Basics.compose

--- a/base/Data/SemigroupInternal.v
+++ b/base/Data/SemigroupInternal.v
@@ -183,28 +183,6 @@ Instance instance_forall___GHC_Base_Ord__f_a____GHC_Base_Ord__Alt_f_a_  {f}
 
 (* Converted value declarations: *)
 
-(* Skipping definition `Data.SemigroupInternal.stimesMonoid' *)
-
-(* Skipping definition `Data.SemigroupInternal.stimesMaybe' *)
-
-(* Skipping definition `Data.SemigroupInternal.stimesList' *)
-
-Definition stimesIdempotentMonoid {b} {a} `{GHC.Real.Integral b}
-  `{GHC.Base.Monoid a}
-   : b -> a -> a :=
-  fun n x =>
-    match GHC.Base.compare n #0 with
-    | Lt =>
-        GHC.Err.errorWithoutStackTrace (GHC.Base.hs_string__
-                                        "stimesIdempotentMonoid: negative multiplier")
-    | Eq => GHC.Base.mempty
-    | Gt => x
-    end.
-
-(* Skipping definition `Data.SemigroupInternal.stimesIdempotent' *)
-
-(* Skipping definition `Data.SemigroupInternal.stimesDefault' *)
-
 Instance Unpeel_Dual a : GHC.Prim.Unpeel (Dual a) a :=
   GHC.Prim.Build_Unpeel _ _ getDual Mk_Dual.
 
@@ -742,59 +720,6 @@ Program Instance Monad__Alt {f} `{GHC.Base.Monad f}
 (* Skipping all instances of class `GHC.Base.Alternative', including
    `Data.SemigroupInternal.Alternative__Alt' *)
 
-Local Definition Monad__Dual_op_zgzgze__
-   : forall {a} {b}, Dual a -> (a -> Dual b) -> Dual b :=
-  fun {a} {b} => fun m k => k (getDual m).
-
-Local Definition Monad__Dual_op_zgzg__
-   : forall {a} {b}, Dual a -> Dual b -> Dual b :=
-  fun {a} {b} => fun m k => Monad__Dual_op_zgzgze__ m (fun arg_0__ => k).
-
-Local Definition Applicative__Dual_op_zlztzg__
-   : forall {a} {b}, Dual (a -> b) -> Dual a -> Dual b :=
-  fun {a} {b} => GHC.Prim.coerce.
-
-Local Definition Functor__Dual_fmap
-   : forall {a} {b}, (a -> b) -> Dual a -> Dual b :=
-  fun {a} {b} => GHC.Prim.coerce.
-
-Local Definition Functor__Dual_op_zlzd__
-   : forall {a} {b}, a -> Dual b -> Dual a :=
-  fun {a} {b} => Functor__Dual_fmap GHC.Base.∘ GHC.Base.const.
-
-Program Instance Functor__Dual : GHC.Base.Functor Dual :=
-  fun _ k__ =>
-    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Dual_fmap ;
-           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Dual_op_zlzd__ |}.
-
-Local Definition Applicative__Dual_liftA2
-   : forall {a} {b} {c}, (a -> b -> c) -> Dual a -> Dual b -> Dual c :=
-  fun {a} {b} {c} => fun f x => Applicative__Dual_op_zlztzg__ (GHC.Base.fmap f x).
-
-Local Definition Applicative__Dual_op_ztzg__
-   : forall {a} {b}, Dual a -> Dual b -> Dual b :=
-  fun {a} {b} =>
-    fun a1 a2 => Applicative__Dual_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
-
-Local Definition Applicative__Dual_pure : forall {a}, a -> Dual a :=
-  fun {a} => Mk_Dual.
-
-Program Instance Applicative__Dual : GHC.Base.Applicative Dual :=
-  fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Dual_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Dual_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Dual_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__Dual_pure |}.
-
-Local Definition Monad__Dual_return_ : forall {a}, a -> Dual a :=
-  fun {a} => GHC.Base.pure.
-
-Program Instance Monad__Dual : GHC.Base.Monad Dual :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Dual_op_zgzg__ ;
-           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Dual_op_zgzgze__ ;
-           GHC.Base.return___ := fun {a} => Monad__Dual_return_ |}.
-
 Local Definition Semigroup__Dual_op_zlzlzgzg__ {inst_a} `{GHC.Base.Semigroup
   inst_a}
    : (Dual inst_a) -> (Dual inst_a) -> (Dual inst_a) :=
@@ -826,6 +751,59 @@ Program Instance Monoid__Dual {a} `{GHC.Base.Monoid a}
     k__ {| GHC.Base.mappend__ := Monoid__Dual_mappend ;
            GHC.Base.mconcat__ := Monoid__Dual_mconcat ;
            GHC.Base.mempty__ := Monoid__Dual_mempty |}.
+
+Local Definition Functor__Dual_fmap
+   : forall {a} {b}, (a -> b) -> Dual a -> Dual b :=
+  fun {a} {b} => GHC.Prim.coerce.
+
+Local Definition Functor__Dual_op_zlzd__
+   : forall {a} {b}, a -> Dual b -> Dual a :=
+  fun {a} {b} => Functor__Dual_fmap GHC.Base.∘ GHC.Base.const.
+
+Program Instance Functor__Dual : GHC.Base.Functor Dual :=
+  fun _ k__ =>
+    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Dual_fmap ;
+           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Dual_op_zlzd__ |}.
+
+Local Definition Applicative__Dual_op_zlztzg__
+   : forall {a} {b}, Dual (a -> b) -> Dual a -> Dual b :=
+  fun {a} {b} => GHC.Prim.coerce.
+
+Local Definition Applicative__Dual_liftA2
+   : forall {a} {b} {c}, (a -> b -> c) -> Dual a -> Dual b -> Dual c :=
+  fun {a} {b} {c} => fun f x => Applicative__Dual_op_zlztzg__ (GHC.Base.fmap f x).
+
+Local Definition Applicative__Dual_op_ztzg__
+   : forall {a} {b}, Dual a -> Dual b -> Dual b :=
+  fun {a} {b} =>
+    fun a1 a2 => Applicative__Dual_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
+
+Local Definition Applicative__Dual_pure : forall {a}, a -> Dual a :=
+  fun {a} => Mk_Dual.
+
+Program Instance Applicative__Dual : GHC.Base.Applicative Dual :=
+  fun _ k__ =>
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Dual_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Dual_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Dual_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__Dual_pure |}.
+
+Local Definition Monad__Dual_op_zgzgze__
+   : forall {a} {b}, Dual a -> (a -> Dual b) -> Dual b :=
+  fun {a} {b} => fun m k => k (getDual m).
+
+Local Definition Monad__Dual_op_zgzg__
+   : forall {a} {b}, Dual a -> Dual b -> Dual b :=
+  fun {a} {b} => fun m k => Monad__Dual_op_zgzgze__ m (fun arg_0__ => k).
+
+Local Definition Monad__Dual_return_ : forall {a}, a -> Dual a :=
+  fun {a} => GHC.Base.pure.
+
+Program Instance Monad__Dual : GHC.Base.Monad Dual :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Dual_op_zgzg__ ;
+           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Dual_op_zgzgze__ ;
+           GHC.Base.return___ := fun {a} => Monad__Dual_return_ |}.
 
 Instance Unpeel_Endo a : GHC.Prim.Unpeel (Endo a) (a -> a) :=
   GHC.Prim.Build_Unpeel _ _ appEndo Mk_Endo.
@@ -897,58 +875,6 @@ Program Instance Monoid__Any : GHC.Base.Monoid Any :=
            GHC.Base.mconcat__ := Monoid__Any_mconcat ;
            GHC.Base.mempty__ := Monoid__Any_mempty |}.
 
-Local Definition Monad__Sum_op_zgzgze__
-   : forall {a} {b}, Sum a -> (a -> Sum b) -> Sum b :=
-  fun {a} {b} => fun m k => k (getSum m).
-
-Local Definition Monad__Sum_op_zgzg__
-   : forall {a} {b}, Sum a -> Sum b -> Sum b :=
-  fun {a} {b} => fun m k => Monad__Sum_op_zgzgze__ m (fun arg_0__ => k).
-
-Local Definition Applicative__Sum_op_zlztzg__
-   : forall {a} {b}, Sum (a -> b) -> Sum a -> Sum b :=
-  fun {a} {b} => GHC.Prim.coerce.
-
-Local Definition Functor__Sum_fmap
-   : forall {a} {b}, (a -> b) -> Sum a -> Sum b :=
-  fun {a} {b} => GHC.Prim.coerce.
-
-Local Definition Functor__Sum_op_zlzd__ : forall {a} {b}, a -> Sum b -> Sum a :=
-  fun {a} {b} => Functor__Sum_fmap GHC.Base.∘ GHC.Base.const.
-
-Program Instance Functor__Sum : GHC.Base.Functor Sum :=
-  fun _ k__ =>
-    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Sum_fmap ;
-           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Sum_op_zlzd__ |}.
-
-Local Definition Applicative__Sum_liftA2
-   : forall {a} {b} {c}, (a -> b -> c) -> Sum a -> Sum b -> Sum c :=
-  fun {a} {b} {c} => fun f x => Applicative__Sum_op_zlztzg__ (GHC.Base.fmap f x).
-
-Local Definition Applicative__Sum_op_ztzg__
-   : forall {a} {b}, Sum a -> Sum b -> Sum b :=
-  fun {a} {b} =>
-    fun a1 a2 => Applicative__Sum_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
-
-Local Definition Applicative__Sum_pure : forall {a}, a -> Sum a :=
-  fun {a} => Mk_Sum.
-
-Program Instance Applicative__Sum : GHC.Base.Applicative Sum :=
-  fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Sum_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Sum_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Sum_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__Sum_pure |}.
-
-Local Definition Monad__Sum_return_ : forall {a}, a -> Sum a :=
-  fun {a} => GHC.Base.pure.
-
-Program Instance Monad__Sum : GHC.Base.Monad Sum :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Sum_op_zgzg__ ;
-           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Sum_op_zgzgze__ ;
-           GHC.Base.return___ := fun {a} => Monad__Sum_return_ |}.
-
 Local Definition Semigroup__Sum_op_zlzlzgzg__ {inst_a} `{GHC.Num.Num inst_a}
    : Sum inst_a -> Sum inst_a -> Sum inst_a :=
   GHC.Prim.coerce _GHC.Num.+_.
@@ -975,59 +901,57 @@ Program Instance Monoid__Sum {a} `{GHC.Num.Num a} : GHC.Base.Monoid (Sum a) :=
            GHC.Base.mconcat__ := Monoid__Sum_mconcat ;
            GHC.Base.mempty__ := Monoid__Sum_mempty |}.
 
-Local Definition Monad__Product_op_zgzgze__
-   : forall {a} {b}, Product a -> (a -> Product b) -> Product b :=
-  fun {a} {b} => fun m k => k (getProduct m).
-
-Local Definition Monad__Product_op_zgzg__
-   : forall {a} {b}, Product a -> Product b -> Product b :=
-  fun {a} {b} => fun m k => Monad__Product_op_zgzgze__ m (fun arg_0__ => k).
-
-Local Definition Applicative__Product_op_zlztzg__
-   : forall {a} {b}, Product (a -> b) -> Product a -> Product b :=
+Local Definition Functor__Sum_fmap
+   : forall {a} {b}, (a -> b) -> Sum a -> Sum b :=
   fun {a} {b} => GHC.Prim.coerce.
 
-Local Definition Functor__Product_fmap
-   : forall {a} {b}, (a -> b) -> Product a -> Product b :=
-  fun {a} {b} => GHC.Prim.coerce.
+Local Definition Functor__Sum_op_zlzd__ : forall {a} {b}, a -> Sum b -> Sum a :=
+  fun {a} {b} => Functor__Sum_fmap GHC.Base.∘ GHC.Base.const.
 
-Local Definition Functor__Product_op_zlzd__
-   : forall {a} {b}, a -> Product b -> Product a :=
-  fun {a} {b} => Functor__Product_fmap GHC.Base.∘ GHC.Base.const.
-
-Program Instance Functor__Product : GHC.Base.Functor Product :=
+Program Instance Functor__Sum : GHC.Base.Functor Sum :=
   fun _ k__ =>
-    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Product_fmap ;
-           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Product_op_zlzd__ |}.
+    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Sum_fmap ;
+           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Sum_op_zlzd__ |}.
 
-Local Definition Applicative__Product_liftA2
-   : forall {a} {b} {c}, (a -> b -> c) -> Product a -> Product b -> Product c :=
-  fun {a} {b} {c} =>
-    fun f x => Applicative__Product_op_zlztzg__ (GHC.Base.fmap f x).
+Local Definition Applicative__Sum_op_zlztzg__
+   : forall {a} {b}, Sum (a -> b) -> Sum a -> Sum b :=
+  fun {a} {b} => GHC.Prim.coerce.
 
-Local Definition Applicative__Product_op_ztzg__
-   : forall {a} {b}, Product a -> Product b -> Product b :=
+Local Definition Applicative__Sum_liftA2
+   : forall {a} {b} {c}, (a -> b -> c) -> Sum a -> Sum b -> Sum c :=
+  fun {a} {b} {c} => fun f x => Applicative__Sum_op_zlztzg__ (GHC.Base.fmap f x).
+
+Local Definition Applicative__Sum_op_ztzg__
+   : forall {a} {b}, Sum a -> Sum b -> Sum b :=
   fun {a} {b} =>
-    fun a1 a2 => Applicative__Product_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
+    fun a1 a2 => Applicative__Sum_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
 
-Local Definition Applicative__Product_pure : forall {a}, a -> Product a :=
-  fun {a} => Mk_Product.
+Local Definition Applicative__Sum_pure : forall {a}, a -> Sum a :=
+  fun {a} => Mk_Sum.
 
-Program Instance Applicative__Product : GHC.Base.Applicative Product :=
+Program Instance Applicative__Sum : GHC.Base.Applicative Sum :=
   fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Product_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Product_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Product_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__Product_pure |}.
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Sum_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Sum_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Sum_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__Sum_pure |}.
 
-Local Definition Monad__Product_return_ : forall {a}, a -> Product a :=
+Local Definition Monad__Sum_op_zgzgze__
+   : forall {a} {b}, Sum a -> (a -> Sum b) -> Sum b :=
+  fun {a} {b} => fun m k => k (getSum m).
+
+Local Definition Monad__Sum_op_zgzg__
+   : forall {a} {b}, Sum a -> Sum b -> Sum b :=
+  fun {a} {b} => fun m k => Monad__Sum_op_zgzgze__ m (fun arg_0__ => k).
+
+Local Definition Monad__Sum_return_ : forall {a}, a -> Sum a :=
   fun {a} => GHC.Base.pure.
 
-Program Instance Monad__Product : GHC.Base.Monad Product :=
+Program Instance Monad__Sum : GHC.Base.Monad Sum :=
   fun _ k__ =>
-    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Product_op_zgzg__ ;
-           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Product_op_zgzgze__ ;
-           GHC.Base.return___ := fun {a} => Monad__Product_return_ |}.
+    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Sum_op_zgzg__ ;
+           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Sum_op_zgzgze__ ;
+           GHC.Base.return___ := fun {a} => Monad__Sum_return_ |}.
 
 Local Definition Semigroup__Product_op_zlzlzgzg__ {inst_a} `{GHC.Num.Num inst_a}
    : Product inst_a -> Product inst_a -> Product inst_a :=
@@ -1057,11 +981,87 @@ Program Instance Monoid__Product {a} `{GHC.Num.Num a}
            GHC.Base.mconcat__ := Monoid__Product_mconcat ;
            GHC.Base.mempty__ := Monoid__Product_mempty |}.
 
-(* Skipping instance `Data.SemigroupInternal.Monoid__Alt' of class
-   `GHC.Base.Monoid' *)
+Local Definition Functor__Product_fmap
+   : forall {a} {b}, (a -> b) -> Product a -> Product b :=
+  fun {a} {b} => GHC.Prim.coerce.
+
+Local Definition Functor__Product_op_zlzd__
+   : forall {a} {b}, a -> Product b -> Product a :=
+  fun {a} {b} => Functor__Product_fmap GHC.Base.∘ GHC.Base.const.
+
+Program Instance Functor__Product : GHC.Base.Functor Product :=
+  fun _ k__ =>
+    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Product_fmap ;
+           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Product_op_zlzd__ |}.
+
+Local Definition Applicative__Product_op_zlztzg__
+   : forall {a} {b}, Product (a -> b) -> Product a -> Product b :=
+  fun {a} {b} => GHC.Prim.coerce.
+
+Local Definition Applicative__Product_liftA2
+   : forall {a} {b} {c}, (a -> b -> c) -> Product a -> Product b -> Product c :=
+  fun {a} {b} {c} =>
+    fun f x => Applicative__Product_op_zlztzg__ (GHC.Base.fmap f x).
+
+Local Definition Applicative__Product_op_ztzg__
+   : forall {a} {b}, Product a -> Product b -> Product b :=
+  fun {a} {b} =>
+    fun a1 a2 => Applicative__Product_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
+
+Local Definition Applicative__Product_pure : forall {a}, a -> Product a :=
+  fun {a} => Mk_Product.
+
+Program Instance Applicative__Product : GHC.Base.Applicative Product :=
+  fun _ k__ =>
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Product_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Product_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Product_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__Product_pure |}.
+
+Local Definition Monad__Product_op_zgzgze__
+   : forall {a} {b}, Product a -> (a -> Product b) -> Product b :=
+  fun {a} {b} => fun m k => k (getProduct m).
+
+Local Definition Monad__Product_op_zgzg__
+   : forall {a} {b}, Product a -> Product b -> Product b :=
+  fun {a} {b} => fun m k => Monad__Product_op_zgzgze__ m (fun arg_0__ => k).
+
+Local Definition Monad__Product_return_ : forall {a}, a -> Product a :=
+  fun {a} => GHC.Base.pure.
+
+Program Instance Monad__Product : GHC.Base.Monad Product :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Product_op_zgzg__ ;
+           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Product_op_zgzgze__ ;
+           GHC.Base.return___ := fun {a} => Monad__Product_return_ |}.
 
 (* Skipping instance `Data.SemigroupInternal.Semigroup__Alt' of class
    `GHC.Base.Semigroup' *)
+
+(* Skipping instance `Data.SemigroupInternal.Monoid__Alt' of class
+   `GHC.Base.Monoid' *)
+
+(* Skipping definition `Data.SemigroupInternal.stimesIdempotent' *)
+
+Definition stimesIdempotentMonoid {b} {a} `{GHC.Real.Integral b}
+  `{GHC.Base.Monoid a}
+   : b -> a -> a :=
+  fun n x =>
+    match GHC.Base.compare n #0 with
+    | Lt =>
+        GHC.Err.errorWithoutStackTrace (GHC.Base.hs_string__
+                                        "stimesIdempotentMonoid: negative multiplier")
+    | Eq => GHC.Base.mempty
+    | Gt => x
+    end.
+
+(* Skipping definition `Data.SemigroupInternal.stimesMonoid' *)
+
+(* Skipping definition `Data.SemigroupInternal.stimesDefault' *)
+
+(* Skipping definition `Data.SemigroupInternal.stimesMaybe' *)
+
+(* Skipping definition `Data.SemigroupInternal.stimesList' *)
 
 (* External variables:
      Eq Gt Lt Type andb bool comparison false list orb true

--- a/base/Data/Traversable.v
+++ b/base/Data/Traversable.v
@@ -61,32 +61,6 @@ Definition traverse `{g__0__ : Traversable t}
 
 (* Converted value declarations: *)
 
-Definition mapAccumR {t} {a} {b} {c} `{Traversable t}
-   : (a -> b -> (a * c)%type) -> a -> t b -> (a * t c)%type :=
-  fun f s t =>
-    Data.Functor.Utils.runStateR (traverse (Data.Functor.Utils.Mk_StateR GHC.Base.∘
-                                            GHC.Base.flip f) t) s.
-
-Definition mapAccumL {t} {a} {b} {c} `{Traversable t}
-   : (a -> b -> (a * c)%type) -> a -> t b -> (a * t c)%type :=
-  fun f s t =>
-    Data.Functor.Utils.runStateL (traverse (Data.Functor.Utils.Mk_StateL GHC.Base.∘
-                                            GHC.Base.flip f) t) s.
-
-Definition for_ {t} {f} {a} {b} `{Traversable t} `{GHC.Base.Applicative f}
-   : t a -> (a -> f b) -> f (t b) :=
-  GHC.Base.flip traverse.
-
-Definition forM {t} {m} {a} {b} `{Traversable t} `{GHC.Base.Monad m}
-   : t a -> (a -> m b) -> m (t b) :=
-  GHC.Base.flip mapM.
-
-(* Skipping definition `Data.Traversable.foldMapDefault' *)
-
-Definition fmapDefault {t} {a} {b} `{Traversable t} : (a -> b) -> t a -> t b :=
-  GHC.Prim.coerce (traverse : (a -> Data.Functor.Identity.Identity b) ->
-                   t a -> Data.Functor.Identity.Identity (t b)).
-
 (* Skipping instance `Data.Traversable.Traversable__URec__Word' of class
    `Data.Traversable.Traversable' *)
 
@@ -173,312 +147,40 @@ Program Instance Traversable__Identity
            traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
              Traversable__Identity_traverse |}.
 
-(* Skipping instance `Data.Traversable.Traversable__U1' of class
-   `Data.Traversable.Traversable' *)
-
-(* Skipping instance `Data.Traversable.Traversable__ZipList' of class
-   `Data.Traversable.Traversable' *)
-
-(* Skipping instance `Data.Traversable.Traversable__Last' of class
-   `Data.Traversable.Traversable' *)
-
-(* Skipping instance `Data.Traversable.Traversable__First' of class
-   `Data.Traversable.Traversable' *)
-
-Local Definition Traversable__Product_traverse
+Local Definition Traversable__option_traverse
    : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f},
-     (a -> f b) ->
-     Data.SemigroupInternal.Product a -> f (Data.SemigroupInternal.Product b) :=
+     forall `{GHC.Base.Applicative f}, (a -> f b) -> option a -> f (option b) :=
   fun {f} {a} {b} `{GHC.Base.Applicative f} =>
     fun arg_0__ arg_1__ =>
       match arg_0__, arg_1__ with
-      | f, Data.SemigroupInternal.Mk_Product x =>
-          Data.SemigroupInternal.Mk_Product Data.Functor.<$> f x
+      | _, None => GHC.Base.pure None
+      | f, Some x => Some Data.Functor.<$> f x
       end.
 
-Local Definition Traversable__Product_mapM
+Local Definition Traversable__option_mapM
    : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m},
-     (a -> m b) ->
-     Data.SemigroupInternal.Product a -> m (Data.SemigroupInternal.Product b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Product_traverse.
+     forall `{GHC.Base.Monad m}, (a -> m b) -> option a -> m (option b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__option_traverse.
 
-Local Definition Traversable__Product_sequenceA
+Local Definition Traversable__option_sequenceA
    : forall {f} {a},
-     forall `{GHC.Base.Applicative f},
-     Data.SemigroupInternal.Product (f a) -> f (Data.SemigroupInternal.Product a) :=
+     forall `{GHC.Base.Applicative f}, option (f a) -> f (option a) :=
   fun {f} {a} `{GHC.Base.Applicative f} =>
-    Traversable__Product_traverse GHC.Base.id.
+    Traversable__option_traverse GHC.Base.id.
 
-Local Definition Traversable__Product_sequence
-   : forall {m} {a},
-     forall `{GHC.Base.Monad m},
-     Data.SemigroupInternal.Product (m a) -> m (Data.SemigroupInternal.Product a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Product_sequenceA.
+Local Definition Traversable__option_sequence
+   : forall {m} {a}, forall `{GHC.Base.Monad m}, option (m a) -> m (option a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__option_sequenceA.
 
-Program Instance Traversable__Product
-   : Traversable Data.SemigroupInternal.Product :=
+Program Instance Traversable__option : Traversable option :=
   fun _ k__ =>
     k__ {| mapM__ := fun {m} {a} {b} `{GHC.Base.Monad m} =>
-             Traversable__Product_mapM ;
-           sequence__ := fun {m} {a} `{GHC.Base.Monad m} => Traversable__Product_sequence ;
+             Traversable__option_mapM ;
+           sequence__ := fun {m} {a} `{GHC.Base.Monad m} => Traversable__option_sequence ;
            sequenceA__ := fun {f} {a} `{GHC.Base.Applicative f} =>
-             Traversable__Product_sequenceA ;
+             Traversable__option_sequenceA ;
            traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-             Traversable__Product_traverse |}.
-
-Local Definition Traversable__Sum_traverse
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f},
-     (a -> f b) ->
-     Data.SemigroupInternal.Sum a -> f (Data.SemigroupInternal.Sum b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, Data.SemigroupInternal.Mk_Sum x =>
-          Data.SemigroupInternal.Mk_Sum Data.Functor.<$> f x
-      end.
-
-Local Definition Traversable__Sum_mapM
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m},
-     (a -> m b) ->
-     Data.SemigroupInternal.Sum a -> m (Data.SemigroupInternal.Sum b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Sum_traverse.
-
-Local Definition Traversable__Sum_sequenceA
-   : forall {f} {a},
-     forall `{GHC.Base.Applicative f},
-     Data.SemigroupInternal.Sum (f a) -> f (Data.SemigroupInternal.Sum a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} => Traversable__Sum_traverse GHC.Base.id.
-
-Local Definition Traversable__Sum_sequence
-   : forall {m} {a},
-     forall `{GHC.Base.Monad m},
-     Data.SemigroupInternal.Sum (m a) -> m (Data.SemigroupInternal.Sum a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Sum_sequenceA.
-
-Program Instance Traversable__Sum : Traversable Data.SemigroupInternal.Sum :=
-  fun _ k__ =>
-    k__ {| mapM__ := fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Sum_mapM ;
-           sequence__ := fun {m} {a} `{GHC.Base.Monad m} => Traversable__Sum_sequence ;
-           sequenceA__ := fun {f} {a} `{GHC.Base.Applicative f} =>
-             Traversable__Sum_sequenceA ;
-           traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-             Traversable__Sum_traverse |}.
-
-Local Definition Traversable__Dual_traverse
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f},
-     (a -> f b) ->
-     Data.SemigroupInternal.Dual a -> f (Data.SemigroupInternal.Dual b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, Data.SemigroupInternal.Mk_Dual x =>
-          Data.SemigroupInternal.Mk_Dual Data.Functor.<$> f x
-      end.
-
-Local Definition Traversable__Dual_mapM
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m},
-     (a -> m b) ->
-     Data.SemigroupInternal.Dual a -> m (Data.SemigroupInternal.Dual b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Dual_traverse.
-
-Local Definition Traversable__Dual_sequenceA
-   : forall {f} {a},
-     forall `{GHC.Base.Applicative f},
-     Data.SemigroupInternal.Dual (f a) -> f (Data.SemigroupInternal.Dual a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} => Traversable__Dual_traverse GHC.Base.id.
-
-Local Definition Traversable__Dual_sequence
-   : forall {m} {a},
-     forall `{GHC.Base.Monad m},
-     Data.SemigroupInternal.Dual (m a) -> m (Data.SemigroupInternal.Dual a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Dual_sequenceA.
-
-Program Instance Traversable__Dual : Traversable Data.SemigroupInternal.Dual :=
-  fun _ k__ =>
-    k__ {| mapM__ := fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Dual_mapM ;
-           sequence__ := fun {m} {a} `{GHC.Base.Monad m} => Traversable__Dual_sequence ;
-           sequenceA__ := fun {f} {a} `{GHC.Base.Applicative f} =>
-             Traversable__Dual_sequenceA ;
-           traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-             Traversable__Dual_traverse |}.
-
-Local Definition Traversable__Const_traverse {inst_m}
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f},
-     (a -> f b) ->
-     (Data.Functor.Const.Const inst_m) a ->
-     f ((Data.Functor.Const.Const inst_m) b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | _, Data.Functor.Const.Mk_Const m =>
-          GHC.Base.pure (Data.Functor.Const.Mk_Const m)
-      end.
-
-Local Definition Traversable__Const_mapM {inst_m}
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m},
-     (a -> m b) ->
-     (Data.Functor.Const.Const inst_m) a ->
-     m ((Data.Functor.Const.Const inst_m) b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Const_traverse.
-
-Local Definition Traversable__Const_sequenceA {inst_m}
-   : forall {f} {a},
-     forall `{GHC.Base.Applicative f},
-     (Data.Functor.Const.Const inst_m) (f a) ->
-     f ((Data.Functor.Const.Const inst_m) a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} =>
-    Traversable__Const_traverse GHC.Base.id.
-
-Local Definition Traversable__Const_sequence {inst_m}
-   : forall {m} {a},
-     forall `{GHC.Base.Monad m},
-     (Data.Functor.Const.Const inst_m) (m a) ->
-     m ((Data.Functor.Const.Const inst_m) a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Const_sequenceA.
-
-Program Instance Traversable__Const {m}
-   : Traversable (Data.Functor.Const.Const m) :=
-  fun _ k__ =>
-    k__ {| mapM__ := fun {m} {a} {b} `{GHC.Base.Monad m} =>
-             Traversable__Const_mapM ;
-           sequence__ := fun {m} {a} `{GHC.Base.Monad m} => Traversable__Const_sequence ;
-           sequenceA__ := fun {f} {a} `{GHC.Base.Applicative f} =>
-             Traversable__Const_sequenceA ;
-           traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-             Traversable__Const_traverse |}.
-
-Local Definition Traversable__Proxy_mapM
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m},
-     (a -> m b) -> Data.Proxy.Proxy a -> m (Data.Proxy.Proxy b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} =>
-    fun arg_0__ arg_1__ => GHC.Base.pure Data.Proxy.Mk_Proxy.
-
-Local Definition Traversable__Proxy_sequence
-   : forall {m} {a},
-     forall `{GHC.Base.Monad m}, Data.Proxy.Proxy (m a) -> m (Data.Proxy.Proxy a) :=
-  fun {m} {a} `{GHC.Base.Monad m} =>
-    fun arg_0__ => GHC.Base.pure Data.Proxy.Mk_Proxy.
-
-Local Definition Traversable__Proxy_sequenceA
-   : forall {f} {a},
-     forall `{GHC.Base.Applicative f},
-     Data.Proxy.Proxy (f a) -> f (Data.Proxy.Proxy a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} =>
-    fun arg_0__ => GHC.Base.pure Data.Proxy.Mk_Proxy.
-
-Local Definition Traversable__Proxy_traverse
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f},
-     (a -> f b) -> Data.Proxy.Proxy a -> f (Data.Proxy.Proxy b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ => GHC.Base.pure Data.Proxy.Mk_Proxy.
-
-Program Instance Traversable__Proxy : Traversable Data.Proxy.Proxy :=
-  fun _ k__ =>
-    k__ {| mapM__ := fun {m} {a} {b} `{GHC.Base.Monad m} =>
-             Traversable__Proxy_mapM ;
-           sequence__ := fun {m} {a} `{GHC.Base.Monad m} => Traversable__Proxy_sequence ;
-           sequenceA__ := fun {f} {a} `{GHC.Base.Applicative f} =>
-             Traversable__Proxy_sequenceA ;
-           traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-             Traversable__Proxy_traverse |}.
-
-(* Skipping instance `Data.Traversable.Traversable__Array' of class
-   `Data.Traversable.Traversable' *)
-
-Local Definition Traversable__pair_type_traverse {inst_a}
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f},
-     (a -> f b) ->
-     (GHC.Tuple.pair_type inst_a) a -> f ((GHC.Tuple.pair_type inst_a) b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, pair x y => GHC.Tuple.pair2 x Data.Functor.<$> f y
-      end.
-
-Local Definition Traversable__pair_type_mapM {inst_a}
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m},
-     (a -> m b) ->
-     (GHC.Tuple.pair_type inst_a) a -> m ((GHC.Tuple.pair_type inst_a) b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__pair_type_traverse.
-
-Local Definition Traversable__pair_type_sequenceA {inst_a}
-   : forall {f} {a},
-     forall `{GHC.Base.Applicative f},
-     (GHC.Tuple.pair_type inst_a) (f a) -> f ((GHC.Tuple.pair_type inst_a) a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} =>
-    Traversable__pair_type_traverse GHC.Base.id.
-
-Local Definition Traversable__pair_type_sequence {inst_a}
-   : forall {m} {a},
-     forall `{GHC.Base.Monad m},
-     (GHC.Tuple.pair_type inst_a) (m a) -> m ((GHC.Tuple.pair_type inst_a) a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__pair_type_sequenceA.
-
-Program Instance Traversable__pair_type {a}
-   : Traversable (GHC.Tuple.pair_type a) :=
-  fun _ k__ =>
-    k__ {| mapM__ := fun {m} {a} {b} `{GHC.Base.Monad m} =>
-             Traversable__pair_type_mapM ;
-           sequence__ := fun {m} {a} `{GHC.Base.Monad m} =>
-             Traversable__pair_type_sequence ;
-           sequenceA__ := fun {f} {a} `{GHC.Base.Applicative f} =>
-             Traversable__pair_type_sequenceA ;
-           traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-             Traversable__pair_type_traverse |}.
-
-Local Definition Traversable__Either_traverse {inst_a}
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f},
-     (a -> f b) ->
-     (Data.Either.Either inst_a) a -> f ((Data.Either.Either inst_a) b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | _, Data.Either.Left x => GHC.Base.pure (Data.Either.Left x)
-      | f, Data.Either.Right y => Data.Either.Right Data.Functor.<$> f y
-      end.
-
-Local Definition Traversable__Either_mapM {inst_a}
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m},
-     (a -> m b) ->
-     (Data.Either.Either inst_a) a -> m ((Data.Either.Either inst_a) b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Either_traverse.
-
-Local Definition Traversable__Either_sequenceA {inst_a}
-   : forall {f} {a},
-     forall `{GHC.Base.Applicative f},
-     (Data.Either.Either inst_a) (f a) -> f ((Data.Either.Either inst_a) a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} =>
-    Traversable__Either_traverse GHC.Base.id.
-
-Local Definition Traversable__Either_sequence {inst_a}
-   : forall {m} {a},
-     forall `{GHC.Base.Monad m},
-     (Data.Either.Either inst_a) (m a) -> m ((Data.Either.Either inst_a) a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Either_sequenceA.
-
-Program Instance Traversable__Either {a} : Traversable (Data.Either.Either a) :=
-  fun _ k__ =>
-    k__ {| mapM__ := fun {m} {a} {b} `{GHC.Base.Monad m} =>
-             Traversable__Either_mapM ;
-           sequence__ := fun {m} {a} `{GHC.Base.Monad m} => Traversable__Either_sequence ;
-           sequenceA__ := fun {f} {a} `{GHC.Base.Applicative f} =>
-             Traversable__Either_sequenceA ;
-           traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-             Traversable__Either_traverse |}.
+             Traversable__option_traverse |}.
 
 Local Definition Traversable__list_traverse
    : forall {f} {a} {b},
@@ -551,40 +253,338 @@ Program Instance Traversable__NonEmpty : Traversable GHC.Base.NonEmpty :=
            traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
              Traversable__NonEmpty_traverse |}.
 
-Local Definition Traversable__option_traverse
+Local Definition Traversable__Either_traverse {inst_a}
    : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f}, (a -> f b) -> option a -> f (option b) :=
+     forall `{GHC.Base.Applicative f},
+     (a -> f b) ->
+     (Data.Either.Either inst_a) a -> f ((Data.Either.Either inst_a) b) :=
   fun {f} {a} {b} `{GHC.Base.Applicative f} =>
     fun arg_0__ arg_1__ =>
       match arg_0__, arg_1__ with
-      | _, None => GHC.Base.pure None
-      | f, Some x => Some Data.Functor.<$> f x
+      | _, Data.Either.Left x => GHC.Base.pure (Data.Either.Left x)
+      | f, Data.Either.Right y => Data.Either.Right Data.Functor.<$> f y
       end.
 
-Local Definition Traversable__option_mapM
+Local Definition Traversable__Either_mapM {inst_a}
    : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m}, (a -> m b) -> option a -> m (option b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__option_traverse.
+     forall `{GHC.Base.Monad m},
+     (a -> m b) ->
+     (Data.Either.Either inst_a) a -> m ((Data.Either.Either inst_a) b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Either_traverse.
 
-Local Definition Traversable__option_sequenceA
+Local Definition Traversable__Either_sequenceA {inst_a}
    : forall {f} {a},
-     forall `{GHC.Base.Applicative f}, option (f a) -> f (option a) :=
+     forall `{GHC.Base.Applicative f},
+     (Data.Either.Either inst_a) (f a) -> f ((Data.Either.Either inst_a) a) :=
   fun {f} {a} `{GHC.Base.Applicative f} =>
-    Traversable__option_traverse GHC.Base.id.
+    Traversable__Either_traverse GHC.Base.id.
 
-Local Definition Traversable__option_sequence
-   : forall {m} {a}, forall `{GHC.Base.Monad m}, option (m a) -> m (option a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__option_sequenceA.
+Local Definition Traversable__Either_sequence {inst_a}
+   : forall {m} {a},
+     forall `{GHC.Base.Monad m},
+     (Data.Either.Either inst_a) (m a) -> m ((Data.Either.Either inst_a) a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Either_sequenceA.
 
-Program Instance Traversable__option : Traversable option :=
+Program Instance Traversable__Either {a} : Traversable (Data.Either.Either a) :=
   fun _ k__ =>
     k__ {| mapM__ := fun {m} {a} {b} `{GHC.Base.Monad m} =>
-             Traversable__option_mapM ;
-           sequence__ := fun {m} {a} `{GHC.Base.Monad m} => Traversable__option_sequence ;
+             Traversable__Either_mapM ;
+           sequence__ := fun {m} {a} `{GHC.Base.Monad m} => Traversable__Either_sequence ;
            sequenceA__ := fun {f} {a} `{GHC.Base.Applicative f} =>
-             Traversable__option_sequenceA ;
+             Traversable__Either_sequenceA ;
            traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-             Traversable__option_traverse |}.
+             Traversable__Either_traverse |}.
+
+Local Definition Traversable__pair_type_traverse {inst_a}
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f},
+     (a -> f b) ->
+     (GHC.Tuple.pair_type inst_a) a -> f ((GHC.Tuple.pair_type inst_a) b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, pair x y => GHC.Tuple.pair2 x Data.Functor.<$> f y
+      end.
+
+Local Definition Traversable__pair_type_mapM {inst_a}
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m},
+     (a -> m b) ->
+     (GHC.Tuple.pair_type inst_a) a -> m ((GHC.Tuple.pair_type inst_a) b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__pair_type_traverse.
+
+Local Definition Traversable__pair_type_sequenceA {inst_a}
+   : forall {f} {a},
+     forall `{GHC.Base.Applicative f},
+     (GHC.Tuple.pair_type inst_a) (f a) -> f ((GHC.Tuple.pair_type inst_a) a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} =>
+    Traversable__pair_type_traverse GHC.Base.id.
+
+Local Definition Traversable__pair_type_sequence {inst_a}
+   : forall {m} {a},
+     forall `{GHC.Base.Monad m},
+     (GHC.Tuple.pair_type inst_a) (m a) -> m ((GHC.Tuple.pair_type inst_a) a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__pair_type_sequenceA.
+
+Program Instance Traversable__pair_type {a}
+   : Traversable (GHC.Tuple.pair_type a) :=
+  fun _ k__ =>
+    k__ {| mapM__ := fun {m} {a} {b} `{GHC.Base.Monad m} =>
+             Traversable__pair_type_mapM ;
+           sequence__ := fun {m} {a} `{GHC.Base.Monad m} =>
+             Traversable__pair_type_sequence ;
+           sequenceA__ := fun {f} {a} `{GHC.Base.Applicative f} =>
+             Traversable__pair_type_sequenceA ;
+           traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+             Traversable__pair_type_traverse |}.
+
+(* Skipping instance `Data.Traversable.Traversable__Array' of class
+   `Data.Traversable.Traversable' *)
+
+Local Definition Traversable__Proxy_mapM
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m},
+     (a -> m b) -> Data.Proxy.Proxy a -> m (Data.Proxy.Proxy b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} =>
+    fun arg_0__ arg_1__ => GHC.Base.pure Data.Proxy.Mk_Proxy.
+
+Local Definition Traversable__Proxy_sequence
+   : forall {m} {a},
+     forall `{GHC.Base.Monad m}, Data.Proxy.Proxy (m a) -> m (Data.Proxy.Proxy a) :=
+  fun {m} {a} `{GHC.Base.Monad m} =>
+    fun arg_0__ => GHC.Base.pure Data.Proxy.Mk_Proxy.
+
+Local Definition Traversable__Proxy_sequenceA
+   : forall {f} {a},
+     forall `{GHC.Base.Applicative f},
+     Data.Proxy.Proxy (f a) -> f (Data.Proxy.Proxy a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} =>
+    fun arg_0__ => GHC.Base.pure Data.Proxy.Mk_Proxy.
+
+Local Definition Traversable__Proxy_traverse
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f},
+     (a -> f b) -> Data.Proxy.Proxy a -> f (Data.Proxy.Proxy b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+    fun arg_0__ arg_1__ => GHC.Base.pure Data.Proxy.Mk_Proxy.
+
+Program Instance Traversable__Proxy : Traversable Data.Proxy.Proxy :=
+  fun _ k__ =>
+    k__ {| mapM__ := fun {m} {a} {b} `{GHC.Base.Monad m} =>
+             Traversable__Proxy_mapM ;
+           sequence__ := fun {m} {a} `{GHC.Base.Monad m} => Traversable__Proxy_sequence ;
+           sequenceA__ := fun {f} {a} `{GHC.Base.Applicative f} =>
+             Traversable__Proxy_sequenceA ;
+           traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+             Traversable__Proxy_traverse |}.
+
+Local Definition Traversable__Const_traverse {inst_m}
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f},
+     (a -> f b) ->
+     (Data.Functor.Const.Const inst_m) a ->
+     f ((Data.Functor.Const.Const inst_m) b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | _, Data.Functor.Const.Mk_Const m =>
+          GHC.Base.pure (Data.Functor.Const.Mk_Const m)
+      end.
+
+Local Definition Traversable__Const_mapM {inst_m}
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m},
+     (a -> m b) ->
+     (Data.Functor.Const.Const inst_m) a ->
+     m ((Data.Functor.Const.Const inst_m) b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Const_traverse.
+
+Local Definition Traversable__Const_sequenceA {inst_m}
+   : forall {f} {a},
+     forall `{GHC.Base.Applicative f},
+     (Data.Functor.Const.Const inst_m) (f a) ->
+     f ((Data.Functor.Const.Const inst_m) a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} =>
+    Traversable__Const_traverse GHC.Base.id.
+
+Local Definition Traversable__Const_sequence {inst_m}
+   : forall {m} {a},
+     forall `{GHC.Base.Monad m},
+     (Data.Functor.Const.Const inst_m) (m a) ->
+     m ((Data.Functor.Const.Const inst_m) a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Const_sequenceA.
+
+Program Instance Traversable__Const {m}
+   : Traversable (Data.Functor.Const.Const m) :=
+  fun _ k__ =>
+    k__ {| mapM__ := fun {m} {a} {b} `{GHC.Base.Monad m} =>
+             Traversable__Const_mapM ;
+           sequence__ := fun {m} {a} `{GHC.Base.Monad m} => Traversable__Const_sequence ;
+           sequenceA__ := fun {f} {a} `{GHC.Base.Applicative f} =>
+             Traversable__Const_sequenceA ;
+           traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+             Traversable__Const_traverse |}.
+
+Local Definition Traversable__Dual_traverse
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f},
+     (a -> f b) ->
+     Data.SemigroupInternal.Dual a -> f (Data.SemigroupInternal.Dual b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, Data.SemigroupInternal.Mk_Dual x =>
+          Data.SemigroupInternal.Mk_Dual Data.Functor.<$> f x
+      end.
+
+Local Definition Traversable__Dual_mapM
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m},
+     (a -> m b) ->
+     Data.SemigroupInternal.Dual a -> m (Data.SemigroupInternal.Dual b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Dual_traverse.
+
+Local Definition Traversable__Dual_sequenceA
+   : forall {f} {a},
+     forall `{GHC.Base.Applicative f},
+     Data.SemigroupInternal.Dual (f a) -> f (Data.SemigroupInternal.Dual a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} => Traversable__Dual_traverse GHC.Base.id.
+
+Local Definition Traversable__Dual_sequence
+   : forall {m} {a},
+     forall `{GHC.Base.Monad m},
+     Data.SemigroupInternal.Dual (m a) -> m (Data.SemigroupInternal.Dual a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Dual_sequenceA.
+
+Program Instance Traversable__Dual : Traversable Data.SemigroupInternal.Dual :=
+  fun _ k__ =>
+    k__ {| mapM__ := fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Dual_mapM ;
+           sequence__ := fun {m} {a} `{GHC.Base.Monad m} => Traversable__Dual_sequence ;
+           sequenceA__ := fun {f} {a} `{GHC.Base.Applicative f} =>
+             Traversable__Dual_sequenceA ;
+           traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+             Traversable__Dual_traverse |}.
+
+Local Definition Traversable__Sum_traverse
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f},
+     (a -> f b) ->
+     Data.SemigroupInternal.Sum a -> f (Data.SemigroupInternal.Sum b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, Data.SemigroupInternal.Mk_Sum x =>
+          Data.SemigroupInternal.Mk_Sum Data.Functor.<$> f x
+      end.
+
+Local Definition Traversable__Sum_mapM
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m},
+     (a -> m b) ->
+     Data.SemigroupInternal.Sum a -> m (Data.SemigroupInternal.Sum b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Sum_traverse.
+
+Local Definition Traversable__Sum_sequenceA
+   : forall {f} {a},
+     forall `{GHC.Base.Applicative f},
+     Data.SemigroupInternal.Sum (f a) -> f (Data.SemigroupInternal.Sum a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} => Traversable__Sum_traverse GHC.Base.id.
+
+Local Definition Traversable__Sum_sequence
+   : forall {m} {a},
+     forall `{GHC.Base.Monad m},
+     Data.SemigroupInternal.Sum (m a) -> m (Data.SemigroupInternal.Sum a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Sum_sequenceA.
+
+Program Instance Traversable__Sum : Traversable Data.SemigroupInternal.Sum :=
+  fun _ k__ =>
+    k__ {| mapM__ := fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Sum_mapM ;
+           sequence__ := fun {m} {a} `{GHC.Base.Monad m} => Traversable__Sum_sequence ;
+           sequenceA__ := fun {f} {a} `{GHC.Base.Applicative f} =>
+             Traversable__Sum_sequenceA ;
+           traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+             Traversable__Sum_traverse |}.
+
+Local Definition Traversable__Product_traverse
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f},
+     (a -> f b) ->
+     Data.SemigroupInternal.Product a -> f (Data.SemigroupInternal.Product b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, Data.SemigroupInternal.Mk_Product x =>
+          Data.SemigroupInternal.Mk_Product Data.Functor.<$> f x
+      end.
+
+Local Definition Traversable__Product_mapM
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m},
+     (a -> m b) ->
+     Data.SemigroupInternal.Product a -> m (Data.SemigroupInternal.Product b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Product_traverse.
+
+Local Definition Traversable__Product_sequenceA
+   : forall {f} {a},
+     forall `{GHC.Base.Applicative f},
+     Data.SemigroupInternal.Product (f a) -> f (Data.SemigroupInternal.Product a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} =>
+    Traversable__Product_traverse GHC.Base.id.
+
+Local Definition Traversable__Product_sequence
+   : forall {m} {a},
+     forall `{GHC.Base.Monad m},
+     Data.SemigroupInternal.Product (m a) -> m (Data.SemigroupInternal.Product a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Product_sequenceA.
+
+Program Instance Traversable__Product
+   : Traversable Data.SemigroupInternal.Product :=
+  fun _ k__ =>
+    k__ {| mapM__ := fun {m} {a} {b} `{GHC.Base.Monad m} =>
+             Traversable__Product_mapM ;
+           sequence__ := fun {m} {a} `{GHC.Base.Monad m} => Traversable__Product_sequence ;
+           sequenceA__ := fun {f} {a} `{GHC.Base.Applicative f} =>
+             Traversable__Product_sequenceA ;
+           traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+             Traversable__Product_traverse |}.
+
+(* Skipping instance `Data.Traversable.Traversable__First' of class
+   `Data.Traversable.Traversable' *)
+
+(* Skipping instance `Data.Traversable.Traversable__Last' of class
+   `Data.Traversable.Traversable' *)
+
+(* Skipping instance `Data.Traversable.Traversable__ZipList' of class
+   `Data.Traversable.Traversable' *)
+
+(* Skipping instance `Data.Traversable.Traversable__U1' of class
+   `Data.Traversable.Traversable' *)
+
+Definition for_ {t} {f} {a} {b} `{Traversable t} `{GHC.Base.Applicative f}
+   : t a -> (a -> f b) -> f (t b) :=
+  GHC.Base.flip traverse.
+
+Definition forM {t} {m} {a} {b} `{Traversable t} `{GHC.Base.Monad m}
+   : t a -> (a -> m b) -> m (t b) :=
+  GHC.Base.flip mapM.
+
+Definition mapAccumL {t} {a} {b} {c} `{Traversable t}
+   : (a -> b -> (a * c)%type) -> a -> t b -> (a * t c)%type :=
+  fun f s t =>
+    Data.Functor.Utils.runStateL (traverse (Data.Functor.Utils.Mk_StateL GHC.Base.∘
+                                            GHC.Base.flip f) t) s.
+
+Definition mapAccumR {t} {a} {b} {c} `{Traversable t}
+   : (a -> b -> (a * c)%type) -> a -> t b -> (a * t c)%type :=
+  fun f s t =>
+    Data.Functor.Utils.runStateR (traverse (Data.Functor.Utils.Mk_StateR GHC.Base.∘
+                                            GHC.Base.flip f) t) s.
+
+Definition fmapDefault {t} {a} {b} `{Traversable t} : (a -> b) -> t a -> t b :=
+  GHC.Prim.coerce (traverse : (a -> Data.Functor.Identity.Identity b) ->
+                   t a -> Data.Functor.Identity.Identity (t b)).
+
+(* Skipping definition `Data.Traversable.foldMapDefault' *)
 
 (* External variables:
      None Some cons list nil op_zt__ option pair Data.Either.Either Data.Either.Left

--- a/base/Data/Tuple.v
+++ b/base/Data/Tuple.v
@@ -19,20 +19,20 @@ Require Coq.Program.Wf.
 
 (* Converted value declarations: *)
 
-Definition swap {a} {b} : (a * b)%type -> (b * a)%type :=
-  fun '(pair a b) => pair b a.
+Definition fst {a} {b} : (a * b)%type -> a :=
+  fun '(pair x _) => x.
 
 Definition snd {a} {b} : (a * b)%type -> b :=
   fun '(pair _ y) => y.
 
-Definition fst {a} {b} : (a * b)%type -> a :=
-  fun '(pair x _) => x.
+Definition curry {a} {b} {c} : ((a * b)%type -> c) -> a -> b -> c :=
+  fun f x y => f (pair x y).
 
 Definition uncurry {a} {b} {c} : (a -> b -> c) -> ((a * b)%type -> c) :=
   fun f p => f (fst p) (snd p).
 
-Definition curry {a} {b} {c} : ((a * b)%type -> c) -> a -> b -> c :=
-  fun f x y => f (pair x y).
+Definition swap {a} {b} : (a * b)%type -> (b * a)%type :=
+  fun '(pair a b) => pair b a.
 
 (* External variables:
      op_zt__ pair

--- a/base/Data/Void.v
+++ b/base/Data/Void.v
@@ -21,12 +21,6 @@ Inductive Void : Type :=.
 
 (* Converted value declarations: *)
 
-Definition absurd {a} : Void -> a :=
-  fun a => match a with end.
-
-Definition vacuous {f} {a} `{GHC.Base.Functor f} : f Void -> f a :=
-  GHC.Base.fmap absurd.
-
 Local Definition Eq___Void_op_zeze__ : Void -> Void -> bool :=
   fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | _, z => true end.
 
@@ -81,6 +75,12 @@ Program Instance Ord__Void : GHC.Base.Ord Void :=
 (* Skipping all instances of class `GHC.Show.Show', including
    `Data.Void.Show__Void' *)
 
+(* Skipping all instances of class `GHC.Arr.Ix', including
+   `Data.Void.Ix__Void' *)
+
+(* Skipping all instances of class `GHC.Exception.Exception', including
+   `Data.Void.Exception__Void' *)
+
 Local Definition Semigroup__Void_op_zlzlzgzg__ : Void -> Void -> Void :=
   fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | a, _ => a end.
 
@@ -88,11 +88,11 @@ Program Instance Semigroup__Void : GHC.Base.Semigroup Void :=
   fun _ k__ =>
     k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__Void_op_zlzlzgzg__ |}.
 
-(* Skipping all instances of class `GHC.Exception.Exception', including
-   `Data.Void.Exception__Void' *)
+Definition absurd {a} : Void -> a :=
+  fun a => match a with end.
 
-(* Skipping all instances of class `GHC.Arr.Ix', including
-   `Data.Void.Ix__Void' *)
+Definition vacuous {f} {a} `{GHC.Base.Functor f} : f Void -> f a :=
+  GHC.Base.fmap absurd.
 
 (* External variables:
      Eq Gt Lt bool comparison negb true GHC.Base.Eq_ GHC.Base.Functor GHC.Base.Ord

--- a/base/GHC/Base.v
+++ b/base/GHC/Base.v
@@ -553,194 +553,6 @@ End ManualNotations.
 
 (* Converted value declarations: *)
 
-Definition when {f} `{(Applicative f)} : bool -> f unit -> f unit :=
-  fun p s => if p : bool then s else pure tt.
-
-(* Skipping definition `GHC.Base.until' *)
-
-(* Skipping definition `GHC.Base.unsafeChr' *)
-
-(* Skipping definition `GHC.Base.unIO' *)
-
-(* Skipping definition `GHC.Base.thenIO' *)
-
-(* Skipping definition `GHC.Base.returnIO' *)
-
-(* Skipping definition `GHC.Base.remInt' *)
-
-(* Skipping definition `GHC.Base.quotRemInt' *)
-
-(* Skipping definition `GHC.Base.quotInt' *)
-
-Definition otherwise : bool :=
-  true.
-
-(* Skipping definition `GHC.Base.ord' *)
-
-Definition op_zlztztzg__ {f} {a} {b} `{Applicative f}
-   : f a -> f (a -> b) -> f b :=
-  liftA2 (fun a f => f a).
-
-Notation "'_<**>_'" := (op_zlztztzg__).
-
-Infix "<**>" := (_<**>_) (at level 99).
-
-Definition op_zezlzl__ {m} {a} {b} `{Monad m} : (a -> m b) -> m a -> m b :=
-  fun f x => x >>= f.
-
-Notation "'_=<<_'" := (op_zezlzl__).
-
-Infix "=<<" := (_=<<_) (at level 99).
-
-Definition op_zdzn__ {a} {b} : (a -> b) -> a -> b :=
-  fun f x => let vx := x in f vx.
-
-Notation "'_$!_'" := (op_zdzn__).
-
-Infix "$!" := (_$!_) (at level 99).
-
-Definition op_zd__ {a} {b} : (a -> b) -> a -> b :=
-  fun f x => f x.
-
-Notation "'_$_'" := (op_zd__).
-
-Infix "$" := (_$_) (at level 99).
-
-Definition op_z2218U__ {b} {c} {a} : (b -> c) -> (a -> b) -> a -> c :=
-  fun f g => fun x => f (g x).
-
-Notation "'_∘_'" := (op_z2218U__).
-
-Infix "∘" := (_∘_) (left associativity, at level 40).
-
-(* Skipping definition `GHC.Base.op_shiftRLzh__' *)
-
-(* Skipping definition `GHC.Base.op_shiftLzh__' *)
-
-(* Skipping definition `GHC.Base.op_iShiftRLzh__' *)
-
-(* Skipping definition `GHC.Base.op_iShiftRAzh__' *)
-
-(* Skipping definition `GHC.Base.op_iShiftLzh__' *)
-
-(* Skipping definition `GHC.Base.op_divModIntzh__' *)
-
-(* Skipping definition `GHC.Base.modInt' *)
-
-(* Skipping definition `GHC.Base.minInt' *)
-
-(* Skipping definition `GHC.Base.maxInt' *)
-
-Definition mapFB {elt} {lst} {a}
-   : (elt -> lst -> lst) -> (a -> elt) -> a -> lst -> lst :=
-  fun c f => fun x ys => c (f x) ys.
-
-Definition map {A B : Type} (f : A -> B) xs :=
-  Coq.Lists.List.map f xs.
-
-Definition liftM5 {m} {a1} {a2} {a3} {a4} {a5} {r} `{(Monad m)}
-   : (a1 -> a2 -> a3 -> a4 -> a5 -> r) ->
-     m a1 -> m a2 -> m a3 -> m a4 -> m a5 -> m r :=
-  fun f m1 m2 m3 m4 m5 =>
-    m1 >>=
-    (fun x1 =>
-       m2 >>=
-       (fun x2 =>
-          m3 >>=
-          (fun x3 => m4 >>= (fun x4 => m5 >>= (fun x5 => return_ (f x1 x2 x3 x4 x5)))))).
-
-Definition liftM4 {m} {a1} {a2} {a3} {a4} {r} `{(Monad m)}
-   : (a1 -> a2 -> a3 -> a4 -> r) -> m a1 -> m a2 -> m a3 -> m a4 -> m r :=
-  fun f m1 m2 m3 m4 =>
-    m1 >>=
-    (fun x1 =>
-       m2 >>=
-       (fun x2 => m3 >>= (fun x3 => m4 >>= (fun x4 => return_ (f x1 x2 x3 x4))))).
-
-Definition liftM3 {m} {a1} {a2} {a3} {r} `{(Monad m)}
-   : (a1 -> a2 -> a3 -> r) -> m a1 -> m a2 -> m a3 -> m r :=
-  fun f m1 m2 m3 =>
-    m1 >>= (fun x1 => m2 >>= (fun x2 => m3 >>= (fun x3 => return_ (f x1 x2 x3)))).
-
-Definition liftM2 {m} {a1} {a2} {r} `{(Monad m)}
-   : (a1 -> a2 -> r) -> m a1 -> m a2 -> m r :=
-  fun f m1 m2 => m1 >>= (fun x1 => m2 >>= (fun x2 => return_ (f x1 x2))).
-
-Definition liftM {m} {a1} {r} `{(Monad m)} : (a1 -> r) -> m a1 -> m r :=
-  fun f m1 => m1 >>= (fun x1 => return_ (f x1)).
-
-Definition liftA3 {f} {a} {b} {c} {d} `{Applicative f}
-   : (a -> b -> c -> d) -> f a -> f b -> f c -> f d :=
-  fun f a b c => liftA2 f a b <*> c.
-
-Definition liftA {f} {a} {b} `{Applicative f} : (a -> b) -> f a -> f b :=
-  fun f a => pure f <*> a.
-
-Definition id {a} : a -> a :=
-  fun x => x.
-
-Definition join {m} {a} `{(Monad m)} : m (m a) -> m a :=
-  fun x => x >>= id.
-
-(* Skipping definition `GHC.Base.getTag' *)
-
-Definition foldr {a} {b} : (a -> b -> b) -> b -> list a -> b :=
-  fun k z =>
-    let fix go arg_0__
-              := match arg_0__ with
-                 | nil => z
-                 | cons y ys => k y (go ys)
-                 end in
-    go.
-
-Definition mapM {m} {a} {b} `{Monad m} : (a -> m b) -> list a -> m (list b) :=
-  fun f as_ =>
-    let k := fun a r => f a >>= (fun x => r >>= (fun xs => return_ (cons x xs))) in
-    foldr k (return_ nil) as_.
-
-Definition sequence {m} {a} `{Monad m} : list (m a) -> m (list a) :=
-  mapM id.
-
-Definition flip {a} {b} {c} : (a -> b -> c) -> b -> a -> c :=
-  fun f x y => f y x.
-
-Fixpoint eqString (arg_0__ arg_1__ : String) : bool
-           := match arg_0__, arg_1__ with
-              | nil, nil => true
-              | cons c1 cs1, cons c2 cs2 => andb (c1 == c2) (eqString cs1 cs2)
-              | _, _ => false
-              end.
-
-(* Skipping definition `GHC.Base.divModInt' *)
-
-(* Skipping definition `GHC.Base.divInt' *)
-
-Definition const {a} {b} : a -> b -> a :=
-  fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | x, _ => x end.
-
-(* Skipping definition `GHC.Base.build' *)
-
-Definition breakpointCond {a} : bool -> a -> a :=
-  fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | _, r => r end.
-
-Definition breakpoint {a} : a -> a :=
-  fun r => r.
-
-(* Skipping definition `GHC.Base.bindIO' *)
-
-(* Skipping definition `GHC.Base.augment' *)
-
-Definition assert {a} : bool -> a -> a :=
-  fun _pred r => r.
-
-Definition asTypeOf {a} : a -> a -> a :=
-  const.
-
-Definition ap {m} {a} {b} `{(Monad m)} : m (a -> b) -> m a -> m b :=
-  fun m1 m2 => m1 >>= (fun x1 => m2 >>= (fun x2 => return_ (x1 x2))).
-
-(* Skipping definition `Coq.Init.Datatypes.app' *)
-
 Local Definition Eq___option_op_zeze__ {inst_a} `{Eq_ inst_a}
    : option inst_a -> option inst_a -> bool :=
   fun arg_0__ arg_1__ =>
@@ -823,18 +635,348 @@ Program Instance Eq___NonEmpty {a} `{Eq_ a} : Eq_ (NonEmpty a) :=
 
 (* Skipping instance `GHC.Base.Ord__NonEmpty' of class `GHC.Base.Ord' *)
 
-Local Definition Functor__list_fmap
-   : forall {a} {b}, (a -> b) -> list a -> list b :=
-  fun {a} {b} => map.
+Local Definition Semigroup__list_op_zlzlzgzg__ {inst_a}
+   : list inst_a -> list inst_a -> list inst_a :=
+  Coq.Init.Datatypes.app.
 
-Local Definition Functor__list_op_zlzd__
-   : forall {a} {b}, a -> list b -> list a :=
-  fun {a} {b} => Functor__list_fmap ∘ const.
+Program Instance Semigroup__list {a} : Semigroup (list a) :=
+  fun _ k__ => k__ {| op_zlzlzgzg____ := Semigroup__list_op_zlzlzgzg__ |}.
 
-Program Instance Functor__list : Functor list :=
+Local Definition Monoid__list_mappend {inst_a}
+   : list inst_a -> list inst_a -> list inst_a :=
+  _<<>>_.
+
+Local Definition Monoid__list_mconcat {inst_a}
+   : list (list inst_a) -> list inst_a :=
+  fun xss =>
+    Coq.Lists.List.flat_map (fun xs =>
+                               Coq.Lists.List.flat_map (fun x => cons x nil) xs) xss.
+
+Local Definition Monoid__list_mempty {inst_a} : list inst_a :=
+  nil.
+
+Program Instance Monoid__list {a} : Monoid (list a) :=
   fun _ k__ =>
-    k__ {| fmap__ := fun {a} {b} => Functor__list_fmap ;
-           op_zlzd____ := fun {a} {b} => Functor__list_op_zlzd__ |}.
+    k__ {| mappend__ := Monoid__list_mappend ;
+           mconcat__ := Monoid__list_mconcat ;
+           mempty__ := Monoid__list_mempty |}.
+
+Local Definition Semigroup__NonEmpty_op_zlzlzgzg__ {inst_a}
+   : (NonEmpty inst_a) -> (NonEmpty inst_a) -> (NonEmpty inst_a) :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | NEcons a as_, NEcons b bs => NEcons a (Coq.Init.Datatypes.app as_ (cons b bs))
+    end.
+
+Program Instance Semigroup__NonEmpty {a} : Semigroup (NonEmpty a) :=
+  fun _ k__ => k__ {| op_zlzlzgzg____ := Semigroup__NonEmpty_op_zlzlzgzg__ |}.
+
+Local Definition Semigroup__arrow_op_zlzlzgzg__ {inst_b} {inst_a} `{Semigroup
+  inst_b}
+   : (inst_a -> inst_b) -> (inst_a -> inst_b) -> (inst_a -> inst_b) :=
+  fun f g => fun x => f x <<>> g x.
+
+Program Instance Semigroup__arrow {b} {a} `{Semigroup b} : Semigroup (a -> b) :=
+  fun _ k__ => k__ {| op_zlzlzgzg____ := Semigroup__arrow_op_zlzlzgzg__ |}.
+
+Local Definition Monoid__arrow_mappend {inst_b} {inst_a} `{Monoid inst_b}
+   : (inst_a -> inst_b) -> (inst_a -> inst_b) -> (inst_a -> inst_b) :=
+  _<<>>_.
+
+Local Definition Monoid__arrow_mempty {inst_b} {inst_a} `{Monoid inst_b}
+   : (inst_a -> inst_b) :=
+  fun arg_0__ => mempty.
+
+Definition foldr {a} {b} : (a -> b -> b) -> b -> list a -> b :=
+  fun k z =>
+    let fix go arg_0__
+              := match arg_0__ with
+                 | nil => z
+                 | cons y ys => k y (go ys)
+                 end in
+    go.
+
+Local Definition Monoid__arrow_mconcat {inst_b} {inst_a} `{Monoid inst_b}
+   : list (inst_a -> inst_b) -> (inst_a -> inst_b) :=
+  foldr Monoid__arrow_mappend Monoid__arrow_mempty.
+
+Program Instance Monoid__arrow {b} {a} `{Monoid b} : Monoid (a -> b) :=
+  fun _ k__ =>
+    k__ {| mappend__ := Monoid__arrow_mappend ;
+           mconcat__ := Monoid__arrow_mconcat ;
+           mempty__ := Monoid__arrow_mempty |}.
+
+Local Definition Semigroup__unit_op_zlzlzgzg__ : unit -> unit -> unit :=
+  fun arg_0__ arg_1__ => tt.
+
+Program Instance Semigroup__unit : Semigroup unit :=
+  fun _ k__ => k__ {| op_zlzlzgzg____ := Semigroup__unit_op_zlzlzgzg__ |}.
+
+Local Definition Monoid__unit_mappend : unit -> unit -> unit :=
+  _<<>>_.
+
+Local Definition Monoid__unit_mconcat : list unit -> unit :=
+  fun arg_0__ => tt.
+
+Local Definition Monoid__unit_mempty : unit :=
+  tt.
+
+Program Instance Monoid__unit : Monoid unit :=
+  fun _ k__ =>
+    k__ {| mappend__ := Monoid__unit_mappend ;
+           mconcat__ := Monoid__unit_mconcat ;
+           mempty__ := Monoid__unit_mempty |}.
+
+(* Skipping instance `GHC.Base.Semigroup__op_zt__' of class
+   `GHC.Base.Semigroup' *)
+
+(* Skipping instance `GHC.Base.Monoid__op_zt__' of class `GHC.Base.Monoid' *)
+
+(* Skipping instance `GHC.Base.Semigroup__op_zt____op_zt__' of class
+   `GHC.Base.Semigroup' *)
+
+(* Skipping instance `GHC.Base.Monoid__op_zt____op_zt__' of class
+   `GHC.Base.Monoid' *)
+
+(* Skipping instance `GHC.Base.Semigroup__op_zt____op_zt____op_zt____23' of
+   class `GHC.Base.Semigroup' *)
+
+(* Skipping instance `GHC.Base.Monoid__op_zt____op_zt____op_zt____23' of class
+   `GHC.Base.Monoid' *)
+
+(* Skipping instance
+   `GHC.Base.Semigroup__op_zt____op_zt____op_zt____op_zt____87' of class
+   `GHC.Base.Semigroup' *)
+
+(* Skipping instance `GHC.Base.Monoid__op_zt____op_zt____op_zt____op_zt____87'
+   of class `GHC.Base.Monoid' *)
+
+Local Definition Semigroup__comparison_op_zlzlzgzg__
+   : comparison -> comparison -> comparison :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Lt, _ => Lt
+    | Eq, y => y
+    | Gt, _ => Gt
+    end.
+
+Program Instance Semigroup__comparison : Semigroup comparison :=
+  fun _ k__ => k__ {| op_zlzlzgzg____ := Semigroup__comparison_op_zlzlzgzg__ |}.
+
+Local Definition Monoid__comparison_mappend
+   : comparison -> comparison -> comparison :=
+  _<<>>_.
+
+Local Definition Monoid__comparison_mempty : comparison :=
+  Eq.
+
+Local Definition Monoid__comparison_mconcat : list comparison -> comparison :=
+  foldr Monoid__comparison_mappend Monoid__comparison_mempty.
+
+Program Instance Monoid__comparison : Monoid comparison :=
+  fun _ k__ =>
+    k__ {| mappend__ := Monoid__comparison_mappend ;
+           mconcat__ := Monoid__comparison_mconcat ;
+           mempty__ := Monoid__comparison_mempty |}.
+
+Local Definition Semigroup__option_op_zlzlzgzg__ {inst_a} `{Semigroup inst_a}
+   : (option inst_a) -> (option inst_a) -> (option inst_a) :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | None, b => b
+    | a, None => a
+    | Some a, Some b => Some (a <<>> b)
+    end.
+
+Program Instance Semigroup__option {a} `{Semigroup a} : Semigroup (option a) :=
+  fun _ k__ => k__ {| op_zlzlzgzg____ := Semigroup__option_op_zlzlzgzg__ |}.
+
+Local Definition Monoid__option_mappend {inst_a} `{Semigroup inst_a}
+   : (option inst_a) -> (option inst_a) -> (option inst_a) :=
+  _<<>>_.
+
+Local Definition Monoid__option_mempty {inst_a} `{Semigroup inst_a}
+   : (option inst_a) :=
+  None.
+
+Local Definition Monoid__option_mconcat {inst_a} `{Semigroup inst_a}
+   : list (option inst_a) -> (option inst_a) :=
+  foldr Monoid__option_mappend Monoid__option_mempty.
+
+Program Instance Monoid__option {a} `{Semigroup a} : Monoid (option a) :=
+  fun _ k__ =>
+    k__ {| mappend__ := Monoid__option_mappend ;
+           mconcat__ := Monoid__option_mconcat ;
+           mempty__ := Monoid__option_mempty |}.
+
+Local Definition Applicative__pair_type_liftA2 {inst_a} `{Monoid inst_a}
+   : forall {a} {b} {c},
+     (a -> b -> c) ->
+     (GHC.Tuple.pair_type inst_a) a ->
+     (GHC.Tuple.pair_type inst_a) b -> (GHC.Tuple.pair_type inst_a) c :=
+  fun {a} {b} {c} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | f, pair u x, pair v y => pair (u <<>> v) (f x y)
+      end.
+
+Local Definition Applicative__pair_type_op_zlztzg__ {inst_a} `{Monoid inst_a}
+   : forall {a} {b},
+     (GHC.Tuple.pair_type inst_a) (a -> b) ->
+     (GHC.Tuple.pair_type inst_a) a -> (GHC.Tuple.pair_type inst_a) b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | pair u f, pair v x => pair (u <<>> v) (f x)
+      end.
+
+Definition id {a} : a -> a :=
+  fun x => x.
+
+Local Definition Functor__pair_type_fmap {inst_a}
+   : forall {a} {b},
+     (a -> b) -> (GHC.Tuple.pair_type inst_a) a -> (GHC.Tuple.pair_type inst_a) b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, pair x y => pair x (f y)
+      end.
+
+Definition op_z2218U__ {b} {c} {a} : (b -> c) -> (a -> b) -> a -> c :=
+  fun f g => fun x => f (g x).
+
+Notation "'_∘_'" := (op_z2218U__).
+
+Infix "∘" := (_∘_) (left associativity, at level 40).
+
+Definition const {a} {b} : a -> b -> a :=
+  fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | x, _ => x end.
+
+Local Definition Functor__pair_type_op_zlzd__ {inst_a}
+   : forall {a} {b},
+     a -> (GHC.Tuple.pair_type inst_a) b -> (GHC.Tuple.pair_type inst_a) a :=
+  fun {a} {b} => Functor__pair_type_fmap ∘ const.
+
+Program Instance Functor__pair_type {a} : Functor (GHC.Tuple.pair_type a) :=
+  fun _ k__ =>
+    k__ {| fmap__ := fun {a} {b} => Functor__pair_type_fmap ;
+           op_zlzd____ := fun {a} {b} => Functor__pair_type_op_zlzd__ |}.
+
+Local Definition Applicative__pair_type_op_ztzg__ {inst_a} `{Monoid inst_a}
+   : forall {a} {b},
+     (GHC.Tuple.pair_type inst_a) a ->
+     (GHC.Tuple.pair_type inst_a) b -> (GHC.Tuple.pair_type inst_a) b :=
+  fun {a} {b} => fun a1 a2 => Applicative__pair_type_op_zlztzg__ (id <$ a1) a2.
+
+Local Definition Applicative__pair_type_pure {inst_a} `{Monoid inst_a}
+   : forall {a}, a -> (GHC.Tuple.pair_type inst_a) a :=
+  fun {a} => fun x => pair mempty x.
+
+Program Instance Applicative__pair_type {a} `{Monoid a}
+   : Applicative (GHC.Tuple.pair_type a) :=
+  fun _ k__ =>
+    k__ {| liftA2__ := fun {a} {b} {c} => Applicative__pair_type_liftA2 ;
+           op_zlztzg____ := fun {a} {b} => Applicative__pair_type_op_zlztzg__ ;
+           op_ztzg____ := fun {a} {b} => Applicative__pair_type_op_ztzg__ ;
+           pure__ := fun {a} => Applicative__pair_type_pure |}.
+
+Local Definition Monad__pair_type_return_ {inst_a} `{Monoid inst_a}
+   : forall {a}, a -> (GHC.Tuple.pair_type inst_a) a :=
+  fun {a} => pure.
+
+Local Definition Monad__pair_type_op_zgzgze__ {inst_a} `{Monoid inst_a}
+   : forall {a} {b},
+     (GHC.Tuple.pair_type inst_a) a ->
+     (a -> (GHC.Tuple.pair_type inst_a) b) -> (GHC.Tuple.pair_type inst_a) b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | pair u a, k => let 'pair v b := k a in pair (u <<>> v) b
+      end.
+
+Local Definition Monad__pair_type_op_zgzg__ {inst_a} `{Monoid inst_a}
+   : forall {a} {b},
+     (GHC.Tuple.pair_type inst_a) a ->
+     (GHC.Tuple.pair_type inst_a) b -> (GHC.Tuple.pair_type inst_a) b :=
+  fun {a} {b} => fun m k => Monad__pair_type_op_zgzgze__ m (fun arg_0__ => k).
+
+Program Instance Monad__pair_type {a} `{Monoid a}
+   : Monad (GHC.Tuple.pair_type a) :=
+  fun _ k__ =>
+    k__ {| op_zgzg____ := fun {a} {b} => Monad__pair_type_op_zgzg__ ;
+           op_zgzgze____ := fun {a} {b} => Monad__pair_type_op_zgzgze__ ;
+           return___ := fun {a} => Monad__pair_type_return_ |}.
+
+(* Skipping instance `GHC.Base.Semigroup__IO' of class `GHC.Base.Semigroup' *)
+
+(* Skipping instance `GHC.Base.Monoid__IO' of class `GHC.Base.Monoid' *)
+
+Local Definition Functor__arrow_fmap {inst_r}
+   : forall {a} {b},
+     (a -> b) -> (GHC.Prim.arrow inst_r) a -> (GHC.Prim.arrow inst_r) b :=
+  fun {a} {b} => _∘_.
+
+Local Definition Functor__arrow_op_zlzd__ {inst_r}
+   : forall {a} {b},
+     a -> (GHC.Prim.arrow inst_r) b -> (GHC.Prim.arrow inst_r) a :=
+  fun {a} {b} => Functor__arrow_fmap ∘ const.
+
+Program Instance Functor__arrow {r} : Functor (GHC.Prim.arrow r) :=
+  fun _ k__ =>
+    k__ {| fmap__ := fun {a} {b} => Functor__arrow_fmap ;
+           op_zlzd____ := fun {a} {b} => Functor__arrow_op_zlzd__ |}.
+
+Local Definition Applicative__arrow_liftA2 {inst_a}
+   : forall {a} {b} {c},
+     (a -> b -> c) ->
+     (GHC.Prim.arrow inst_a) a ->
+     (GHC.Prim.arrow inst_a) b -> (GHC.Prim.arrow inst_a) c :=
+  fun {a} {b} {c} => fun q f g x => q (f x) (g x).
+
+Local Definition Applicative__arrow_op_zlztzg__ {inst_a}
+   : forall {a} {b},
+     (GHC.Prim.arrow inst_a) (a -> b) ->
+     (GHC.Prim.arrow inst_a) a -> (GHC.Prim.arrow inst_a) b :=
+  fun {a} {b} => fun f g x => f x (g x).
+
+Local Definition Applicative__arrow_op_ztzg__ {inst_a}
+   : forall {a} {b},
+     (GHC.Prim.arrow inst_a) a ->
+     (GHC.Prim.arrow inst_a) b -> (GHC.Prim.arrow inst_a) b :=
+  fun {a} {b} => fun a1 a2 => Applicative__arrow_op_zlztzg__ (id <$ a1) a2.
+
+Local Definition Applicative__arrow_pure {inst_a}
+   : forall {a}, a -> (GHC.Prim.arrow inst_a) a :=
+  fun {a} => const.
+
+Program Instance Applicative__arrow {a} : Applicative (GHC.Prim.arrow a) :=
+  fun _ k__ =>
+    k__ {| liftA2__ := fun {a} {b} {c} => Applicative__arrow_liftA2 ;
+           op_zlztzg____ := fun {a} {b} => Applicative__arrow_op_zlztzg__ ;
+           op_ztzg____ := fun {a} {b} => Applicative__arrow_op_ztzg__ ;
+           pure__ := fun {a} => Applicative__arrow_pure |}.
+
+Local Definition Monad__arrow_op_zgzgze__ {inst_r}
+   : forall {a} {b},
+     (GHC.Prim.arrow inst_r) a ->
+     (a -> (GHC.Prim.arrow inst_r) b) -> (GHC.Prim.arrow inst_r) b :=
+  fun {a} {b} => fun f k => fun r => k (f r) r.
+
+Local Definition Monad__arrow_op_zgzg__ {inst_r}
+   : forall {a} {b},
+     (GHC.Prim.arrow inst_r) a ->
+     (GHC.Prim.arrow inst_r) b -> (GHC.Prim.arrow inst_r) b :=
+  fun {a} {b} => fun m k => Monad__arrow_op_zgzgze__ m (fun arg_0__ => k).
+
+Local Definition Monad__arrow_return_ {inst_r}
+   : forall {a}, a -> (GHC.Prim.arrow inst_r) a :=
+  fun {a} => pure.
+
+Program Instance Monad__arrow {r} : Monad (GHC.Prim.arrow r) :=
+  fun _ k__ =>
+    k__ {| op_zgzg____ := fun {a} {b} => Monad__arrow_op_zgzg__ ;
+           op_zgzgze____ := fun {a} {b} => Monad__arrow_op_zgzgze__ ;
+           return___ := fun {a} => Monad__arrow_return_ |}.
 
 Local Definition Functor__option_fmap
    : forall {a} {b}, (a -> b) -> option a -> option b :=
@@ -853,74 +995,6 @@ Program Instance Functor__option : Functor option :=
   fun _ k__ =>
     k__ {| fmap__ := fun {a} {b} => Functor__option_fmap ;
            op_zlzd____ := fun {a} {b} => Functor__option_op_zlzd__ |}.
-
-Local Definition Functor__pair_type_fmap {inst_a}
-   : forall {a} {b},
-     (a -> b) -> (GHC.Tuple.pair_type inst_a) a -> (GHC.Tuple.pair_type inst_a) b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, pair x y => pair x (f y)
-      end.
-
-Local Definition Functor__pair_type_op_zlzd__ {inst_a}
-   : forall {a} {b},
-     a -> (GHC.Tuple.pair_type inst_a) b -> (GHC.Tuple.pair_type inst_a) a :=
-  fun {a} {b} => Functor__pair_type_fmap ∘ const.
-
-Program Instance Functor__pair_type {a} : Functor (GHC.Tuple.pair_type a) :=
-  fun _ k__ =>
-    k__ {| fmap__ := fun {a} {b} => Functor__pair_type_fmap ;
-           op_zlzd____ := fun {a} {b} => Functor__pair_type_op_zlzd__ |}.
-
-Local Definition Functor__arrow_fmap {inst_r}
-   : forall {a} {b},
-     (a -> b) -> (GHC.Prim.arrow inst_r) a -> (GHC.Prim.arrow inst_r) b :=
-  fun {a} {b} => _∘_.
-
-Local Definition Functor__arrow_op_zlzd__ {inst_r}
-   : forall {a} {b},
-     a -> (GHC.Prim.arrow inst_r) b -> (GHC.Prim.arrow inst_r) a :=
-  fun {a} {b} => Functor__arrow_fmap ∘ const.
-
-Program Instance Functor__arrow {r} : Functor (GHC.Prim.arrow r) :=
-  fun _ k__ =>
-    k__ {| fmap__ := fun {a} {b} => Functor__arrow_fmap ;
-           op_zlzd____ := fun {a} {b} => Functor__arrow_op_zlzd__ |}.
-
-(* Skipping instance `GHC.Base.Applicative__IO' of class
-   `GHC.Base.Applicative' *)
-
-Local Definition Applicative__list_liftA2
-   : forall {a} {b} {c}, (a -> b -> c) -> list a -> list b -> list c :=
-  fun {a} {b} {c} =>
-    fun f xs ys =>
-      Coq.Lists.List.flat_map (fun x =>
-                                 Coq.Lists.List.flat_map (fun y => cons (f x y) nil) ys) xs.
-
-Local Definition Applicative__list_op_zlztzg__
-   : forall {a} {b}, list (a -> b) -> list a -> list b :=
-  fun {a} {b} =>
-    fun fs xs =>
-      Coq.Lists.List.flat_map (fun f =>
-                                 Coq.Lists.List.flat_map (fun x => cons (f x) nil) xs) fs.
-
-Local Definition Applicative__list_op_ztzg__
-   : forall {a} {b}, list a -> list b -> list b :=
-  fun {a} {b} =>
-    fun xs ys =>
-      Coq.Lists.List.flat_map (fun _ =>
-                                 Coq.Lists.List.flat_map (fun y => cons y nil) ys) xs.
-
-Local Definition Applicative__list_pure : forall {a}, a -> list a :=
-  fun {a} => fun x => cons x nil.
-
-Program Instance Applicative__list : Applicative list :=
-  fun _ k__ =>
-    k__ {| liftA2__ := fun {a} {b} {c} => Applicative__list_liftA2 ;
-           op_zlztzg____ := fun {a} {b} => Applicative__list_op_zlztzg__ ;
-           op_ztzg____ := fun {a} {b} => Applicative__list_op_ztzg__ ;
-           pure__ := fun {a} => Applicative__list_pure |}.
 
 Local Definition Applicative__option_liftA2
    : forall {a} {b} {c}, (a -> b -> c) -> option a -> option b -> option c :=
@@ -959,47 +1033,104 @@ Program Instance Applicative__option : Applicative option :=
            op_ztzg____ := fun {a} {b} => Applicative__option_op_ztzg__ ;
            pure__ := fun {a} => Applicative__option_pure |}.
 
-Local Definition Applicative__arrow_liftA2 {inst_a}
-   : forall {a} {b} {c},
-     (a -> b -> c) ->
-     (GHC.Prim.arrow inst_a) a ->
-     (GHC.Prim.arrow inst_a) b -> (GHC.Prim.arrow inst_a) c :=
-  fun {a} {b} {c} => fun q f g x => q (f x) (g x).
+Local Definition Monad__option_op_zgzg__
+   : forall {a} {b}, option a -> option b -> option b :=
+  fun {a} {b} => _*>_.
 
-Local Definition Applicative__arrow_op_zlztzg__ {inst_a}
-   : forall {a} {b},
-     (GHC.Prim.arrow inst_a) (a -> b) ->
-     (GHC.Prim.arrow inst_a) a -> (GHC.Prim.arrow inst_a) b :=
-  fun {a} {b} => fun f g x => f x (g x).
+Local Definition Monad__option_op_zgzgze__
+   : forall {a} {b}, option a -> (a -> option b) -> option b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | Some x, k => k x
+      | None, _ => None
+      end.
 
-Local Definition Applicative__arrow_op_ztzg__ {inst_a}
-   : forall {a} {b},
-     (GHC.Prim.arrow inst_a) a ->
-     (GHC.Prim.arrow inst_a) b -> (GHC.Prim.arrow inst_a) b :=
-  fun {a} {b} => fun a1 a2 => Applicative__arrow_op_zlztzg__ (id <$ a1) a2.
+Local Definition Monad__option_return_ : forall {a}, a -> option a :=
+  fun {a} => pure.
 
-Local Definition Applicative__arrow_pure {inst_a}
-   : forall {a}, a -> (GHC.Prim.arrow inst_a) a :=
-  fun {a} => const.
-
-Program Instance Applicative__arrow {a} : Applicative (GHC.Prim.arrow a) :=
+Program Instance Monad__option : Monad option :=
   fun _ k__ =>
-    k__ {| liftA2__ := fun {a} {b} {c} => Applicative__arrow_liftA2 ;
-           op_zlztzg____ := fun {a} {b} => Applicative__arrow_op_zlztzg__ ;
-           op_ztzg____ := fun {a} {b} => Applicative__arrow_op_ztzg__ ;
-           pure__ := fun {a} => Applicative__arrow_pure |}.
-
-(* Skipping all instances of class `GHC.Base.Alternative', including
-   `GHC.Base.Alternative__IO' *)
-
-(* Skipping all instances of class `GHC.Base.Alternative', including
-   `GHC.Base.Alternative__list' *)
+    k__ {| op_zgzg____ := fun {a} {b} => Monad__option_op_zgzg__ ;
+           op_zgzgze____ := fun {a} {b} => Monad__option_op_zgzgze__ ;
+           return___ := fun {a} => Monad__option_return_ |}.
 
 (* Skipping all instances of class `GHC.Base.Alternative', including
    `GHC.Base.Alternative__option' *)
 
+(* Skipping all instances of class `GHC.Base.MonadPlus', including
+   `GHC.Base.MonadPlus__option' *)
+
+Definition map {A B : Type} (f : A -> B) xs :=
+  Coq.Lists.List.map f xs.
+
+Local Definition Functor__list_fmap
+   : forall {a} {b}, (a -> b) -> list a -> list b :=
+  fun {a} {b} => map.
+
+Local Definition Functor__list_op_zlzd__
+   : forall {a} {b}, a -> list b -> list a :=
+  fun {a} {b} => Functor__list_fmap ∘ const.
+
+Program Instance Functor__list : Functor list :=
+  fun _ k__ =>
+    k__ {| fmap__ := fun {a} {b} => Functor__list_fmap ;
+           op_zlzd____ := fun {a} {b} => Functor__list_op_zlzd__ |}.
+
+Local Definition Functor__NonEmpty_fmap
+   : forall {a} {b}, (a -> b) -> NonEmpty a -> NonEmpty b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, NEcons a as_ => NEcons (f a) (fmap f as_)
+      end.
+
+Local Definition Functor__NonEmpty_op_zlzd__
+   : forall {a} {b}, a -> NonEmpty b -> NonEmpty a :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | b, NEcons _ as_ => NEcons b (b <$ as_)
+      end.
+
+Program Instance Functor__NonEmpty : Functor NonEmpty :=
+  fun _ k__ =>
+    k__ {| fmap__ := fun {a} {b} => Functor__NonEmpty_fmap ;
+           op_zlzd____ := fun {a} {b} => Functor__NonEmpty_op_zlzd__ |}.
+
 Local Definition Applicative__NonEmpty_pure : forall {a}, a -> NonEmpty a :=
   fun {a} => fun a => NEcons a nil.
+
+Local Definition Applicative__list_liftA2
+   : forall {a} {b} {c}, (a -> b -> c) -> list a -> list b -> list c :=
+  fun {a} {b} {c} =>
+    fun f xs ys =>
+      Coq.Lists.List.flat_map (fun x =>
+                                 Coq.Lists.List.flat_map (fun y => cons (f x y) nil) ys) xs.
+
+Local Definition Applicative__list_op_zlztzg__
+   : forall {a} {b}, list (a -> b) -> list a -> list b :=
+  fun {a} {b} =>
+    fun fs xs =>
+      Coq.Lists.List.flat_map (fun f =>
+                                 Coq.Lists.List.flat_map (fun x => cons (f x) nil) xs) fs.
+
+Local Definition Applicative__list_op_ztzg__
+   : forall {a} {b}, list a -> list b -> list b :=
+  fun {a} {b} =>
+    fun xs ys =>
+      Coq.Lists.List.flat_map (fun _ =>
+                                 Coq.Lists.List.flat_map (fun y => cons y nil) ys) xs.
+
+Local Definition Applicative__list_pure : forall {a}, a -> list a :=
+  fun {a} => fun x => cons x nil.
+
+Program Instance Applicative__list : Applicative list :=
+  fun _ k__ =>
+    k__ {| liftA2__ := fun {a} {b} {c} => Applicative__list_liftA2 ;
+           op_zlztzg____ := fun {a} {b} => Applicative__list_op_zlztzg__ ;
+           op_ztzg____ := fun {a} {b} => Applicative__list_op_ztzg__ ;
+           pure__ := fun {a} => Applicative__list_pure |}.
 
 Local Definition Monad__list_return_ : forall {a}, a -> list a :=
   fun {a} => pure.
@@ -1046,27 +1177,6 @@ Local Definition Applicative__NonEmpty_op_zlztzg__ {a} {b}
     Monad__NonEmpty_op_zgzgze__ m1 (fun x1 =>
                                    Monad__NonEmpty_op_zgzgze__ m2 (fun x2 => Applicative__NonEmpty_pure (x1 x2))).
 
-Local Definition Functor__NonEmpty_fmap
-   : forall {a} {b}, (a -> b) -> NonEmpty a -> NonEmpty b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, NEcons a as_ => NEcons (f a) (fmap f as_)
-      end.
-
-Local Definition Functor__NonEmpty_op_zlzd__
-   : forall {a} {b}, a -> NonEmpty b -> NonEmpty a :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | b, NEcons _ as_ => NEcons b (b <$ as_)
-      end.
-
-Program Instance Functor__NonEmpty : Functor NonEmpty :=
-  fun _ k__ =>
-    k__ {| fmap__ := fun {a} {b} => Functor__NonEmpty_fmap ;
-           op_zlzd____ := fun {a} {b} => Functor__NonEmpty_op_zlzd__ |}.
-
 Local Definition Applicative__NonEmpty_op_ztzg__
    : forall {a} {b}, NonEmpty a -> NonEmpty b -> NonEmpty b :=
   fun {a} {b} => fun a1 a2 => Applicative__NonEmpty_op_zlztzg__ (id <$ a1) a2.
@@ -1077,218 +1187,6 @@ Program Instance Applicative__NonEmpty : Applicative NonEmpty :=
            op_zlztzg____ := fun {a} {b} => Applicative__NonEmpty_op_zlztzg__ ;
            op_ztzg____ := fun {a} {b} => Applicative__NonEmpty_op_ztzg__ ;
            pure__ := fun {a} => Applicative__NonEmpty_pure |}.
-
-(* Skipping instance `GHC.Base.Semigroup__IO' of class `GHC.Base.Semigroup' *)
-
-Local Definition Semigroup__option_op_zlzlzgzg__ {inst_a} `{Semigroup inst_a}
-   : (option inst_a) -> (option inst_a) -> (option inst_a) :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | None, b => b
-    | a, None => a
-    | Some a, Some b => Some (a <<>> b)
-    end.
-
-Program Instance Semigroup__option {a} `{Semigroup a} : Semigroup (option a) :=
-  fun _ k__ => k__ {| op_zlzlzgzg____ := Semigroup__option_op_zlzlzgzg__ |}.
-
-Local Definition Semigroup__comparison_op_zlzlzgzg__
-   : comparison -> comparison -> comparison :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Lt, _ => Lt
-    | Eq, y => y
-    | Gt, _ => Gt
-    end.
-
-Program Instance Semigroup__comparison : Semigroup comparison :=
-  fun _ k__ => k__ {| op_zlzlzgzg____ := Semigroup__comparison_op_zlzlzgzg__ |}.
-
-(* Skipping instance
-   `GHC.Base.Semigroup__op_zt____op_zt____op_zt____op_zt____87' of class
-   `GHC.Base.Semigroup' *)
-
-(* Skipping instance `GHC.Base.Semigroup__op_zt____op_zt____op_zt____23' of
-   class `GHC.Base.Semigroup' *)
-
-(* Skipping instance `GHC.Base.Semigroup__op_zt____op_zt__' of class
-   `GHC.Base.Semigroup' *)
-
-(* Skipping instance `GHC.Base.Semigroup__op_zt__' of class
-   `GHC.Base.Semigroup' *)
-
-Local Definition Semigroup__unit_op_zlzlzgzg__ : unit -> unit -> unit :=
-  fun arg_0__ arg_1__ => tt.
-
-Program Instance Semigroup__unit : Semigroup unit :=
-  fun _ k__ => k__ {| op_zlzlzgzg____ := Semigroup__unit_op_zlzlzgzg__ |}.
-
-Local Definition Semigroup__arrow_op_zlzlzgzg__ {inst_b} {inst_a} `{Semigroup
-  inst_b}
-   : (inst_a -> inst_b) -> (inst_a -> inst_b) -> (inst_a -> inst_b) :=
-  fun f g => fun x => f x <<>> g x.
-
-Program Instance Semigroup__arrow {b} {a} `{Semigroup b} : Semigroup (a -> b) :=
-  fun _ k__ => k__ {| op_zlzlzgzg____ := Semigroup__arrow_op_zlzlzgzg__ |}.
-
-Local Definition Semigroup__NonEmpty_op_zlzlzgzg__ {inst_a}
-   : (NonEmpty inst_a) -> (NonEmpty inst_a) -> (NonEmpty inst_a) :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | NEcons a as_, NEcons b bs => NEcons a (Coq.Init.Datatypes.app as_ (cons b bs))
-    end.
-
-Program Instance Semigroup__NonEmpty {a} : Semigroup (NonEmpty a) :=
-  fun _ k__ => k__ {| op_zlzlzgzg____ := Semigroup__NonEmpty_op_zlzlzgzg__ |}.
-
-Local Definition Semigroup__list_op_zlzlzgzg__ {inst_a}
-   : list inst_a -> list inst_a -> list inst_a :=
-  Coq.Init.Datatypes.app.
-
-Program Instance Semigroup__list {a} : Semigroup (list a) :=
-  fun _ k__ => k__ {| op_zlzlzgzg____ := Semigroup__list_op_zlzlzgzg__ |}.
-
-(* Skipping instance `GHC.Base.Monoid__IO' of class `GHC.Base.Monoid' *)
-
-Local Definition Applicative__pair_type_liftA2 {inst_a} `{Monoid inst_a}
-   : forall {a} {b} {c},
-     (a -> b -> c) ->
-     (GHC.Tuple.pair_type inst_a) a ->
-     (GHC.Tuple.pair_type inst_a) b -> (GHC.Tuple.pair_type inst_a) c :=
-  fun {a} {b} {c} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | f, pair u x, pair v y => pair (u <<>> v) (f x y)
-      end.
-
-Local Definition Applicative__pair_type_op_zlztzg__ {inst_a} `{Monoid inst_a}
-   : forall {a} {b},
-     (GHC.Tuple.pair_type inst_a) (a -> b) ->
-     (GHC.Tuple.pair_type inst_a) a -> (GHC.Tuple.pair_type inst_a) b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | pair u f, pair v x => pair (u <<>> v) (f x)
-      end.
-
-Local Definition Applicative__pair_type_op_ztzg__ {inst_a} `{Monoid inst_a}
-   : forall {a} {b},
-     (GHC.Tuple.pair_type inst_a) a ->
-     (GHC.Tuple.pair_type inst_a) b -> (GHC.Tuple.pair_type inst_a) b :=
-  fun {a} {b} => fun a1 a2 => Applicative__pair_type_op_zlztzg__ (id <$ a1) a2.
-
-Local Definition Applicative__pair_type_pure {inst_a} `{Monoid inst_a}
-   : forall {a}, a -> (GHC.Tuple.pair_type inst_a) a :=
-  fun {a} => fun x => pair mempty x.
-
-Program Instance Applicative__pair_type {a} `{Monoid a}
-   : Applicative (GHC.Tuple.pair_type a) :=
-  fun _ k__ =>
-    k__ {| liftA2__ := fun {a} {b} {c} => Applicative__pair_type_liftA2 ;
-           op_zlztzg____ := fun {a} {b} => Applicative__pair_type_op_zlztzg__ ;
-           op_ztzg____ := fun {a} {b} => Applicative__pair_type_op_ztzg__ ;
-           pure__ := fun {a} => Applicative__pair_type_pure |}.
-
-Local Definition Monoid__option_mappend {inst_a} `{Semigroup inst_a}
-   : (option inst_a) -> (option inst_a) -> (option inst_a) :=
-  _<<>>_.
-
-Local Definition Monoid__option_mempty {inst_a} `{Semigroup inst_a}
-   : (option inst_a) :=
-  None.
-
-Local Definition Monoid__option_mconcat {inst_a} `{Semigroup inst_a}
-   : list (option inst_a) -> (option inst_a) :=
-  foldr Monoid__option_mappend Monoid__option_mempty.
-
-Program Instance Monoid__option {a} `{Semigroup a} : Monoid (option a) :=
-  fun _ k__ =>
-    k__ {| mappend__ := Monoid__option_mappend ;
-           mconcat__ := Monoid__option_mconcat ;
-           mempty__ := Monoid__option_mempty |}.
-
-Local Definition Monoid__comparison_mappend
-   : comparison -> comparison -> comparison :=
-  _<<>>_.
-
-Local Definition Monoid__comparison_mempty : comparison :=
-  Eq.
-
-Local Definition Monoid__comparison_mconcat : list comparison -> comparison :=
-  foldr Monoid__comparison_mappend Monoid__comparison_mempty.
-
-Program Instance Monoid__comparison : Monoid comparison :=
-  fun _ k__ =>
-    k__ {| mappend__ := Monoid__comparison_mappend ;
-           mconcat__ := Monoid__comparison_mconcat ;
-           mempty__ := Monoid__comparison_mempty |}.
-
-(* Skipping instance `GHC.Base.Monoid__op_zt____op_zt____op_zt____op_zt____87'
-   of class `GHC.Base.Monoid' *)
-
-(* Skipping instance `GHC.Base.Monoid__op_zt____op_zt____op_zt____23' of class
-   `GHC.Base.Monoid' *)
-
-(* Skipping instance `GHC.Base.Monoid__op_zt____op_zt__' of class
-   `GHC.Base.Monoid' *)
-
-(* Skipping instance `GHC.Base.Monoid__op_zt__' of class `GHC.Base.Monoid' *)
-
-Local Definition Monoid__unit_mappend : unit -> unit -> unit :=
-  _<<>>_.
-
-Local Definition Monoid__unit_mconcat : list unit -> unit :=
-  fun arg_0__ => tt.
-
-Local Definition Monoid__unit_mempty : unit :=
-  tt.
-
-Program Instance Monoid__unit : Monoid unit :=
-  fun _ k__ =>
-    k__ {| mappend__ := Monoid__unit_mappend ;
-           mconcat__ := Monoid__unit_mconcat ;
-           mempty__ := Monoid__unit_mempty |}.
-
-Local Definition Monoid__arrow_mappend {inst_b} {inst_a} `{Monoid inst_b}
-   : (inst_a -> inst_b) -> (inst_a -> inst_b) -> (inst_a -> inst_b) :=
-  _<<>>_.
-
-Local Definition Monoid__arrow_mempty {inst_b} {inst_a} `{Monoid inst_b}
-   : (inst_a -> inst_b) :=
-  fun arg_0__ => mempty.
-
-Local Definition Monoid__arrow_mconcat {inst_b} {inst_a} `{Monoid inst_b}
-   : list (inst_a -> inst_b) -> (inst_a -> inst_b) :=
-  foldr Monoid__arrow_mappend Monoid__arrow_mempty.
-
-Program Instance Monoid__arrow {b} {a} `{Monoid b} : Monoid (a -> b) :=
-  fun _ k__ =>
-    k__ {| mappend__ := Monoid__arrow_mappend ;
-           mconcat__ := Monoid__arrow_mconcat ;
-           mempty__ := Monoid__arrow_mempty |}.
-
-Local Definition Monoid__list_mappend {inst_a}
-   : list inst_a -> list inst_a -> list inst_a :=
-  _<<>>_.
-
-Local Definition Monoid__list_mconcat {inst_a}
-   : list (list inst_a) -> list inst_a :=
-  fun xss =>
-    Coq.Lists.List.flat_map (fun xs =>
-                               Coq.Lists.List.flat_map (fun x => cons x nil) xs) xss.
-
-Local Definition Monoid__list_mempty {inst_a} : list inst_a :=
-  nil.
-
-Program Instance Monoid__list {a} : Monoid (list a) :=
-  fun _ k__ =>
-    k__ {| mappend__ := Monoid__list_mappend ;
-           mconcat__ := Monoid__list_mconcat ;
-           mempty__ := Monoid__list_mempty |}.
-
-(* Skipping instance `GHC.Base.Monad__IO' of class `GHC.Base.Monad' *)
-
-(* Skipping instance `GHC.Base.Functor__IO' of class `GHC.Base.Functor' *)
 
 Local Definition Monad__NonEmpty_return_ : forall {a}, a -> NonEmpty a :=
   fun {a} => pure.
@@ -1303,85 +1201,187 @@ Program Instance Monad__NonEmpty : Monad NonEmpty :=
            op_zgzgze____ := fun {a} {b} => Monad__NonEmpty_op_zgzgze__ ;
            return___ := fun {a} => Monad__NonEmpty_return_ |}.
 
-Local Definition Monad__option_op_zgzg__
-   : forall {a} {b}, option a -> option b -> option b :=
-  fun {a} {b} => _*>_.
-
-Local Definition Monad__option_op_zgzgze__
-   : forall {a} {b}, option a -> (a -> option b) -> option b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | Some x, k => k x
-      | None, _ => None
-      end.
-
-Local Definition Monad__option_return_ : forall {a}, a -> option a :=
-  fun {a} => pure.
-
-Program Instance Monad__option : Monad option :=
-  fun _ k__ =>
-    k__ {| op_zgzg____ := fun {a} {b} => Monad__option_op_zgzg__ ;
-           op_zgzgze____ := fun {a} {b} => Monad__option_op_zgzgze__ ;
-           return___ := fun {a} => Monad__option_return_ |}.
-
-Local Definition Monad__arrow_op_zgzgze__ {inst_r}
-   : forall {a} {b},
-     (GHC.Prim.arrow inst_r) a ->
-     (a -> (GHC.Prim.arrow inst_r) b) -> (GHC.Prim.arrow inst_r) b :=
-  fun {a} {b} => fun f k => fun r => k (f r) r.
-
-Local Definition Monad__arrow_op_zgzg__ {inst_r}
-   : forall {a} {b},
-     (GHC.Prim.arrow inst_r) a ->
-     (GHC.Prim.arrow inst_r) b -> (GHC.Prim.arrow inst_r) b :=
-  fun {a} {b} => fun m k => Monad__arrow_op_zgzgze__ m (fun arg_0__ => k).
-
-Local Definition Monad__arrow_return_ {inst_r}
-   : forall {a}, a -> (GHC.Prim.arrow inst_r) a :=
-  fun {a} => pure.
-
-Program Instance Monad__arrow {r} : Monad (GHC.Prim.arrow r) :=
-  fun _ k__ =>
-    k__ {| op_zgzg____ := fun {a} {b} => Monad__arrow_op_zgzg__ ;
-           op_zgzgze____ := fun {a} {b} => Monad__arrow_op_zgzgze__ ;
-           return___ := fun {a} => Monad__arrow_return_ |}.
-
-Local Definition Monad__pair_type_return_ {inst_a} `{Monoid inst_a}
-   : forall {a}, a -> (GHC.Tuple.pair_type inst_a) a :=
-  fun {a} => pure.
-
-Local Definition Monad__pair_type_op_zgzgze__ {inst_a} `{Monoid inst_a}
-   : forall {a} {b},
-     (GHC.Tuple.pair_type inst_a) a ->
-     (a -> (GHC.Tuple.pair_type inst_a) b) -> (GHC.Tuple.pair_type inst_a) b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | pair u a, k => let 'pair v b := k a in pair (u <<>> v) b
-      end.
-
-Local Definition Monad__pair_type_op_zgzg__ {inst_a} `{Monoid inst_a}
-   : forall {a} {b},
-     (GHC.Tuple.pair_type inst_a) a ->
-     (GHC.Tuple.pair_type inst_a) b -> (GHC.Tuple.pair_type inst_a) b :=
-  fun {a} {b} => fun m k => Monad__pair_type_op_zgzgze__ m (fun arg_0__ => k).
-
-Program Instance Monad__pair_type {a} `{Monoid a}
-   : Monad (GHC.Tuple.pair_type a) :=
-  fun _ k__ =>
-    k__ {| op_zgzg____ := fun {a} {b} => Monad__pair_type_op_zgzg__ ;
-           op_zgzgze____ := fun {a} {b} => Monad__pair_type_op_zgzgze__ ;
-           return___ := fun {a} => Monad__pair_type_return_ |}.
-
-(* Skipping all instances of class `GHC.Base.MonadPlus', including
-   `GHC.Base.MonadPlus__IO' *)
+(* Skipping all instances of class `GHC.Base.Alternative', including
+   `GHC.Base.Alternative__list' *)
 
 (* Skipping all instances of class `GHC.Base.MonadPlus', including
    `GHC.Base.MonadPlus__list' *)
 
+(* Skipping instance `GHC.Base.Functor__IO' of class `GHC.Base.Functor' *)
+
+(* Skipping instance `GHC.Base.Applicative__IO' of class
+   `GHC.Base.Applicative' *)
+
+(* Skipping instance `GHC.Base.Monad__IO' of class `GHC.Base.Monad' *)
+
+(* Skipping all instances of class `GHC.Base.Alternative', including
+   `GHC.Base.Alternative__IO' *)
+
 (* Skipping all instances of class `GHC.Base.MonadPlus', including
-   `GHC.Base.MonadPlus__option' *)
+   `GHC.Base.MonadPlus__IO' *)
+
+Definition op_zlztztzg__ {f} {a} {b} `{Applicative f}
+   : f a -> f (a -> b) -> f b :=
+  liftA2 (fun a f => f a).
+
+Notation "'_<**>_'" := (op_zlztztzg__).
+
+Infix "<**>" := (_<**>_) (at level 99).
+
+Definition liftA {f} {a} {b} `{Applicative f} : (a -> b) -> f a -> f b :=
+  fun f a => pure f <*> a.
+
+Definition liftA3 {f} {a} {b} {c} {d} `{Applicative f}
+   : (a -> b -> c -> d) -> f a -> f b -> f c -> f d :=
+  fun f a b c => liftA2 f a b <*> c.
+
+Definition join {m} {a} `{(Monad m)} : m (m a) -> m a :=
+  fun x => x >>= id.
+
+Definition op_zezlzl__ {m} {a} {b} `{Monad m} : (a -> m b) -> m a -> m b :=
+  fun f x => x >>= f.
+
+Notation "'_=<<_'" := (op_zezlzl__).
+
+Infix "=<<" := (_=<<_) (at level 99).
+
+Definition when {f} `{(Applicative f)} : bool -> f unit -> f unit :=
+  fun p s => if p : bool then s else pure tt.
+
+Definition mapM {m} {a} {b} `{Monad m} : (a -> m b) -> list a -> m (list b) :=
+  fun f as_ =>
+    let k := fun a r => f a >>= (fun x => r >>= (fun xs => return_ (cons x xs))) in
+    foldr k (return_ nil) as_.
+
+Definition sequence {m} {a} `{Monad m} : list (m a) -> m (list a) :=
+  mapM id.
+
+Definition liftM {m} {a1} {r} `{(Monad m)} : (a1 -> r) -> m a1 -> m r :=
+  fun f m1 => m1 >>= (fun x1 => return_ (f x1)).
+
+Definition liftM2 {m} {a1} {a2} {r} `{(Monad m)}
+   : (a1 -> a2 -> r) -> m a1 -> m a2 -> m r :=
+  fun f m1 m2 => m1 >>= (fun x1 => m2 >>= (fun x2 => return_ (f x1 x2))).
+
+Definition liftM3 {m} {a1} {a2} {a3} {r} `{(Monad m)}
+   : (a1 -> a2 -> a3 -> r) -> m a1 -> m a2 -> m a3 -> m r :=
+  fun f m1 m2 m3 =>
+    m1 >>= (fun x1 => m2 >>= (fun x2 => m3 >>= (fun x3 => return_ (f x1 x2 x3)))).
+
+Definition liftM4 {m} {a1} {a2} {a3} {a4} {r} `{(Monad m)}
+   : (a1 -> a2 -> a3 -> a4 -> r) -> m a1 -> m a2 -> m a3 -> m a4 -> m r :=
+  fun f m1 m2 m3 m4 =>
+    m1 >>=
+    (fun x1 =>
+       m2 >>=
+       (fun x2 => m3 >>= (fun x3 => m4 >>= (fun x4 => return_ (f x1 x2 x3 x4))))).
+
+Definition liftM5 {m} {a1} {a2} {a3} {a4} {a5} {r} `{(Monad m)}
+   : (a1 -> a2 -> a3 -> a4 -> a5 -> r) ->
+     m a1 -> m a2 -> m a3 -> m a4 -> m a5 -> m r :=
+  fun f m1 m2 m3 m4 m5 =>
+    m1 >>=
+    (fun x1 =>
+       m2 >>=
+       (fun x2 =>
+          m3 >>=
+          (fun x3 => m4 >>= (fun x4 => m5 >>= (fun x5 => return_ (f x1 x2 x3 x4 x5)))))).
+
+Definition ap {m} {a} {b} `{(Monad m)} : m (a -> b) -> m a -> m b :=
+  fun m1 m2 => m1 >>= (fun x1 => m2 >>= (fun x2 => return_ (x1 x2))).
+
+(* Skipping definition `GHC.Base.build' *)
+
+(* Skipping definition `GHC.Base.augment' *)
+
+Definition mapFB {elt} {lst} {a}
+   : (elt -> lst -> lst) -> (a -> elt) -> a -> lst -> lst :=
+  fun c f => fun x ys => c (f x) ys.
+
+(* Skipping definition `Coq.Init.Datatypes.app' *)
+
+Definition otherwise : bool :=
+  true.
+
+(* Skipping definition `GHC.Base.unsafeChr' *)
+
+(* Skipping definition `GHC.Base.ord' *)
+
+Fixpoint eqString (arg_0__ arg_1__ : String) : bool
+           := match arg_0__, arg_1__ with
+              | nil, nil => true
+              | cons c1 cs1, cons c2 cs2 => andb (c1 == c2) (eqString cs1 cs2)
+              | _, _ => false
+              end.
+
+(* Skipping definition `GHC.Base.minInt' *)
+
+(* Skipping definition `GHC.Base.maxInt' *)
+
+Definition assert {a} : bool -> a -> a :=
+  fun _pred r => r.
+
+Definition breakpoint {a} : a -> a :=
+  fun r => r.
+
+Definition breakpointCond {a} : bool -> a -> a :=
+  fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | _, r => r end.
+
+Definition flip {a} {b} {c} : (a -> b -> c) -> b -> a -> c :=
+  fun f x y => f y x.
+
+Definition op_zd__ {a} {b} : (a -> b) -> a -> b :=
+  fun f x => f x.
+
+Notation "'_$_'" := (op_zd__).
+
+Infix "$" := (_$_) (at level 99).
+
+Definition op_zdzn__ {a} {b} : (a -> b) -> a -> b :=
+  fun f x => let vx := x in f vx.
+
+Notation "'_$!_'" := (op_zdzn__).
+
+Infix "$!" := (_$!_) (at level 99).
+
+(* Skipping definition `GHC.Base.until' *)
+
+Definition asTypeOf {a} : a -> a -> a :=
+  const.
+
+(* Skipping definition `GHC.Base.returnIO' *)
+
+(* Skipping definition `GHC.Base.bindIO' *)
+
+(* Skipping definition `GHC.Base.thenIO' *)
+
+(* Skipping definition `GHC.Base.unIO' *)
+
+(* Skipping definition `GHC.Base.getTag' *)
+
+(* Skipping definition `GHC.Base.quotInt' *)
+
+(* Skipping definition `GHC.Base.remInt' *)
+
+(* Skipping definition `GHC.Base.divInt' *)
+
+(* Skipping definition `GHC.Base.modInt' *)
+
+(* Skipping definition `GHC.Base.quotRemInt' *)
+
+(* Skipping definition `GHC.Base.divModInt' *)
+
+(* Skipping definition `GHC.Base.op_divModIntzh__' *)
+
+(* Skipping definition `GHC.Base.op_shiftLzh__' *)
+
+(* Skipping definition `GHC.Base.op_shiftRLzh__' *)
+
+(* Skipping definition `GHC.Base.op_iShiftLzh__' *)
+
+(* Skipping definition `GHC.Base.op_iShiftRAzh__' *)
+
+(* Skipping definition `GHC.Base.op_iShiftRLzh__' *)
 
 Module Notations.
 Export ManualNotations.
@@ -1397,16 +1397,16 @@ Notation "'_GHC.Base.>>_'" := (op_zgzg__).
 Infix "GHC.Base.>>" := (_>>_) (at level 99).
 Notation "'_GHC.Base.>>=_'" := (op_zgzgze__).
 Infix "GHC.Base.>>=" := (_>>=_) (at level 99).
+Notation "'_GHC.Base.∘_'" := (op_z2218U__).
+Infix "GHC.Base.∘" := (_∘_) (left associativity, at level 40).
 Notation "'_GHC.Base.<**>_'" := (op_zlztztzg__).
 Infix "GHC.Base.<**>" := (_<**>_) (at level 99).
 Notation "'_GHC.Base.=<<_'" := (op_zezlzl__).
 Infix "GHC.Base.=<<" := (_=<<_) (at level 99).
-Notation "'_GHC.Base.$!_'" := (op_zdzn__).
-Infix "GHC.Base.$!" := (_$!_) (at level 99).
 Notation "'_GHC.Base.$_'" := (op_zd__).
 Infix "GHC.Base.$" := (_$_) (at level 99).
-Notation "'_GHC.Base.∘_'" := (op_z2218U__).
-Infix "GHC.Base.∘" := (_∘_) (left associativity, at level 40).
+Notation "'_GHC.Base.$!_'" := (op_zdzn__).
+Infix "GHC.Base.$!" := (_$!_) (at level 99).
 End Notations.
 
 (* External variables:

--- a/base/GHC/List.v
+++ b/base/GHC/List.v
@@ -75,63 +75,20 @@ Import GHC.Num.Notations.
 
 (* Converted value declarations: *)
 
-Definition zipWithFB {a} {b} {c} {d} {e}
-   : (a -> b -> c) -> (d -> e -> a) -> d -> e -> b -> c :=
-  fun c f => fun x y r => c (f x y) r.
+Definition prel_list_str : String :=
+  GHC.Base.hs_string__ "Prelude.".
 
-Definition zipWith3 {a} {b} {c} {d}
-   : (a -> b -> c -> d) -> list a -> list b -> list c -> list d :=
-  fun z =>
-    let fix go arg_0__ arg_1__ arg_2__
-              := match arg_0__, arg_1__, arg_2__ with
-                 | cons a as_, cons b bs, cons c cs => cons (z a b c) (go as_ bs cs)
-                 | _, _, _ => nil
-                 end in
-    go.
+Definition errorEmptyList {a} `{_ : GHC.Err.Default a} : String -> a :=
+  fun fun_ =>
+    GHC.Err.errorWithoutStackTrace (Coq.Init.Datatypes.app prel_list_str
+                                                           (Coq.Init.Datatypes.app fun_ (GHC.Base.hs_string__
+                                                                                    ": empty list"))).
 
-Definition zipWith {a} {b} {c} : (a -> b -> c) -> list a -> list b -> list c :=
-  fun f =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | nil, _ => nil
-                 | _, nil => nil
-                 | cons x xs, cons y ys => cons (f x y) (go xs ys)
-                 end in
-    go.
+Definition badHead {a} `{_ : GHC.Err.Default a} : a :=
+  errorEmptyList (GHC.Base.hs_string__ "head").
 
-Definition zipFB {a} {b} {c} {d}
-   : ((a * b)%type -> c -> d) -> a -> b -> c -> d :=
-  fun c => fun x y r => c (pair x y) r.
-
-Fixpoint zip3 {a} {b} {c} (arg_0__ : list a) (arg_1__ : list b) (arg_2__
-                : list c) : list (a * b * c)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | cons a as_, cons b bs, cons c cs => cons (pair (pair a b) c) (zip3 as_ bs cs)
-              | _, _, _ => nil
-              end.
-
-Fixpoint zip {a} {b} (arg_0__ : list a) (arg_1__ : list b) : list (a * b)%type
-           := match arg_0__, arg_1__ with
-              | nil, _bs => nil
-              | _as, nil => nil
-              | cons a as_, cons b bs => cons (pair a b) (zip as_ bs)
-              end.
-
-Definition unzip3 {a} {b} {c}
-   : list (a * b * c)%type -> (list a * list b * list c)%type :=
-  foldr (fun arg_0__ arg_1__ =>
-           match arg_0__, arg_1__ with
-           | pair (pair a b) c, pair (pair as_ bs) cs =>
-               pair (pair (cons a as_) (cons b bs)) (cons c cs)
-           end) (pair (pair nil nil) nil).
-
-Definition unzip {a} {b} : list (a * b)%type -> (list a * list b)%type :=
-  foldr (fun arg_0__ arg_1__ =>
-           match arg_0__, arg_1__ with
-           | pair a b, pair as_ bs => pair (cons a as_) (cons b bs)
-           end) (pair nil nil).
-
-(* Skipping definition `GHC.List.unsafeTake' *)
+Definition head {a} `{_ : GHC.Err.Default a} : list a -> a :=
+  fun arg_0__ => match arg_0__ with | cons x _ => x | nil => badHead end.
 
 Definition uncons {a} : list a -> option (a * list a)%type :=
   fun arg_0__ =>
@@ -140,40 +97,146 @@ Definition uncons {a} : list a -> option (a * list a)%type :=
     | cons x xs => Some (pair x xs)
     end.
 
-Definition takeWhileFB {a} {b}
-   : (a -> bool) -> (a -> b -> b) -> b -> a -> b -> b :=
-  fun p c n => fun x r => if p x : bool then c x r else n.
+Definition tail {a} `{_ : GHC.Err.Default a} : list a -> list a :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | cons _ xs => xs
+    | nil => errorEmptyList (GHC.Base.hs_string__ "tail")
+    end.
 
-Fixpoint takeWhile {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : list a
+(* Skipping definition `GHC.Base.foldl' *)
+
+Definition lastError {a} `{_ : GHC.Err.Default a} : a :=
+  errorEmptyList (GHC.Base.hs_string__ "last").
+
+Definition last {a} `{_ : GHC.Err.Default a} : list a -> a :=
+  fun xs =>
+    foldl (fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | _, x => x end)
+    lastError xs.
+
+Definition init {a} `{_ : GHC.Err.Default a} : list a -> list a :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | nil => errorEmptyList (GHC.Base.hs_string__ "init")
+    | cons x xs =>
+        let fix init' arg_2__ arg_3__
+                  := match arg_2__, arg_3__ with
+                     | _, nil => nil
+                     | y, cons z zs => cons y (init' z zs)
+                     end in
+        init' x xs
+    end.
+
+Definition null {a} : list a -> bool :=
+  fun arg_0__ => match arg_0__ with | nil => true | cons _ _ => false end.
+
+Fixpoint lenAcc {a} (arg_0__ : list a) (arg_1__ : GHC.Num.Int) : GHC.Num.Int
            := match arg_0__, arg_1__ with
-              | _, nil => nil
-              | p, cons x xs => if p x : bool then cons x (takeWhile p xs) else nil
+              | nil, n => n
+              | cons _ ys, n => lenAcc ys (n GHC.Num.+ #1)
               end.
 
-Definition takeFB {a} {b}
-   : (a -> b -> b) -> b -> a -> (GHC.Num.Int -> b) -> GHC.Num.Int -> b :=
-  fun c n x xs =>
-    fun m =>
-      let 'num_0__ := m in
-      if num_0__ == #1 : bool then c x n else
-      c x (xs (m GHC.Num.- #1)).
+Definition length {a} : list a -> GHC.Num.Int :=
+  fun xs => lenAcc xs #0.
 
-(* Skipping definition `GHC.List.take' *)
+Definition lengthFB {x}
+   : x -> (GHC.Num.Int -> GHC.Num.Int) -> GHC.Num.Int -> GHC.Num.Int :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | _, r => fun a => r (a GHC.Num.+ #1)
+    end.
+
+Definition idLength : GHC.Num.Int -> GHC.Num.Int :=
+  id.
+
+Fixpoint filter {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : list a
+           := match arg_0__, arg_1__ with
+              | _pred, nil => nil
+              | pred, cons x xs =>
+                  if pred x : bool then cons x (filter pred xs) else
+                  filter pred xs
+              end.
+
+Definition filterFB {a} {b} : (a -> b -> b) -> (a -> bool) -> a -> b -> b :=
+  fun c p x r => if p x : bool then c x r else r.
+
+(* Skipping definition `GHC.Base.foldl'' *)
+
+Definition foldl1 {a} `{_ : GHC.Err.Default a} : (a -> a -> a) -> list a -> a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, cons x xs => foldl f x xs
+    | _, nil => errorEmptyList (GHC.Base.hs_string__ "foldl1")
+    end.
+
+Definition foldl1' {a} `{_ : GHC.Err.Default a}
+   : (a -> a -> a) -> list a -> a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, cons x xs => foldl' f x xs
+    | _, nil => errorEmptyList (GHC.Base.hs_string__ "foldl1'")
+    end.
+
+Definition sum {a} `{(GHC.Num.Num a)} : list a -> a :=
+  foldl _GHC.Num.+_ #0.
+
+Definition product {a} `{(GHC.Num.Num a)} : list a -> a :=
+  foldl _GHC.Num.*_ #1.
+
+Definition scanl {b} {a} : (b -> a -> b) -> b -> list a -> list b :=
+  let scanlGo {b} {a} : (b -> a -> b) -> b -> list a -> list b :=
+    fix scanlGo (f : (b -> a -> b)) (q : b) (ls : list a) : list b
+          := cons q (match ls with
+                   | nil => nil
+                   | cons x xs => scanlGo f (f q x) xs
+                   end) in
+  scanlGo.
+
+Definition scanlFB {b} {a} {c}
+   : (b -> a -> b) -> (b -> c -> c) -> a -> (b -> c) -> b -> c :=
+  fun f c => fun b g => (fun x => let b' := f x b in c b' (g b')).
+
+Definition constScanl {a} {b} : a -> b -> a :=
+  const.
+
+Definition scanl1 {a} : (a -> a -> a) -> list a -> list a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, cons x xs => scanl f x xs
+    | _, nil => nil
+    end.
+
+Definition scanl' {b} {a} : (b -> a -> b) -> b -> list a -> list b :=
+  let scanlGo' {b} {a} : (b -> a -> b) -> b -> list a -> list b :=
+    fix scanlGo' (f : (b -> a -> b)) (q : b) (ls : list a) : list b
+          := cons q (match ls with
+                   | nil => nil
+                   | cons x xs => scanlGo' f (f q x) xs
+                   end) in
+  scanlGo'.
+
+Definition scanlFB' {b} {a} {c}
+   : (b -> a -> b) -> (b -> c -> c) -> a -> (b -> c) -> b -> c :=
+  fun f c => fun b g => (fun x => let b' := f x b in c b' (g b')).
+
+Definition flipSeqScanl' {a} {b} : a -> b -> a :=
+  fun a _b => a.
+
+Definition foldr1 {a} `{_ : GHC.Err.Default a} : (a -> a -> a) -> list a -> a :=
+  fun f =>
+    let fix go arg_0__
+              := match arg_0__ with
+                 | cons x nil => x
+                 | cons x xs => f x (go xs)
+                 | nil => errorEmptyList (GHC.Base.hs_string__ "foldr1")
+                 end in
+    go.
+
+(* Skipping definition `GHC.List.scanr' *)
 
 Definition strictUncurryScanr {a} {b} {c}
    : (a -> b -> c) -> (a * b)%type -> c :=
   fun f pair_ => let 'pair x y := pair_ in f x y.
-
-(* Skipping definition `GHC.List.splitAt' *)
-
-Fixpoint span {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : (list a *
-                                                                list a)%type
-           := match arg_0__, arg_1__ with
-              | _, (nil as xs) => pair xs xs
-              | p, (cons x xs' as xs) =>
-                  if p x : bool then let 'pair ys zs := span p xs' in pair (cons x ys) zs else
-                  pair nil xs
-              end.
 
 Definition scanrFB {a} {b} {c}
    : (a -> b -> b) -> (b -> c -> c) -> a -> (b * c)%type -> (b * c)%type :=
@@ -195,40 +258,91 @@ Fixpoint scanr1 {a} `{_ : GHC.Err.Default a} (arg_0__ : a -> a -> a) (arg_1__
                   end
               end.
 
-(* Skipping definition `GHC.List.scanr' *)
-
-Definition scanlFB' {b} {a} {c}
-   : (b -> a -> b) -> (b -> c -> c) -> a -> (b -> c) -> b -> c :=
-  fun f c => fun b g => (fun x => let b' := f x b in c b' (g b')).
-
-Definition scanlFB {b} {a} {c}
-   : (b -> a -> b) -> (b -> c -> c) -> a -> (b -> c) -> b -> c :=
-  fun f c => fun b g => (fun x => let b' := f x b in c b' (g b')).
-
-Definition scanl' {b} {a} : (b -> a -> b) -> b -> list a -> list b :=
-  let scanlGo' {b} {a} : (b -> a -> b) -> b -> list a -> list b :=
-    fix scanlGo' (f : (b -> a -> b)) (q : b) (ls : list a) : list b
-          := cons q (match ls with
-                   | nil => nil
-                   | cons x xs => scanlGo' f (f q x) xs
-                   end) in
-  scanlGo'.
-
-Definition scanl {b} {a} : (b -> a -> b) -> b -> list a -> list b :=
-  let scanlGo {b} {a} : (b -> a -> b) -> b -> list a -> list b :=
-    fix scanlGo (f : (b -> a -> b)) (q : b) (ls : list a) : list b
-          := cons q (match ls with
-                   | nil => nil
-                   | cons x xs => scanlGo f (f q x) xs
-                   end) in
-  scanlGo.
-
-Definition scanl1 {a} : (a -> a -> a) -> list a -> list a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, cons x xs => scanl f x xs
-    | _, nil => nil
+Definition maximum {a} `{_ : GHC.Err.Default a} {_ : Eq_ a} {_ : Ord a}
+   : list a -> a :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | nil => errorEmptyList (GHC.Base.hs_string__ "maximum")
+    | xs => foldl1 max xs
     end.
+
+Definition minimum {a} `{_ : GHC.Err.Default a} {_ : Eq_ a} {_ : Ord a}
+   : list a -> a :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | nil => errorEmptyList (GHC.Base.hs_string__ "minimum")
+    | xs => foldl1 min xs
+    end.
+
+(* Skipping definition `GHC.List.iterate' *)
+
+(* Skipping definition `GHC.List.iterateFB' *)
+
+(* Skipping definition `GHC.List.iterate'' *)
+
+(* Skipping definition `GHC.List.iterate'FB' *)
+
+(* Skipping definition `GHC.List.repeat' *)
+
+(* Skipping definition `GHC.List.repeatFB' *)
+
+(* Skipping definition `GHC.List.replicate' *)
+
+(* Skipping definition `GHC.List.cycle' *)
+
+Fixpoint takeWhile {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : list a
+           := match arg_0__, arg_1__ with
+              | _, nil => nil
+              | p, cons x xs => if p x : bool then cons x (takeWhile p xs) else nil
+              end.
+
+Definition takeWhileFB {a} {b}
+   : (a -> bool) -> (a -> b -> b) -> b -> a -> b -> b :=
+  fun p c n => fun x r => if p x : bool then c x r else n.
+
+Fixpoint dropWhile {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : list a
+           := match arg_0__, arg_1__ with
+              | _, nil => nil
+              | p, (cons x xs' as xs) => if p x : bool then dropWhile p xs' else xs
+              end.
+
+(* Skipping definition `GHC.List.take' *)
+
+(* Skipping definition `GHC.List.unsafeTake' *)
+
+Definition flipSeqTake {a} : a -> GHC.Num.Int -> a :=
+  fun x _n => x.
+
+Definition takeFB {a} {b}
+   : (a -> b -> b) -> b -> a -> (GHC.Num.Int -> b) -> GHC.Num.Int -> b :=
+  fun c n x xs =>
+    fun m =>
+      let 'num_0__ := m in
+      if num_0__ == #1 : bool then c x n else
+      c x (xs (m GHC.Num.- #1)).
+
+(* Skipping definition `GHC.List.drop' *)
+
+(* Skipping definition `GHC.List.splitAt' *)
+
+Fixpoint span {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : (list a *
+                                                                list a)%type
+           := match arg_0__, arg_1__ with
+              | _, (nil as xs) => pair xs xs
+              | p, (cons x xs' as xs) =>
+                  if p x : bool then let 'pair ys zs := span p xs' in pair (cons x ys) zs else
+                  pair nil xs
+              end.
+
+Fixpoint break {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : (list a *
+                                                                 list a)%type
+           := match arg_0__, arg_1__ with
+              | _, (nil as xs) => pair xs xs
+              | p, (cons x xs' as xs) =>
+                  if p x : bool then pair nil xs else
+                  let 'pair ys zs := break p xs' in
+                  pair (cons x ys) zs
+              end.
 
 Definition reverse {a} : list a -> list a :=
   fun l =>
@@ -239,19 +353,11 @@ Definition reverse {a} : list a -> list a :=
                  end in
     rev l nil.
 
-(* Skipping definition `GHC.List.replicate' *)
-
-(* Skipping definition `GHC.List.repeatFB' *)
-
-(* Skipping definition `GHC.List.repeat' *)
-
-Definition prel_list_str : String :=
-  GHC.Base.hs_string__ "Prelude.".
-
-Definition tooLarge {a} `{_ : GHC.Err.Default a} : GHC.Num.Int -> a :=
-  fun arg_0__ =>
-    GHC.Err.errorWithoutStackTrace (Coq.Init.Datatypes.app prel_list_str
-                                                           (GHC.Base.hs_string__ "!!: index too large")).
+Fixpoint and (arg_0__ : list bool) : bool
+           := match arg_0__ with
+              | nil => true
+              | cons x xs => andb x (and xs)
+              end.
 
 Fixpoint or (arg_0__ : list bool) : bool
            := match arg_0__ with
@@ -259,14 +365,46 @@ Fixpoint or (arg_0__ : list bool) : bool
               | cons x xs => orb x (or xs)
               end.
 
-Definition null {a} : list a -> bool :=
-  fun arg_0__ => match arg_0__ with | nil => true | cons _ _ => false end.
+Fixpoint any {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : bool
+           := match arg_0__, arg_1__ with
+              | _, nil => false
+              | p, cons x xs => orb (p x) (any p xs)
+              end.
+
+Fixpoint all {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : bool
+           := match arg_0__, arg_1__ with
+              | _, nil => true
+              | p, cons x xs => andb (p x) (all p xs)
+              end.
+
+Fixpoint elem {a} `{(Eq_ a)} (arg_0__ : a) (arg_1__ : list a) : bool
+           := match arg_0__, arg_1__ with
+              | _, nil => false
+              | x, cons y ys => orb (x == y) (elem x ys)
+              end.
 
 Fixpoint notElem {a} `{(Eq_ a)} (arg_0__ : a) (arg_1__ : list a) : bool
            := match arg_0__, arg_1__ with
               | _, nil => true
               | x, cons y ys => andb (x /= y) (notElem x ys)
               end.
+
+Fixpoint lookup {a} {b} `{(Eq_ a)} (arg_0__ : a) (arg_1__ : list (a * b)%type)
+           : option b
+           := match arg_0__, arg_1__ with
+              | _key, nil => None
+              | key, cons (pair x y) xys => if key == x : bool then Some y else lookup key xys
+              end.
+
+(* Skipping definition `Coq.Lists.List.flat_map' *)
+
+Definition concat {a} : list (list a) -> list a :=
+  foldr Coq.Init.Datatypes.app nil.
+
+Definition tooLarge {a} `{_ : GHC.Err.Default a} : GHC.Num.Int -> a :=
+  fun arg_0__ =>
+    GHC.Err.errorWithoutStackTrace (Coq.Init.Datatypes.app prel_list_str
+                                                           (GHC.Base.hs_string__ "!!: index too large")).
 
 Definition negIndex {a} `{_ : GHC.Err.Default a} : a :=
   GHC.Err.errorWithoutStackTrace (Coq.Init.Datatypes.app prel_list_str
@@ -285,48 +423,6 @@ Notation "'_!!_'" := (op_znzn__).
 
 Infix "!!" := (_!!_) (at level 99).
 
-Fixpoint lookup {a} {b} `{(Eq_ a)} (arg_0__ : a) (arg_1__ : list (a * b)%type)
-           : option b
-           := match arg_0__, arg_1__ with
-              | _key, nil => None
-              | key, cons (pair x y) xys => if key == x : bool then Some y else lookup key xys
-              end.
-
-Definition lengthFB {x}
-   : x -> (GHC.Num.Int -> GHC.Num.Int) -> GHC.Num.Int -> GHC.Num.Int :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | _, r => fun a => r (a GHC.Num.+ #1)
-    end.
-
-Fixpoint lenAcc {a} (arg_0__ : list a) (arg_1__ : GHC.Num.Int) : GHC.Num.Int
-           := match arg_0__, arg_1__ with
-              | nil, n => n
-              | cons _ ys, n => lenAcc ys (n GHC.Num.+ #1)
-              end.
-
-Definition length {a} : list a -> GHC.Num.Int :=
-  fun xs => lenAcc xs #0.
-
-(* Skipping definition `GHC.List.iterateFB' *)
-
-(* Skipping definition `GHC.List.iterate'FB' *)
-
-(* Skipping definition `GHC.List.iterate'' *)
-
-(* Skipping definition `GHC.List.iterate' *)
-
-Definition idLength : GHC.Num.Int -> GHC.Num.Int :=
-  id.
-
-Definition foldr2_left {a} {b} {c} {d}
-   : (a -> b -> c -> d) -> d -> a -> (list b -> c) -> list b -> d :=
-  fun arg_0__ arg_1__ arg_2__ arg_3__ arg_4__ =>
-    match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__ with
-    | _k, z, _x, _r, nil => z
-    | k, _z, x, r, cons y ys => k x y (r ys)
-    end.
-
 Definition foldr2 {a} {b} {c}
    : (a -> b -> c -> c) -> c -> list a -> list b -> c :=
   fun k z =>
@@ -338,165 +434,69 @@ Definition foldr2 {a} {b} {c}
                  end in
     go.
 
-Definition flipSeqTake {a} : a -> GHC.Num.Int -> a :=
-  fun x _n => x.
+Definition foldr2_left {a} {b} {c} {d}
+   : (a -> b -> c -> d) -> d -> a -> (list b -> c) -> list b -> d :=
+  fun arg_0__ arg_1__ arg_2__ arg_3__ arg_4__ =>
+    match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__ with
+    | _k, z, _x, _r, nil => z
+    | k, _z, x, r, cons y ys => k x y (r ys)
+    end.
 
-Definition flipSeqScanl' {a} {b} : a -> b -> a :=
-  fun a _b => a.
-
-Definition filterFB {a} {b} : (a -> b -> b) -> (a -> bool) -> a -> b -> b :=
-  fun c p x r => if p x : bool then c x r else r.
-
-Fixpoint filter {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : list a
+Fixpoint zip {a} {b} (arg_0__ : list a) (arg_1__ : list b) : list (a * b)%type
            := match arg_0__, arg_1__ with
-              | _pred, nil => nil
-              | pred, cons x xs =>
-                  if pred x : bool then cons x (filter pred xs) else
-                  filter pred xs
+              | nil, _bs => nil
+              | _as, nil => nil
+              | cons a as_, cons b bs => cons (pair a b) (zip as_ bs)
               end.
 
-Definition errorEmptyList {a} `{_ : GHC.Err.Default a} : String -> a :=
-  fun fun_ =>
-    GHC.Err.errorWithoutStackTrace (Coq.Init.Datatypes.app prel_list_str
-                                                           (Coq.Init.Datatypes.app fun_ (GHC.Base.hs_string__
-                                                                                    ": empty list"))).
+Definition zipFB {a} {b} {c} {d}
+   : ((a * b)%type -> c -> d) -> a -> b -> c -> d :=
+  fun c => fun x y r => c (pair x y) r.
 
-Definition foldr1 {a} `{_ : GHC.Err.Default a} : (a -> a -> a) -> list a -> a :=
+Fixpoint zip3 {a} {b} {c} (arg_0__ : list a) (arg_1__ : list b) (arg_2__
+                : list c) : list (a * b * c)%type
+           := match arg_0__, arg_1__, arg_2__ with
+              | cons a as_, cons b bs, cons c cs => cons (pair (pair a b) c) (zip3 as_ bs cs)
+              | _, _, _ => nil
+              end.
+
+Definition zipWith {a} {b} {c} : (a -> b -> c) -> list a -> list b -> list c :=
   fun f =>
-    let fix go arg_0__
-              := match arg_0__ with
-                 | cons x nil => x
-                 | cons x xs => f x (go xs)
-                 | nil => errorEmptyList (GHC.Base.hs_string__ "foldr1")
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | nil, _ => nil
+                 | _, nil => nil
+                 | cons x xs, cons y ys => cons (f x y) (go xs ys)
                  end in
     go.
 
-Definition init {a} `{_ : GHC.Err.Default a} : list a -> list a :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | nil => errorEmptyList (GHC.Base.hs_string__ "init")
-    | cons x xs =>
-        let fix init' arg_2__ arg_3__
-                  := match arg_2__, arg_3__ with
-                     | _, nil => nil
-                     | y, cons z zs => cons y (init' z zs)
-                     end in
-        init' x xs
-    end.
+Definition zipWithFB {a} {b} {c} {d} {e}
+   : (a -> b -> c) -> (d -> e -> a) -> d -> e -> b -> c :=
+  fun c f => fun x y r => c (f x y) r.
 
-Definition lastError {a} `{_ : GHC.Err.Default a} : a :=
-  errorEmptyList (GHC.Base.hs_string__ "last").
+Definition zipWith3 {a} {b} {c} {d}
+   : (a -> b -> c -> d) -> list a -> list b -> list c -> list d :=
+  fun z =>
+    let fix go arg_0__ arg_1__ arg_2__
+              := match arg_0__, arg_1__, arg_2__ with
+                 | cons a as_, cons b bs, cons c cs => cons (z a b c) (go as_ bs cs)
+                 | _, _, _ => nil
+                 end in
+    go.
 
-Definition tail {a} `{_ : GHC.Err.Default a} : list a -> list a :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | cons _ xs => xs
-    | nil => errorEmptyList (GHC.Base.hs_string__ "tail")
-    end.
+Definition unzip {a} {b} : list (a * b)%type -> (list a * list b)%type :=
+  foldr (fun arg_0__ arg_1__ =>
+           match arg_0__, arg_1__ with
+           | pair a b, pair as_ bs => pair (cons a as_) (cons b bs)
+           end) (pair nil nil).
 
-Fixpoint elem {a} `{(Eq_ a)} (arg_0__ : a) (arg_1__ : list a) : bool
-           := match arg_0__, arg_1__ with
-              | _, nil => false
-              | x, cons y ys => orb (x == y) (elem x ys)
-              end.
-
-Fixpoint dropWhile {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : list a
-           := match arg_0__, arg_1__ with
-              | _, nil => nil
-              | p, (cons x xs' as xs) => if p x : bool then dropWhile p xs' else xs
-              end.
-
-(* Skipping definition `GHC.List.drop' *)
-
-(* Skipping definition `GHC.List.cycle' *)
-
-Definition constScanl {a} {b} : a -> b -> a :=
-  const.
-
-Definition concat {a} : list (list a) -> list a :=
-  foldr Coq.Init.Datatypes.app nil.
-
-Fixpoint break {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : (list a *
-                                                                 list a)%type
-           := match arg_0__, arg_1__ with
-              | _, (nil as xs) => pair xs xs
-              | p, (cons x xs' as xs) =>
-                  if p x : bool then pair nil xs else
-                  let 'pair ys zs := break p xs' in
-                  pair (cons x ys) zs
-              end.
-
-Definition badHead {a} `{_ : GHC.Err.Default a} : a :=
-  errorEmptyList (GHC.Base.hs_string__ "head").
-
-Definition head {a} `{_ : GHC.Err.Default a} : list a -> a :=
-  fun arg_0__ => match arg_0__ with | cons x _ => x | nil => badHead end.
-
-Fixpoint any {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : bool
-           := match arg_0__, arg_1__ with
-              | _, nil => false
-              | p, cons x xs => orb (p x) (any p xs)
-              end.
-
-Fixpoint and (arg_0__ : list bool) : bool
-           := match arg_0__ with
-              | nil => true
-              | cons x xs => andb x (and xs)
-              end.
-
-Fixpoint all {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : bool
-           := match arg_0__, arg_1__ with
-              | _, nil => true
-              | p, cons x xs => andb (p x) (all p xs)
-              end.
-
-(* Skipping definition `GHC.Base.foldl'' *)
-
-Definition foldl1' {a} `{_ : GHC.Err.Default a}
-   : (a -> a -> a) -> list a -> a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, cons x xs => foldl' f x xs
-    | _, nil => errorEmptyList (GHC.Base.hs_string__ "foldl1'")
-    end.
-
-(* Skipping definition `GHC.Base.foldl' *)
-
-Definition foldl1 {a} `{_ : GHC.Err.Default a} : (a -> a -> a) -> list a -> a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, cons x xs => foldl f x xs
-    | _, nil => errorEmptyList (GHC.Base.hs_string__ "foldl1")
-    end.
-
-Definition maximum {a} `{_ : GHC.Err.Default a} {_ : Eq_ a} {_ : Ord a}
-   : list a -> a :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | nil => errorEmptyList (GHC.Base.hs_string__ "maximum")
-    | xs => foldl1 max xs
-    end.
-
-Definition minimum {a} `{_ : GHC.Err.Default a} {_ : Eq_ a} {_ : Ord a}
-   : list a -> a :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | nil => errorEmptyList (GHC.Base.hs_string__ "minimum")
-    | xs => foldl1 min xs
-    end.
-
-Definition last {a} `{_ : GHC.Err.Default a} : list a -> a :=
-  fun xs =>
-    foldl (fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | _, x => x end)
-    lastError xs.
-
-Definition product {a} `{(GHC.Num.Num a)} : list a -> a :=
-  foldl _GHC.Num.*_ #1.
-
-Definition sum {a} `{(GHC.Num.Num a)} : list a -> a :=
-  foldl _GHC.Num.+_ #0.
-
-(* Skipping definition `Coq.Lists.List.flat_map' *)
+Definition unzip3 {a} {b} {c}
+   : list (a * b * c)%type -> (list a * list b * list c)%type :=
+  foldr (fun arg_0__ arg_1__ =>
+           match arg_0__, arg_1__ with
+           | pair (pair a b) c, pair (pair as_ bs) cs =>
+               pair (pair (cons a as_) (cons b bs)) (cons c cs)
+           end) (pair (pair nil nil) nil).
 
 Module Notations.
 Notation "'_GHC.List.!!_'" := (op_znzn__).

--- a/examples/base-src/module-edits/Data/Foldable/edits
+++ b/examples/base-src/module-edits/Data/Foldable/edits
@@ -42,6 +42,7 @@ skip Data.Foldable.Foldable__Last
 # skip Data.Foldable.GHC_Base_Ord_a___GHC_Base_Monoid__Min_a_
 
 order Data.Foldable.Foldable__list Data.Foldable.concatMap Data.Foldable.concat
+order Data.Foldable.Foldable__list Data.Foldable.Foldable__NonEmpty_fold
 redefine Definition Data.Foldable.hash_compose {a} {b} {c} := @Coq.Program.Basics.compose a b c.
 
 # Generic stuff

--- a/examples/base-src/module-edits/Data/Functor/Const/edits
+++ b/examples/base-src/module-edits/Data/Functor/Const/edits
@@ -15,6 +15,5 @@ delete unused type variables Data.Functor.Const.Semigroup__Const
 delete unused type variables Data.Functor.Const.Monoid__Const
 
 order Unpeel_Const Data.Functor.Const.Eq___Const_op_zeze__
-order Unpeel_Const Data.Functor.Const.Eq___Const_op_zsze__
 
 order Data.Functor.Const.Functor__Const Data.Functor.Const.Applicative__Const_op_ztzg__

--- a/examples/base-src/module-edits/Data/Semigroup/Internal/edits
+++ b/examples/base-src/module-edits/Data/Semigroup/Internal/edits
@@ -21,17 +21,11 @@ add Data.SemigroupInternal Instance Unpeel_Sum a : GHC.Prim.Unpeel (Sum a) a :=
 	 GHC.Prim.Build_Unpeel _ _ getSum Mk_Sum.
 
 order Unpeel_Any     Data.SemigroupInternal.Eq___Any_op_zeze__
-order Unpeel_Any     Data.SemigroupInternal.Eq___Any_op_zsze__
 order Unpeel_All     Data.SemigroupInternal.Eq___All_op_zeze__
-order Unpeel_All     Data.SemigroupInternal.Eq___All_op_zsze__
 order Unpeel_Alt     Data.SemigroupInternal.Eq___Alt_op_zeze__
-order Unpeel_Alt     Data.SemigroupInternal.Eq___Alt_op_zsze__
 order Unpeel_Product Data.SemigroupInternal.Eq___Product_op_zeze__
-order Unpeel_Product Data.SemigroupInternal.Eq___Product_op_zsze__
 order Unpeel_Sum     Data.SemigroupInternal.Eq___Sum_op_zeze__
-order Unpeel_Sum     Data.SemigroupInternal.Eq___Sum_op_zsze__
 order Unpeel_Dual    Data.SemigroupInternal.Eq___Dual_op_zeze__
-order Unpeel_Dual    Data.SemigroupInternal.Eq___Dual_op_zsze__
 order Unpeel_Endo    Data.SemigroupInternal.Semigroup__Endo_op_zlzlzgzg__
 
 order Data.SemigroupInternal.Eq___Any     Data.SemigroupInternal.Ord__Any

--- a/examples/base-src/module-edits/Data/Semigroup/edits
+++ b/examples/base-src/module-edits/Data/Semigroup/edits
@@ -41,22 +41,11 @@ skip Data.Semigroup.Monoid__Max
 ##################################
 
 order Unpeel_Min Data.Semigroup.Eq___Min_op_zeze__
-order Unpeel_Min Data.Semigroup.Eq___Min_op_zsze__
-
 order Unpeel_Max Data.Semigroup.Eq___Max_op_zeze__
-order Unpeel_Max Data.Semigroup.Eq___Max_op_zsze__
-
 order Unpeel_First Data.Semigroup.Eq___First_op_zeze__
-order Unpeel_First Data.Semigroup.Eq___First_op_zsze__
-
 order Unpeel_Last Data.Semigroup.Eq___Last_op_zeze__
-order Unpeel_Last Data.Semigroup.Eq___Last_op_zsze__
-
-order Unpeel_Option Data.Semigroup.Eq___Option_op_zeze__
-order Unpeel_Option Data.Semigroup.Eq___Option_op_zsze__
-
 order Unpeel_WrappedMonoid Data.Semigroup.Eq___WrappedMonoid_op_zeze__
-order Unpeel_WrappedMonoid Data.Semigroup.Eq___WrappedMonoid_op_zsze__
+order Unpeel_Option Data.Semigroup.Eq___Option_op_zeze__
 
 order Data.Semigroup.Eq___Max           Data.Semigroup.Ord__Max
 order Data.Semigroup.Eq___Min           Data.Semigroup.Ord__Min

--- a/examples/containers/hs-spec/IntSetProperties.v
+++ b/examples/containers/hs-spec/IntSetProperties.v
@@ -56,327 +56,20 @@ Import Test.QuickCheck.Property.Notations.
 
 (* Converted value declarations: *)
 
-Definition toSet
-   : Data.IntSet.Internal.IntSet ->
-     Data.Set.Internal.Set_ Coq.Numbers.BinNums.N :=
-  Data.Set.Internal.fromList GHC.Base.∘ Data.IntSet.Internal.toList.
+(* Skipping all instances of class `Test.QuickCheck.Arbitrary.Arbitrary',
+   including `IntSetProperties.Arbitrary__IntSet' *)
 
-(* Skipping definition `IntSetProperties.test_split' *)
+(* Skipping definition `IntSetProperties.main' *)
 
 (* Skipping definition `IntSetProperties.test_lookupLT' *)
 
-(* Skipping definition `IntSetProperties.test_lookupLE' *)
-
 (* Skipping definition `IntSetProperties.test_lookupGT' *)
+
+(* Skipping definition `IntSetProperties.test_lookupLE' *)
 
 (* Skipping definition `IntSetProperties.test_lookupGE' *)
 
-(* Skipping definition `IntSetProperties.test_LookupSomething' *)
-
-Definition prop_splitRoot : Data.IntSet.Internal.IntSet -> bool :=
-  fun s =>
-    let loop :=
-      fun arg_0__ =>
-        match arg_0__ with
-        | nil => true
-        | cons s1 rst =>
-            Data.Foldable.null (Coq.Lists.List.flat_map (fun x =>
-                                                           Coq.Lists.List.flat_map (fun y =>
-                                                                                      if x GHC.Base.> y : bool
-                                                                                      then cons (pair x y) nil else
-                                                                                      nil) (Data.IntSet.Internal.toList
-                                                                                    (Data.IntSet.Internal.unions rst)))
-                                                        (Data.IntSet.Internal.toList s1))
-        end in
-    let ls := Data.IntSet.Internal.splitRoot s in
-    andb (loop ls) (s GHC.Base.== Data.IntSet.Internal.unions ls).
-
-Definition prop_splitMember
-   : Data.IntSet.Internal.IntSet -> Coq.Numbers.BinNums.N -> Prop :=
-  fun s i =>
-    let 'pair (pair s1 t) s2 := Data.IntSet.Internal.splitMember i s in
-    IntSetValidity.valid s1 Test.QuickCheck.Property..&&.(**)
-    (IntSetValidity.valid s2 Test.QuickCheck.Property..&&.(**)
-     (Data.Foldable.all (fun arg_1__ => arg_1__ GHC.Base.< i)
-      (Data.IntSet.Internal.toList s1) Test.QuickCheck.Property..&&.(**)
-      (Data.Foldable.all (fun arg_2__ => arg_2__ GHC.Base.> i)
-       (Data.IntSet.Internal.toList s2) Test.QuickCheck.Property..&&.(**)
-       ((t Test.QuickCheck.Property.=== Data.IntSet.Internal.member i s)
-        Test.QuickCheck.Property..&&.(**)
-        (Data.IntSet.Internal.delete i s Test.QuickCheck.Property.===
-         Data.IntSet.Internal.union s1 s2))))).
-
-Definition prop_split
-   : Data.IntSet.Internal.IntSet -> Coq.Numbers.BinNums.N -> Prop :=
-  fun s i =>
-    let 'pair s1 s2 := Data.IntSet.Internal.split i s in
-    IntSetValidity.valid s1 Test.QuickCheck.Property..&&.(**)
-    (IntSetValidity.valid s2 Test.QuickCheck.Property..&&.(**)
-     (Data.Foldable.all (fun arg_1__ => arg_1__ GHC.Base.< i)
-      (Data.IntSet.Internal.toList s1) Test.QuickCheck.Property..&&.(**)
-      (Data.Foldable.all (fun arg_2__ => arg_2__ GHC.Base.> i)
-       (Data.IntSet.Internal.toList s2) Test.QuickCheck.Property..&&.(**)
-       (Data.IntSet.Internal.delete i s Test.QuickCheck.Property.===
-        Data.IntSet.Internal.union s1 s2)))).
-
-Definition prop_size : Data.IntSet.Internal.IntSet -> Prop :=
-  fun s =>
-    let sz := Data.IntSet.Internal.size s in
-    (sz Test.QuickCheck.Property.===
-     Data.IntSet.Internal.foldl' (fun arg_1__ arg_2__ =>
-                                    match arg_1__, arg_2__ with
-                                    | i, _ => i GHC.Num.+ #1
-                                    end) (#0 : Coq.Numbers.BinNums.N) s) Test.QuickCheck.Property..&&.(**)
-    (sz Test.QuickCheck.Property.===
-     Coq.NArith.BinNat.N.of_nat (Coq.Init.Datatypes.length
-                                 (Data.IntSet.Internal.toList s))).
-
-(* Skipping definition `IntSetProperties.prop_readShow' *)
-
-Definition prop_partition
-   : Data.IntSet.Internal.IntSet -> Coq.Numbers.BinNums.N -> Prop :=
-  fun s i =>
-    let 'pair s1 s2 := Data.IntSet.Internal.partition GHC.Real.odd s in
-    IntSetValidity.valid s1 Test.QuickCheck.Property..&&.(**)
-    (IntSetValidity.valid s2 Test.QuickCheck.Property..&&.(**)
-     (Data.Foldable.all GHC.Real.odd (Data.IntSet.Internal.toList s1)
-      Test.QuickCheck.Property..&&.(**)
-      (Data.Foldable.all GHC.Real.even (Data.IntSet.Internal.toList s2)
-       Test.QuickCheck.Property..&&.(**)
-       (s Test.QuickCheck.Property.=== Data.IntSet.Internal.union s1 s2)))).
-
-Definition prop_ord
-   : Data.IntSet.Internal.IntSet -> Data.IntSet.Internal.IntSet -> bool :=
-  fun s1 s2 =>
-    GHC.Base.compare s1 s2 GHC.Base.==
-    GHC.Base.compare (Data.IntSet.Internal.toList s1) (Data.IntSet.Internal.toList
-                      s2).
-
-(* Skipping definition `IntSetProperties.prop_minView' *)
-
-(* Skipping definition `IntSetProperties.prop_maxView' *)
-
-Definition prop_map : Data.IntSet.Internal.IntSet -> bool :=
-  fun s => Data.IntSet.Internal.map GHC.Base.id s GHC.Base.== s.
-
-Definition prop_isSubsetOf2
-   : Data.IntSet.Internal.IntSet -> Data.IntSet.Internal.IntSet -> bool :=
-  fun a b => Data.IntSet.Internal.isSubsetOf a (Data.IntSet.Internal.union a b).
-
-Definition prop_isSubsetOf
-   : Data.IntSet.Internal.IntSet -> Data.IntSet.Internal.IntSet -> bool :=
-  fun a b =>
-    Data.IntSet.Internal.isSubsetOf a b GHC.Base.==
-    Data.Set.Internal.isSubsetOf (toSet a) (toSet b).
-
-Definition prop_isProperSubsetOf2
-   : Data.IntSet.Internal.IntSet -> Data.IntSet.Internal.IntSet -> bool :=
-  fun a b =>
-    let c := Data.IntSet.Internal.union a b in
-    Data.IntSet.Internal.isProperSubsetOf a c GHC.Base.== (a GHC.Base./= c).
-
-Definition prop_isProperSubsetOf
-   : Data.IntSet.Internal.IntSet -> Data.IntSet.Internal.IntSet -> bool :=
-  fun a b =>
-    Data.IntSet.Internal.isProperSubsetOf a b GHC.Base.==
-    Data.Set.Internal.isProperSubsetOf (toSet a) (toSet b).
-
-(* Skipping definition `IntSetProperties.prop_fromList' *)
-
-Definition prop_foldR' : Data.IntSet.Internal.IntSet -> bool :=
-  fun s =>
-    Data.IntSet.Internal.foldr' cons nil s GHC.Base.==
-    Data.IntSet.Internal.toList s.
-
-Definition prop_foldR : Data.IntSet.Internal.IntSet -> bool :=
-  fun s =>
-    Data.IntSet.Internal.foldr cons nil s GHC.Base.== Data.IntSet.Internal.toList s.
-
-Definition prop_foldL' : Data.IntSet.Internal.IntSet -> bool :=
-  fun s =>
-    Data.IntSet.Internal.foldl' (GHC.Base.flip cons) nil s GHC.Base.==
-    Data.Foldable.foldl' (GHC.Base.flip cons) nil (Data.IntSet.Internal.toList s).
-
-Definition prop_foldL : Data.IntSet.Internal.IntSet -> bool :=
-  fun s =>
-    Data.IntSet.Internal.foldl (GHC.Base.flip cons) nil s GHC.Base.==
-    Data.Foldable.foldl (GHC.Base.flip cons) nil (Data.IntSet.Internal.toList s).
-
-(* Skipping definition `IntSetProperties.prop_findMin' *)
-
-(* Skipping definition `IntSetProperties.prop_findMax' *)
-
-Definition prop_filter
-   : Data.IntSet.Internal.IntSet -> Coq.Numbers.BinNums.N -> Prop :=
-  fun s i =>
-    let evens := Data.IntSet.Internal.filter GHC.Real.even s in
-    let odds := Data.IntSet.Internal.filter GHC.Real.odd s in
-    let parts := Data.IntSet.Internal.partition GHC.Real.odd s in
-    IntSetValidity.valid odds Test.QuickCheck.Property..&&.(**)
-    (IntSetValidity.valid evens Test.QuickCheck.Property..&&.(**)
-     (parts Test.QuickCheck.Property.=== pair odds evens)).
-
-Definition prop_disjoint
-   : Data.IntSet.Internal.IntSet -> Data.IntSet.Internal.IntSet -> bool :=
-  fun a b =>
-    Data.IntSet.Internal.disjoint a b GHC.Base.==
-    Data.IntSet.Internal.null (Data.IntSet.Internal.intersection a b).
-
-(* Skipping definition `IntSetProperties.prop_bitcount' *)
-
-Definition prop_UnionInsert
-   : Coq.Numbers.BinNums.N -> Data.IntSet.Internal.IntSet -> Prop :=
-  fun x t =>
-    let 't' := Data.IntSet.Internal.union t (Data.IntSet.Internal.singleton x) in
-    IntSetValidity.valid t' Test.QuickCheck.Property..&&.(**)
-    (t' Test.QuickCheck.Property.=== Data.IntSet.Internal.insert x t).
-
-Definition prop_UnionComm
-   : Data.IntSet.Internal.IntSet -> Data.IntSet.Internal.IntSet -> bool :=
-  fun t1 t2 =>
-    (Data.IntSet.Internal.union t1 t2 GHC.Base.== Data.IntSet.Internal.union t2 t1).
-
-Definition prop_UnionAssoc
-   : Data.IntSet.Internal.IntSet ->
-     Data.IntSet.Internal.IntSet -> Data.IntSet.Internal.IntSet -> bool :=
-  fun t1 t2 t3 =>
-    Data.IntSet.Internal.union t1 (Data.IntSet.Internal.union t2 t3) GHC.Base.==
-    Data.IntSet.Internal.union (Data.IntSet.Internal.union t1 t2) t3.
-
-Definition prop_SingletonValid : Coq.Numbers.BinNums.N -> Prop :=
-  fun x => IntSetValidity.valid (Data.IntSet.Internal.singleton x).
-
-Definition prop_Single : Coq.Numbers.BinNums.N -> bool :=
-  fun x =>
-    (Data.IntSet.Internal.insert x Data.IntSet.Internal.empty GHC.Base.==
-     Data.IntSet.Internal.singleton x).
-
-Fixpoint prop_Prefix (arg_0__ : Data.IntSet.Internal.IntSet) : bool
-           := match arg_0__ with
-              | (Data.IntSet.Internal.Bin prefix msk left_ right_ as s) =>
-                  andb (Data.Foldable.all (fun elem =>
-                                             Data.IntSet.Internal.match_ elem prefix msk) (Data.IntSet.Internal.toList
-                                                                                           s)) (andb (prop_Prefix left_)
-                                                                                                     (prop_Prefix
-                                                                                                      right_))
-              | _ => true
-              end.
-
-(* Skipping definition `IntSetProperties.prop_Ordered' *)
-
-Definition prop_NotMember
-   : list Coq.Numbers.BinNums.N -> Coq.Numbers.BinNums.N -> bool :=
-  fun xs n =>
-    let m := Data.IntSet.Internal.fromList xs in
-    Data.Foldable.all (fun k =>
-                         Data.IntSet.Internal.notMember k m GHC.Base.== (Data.Foldable.notElem k xs))
-    (cons n xs).
-
-Definition prop_MemberFromList : list Coq.Numbers.BinNums.N -> bool :=
-  fun xs =>
-    let abs_xs :=
-      Coq.Lists.List.flat_map (fun x =>
-                                 if x GHC.Base./= #0 : bool then cons (GHC.Num.abs x) nil else
-                                 nil) xs in
-    let t := Data.IntSet.Internal.fromList abs_xs in
-    andb (Data.Foldable.all (fun arg_2__ => Data.IntSet.Internal.member arg_2__ t)
-          abs_xs) (Data.Foldable.all ((fun arg_3__ =>
-                                         Data.IntSet.Internal.notMember arg_3__ t) GHC.Base.∘
-                                      GHC.Num.negate) abs_xs).
-
-Definition prop_Member
-   : list Coq.Numbers.BinNums.N -> Coq.Numbers.BinNums.N -> bool :=
-  fun xs n =>
-    let m := Data.IntSet.Internal.fromList xs in
-    Data.Foldable.all (fun k =>
-                         Data.IntSet.Internal.member k m GHC.Base.== (Data.Foldable.elem k xs)) (cons n
-                                                                                                      xs).
-
-(* Skipping definition `IntSetProperties.prop_LookupLT' *)
-
-(* Skipping definition `IntSetProperties.prop_LookupLE' *)
-
-(* Skipping definition `IntSetProperties.prop_LookupGT' *)
-
-(* Skipping definition `IntSetProperties.prop_LookupGE' *)
-
-Definition prop_List : list Coq.Numbers.BinNums.N -> bool :=
-  fun xs =>
-    (Data.OldList.sort (Data.OldList.nub xs) GHC.Base.==
-     Data.IntSet.Internal.toAscList (Data.IntSet.Internal.fromList xs)).
-
-Definition prop_LeftRight : Data.IntSet.Internal.IntSet -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Data.IntSet.Internal.Bin _ msk left_ right_ =>
-        andb (Data.Foldable.and (Coq.Lists.List.flat_map (fun x =>
-                                                            cons ((x Data.Bits..&.(**) msk) GHC.Base.== #0) nil)
-                                                         (Data.IntSet.Internal.toList left_))) (Data.Foldable.and
-              (Coq.Lists.List.flat_map (fun x =>
-                                          cons ((x Data.Bits..&.(**) msk) GHC.Base.== msk) nil)
-                                       (Data.IntSet.Internal.toList right_)))
-    | _ => true
-    end.
-
-Definition prop_Int
-   : list Coq.Numbers.BinNums.N -> list Coq.Numbers.BinNums.N -> Prop :=
-  fun xs ys =>
-    let 't := Data.IntSet.Internal.intersection (Data.IntSet.Internal.fromList xs)
-                (Data.IntSet.Internal.fromList ys) in
-    IntSetValidity.valid t Test.QuickCheck.Property..&&.(**)
-    (Data.IntSet.Internal.toAscList t Test.QuickCheck.Property.===
-     Data.OldList.sort (Data.OldList.nub ((Data.OldList.intersect) (xs) (ys)))).
-
-Definition prop_InsertIntoEmptyValid : Coq.Numbers.BinNums.N -> Prop :=
-  fun x =>
-    IntSetValidity.valid (Data.IntSet.Internal.insert x Data.IntSet.Internal.empty).
-
-Definition prop_InsertDelete
-   : Coq.Numbers.BinNums.N -> Data.IntSet.Internal.IntSet -> Prop :=
-  fun k t =>
-    negb (Data.IntSet.Internal.member k t) Test.QuickCheck.Property.==>
-    (let 't' := Data.IntSet.Internal.delete k (Data.IntSet.Internal.insert k t) in
-     IntSetValidity.valid t' Test.QuickCheck.Property..&&.(**)
-     (t' Test.QuickCheck.Property.=== t)).
-
-Definition prop_EmptyValid : Prop :=
-  IntSetValidity.valid Data.IntSet.Internal.empty.
-
-Definition prop_Diff
-   : list Coq.Numbers.BinNums.N -> list Coq.Numbers.BinNums.N -> Prop :=
-  fun xs ys =>
-    let 't := Data.IntSet.Internal.difference (Data.IntSet.Internal.fromList xs)
-                (Data.IntSet.Internal.fromList ys) in
-    IntSetValidity.valid t Test.QuickCheck.Property..&&.(**)
-    (Data.IntSet.Internal.toAscList t Test.QuickCheck.Property.===
-     Data.OldList.sort (_Data.OldList.\\_ (Data.OldList.nub xs) (Data.OldList.nub
-                                                                 ys))).
-
-Definition prop_DescList : list Coq.Numbers.BinNums.N -> bool :=
-  fun xs =>
-    (GHC.List.reverse (Data.OldList.sort (Data.OldList.nub xs)) GHC.Base.==
-     Data.IntSet.Internal.toDescList (Data.IntSet.Internal.fromList xs)).
-
-Definition prop_AscDescList : list Coq.Numbers.BinNums.N -> bool :=
-  fun xs =>
-    let s := Data.IntSet.Internal.fromList xs in
-    Data.IntSet.Internal.toAscList s GHC.Base.==
-    GHC.List.reverse (Data.IntSet.Internal.toDescList s).
-
-Definition powersOf2 : Data.IntSet.Internal.IntSet :=
-  Data.IntSet.Internal.fromList (Coq.Lists.List.flat_map (fun i =>
-                                                            cons (Coq.NArith.BinNat.N.pow #2 i) nil)
-                                                         (GHC.Enum.enumFromTo #0 #63)).
-
-Fixpoint prop_MaskPow2 (arg_0__ : Data.IntSet.Internal.IntSet) : bool
-           := match arg_0__ with
-              | Data.IntSet.Internal.Bin _ msk left_ right_ =>
-                  andb (Data.IntSet.Internal.member msk powersOf2) (andb (prop_MaskPow2 left_)
-                                                                         (prop_MaskPow2 right_))
-              | _ => true
-              end.
-
-(* Skipping definition `IntSetProperties.main' *)
+(* Skipping definition `IntSetProperties.test_split' *)
 
 Definition forValid {a} `{Test.QuickCheck.Property.Testable a}
    : (Data.IntSet.Internal.IntSet -> a) -> Prop :=
@@ -425,8 +118,315 @@ Definition forValidUnitTree {a} `{Test.QuickCheck.Property.Testable a}
 Definition prop_Valid : Prop :=
   forValidUnitTree (fun t => IntSetValidity.valid t).
 
-(* Skipping all instances of class `Test.QuickCheck.Arbitrary.Arbitrary',
-   including `IntSetProperties.Arbitrary__IntSet' *)
+Definition prop_EmptyValid : Prop :=
+  IntSetValidity.valid Data.IntSet.Internal.empty.
+
+Definition prop_SingletonValid : Coq.Numbers.BinNums.N -> Prop :=
+  fun x => IntSetValidity.valid (Data.IntSet.Internal.singleton x).
+
+Definition prop_InsertIntoEmptyValid : Coq.Numbers.BinNums.N -> Prop :=
+  fun x =>
+    IntSetValidity.valid (Data.IntSet.Internal.insert x Data.IntSet.Internal.empty).
+
+Definition prop_Single : Coq.Numbers.BinNums.N -> bool :=
+  fun x =>
+    (Data.IntSet.Internal.insert x Data.IntSet.Internal.empty GHC.Base.==
+     Data.IntSet.Internal.singleton x).
+
+Definition prop_Member
+   : list Coq.Numbers.BinNums.N -> Coq.Numbers.BinNums.N -> bool :=
+  fun xs n =>
+    let m := Data.IntSet.Internal.fromList xs in
+    Data.Foldable.all (fun k =>
+                         Data.IntSet.Internal.member k m GHC.Base.== (Data.Foldable.elem k xs)) (cons n
+                                                                                                      xs).
+
+Definition prop_NotMember
+   : list Coq.Numbers.BinNums.N -> Coq.Numbers.BinNums.N -> bool :=
+  fun xs n =>
+    let m := Data.IntSet.Internal.fromList xs in
+    Data.Foldable.all (fun k =>
+                         Data.IntSet.Internal.notMember k m GHC.Base.== (Data.Foldable.notElem k xs))
+    (cons n xs).
+
+(* Skipping definition `IntSetProperties.test_LookupSomething' *)
+
+(* Skipping definition `IntSetProperties.prop_LookupLT' *)
+
+(* Skipping definition `IntSetProperties.prop_LookupGT' *)
+
+(* Skipping definition `IntSetProperties.prop_LookupLE' *)
+
+(* Skipping definition `IntSetProperties.prop_LookupGE' *)
+
+Definition prop_InsertDelete
+   : Coq.Numbers.BinNums.N -> Data.IntSet.Internal.IntSet -> Prop :=
+  fun k t =>
+    negb (Data.IntSet.Internal.member k t) Test.QuickCheck.Property.==>
+    (let 't' := Data.IntSet.Internal.delete k (Data.IntSet.Internal.insert k t) in
+     IntSetValidity.valid t' Test.QuickCheck.Property..&&.(**)
+     (t' Test.QuickCheck.Property.=== t)).
+
+Definition prop_MemberFromList : list Coq.Numbers.BinNums.N -> bool :=
+  fun xs =>
+    let abs_xs :=
+      Coq.Lists.List.flat_map (fun x =>
+                                 if x GHC.Base./= #0 : bool then cons (GHC.Num.abs x) nil else
+                                 nil) xs in
+    let t := Data.IntSet.Internal.fromList abs_xs in
+    andb (Data.Foldable.all (fun arg_2__ => Data.IntSet.Internal.member arg_2__ t)
+          abs_xs) (Data.Foldable.all ((fun arg_3__ =>
+                                         Data.IntSet.Internal.notMember arg_3__ t) GHC.Base.∘
+                                      GHC.Num.negate) abs_xs).
+
+Definition prop_UnionInsert
+   : Coq.Numbers.BinNums.N -> Data.IntSet.Internal.IntSet -> Prop :=
+  fun x t =>
+    let 't' := Data.IntSet.Internal.union t (Data.IntSet.Internal.singleton x) in
+    IntSetValidity.valid t' Test.QuickCheck.Property..&&.(**)
+    (t' Test.QuickCheck.Property.=== Data.IntSet.Internal.insert x t).
+
+Definition prop_UnionAssoc
+   : Data.IntSet.Internal.IntSet ->
+     Data.IntSet.Internal.IntSet -> Data.IntSet.Internal.IntSet -> bool :=
+  fun t1 t2 t3 =>
+    Data.IntSet.Internal.union t1 (Data.IntSet.Internal.union t2 t3) GHC.Base.==
+    Data.IntSet.Internal.union (Data.IntSet.Internal.union t1 t2) t3.
+
+Definition prop_UnionComm
+   : Data.IntSet.Internal.IntSet -> Data.IntSet.Internal.IntSet -> bool :=
+  fun t1 t2 =>
+    (Data.IntSet.Internal.union t1 t2 GHC.Base.== Data.IntSet.Internal.union t2 t1).
+
+Definition prop_Diff
+   : list Coq.Numbers.BinNums.N -> list Coq.Numbers.BinNums.N -> Prop :=
+  fun xs ys =>
+    let 't := Data.IntSet.Internal.difference (Data.IntSet.Internal.fromList xs)
+                (Data.IntSet.Internal.fromList ys) in
+    IntSetValidity.valid t Test.QuickCheck.Property..&&.(**)
+    (Data.IntSet.Internal.toAscList t Test.QuickCheck.Property.===
+     Data.OldList.sort (_Data.OldList.\\_ (Data.OldList.nub xs) (Data.OldList.nub
+                                                                 ys))).
+
+Definition prop_Int
+   : list Coq.Numbers.BinNums.N -> list Coq.Numbers.BinNums.N -> Prop :=
+  fun xs ys =>
+    let 't := Data.IntSet.Internal.intersection (Data.IntSet.Internal.fromList xs)
+                (Data.IntSet.Internal.fromList ys) in
+    IntSetValidity.valid t Test.QuickCheck.Property..&&.(**)
+    (Data.IntSet.Internal.toAscList t Test.QuickCheck.Property.===
+     Data.OldList.sort (Data.OldList.nub ((Data.OldList.intersect) (xs) (ys)))).
+
+Definition prop_disjoint
+   : Data.IntSet.Internal.IntSet -> Data.IntSet.Internal.IntSet -> bool :=
+  fun a b =>
+    Data.IntSet.Internal.disjoint a b GHC.Base.==
+    Data.IntSet.Internal.null (Data.IntSet.Internal.intersection a b).
+
+(* Skipping definition `IntSetProperties.prop_Ordered' *)
+
+Definition prop_List : list Coq.Numbers.BinNums.N -> bool :=
+  fun xs =>
+    (Data.OldList.sort (Data.OldList.nub xs) GHC.Base.==
+     Data.IntSet.Internal.toAscList (Data.IntSet.Internal.fromList xs)).
+
+Definition prop_DescList : list Coq.Numbers.BinNums.N -> bool :=
+  fun xs =>
+    (GHC.List.reverse (Data.OldList.sort (Data.OldList.nub xs)) GHC.Base.==
+     Data.IntSet.Internal.toDescList (Data.IntSet.Internal.fromList xs)).
+
+Definition prop_AscDescList : list Coq.Numbers.BinNums.N -> bool :=
+  fun xs =>
+    let s := Data.IntSet.Internal.fromList xs in
+    Data.IntSet.Internal.toAscList s GHC.Base.==
+    GHC.List.reverse (Data.IntSet.Internal.toDescList s).
+
+(* Skipping definition `IntSetProperties.prop_fromList' *)
+
+Definition powersOf2 : Data.IntSet.Internal.IntSet :=
+  Data.IntSet.Internal.fromList (Coq.Lists.List.flat_map (fun i =>
+                                                            cons (Coq.NArith.BinNat.N.pow #2 i) nil)
+                                                         (GHC.Enum.enumFromTo #0 #63)).
+
+Fixpoint prop_MaskPow2 (arg_0__ : Data.IntSet.Internal.IntSet) : bool
+           := match arg_0__ with
+              | Data.IntSet.Internal.Bin _ msk left_ right_ =>
+                  andb (Data.IntSet.Internal.member msk powersOf2) (andb (prop_MaskPow2 left_)
+                                                                         (prop_MaskPow2 right_))
+              | _ => true
+              end.
+
+Fixpoint prop_Prefix (arg_0__ : Data.IntSet.Internal.IntSet) : bool
+           := match arg_0__ with
+              | (Data.IntSet.Internal.Bin prefix msk left_ right_ as s) =>
+                  andb (Data.Foldable.all (fun elem =>
+                                             Data.IntSet.Internal.match_ elem prefix msk) (Data.IntSet.Internal.toList
+                                                                                           s)) (andb (prop_Prefix left_)
+                                                                                                     (prop_Prefix
+                                                                                                      right_))
+              | _ => true
+              end.
+
+Definition prop_LeftRight : Data.IntSet.Internal.IntSet -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Data.IntSet.Internal.Bin _ msk left_ right_ =>
+        andb (Data.Foldable.and (Coq.Lists.List.flat_map (fun x =>
+                                                            cons ((x Data.Bits..&.(**) msk) GHC.Base.== #0) nil)
+                                                         (Data.IntSet.Internal.toList left_))) (Data.Foldable.and
+              (Coq.Lists.List.flat_map (fun x =>
+                                          cons ((x Data.Bits..&.(**) msk) GHC.Base.== msk) nil)
+                                       (Data.IntSet.Internal.toList right_)))
+    | _ => true
+    end.
+
+Definition toSet
+   : Data.IntSet.Internal.IntSet ->
+     Data.Set.Internal.Set_ Coq.Numbers.BinNums.N :=
+  Data.Set.Internal.fromList GHC.Base.∘ Data.IntSet.Internal.toList.
+
+Definition prop_isProperSubsetOf
+   : Data.IntSet.Internal.IntSet -> Data.IntSet.Internal.IntSet -> bool :=
+  fun a b =>
+    Data.IntSet.Internal.isProperSubsetOf a b GHC.Base.==
+    Data.Set.Internal.isProperSubsetOf (toSet a) (toSet b).
+
+Definition prop_isProperSubsetOf2
+   : Data.IntSet.Internal.IntSet -> Data.IntSet.Internal.IntSet -> bool :=
+  fun a b =>
+    let c := Data.IntSet.Internal.union a b in
+    Data.IntSet.Internal.isProperSubsetOf a c GHC.Base.== (a GHC.Base./= c).
+
+Definition prop_isSubsetOf
+   : Data.IntSet.Internal.IntSet -> Data.IntSet.Internal.IntSet -> bool :=
+  fun a b =>
+    Data.IntSet.Internal.isSubsetOf a b GHC.Base.==
+    Data.Set.Internal.isSubsetOf (toSet a) (toSet b).
+
+Definition prop_isSubsetOf2
+   : Data.IntSet.Internal.IntSet -> Data.IntSet.Internal.IntSet -> bool :=
+  fun a b => Data.IntSet.Internal.isSubsetOf a (Data.IntSet.Internal.union a b).
+
+Definition prop_size : Data.IntSet.Internal.IntSet -> Prop :=
+  fun s =>
+    let sz := Data.IntSet.Internal.size s in
+    (sz Test.QuickCheck.Property.===
+     Data.IntSet.Internal.foldl' (fun arg_1__ arg_2__ =>
+                                    match arg_1__, arg_2__ with
+                                    | i, _ => i GHC.Num.+ #1
+                                    end) (#0 : Coq.Numbers.BinNums.N) s) Test.QuickCheck.Property..&&.(**)
+    (sz Test.QuickCheck.Property.===
+     Coq.NArith.BinNat.N.of_nat (Coq.Init.Datatypes.length
+                                 (Data.IntSet.Internal.toList s))).
+
+(* Skipping definition `IntSetProperties.prop_findMax' *)
+
+(* Skipping definition `IntSetProperties.prop_findMin' *)
+
+Definition prop_ord
+   : Data.IntSet.Internal.IntSet -> Data.IntSet.Internal.IntSet -> bool :=
+  fun s1 s2 =>
+    GHC.Base.compare s1 s2 GHC.Base.==
+    GHC.Base.compare (Data.IntSet.Internal.toList s1) (Data.IntSet.Internal.toList
+                      s2).
+
+(* Skipping definition `IntSetProperties.prop_readShow' *)
+
+Definition prop_foldR : Data.IntSet.Internal.IntSet -> bool :=
+  fun s =>
+    Data.IntSet.Internal.foldr cons nil s GHC.Base.== Data.IntSet.Internal.toList s.
+
+Definition prop_foldR' : Data.IntSet.Internal.IntSet -> bool :=
+  fun s =>
+    Data.IntSet.Internal.foldr' cons nil s GHC.Base.==
+    Data.IntSet.Internal.toList s.
+
+Definition prop_foldL : Data.IntSet.Internal.IntSet -> bool :=
+  fun s =>
+    Data.IntSet.Internal.foldl (GHC.Base.flip cons) nil s GHC.Base.==
+    Data.Foldable.foldl (GHC.Base.flip cons) nil (Data.IntSet.Internal.toList s).
+
+Definition prop_foldL' : Data.IntSet.Internal.IntSet -> bool :=
+  fun s =>
+    Data.IntSet.Internal.foldl' (GHC.Base.flip cons) nil s GHC.Base.==
+    Data.Foldable.foldl' (GHC.Base.flip cons) nil (Data.IntSet.Internal.toList s).
+
+Definition prop_map : Data.IntSet.Internal.IntSet -> bool :=
+  fun s => Data.IntSet.Internal.map GHC.Base.id s GHC.Base.== s.
+
+(* Skipping definition `IntSetProperties.prop_maxView' *)
+
+(* Skipping definition `IntSetProperties.prop_minView' *)
+
+Definition prop_split
+   : Data.IntSet.Internal.IntSet -> Coq.Numbers.BinNums.N -> Prop :=
+  fun s i =>
+    let 'pair s1 s2 := Data.IntSet.Internal.split i s in
+    IntSetValidity.valid s1 Test.QuickCheck.Property..&&.(**)
+    (IntSetValidity.valid s2 Test.QuickCheck.Property..&&.(**)
+     (Data.Foldable.all (fun arg_1__ => arg_1__ GHC.Base.< i)
+      (Data.IntSet.Internal.toList s1) Test.QuickCheck.Property..&&.(**)
+      (Data.Foldable.all (fun arg_2__ => arg_2__ GHC.Base.> i)
+       (Data.IntSet.Internal.toList s2) Test.QuickCheck.Property..&&.(**)
+       (Data.IntSet.Internal.delete i s Test.QuickCheck.Property.===
+        Data.IntSet.Internal.union s1 s2)))).
+
+Definition prop_splitMember
+   : Data.IntSet.Internal.IntSet -> Coq.Numbers.BinNums.N -> Prop :=
+  fun s i =>
+    let 'pair (pair s1 t) s2 := Data.IntSet.Internal.splitMember i s in
+    IntSetValidity.valid s1 Test.QuickCheck.Property..&&.(**)
+    (IntSetValidity.valid s2 Test.QuickCheck.Property..&&.(**)
+     (Data.Foldable.all (fun arg_1__ => arg_1__ GHC.Base.< i)
+      (Data.IntSet.Internal.toList s1) Test.QuickCheck.Property..&&.(**)
+      (Data.Foldable.all (fun arg_2__ => arg_2__ GHC.Base.> i)
+       (Data.IntSet.Internal.toList s2) Test.QuickCheck.Property..&&.(**)
+       ((t Test.QuickCheck.Property.=== Data.IntSet.Internal.member i s)
+        Test.QuickCheck.Property..&&.(**)
+        (Data.IntSet.Internal.delete i s Test.QuickCheck.Property.===
+         Data.IntSet.Internal.union s1 s2))))).
+
+Definition prop_splitRoot : Data.IntSet.Internal.IntSet -> bool :=
+  fun s =>
+    let loop :=
+      fun arg_0__ =>
+        match arg_0__ with
+        | nil => true
+        | cons s1 rst =>
+            Data.Foldable.null (Coq.Lists.List.flat_map (fun x =>
+                                                           Coq.Lists.List.flat_map (fun y =>
+                                                                                      if x GHC.Base.> y : bool
+                                                                                      then cons (pair x y) nil else
+                                                                                      nil) (Data.IntSet.Internal.toList
+                                                                                    (Data.IntSet.Internal.unions rst)))
+                                                        (Data.IntSet.Internal.toList s1))
+        end in
+    let ls := Data.IntSet.Internal.splitRoot s in
+    andb (loop ls) (s GHC.Base.== Data.IntSet.Internal.unions ls).
+
+Definition prop_partition
+   : Data.IntSet.Internal.IntSet -> Coq.Numbers.BinNums.N -> Prop :=
+  fun s i =>
+    let 'pair s1 s2 := Data.IntSet.Internal.partition GHC.Real.odd s in
+    IntSetValidity.valid s1 Test.QuickCheck.Property..&&.(**)
+    (IntSetValidity.valid s2 Test.QuickCheck.Property..&&.(**)
+     (Data.Foldable.all GHC.Real.odd (Data.IntSet.Internal.toList s1)
+      Test.QuickCheck.Property..&&.(**)
+      (Data.Foldable.all GHC.Real.even (Data.IntSet.Internal.toList s2)
+       Test.QuickCheck.Property..&&.(**)
+       (s Test.QuickCheck.Property.=== Data.IntSet.Internal.union s1 s2)))).
+
+Definition prop_filter
+   : Data.IntSet.Internal.IntSet -> Coq.Numbers.BinNums.N -> Prop :=
+  fun s i =>
+    let evens := Data.IntSet.Internal.filter GHC.Real.even s in
+    let odds := Data.IntSet.Internal.filter GHC.Real.odd s in
+    let parts := Data.IntSet.Internal.partition GHC.Real.odd s in
+    IntSetValidity.valid odds Test.QuickCheck.Property..&&.(**)
+    (IntSetValidity.valid evens Test.QuickCheck.Property..&&.(**)
+     (parts Test.QuickCheck.Property.=== pair odds evens)).
+
+(* Skipping definition `IntSetProperties.prop_bitcount' *)
 
 (* External variables:
      Prop andb bool cons list negb nil pair true Coq.Init.Datatypes.length

--- a/examples/containers/lib/Data/IntMap/Internal.v
+++ b/examples/containers/lib/Data/IntMap/Internal.v
@@ -150,856 +150,6 @@ Require Import Coq.Numbers.BinNums.
 
 (* Converted value declarations: *)
 
-(* Skipping definition `Data.IntSet.Internal.zero' *)
-
-(* Skipping definition `Data.IntSet.Internal.mask' *)
-
-Definition zipWithMaybeMatched {f} {x} {y} {z} `{GHC.Base.Applicative f}
-   : (Data.IntSet.Internal.Key -> x -> y -> option z) -> WhenMatched f x y z :=
-  fun f => Mk_WhenMatched (fun k x y => GHC.Base.pure (f k x y)).
-
-Definition zipWithMaybeAMatched {x} {y} {f} {z}
-   : (Data.IntSet.Internal.Key -> x -> y -> f (option z)) ->
-     WhenMatched f x y z :=
-  fun f => Mk_WhenMatched (fun k x y => f k x y).
-
-Definition zipWithMatched {f} {x} {y} {z} `{GHC.Base.Applicative f}
-   : (Data.IntSet.Internal.Key -> x -> y -> z) -> WhenMatched f x y z :=
-  fun f =>
-    Mk_WhenMatched (fun k x y => (GHC.Base.pure GHC.Base.∘ Some) (f k x y)).
-
-Definition zipWithAMatched {f} {x} {y} {z} `{GHC.Base.Applicative f}
-   : (Data.IntSet.Internal.Key -> x -> y -> f z) -> WhenMatched f x y z :=
-  fun f => Mk_WhenMatched (fun k x y => Some Data.Functor.<$> f k x y).
-
-(* Skipping definition `Data.IntMap.Internal.withEmpty' *)
-
-(* Skipping definition `Data.IntMap.Internal.withBar' *)
-
-(* Skipping definition `Data.IntMap.Internal.updateMinWithKey' *)
-
-(* Skipping definition `Data.IntMap.Internal.updateMin' *)
-
-(* Skipping definition `Data.IntMap.Internal.updateMaxWithKey' *)
-
-(* Skipping definition `Data.IntMap.Internal.updateMax' *)
-
-Fixpoint unsafeFindMin {a} (arg_0__ : IntMap a) : option
-                                                  (Data.IntSet.Internal.Key * a)%type
-           := match arg_0__ with
-              | Nil => None
-              | Tip ky y => Some (pair ky y)
-              | Bin _ _ l _ => unsafeFindMin l
-              end.
-
-Fixpoint unsafeFindMax {a} (arg_0__ : IntMap a) : option
-                                                  (Data.IntSet.Internal.Key * a)%type
-           := match arg_0__ with
-              | Nil => None
-              | Tip ky y => Some (pair ky y)
-              | Bin _ _ _ r => unsafeFindMax r
-              end.
-
-Definition traverseWithKey {t} {a} {b} `{GHC.Base.Applicative t}
-   : (Data.IntSet.Internal.Key -> a -> t b) -> IntMap a -> t (IntMap b) :=
-  fun f =>
-    let fix go arg_0__
-              := match arg_0__ with
-                 | Nil => GHC.Base.pure Nil
-                 | Tip k v => Tip k Data.Functor.<$> f k v
-                 | Bin p m l r => GHC.Base.liftA2 (Bin p m) (go l) (go r)
-                 end in
-    go.
-
-Definition traverseMissing {f} {x} {y} `{GHC.Base.Applicative f}
-   : (Data.IntSet.Internal.Key -> x -> f y) -> WhenMissing f x y :=
-  fun f =>
-    Mk_WhenMissing (traverseWithKey f) (fun k x => Some Data.Functor.<$> f k x).
-
-Definition splitRoot {a} : IntMap a -> list (IntMap a) :=
-  fun orig =>
-    match orig with
-    | Nil => nil
-    | (Tip _ _ as x) => cons x nil
-    | Bin _ m l r =>
-        if m GHC.Base.< #0 : bool then cons r (cons l nil) else
-        cons l (cons r nil)
-    end.
-
-Definition size {a} : IntMap a -> Coq.Numbers.BinNums.N :=
-  let fix go arg_0__ arg_1__
-            := match arg_0__, arg_1__ with
-               | acc, Bin _ _ l r => go (go acc l) r
-               | acc, Tip _ _ => #1 GHC.Num.+ acc
-               | acc, Nil => acc
-               end in
-  go #0.
-
-Definition singleton {a} : Data.IntSet.Internal.Key -> a -> IntMap a :=
-  fun k x => Tip k x.
-
-(* Skipping definition `Data.IntMap.Internal.showsTreeHang' *)
-
-(* Skipping definition `Data.IntMap.Internal.showsTree' *)
-
-(* Skipping definition `Data.IntMap.Internal.showsBars' *)
-
-(* Skipping definition `Data.IntMap.Internal.showWide' *)
-
-(* Skipping definition `Data.IntMap.Internal.showTreeWith' *)
-
-(* Skipping definition `Data.IntMap.Internal.showTree' *)
-
-(* Skipping definition `Data.IntMap.Internal.showBin' *)
-
-Definition shorter : Mask -> Mask -> bool :=
-  fun m1 m2 => (m1) GHC.Base.> (m2).
-
-Definition runWhenMissing {f} {x} {y}
-   : WhenMissing f x y -> Data.IntSet.Internal.Key -> x -> f (option y) :=
-  missingKey.
-
-Definition runWhenMatched {f} {x} {y} {z}
-   : WhenMatched f x y z -> Data.IntSet.Internal.Key -> x -> y -> f (option z) :=
-  matchedKey.
-
-Definition preserveMissing {f} {x} `{GHC.Base.Applicative f}
-   : WhenMissing f x x :=
-  Mk_WhenMissing GHC.Base.pure (fun arg_0__ arg_1__ =>
-                    match arg_0__, arg_1__ with
-                    | _, v => GHC.Base.pure (Some v)
-                    end).
-
-(* Skipping definition `Data.IntMap.Internal.op_zn__' *)
-
-Definition null {a} : IntMap a -> bool :=
-  fun arg_0__ => match arg_0__ with | Nil => true | _ => false end.
-
-Definition nomatch : Data.IntSet.Internal.Key -> Prefix -> Mask -> bool :=
-  fun i p m => (Data.IntSet.Internal.mask i m) GHC.Base./= p.
-
-Definition node : GHC.Base.String :=
-  GHC.Base.hs_string__ "+--".
-
-Fixpoint nequal {a} `{GHC.Base.Eq_ a} (arg_0__ arg_1__ : IntMap a) : bool
-           := match arg_0__, arg_1__ with
-              | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
-                  orb (m1 GHC.Base./= m2) (orb (p1 GHC.Base./= p2) (orb (nequal l1 l2) (nequal r1
-                                                                         r2)))
-              | Tip kx x, Tip ky y => orb (kx GHC.Base./= ky) (x GHC.Base./= y)
-              | Nil, Nil => false
-              | _, _ => true
-              end.
-
-(* Skipping definition `Data.IntMap.Internal.natFromInt' *)
-
-(* Skipping definition `Data.IntMap.Internal.minViewWithKeySure' *)
-
-(* Skipping definition `Data.IntMap.Internal.minViewWithKey' *)
-
-(* Skipping definition `Data.IntMap.Internal.minView' *)
-
-(* Skipping definition `Data.IntMap.Internal.mergeA' *)
-
-(* Skipping definition `Data.IntMap.Internal.merge' *)
-
-Definition member {a} : Data.IntSet.Internal.Key -> IntMap a -> bool :=
-  fun k =>
-    let fix go arg_0__
-              := match arg_0__ with
-                 | Bin p m l r =>
-                     if nomatch k p m : bool then false else
-                     if Data.IntSet.Internal.zero k m : bool then go l else
-                     go r
-                 | Tip kx _ => k GHC.Base.== kx
-                 | Nil => false
-                 end in
-    go.
-
-Definition notMember {a} : Data.IntSet.Internal.Key -> IntMap a -> bool :=
-  fun k m => negb (member k m).
-
-(* Skipping definition `Data.IntMap.Internal.maxViewWithKeySure' *)
-
-(* Skipping definition `Data.IntMap.Internal.maxViewWithKey' *)
-
-(* Skipping definition `Data.IntMap.Internal.maxView' *)
-
-Definition match_ : Data.IntSet.Internal.Key -> Prefix -> Mask -> bool :=
-  fun i p m => (Data.IntSet.Internal.mask i m) GHC.Base.== p.
-
-Definition maskW : Nat -> Nat -> Prefix :=
-  fun i m => i Data.Bits..&.(**) (Data.Bits.xor (complement' (m GHC.Num.- #1)) m).
-
-Fixpoint mapWithKey {a} {b} (f : (Data.IntSet.Internal.Key -> a -> b)) (t
-                      : IntMap a) : IntMap b
-           := match t with
-              | Bin p m l r => Bin p m (mapWithKey f l) (mapWithKey f r)
-              | Tip k x => Tip k (f k x)
-              | Nil => Nil
-              end.
-
-Definition map {a} {b} : (a -> b) -> IntMap a -> IntMap b :=
-  fun f =>
-    let fix go arg_0__
-              := match arg_0__ with
-                 | Bin p m l r => Bin p m (go l) (go r)
-                 | Tip k x => Tip k (f x)
-                 | Nil => Nil
-                 end in
-    go.
-
-Local Definition Functor__IntMap_fmap
-   : forall {a} {b}, (a -> b) -> IntMap a -> IntMap b :=
-  fun {a} {b} => map.
-
-Definition Functor__IntMap_op_zlzd__ {a} {b} :=
-  (@IntMap_op_zlzd__ a b).
-
-Program Instance Functor__IntMap : GHC.Base.Functor IntMap :=
-  fun _ k__ =>
-    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__IntMap_fmap ;
-           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__IntMap_op_zlzd__ |}.
-
-Definition mapWhenMissing {f} {a} {b} {x} `{GHC.Base.Applicative f}
-  `{GHC.Base.Monad f}
-   : (a -> b) -> WhenMissing f x a -> WhenMissing f x b :=
-  fun f t =>
-    Mk_WhenMissing (fun m =>
-                      missingSubtree t m GHC.Base.>>= (fun m' => GHC.Base.pure (GHC.Base.fmap f m')))
-                   (fun k x =>
-                      missingKey t k x GHC.Base.>>= (fun q => (GHC.Base.pure (GHC.Base.fmap f q)))).
-
-Definition mapWhenMatched {f} {a} {b} {x} {y} `{GHC.Base.Functor f}
-   : (a -> b) -> WhenMatched f x y a -> WhenMatched f x y b :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, Mk_WhenMatched g =>
-        Mk_WhenMatched (fun k x y => GHC.Base.fmap (GHC.Base.fmap f) (g k x y))
-    end.
-
-Definition mapMissing {f} {x} {y} `{GHC.Base.Applicative f}
-   : (Data.IntSet.Internal.Key -> x -> y) -> WhenMissing f x y :=
-  fun f =>
-    Mk_WhenMissing (fun m => GHC.Base.pure (mapWithKey f m)) (fun k x =>
-                      GHC.Base.pure (Some (f k x))).
-
-Definition mapLT {a}
-   : (IntMap a -> IntMap a) -> SplitLookup a -> SplitLookup a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, Mk_SplitLookup lt fnd gt => Mk_SplitLookup (f lt) fnd gt
-    end.
-
-(* Skipping definition `Data.IntMap.Internal.mapKeysMonotonic' *)
-
-Definition mapGentlyWhenMissing {f} {a} {b} {x} `{GHC.Base.Functor f}
-   : (a -> b) -> WhenMissing f x a -> WhenMissing f x b :=
-  fun f t =>
-    Mk_WhenMissing (fun m => GHC.Base.fmap f Data.Functor.<$> missingSubtree t m)
-                   (fun k x => GHC.Base.fmap f Data.Functor.<$> missingKey t k x).
-
-Definition mapGentlyWhenMatched {f} {a} {b} {x} {y} `{GHC.Base.Functor f}
-   : (a -> b) -> WhenMatched f x y a -> WhenMatched f x y b :=
-  fun f t =>
-    zipWithMaybeAMatched (fun k x y =>
-                            GHC.Base.fmap f Data.Functor.<$> runWhenMatched t k x y).
-
-Definition mapGT {a}
-   : (IntMap a -> IntMap a) -> SplitLookup a -> SplitLookup a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, Mk_SplitLookup lt fnd gt => Mk_SplitLookup lt fnd (f gt)
-    end.
-
-Fixpoint mapAccumRWithKey {a} {b} {c} (f
-                            : (a -> Data.IntSet.Internal.Key -> b -> (a * c)%type)) (a0 : a) (t : IntMap b)
-           : (a * IntMap c)%type
-           := match t with
-              | Bin p m l r =>
-                  let 'pair a1 r' := mapAccumRWithKey f a0 r in
-                  let 'pair a2 l' := mapAccumRWithKey f a1 l in
-                  pair a2 (Bin p m l' r')
-              | Tip k x => let 'pair a' x' := f a0 k x in pair a' (Tip k x')
-              | Nil => pair a0 Nil
-              end.
-
-Fixpoint mapAccumL {a} {b} {c} (f
-                     : (a -> Data.IntSet.Internal.Key -> b -> (a * c)%type)) (a0 : a) (t : IntMap b)
-           : (a * IntMap c)%type
-           := match t with
-              | Bin p m l r =>
-                  let 'pair a1 l' := mapAccumL f a0 l in
-                  let 'pair a2 r' := mapAccumL f a1 r in
-                  pair a2 (Bin p m l' r')
-              | Tip k x => let 'pair a' x' := f a0 k x in pair a' (Tip k x')
-              | Nil => pair a0 Nil
-              end.
-
-Definition mapAccumWithKey {a} {b} {c}
-   : (a -> Data.IntSet.Internal.Key -> b -> (a * c)%type) ->
-     a -> IntMap b -> (a * IntMap c)%type :=
-  fun f a t => mapAccumL f a t.
-
-Definition mapAccum {a} {b} {c}
-   : (a -> b -> (a * c)%type) -> a -> IntMap b -> (a * IntMap c)%type :=
-  fun f =>
-    mapAccumWithKey (fun arg_0__ arg_1__ arg_2__ =>
-                       match arg_0__, arg_1__, arg_2__ with
-                       | a', _, x => f a' x
-                       end).
-
-Fixpoint lookupPrefix {a} (arg_0__ : IntSetPrefix) (arg_1__ : IntMap a) : IntMap
-                                                                          a
-           := match arg_0__, arg_1__ with
-              | kp, (Bin p m l r as t) =>
-                  if (m Data.Bits..&.(**) Data.IntSet.Internal.suffixBitMask) GHC.Base./=
-                     #0 : bool
-                  then if Coq.NArith.BinNat.N.ldiff p Data.IntSet.Internal.suffixBitMask
-                          GHC.Base.==
-                          kp : bool
-                       then t
-                       else Nil else
-                  if nomatch kp p m : bool then Nil else
-                  if Data.IntSet.Internal.zero kp m : bool then lookupPrefix kp l else
-                  lookupPrefix kp r
-              | kp, (Tip kx _ as t) =>
-                  if (Coq.NArith.BinNat.N.ldiff kx Data.IntSet.Internal.suffixBitMask) GHC.Base.==
-                     kp : bool
-                  then t else
-                  Nil
-              | _, Nil => Nil
-              end.
-
-Definition lookupMin {a}
-   : IntMap a -> option (Data.IntSet.Internal.Key * a)%type :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Nil => None
-    | Tip k v => Some (pair k v)
-    | Bin _ m l r =>
-        let fix go arg_2__
-                  := match arg_2__ with
-                     | Tip k v => Some (pair k v)
-                     | Bin _ _ l' _ => go l'
-                     | Nil => None
-                     end in
-        if m GHC.Base.< #0 : bool then go r else
-        go l
-    end.
-
-Definition lookupMax {a}
-   : IntMap a -> option (Data.IntSet.Internal.Key * a)%type :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Nil => None
-    | Tip k v => Some (pair k v)
-    | Bin _ m l r =>
-        let fix go arg_2__
-                  := match arg_2__ with
-                     | Tip k v => Some (pair k v)
-                     | Bin _ _ _ r' => go r'
-                     | Nil => None
-                     end in
-        if m GHC.Base.< #0 : bool then go l else
-        go r
-    end.
-
-Definition lookupLT {a}
-   : Data.IntSet.Internal.Key ->
-     IntMap a -> option (Data.IntSet.Internal.Key * a)%type :=
-  fun k t =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | def, Bin p m l r =>
-                     if nomatch k p m : bool
-                     then if k GHC.Base.< p : bool
-                          then unsafeFindMax def
-                          else unsafeFindMax r else
-                     if Data.IntSet.Internal.zero k m : bool then go def l else
-                     go l r
-                 | def, Tip ky y =>
-                     if k GHC.Base.<= ky : bool then unsafeFindMax def else
-                     Some (pair ky y)
-                 | def, Nil => unsafeFindMax def
-                 end in
-    let j_10__ := go Nil t in
-    match t with
-    | Bin _ m l r =>
-        if m GHC.Base.< #0 : bool
-        then if k GHC.Base.>= #0 : bool
-             then go r l
-             else go Nil r else
-        j_10__
-    | _ => j_10__
-    end.
-
-Definition lookupLE {a}
-   : Data.IntSet.Internal.Key ->
-     IntMap a -> option (Data.IntSet.Internal.Key * a)%type :=
-  fun k t =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | def, Bin p m l r =>
-                     if nomatch k p m : bool
-                     then if k GHC.Base.< p : bool
-                          then unsafeFindMax def
-                          else unsafeFindMax r else
-                     if Data.IntSet.Internal.zero k m : bool then go def l else
-                     go l r
-                 | def, Tip ky y =>
-                     if k GHC.Base.< ky : bool then unsafeFindMax def else
-                     Some (pair ky y)
-                 | def, Nil => unsafeFindMax def
-                 end in
-    let j_10__ := go Nil t in
-    match t with
-    | Bin _ m l r =>
-        if m GHC.Base.< #0 : bool
-        then if k GHC.Base.>= #0 : bool
-             then go r l
-             else go Nil r else
-        j_10__
-    | _ => j_10__
-    end.
-
-Definition lookupGT {a}
-   : Data.IntSet.Internal.Key ->
-     IntMap a -> option (Data.IntSet.Internal.Key * a)%type :=
-  fun k t =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | def, Bin p m l r =>
-                     if nomatch k p m : bool
-                     then if k GHC.Base.< p : bool
-                          then unsafeFindMin l
-                          else unsafeFindMin def else
-                     if Data.IntSet.Internal.zero k m : bool then go r l else
-                     go def r
-                 | def, Tip ky y =>
-                     if k GHC.Base.>= ky : bool then unsafeFindMin def else
-                     Some (pair ky y)
-                 | def, Nil => unsafeFindMin def
-                 end in
-    let j_10__ := go Nil t in
-    match t with
-    | Bin _ m l r =>
-        if m GHC.Base.< #0 : bool
-        then if k GHC.Base.>= #0 : bool
-             then go Nil l
-             else go l r else
-        j_10__
-    | _ => j_10__
-    end.
-
-Definition lookupGE {a}
-   : Data.IntSet.Internal.Key ->
-     IntMap a -> option (Data.IntSet.Internal.Key * a)%type :=
-  fun k t =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | def, Bin p m l r =>
-                     if nomatch k p m : bool
-                     then if k GHC.Base.< p : bool
-                          then unsafeFindMin l
-                          else unsafeFindMin def else
-                     if Data.IntSet.Internal.zero k m : bool then go r l else
-                     go def r
-                 | def, Tip ky y =>
-                     if k GHC.Base.> ky : bool then unsafeFindMin def else
-                     Some (pair ky y)
-                 | def, Nil => unsafeFindMin def
-                 end in
-    let j_10__ := go Nil t in
-    match t with
-    | Bin _ m l r =>
-        if m GHC.Base.< #0 : bool
-        then if k GHC.Base.>= #0 : bool
-             then go Nil l
-             else go l r else
-        j_10__
-    | _ => j_10__
-    end.
-
-Definition lookup {a} : Data.IntSet.Internal.Key -> IntMap a -> option a :=
-  fun k =>
-    let fix go arg_0__
-              := match arg_0__ with
-                 | Bin p m l r =>
-                     if nomatch k p m : bool then None else
-                     if Data.IntSet.Internal.zero k m : bool then go l else
-                     go r
-                 | Tip kx x => if k GHC.Base.== kx : bool then Some x else None
-                 | Nil => None
-                 end in
-    go.
-
-Definition op_znz3fU__ {a} : IntMap a -> Data.IntSet.Internal.Key -> option a :=
-  fun m k => lookup k m.
-
-Notation "'_!?_'" := (op_znz3fU__).
-
-Infix "!?" := (_!?_) (at level 99).
-
-Fixpoint submapCmp {a} {b} (arg_0__ : (a -> b -> bool)) (arg_1__ : IntMap a)
-                   (arg_2__ : IntMap b) : comparison
-           := match arg_0__, arg_1__, arg_2__ with
-              | predicate, (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
-                  let submapCmpEq :=
-                    match pair (submapCmp predicate l1 l2) (submapCmp predicate r1 r2) with
-                    | pair Gt _ => Gt
-                    | pair _ Gt => Gt
-                    | pair Eq Eq => Eq
-                    | _ => Lt
-                    end in
-                  let submapCmpLt :=
-                    if nomatch p1 p2 m2 : bool then Gt else
-                    if Data.IntSet.Internal.zero p1 m2 : bool then submapCmp predicate t1 l2 else
-                    submapCmp predicate t1 r2 in
-                  if shorter m1 m2 : bool then Gt else
-                  if shorter m2 m1 : bool then submapCmpLt else
-                  if p1 GHC.Base.== p2 : bool then submapCmpEq else
-                  Gt
-              | _, _, _ =>
-                  match arg_0__, arg_1__, arg_2__ with
-                  | _, Bin _ _ _ _, _ => Gt
-                  | predicate, Tip kx x, Tip ky y =>
-                      if andb (kx GHC.Base.== ky) (predicate x y) : bool then Eq else
-                      Gt
-                  | _, _, _ =>
-                      match arg_0__, arg_1__, arg_2__ with
-                      | predicate, Tip k x, t =>
-                          match lookup k t with
-                          | Some y => if predicate x y : bool then Lt else Gt
-                          | _ => Gt
-                          end
-                      | _, Nil, Nil => Eq
-                      | _, Nil, _ => Lt
-                      | _, _, _ => GHC.Err.patternFailure
-                      end
-                  end
-              end.
-
-Definition lmapWhenMissing {b} {a} {f} {x}
-   : (b -> a) -> WhenMissing f a x -> WhenMissing f b x :=
-  fun f t =>
-    Mk_WhenMissing (fun m => missingSubtree t (GHC.Base.fmap f m)) (fun k x =>
-                      missingKey t k (f x)).
-
-Fixpoint keysSet {a} (arg_0__ : IntMap a) : Data.IntSet.Internal.IntSet
-           := match arg_0__ with
-              | Nil => Data.IntSet.Internal.Nil
-              | Tip kx _ => Data.IntSet.Internal.singleton kx
-              | Bin p m l r =>
-                  let fix computeBm arg_2__ arg_3__
-                            := match arg_2__, arg_3__ with
-                               | acc, Bin _ _ l' r' => computeBm (computeBm acc l') r'
-                               | acc, Tip kx _ => acc Data.Bits..|.(**) Data.IntSet.Internal.bitmapOf kx
-                               | _, Nil => GHC.Err.error (GHC.Base.hs_string__ "Data.IntSet.keysSet: Nil")
-                               end in
-                  if (m Data.Bits..&.(**) Data.IntSet.Internal.suffixBitMask) GHC.Base.==
-                     #0 : bool
-                  then Data.IntSet.Internal.Bin p m (keysSet l) (keysSet r) else
-                  Data.IntSet.Internal.Tip (Coq.NArith.BinNat.N.ldiff p
-                                                                      Data.IntSet.Internal.suffixBitMask) (computeBm
-                                                                                                           (computeBm #0
-                                                                                                            l) r)
-              end.
-
-Fixpoint isSubmapOfBy {a} {b} (arg_0__ : (a -> b -> bool)) (arg_1__ : IntMap a)
-                      (arg_2__ : IntMap b) : bool
-           := match arg_0__, arg_1__, arg_2__ with
-              | predicate, (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
-                  if shorter m1 m2 : bool then false else
-                  if shorter m2 m1 : bool
-                  then andb (match_ p1 p2 m2) (if Data.IntSet.Internal.zero p1 m2 : bool
-                             then isSubmapOfBy predicate t1 l2
-                             else isSubmapOfBy predicate t1 r2) else
-                  andb (p1 GHC.Base.== p2) (andb (isSubmapOfBy predicate l1 l2) (isSubmapOfBy
-                                                  predicate r1 r2))
-              | _, _, _ =>
-                  match arg_0__, arg_1__, arg_2__ with
-                  | _, Bin _ _ _ _, _ => false
-                  | predicate, Tip k x, t =>
-                      match lookup k t with
-                      | Some y => predicate x y
-                      | None => false
-                      end
-                  | _, Nil, _ => true
-                  end
-              end.
-
-Definition isSubmapOf {a} `{GHC.Base.Eq_ a} : IntMap a -> IntMap a -> bool :=
-  fun m1 m2 => isSubmapOfBy _GHC.Base.==_ m1 m2.
-
-Definition isProperSubmapOfBy {a} {b}
-   : (a -> b -> bool) -> IntMap a -> IntMap b -> bool :=
-  fun predicate t1 t2 =>
-    match submapCmp predicate t1 t2 with
-    | Lt => true
-    | _ => false
-    end.
-
-Definition isProperSubmapOf {a} `{GHC.Base.Eq_ a}
-   : IntMap a -> IntMap a -> bool :=
-  fun m1 m2 => isProperSubmapOfBy _GHC.Base.==_ m1 m2.
-
-(* Skipping definition `Data.IntMap.Internal.intMapDataType' *)
-
-(* Skipping definition `Data.IntMap.Internal.intFromNat' *)
-
-Fixpoint fromSet {a} (arg_0__ : (Data.IntSet.Internal.Key -> a)) (arg_1__
-                   : Data.IntSet.Internal.IntSet) : IntMap a
-           := match arg_0__, arg_1__ with
-              | _, Data.IntSet.Internal.Nil => Nil
-              | f, Data.IntSet.Internal.Bin p m l r => Bin p m (fromSet f l) (fromSet f r)
-              | f, Data.IntSet.Internal.Tip kx bm =>
-                  let buildTree :=
-                    GHC.DeferredFix.deferredFix4 (fun buildTree g prefix bmask bits =>
-                                                    let 'num_3__ := bits in
-                                                    if num_3__ GHC.Base.== #0 : bool then Tip prefix (g prefix) else
-                                                    let 'bits2 := Utils.Containers.Internal.BitUtil.shiftRL (bits) #1 in
-                                                    if (bmask Data.Bits..&.(**)
-                                                        ((Utils.Containers.Internal.BitUtil.shiftLL #1 bits2) GHC.Num.-
-                                                         #1)) GHC.Base.==
-                                                       #0 : bool
-                                                    then buildTree g (prefix GHC.Num.+ bits2)
-                                                         (Utils.Containers.Internal.BitUtil.shiftRL bmask bits2)
-                                                         bits2 else
-                                                    if ((Utils.Containers.Internal.BitUtil.shiftRL bmask bits2)
-                                                        Data.Bits..&.(**)
-                                                        ((Utils.Containers.Internal.BitUtil.shiftLL #1 bits2) GHC.Num.-
-                                                         #1)) GHC.Base.==
-                                                       #0 : bool
-                                                    then buildTree g prefix bmask bits2 else
-                                                    Bin prefix bits2 (buildTree g prefix bmask bits2) (buildTree g
-                                                                                                       (prefix GHC.Num.+
-                                                                                                        bits2)
-                                                                                                       (Utils.Containers.Internal.BitUtil.shiftRL
-                                                                                                        bmask bits2)
-                                                                                                       bits2)) in
-                  buildTree f kx bm (Data.IntSet.Internal.suffixBitMask GHC.Num.+ #1)
-              end.
-
-(* Skipping definition `Data.IntMap.Internal.fromListConstr' *)
-
-(* Skipping definition `Data.IntMap.Internal.fromDistinctAscList' *)
-
-(* Skipping definition `Data.IntMap.Internal.fromAscListWithKey' *)
-
-(* Skipping definition `Data.IntMap.Internal.fromAscListWith' *)
-
-(* Skipping definition `Data.IntMap.Internal.fromAscList' *)
-
-Definition foldrWithKey' {a} {b}
-   : (Data.IntSet.Internal.Key -> a -> b -> b) -> b -> IntMap a -> b :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx x => f kx x z'
-                 | z', Bin _ _ l r => go (go z' r) l
-                 end in
-    fun t =>
-      match t with
-      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
-      | _ => go z t
-      end.
-
-Definition foldrWithKey {a} {b}
-   : (Data.IntSet.Internal.Key -> a -> b -> b) -> b -> IntMap a -> b :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx x => f kx x z'
-                 | z', Bin _ _ l r => go (go z' r) l
-                 end in
-    fun t =>
-      match t with
-      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
-      | _ => go z t
-      end.
-
-Definition keys {a} : IntMap a -> list Data.IntSet.Internal.Key :=
-  foldrWithKey (fun arg_0__ arg_1__ arg_2__ =>
-                  match arg_0__, arg_1__, arg_2__ with
-                  | k, _, ks => cons k ks
-                  end) nil.
-
-Definition toAscList {a}
-   : IntMap a -> list (Data.IntSet.Internal.Key * a)%type :=
-  foldrWithKey (fun k x xs => cons (pair k x) xs) nil.
-
-Definition toList {a} : IntMap a -> list (Data.IntSet.Internal.Key * a)%type :=
-  toAscList.
-
-Definition foldrFB {a} {b}
-   : (Data.IntSet.Internal.Key -> a -> b -> b) -> b -> IntMap a -> b :=
-  foldrWithKey.
-
-Definition foldr' {a} {b} : (a -> b -> b) -> b -> IntMap a -> b :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip _ x => f x z'
-                 | z', Bin _ _ l r => go (go z' r) l
-                 end in
-    fun t =>
-      match t with
-      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
-      | _ => go z t
-      end.
-
-Definition foldr {a} {b} : (a -> b -> b) -> b -> IntMap a -> b :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip _ x => f x z'
-                 | z', Bin _ _ l r => go (go z' r) l
-                 end in
-    fun t =>
-      match t with
-      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
-      | _ => go z t
-      end.
-
-Definition foldlWithKey' {a} {b}
-   : (a -> Data.IntSet.Internal.Key -> b -> a) -> a -> IntMap b -> a :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx x => f z' kx x
-                 | z', Bin _ _ l r => go (go z' l) r
-                 end in
-    fun t =>
-      match t with
-      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r
-      | _ => go z t
-      end.
-
-Definition foldlWithKey {a} {b}
-   : (a -> Data.IntSet.Internal.Key -> b -> a) -> a -> IntMap b -> a :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx x => f z' kx x
-                 | z', Bin _ _ l r => go (go z' l) r
-                 end in
-    fun t =>
-      match t with
-      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r
-      | _ => go z t
-      end.
-
-Definition toDescList {a}
-   : IntMap a -> list (Data.IntSet.Internal.Key * a)%type :=
-  foldlWithKey (fun xs k x => cons (pair k x) xs) nil.
-
-Definition foldlFB {a} {b}
-   : (a -> Data.IntSet.Internal.Key -> b -> a) -> a -> IntMap b -> a :=
-  foldlWithKey.
-
-Definition foldl' {a} {b} : (a -> b -> a) -> a -> IntMap b -> a :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip _ x => f z' x
-                 | z', Bin _ _ l r => go (go z' l) r
-                 end in
-    fun t =>
-      match t with
-      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r
-      | _ => go z t
-      end.
-
-Definition foldl {a} {b} : (a -> b -> a) -> a -> IntMap b -> a :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip _ x => f z' x
-                 | z', Bin _ _ l r => go (go z' l) r
-                 end in
-    fun t =>
-      match t with
-      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r
-      | _ => go z t
-      end.
-
-Definition foldMapWithKey {m} {a} `{GHC.Base.Monoid m}
-   : (Data.IntSet.Internal.Key -> a -> m) -> IntMap a -> m :=
-  fun f =>
-    let fix go arg_0__
-              := match arg_0__ with
-                 | Nil => GHC.Base.mempty
-                 | Tip kx x => f kx x
-                 | Bin _ _ l r => GHC.Base.mappend (go l) (go r)
-                 end in
-    go.
-
-Definition findWithDefault {a}
-   : a -> Data.IntSet.Internal.Key -> IntMap a -> a :=
-  fun def k =>
-    let fix go arg_0__
-              := match arg_0__ with
-                 | Bin p m l r =>
-                     if nomatch k p m : bool then def else
-                     if Data.IntSet.Internal.zero k m : bool then go l else
-                     go r
-                 | Tip kx x => if k GHC.Base.== kx : bool then x else def
-                 | Nil => def
-                 end in
-    go.
-
-(* Skipping definition `Data.IntMap.Internal.findMin' *)
-
-(* Skipping definition `Data.IntMap.Internal.findMax' *)
-
-(* Skipping definition `Data.IntMap.Internal.find' *)
-
-Fixpoint equal {a} `{GHC.Base.Eq_ a} (arg_0__ arg_1__ : IntMap a) : bool
-           := match arg_0__, arg_1__ with
-              | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
-                  andb (m1 GHC.Base.== m2) (andb (p1 GHC.Base.== p2) (andb (equal l1 l2) (equal r1
-                                                                            r2)))
-              | Tip kx x, Tip ky y => andb (kx GHC.Base.== ky) (x GHC.Base.== y)
-              | Nil, Nil => true
-              | _, _ => false
-              end.
-
-Definition empty {a} : IntMap a :=
-  Nil.
-
-Definition elems {a} : IntMap a -> list a :=
-  foldr cons nil.
-
-Definition dropMissing {f} {x} {y} `{GHC.Base.Applicative f}
-   : WhenMissing f x y :=
-  Mk_WhenMissing (GHC.Base.const (GHC.Base.pure Nil)) (fun arg_0__ arg_1__ =>
-                    GHC.Base.pure None).
-
-(* Skipping definition `Data.IntMap.Internal.deleteMin' *)
-
-(* Skipping definition `Data.IntMap.Internal.deleteMax' *)
-
-(* Skipping definition `Data.IntMap.Internal.deleteFindMin' *)
-
-(* Skipping definition `Data.IntMap.Internal.deleteFindMax' *)
-
-Definition contramapSecondWhenMatched {b} {a} {f} {x} {z}
-   : (b -> a) -> WhenMatched f x a z -> WhenMatched f x b z :=
-  fun f t => Mk_WhenMatched (fun k x y => runWhenMatched t k x (f y)).
-
-Definition contramapFirstWhenMatched {b} {a} {f} {y} {z}
-   : (b -> a) -> WhenMatched f a y z -> WhenMatched f b y z :=
-  fun f t => Mk_WhenMatched (fun k x y => runWhenMatched t k (f x) y).
-
 Definition branchMask : Prefix -> Prefix -> Mask :=
   fun p1 p2 =>
     Utils.Containers.Internal.BitUtil.highestBitMask (Data.Bits.xor p1 p2).
@@ -1011,102 +161,11 @@ Definition link {a} : Prefix -> IntMap a -> Prefix -> IntMap a -> IntMap a :=
     if Data.IntSet.Internal.zero p1 m : bool then Bin p m t1 t2 else
     Bin p m t2 t1.
 
-Fixpoint insert {a} (arg_0__ : Data.IntSet.Internal.Key) (arg_1__ : a) (arg_2__
-                  : IntMap a) : IntMap a
-           := match arg_0__, arg_1__, arg_2__ with
-              | k, x, (Bin p m l r as t) =>
-                  if nomatch k p m : bool then link k (Tip k x) p t else
-                  if Data.IntSet.Internal.zero k m : bool then Bin p m (insert k x l) r else
-                  Bin p m l (insert k x r)
-              | k, x, (Tip ky _ as t) =>
-                  if k GHC.Base.== ky : bool then Tip k x else
-                  link k (Tip k x) ky t
-              | k, x, Nil => Tip k x
-              end.
+Definition nomatch : Data.IntSet.Internal.Key -> Prefix -> Mask -> bool :=
+  fun i p m => (Data.IntSet.Internal.mask i m) GHC.Base./= p.
 
-Definition fromList {a}
-   : list (Data.IntSet.Internal.Key * a)%type -> IntMap a :=
-  fun xs =>
-    let ins :=
-      fun arg_0__ arg_1__ =>
-        match arg_0__, arg_1__ with
-        | t, pair k x => insert k x t
-        end in
-    Data.Foldable.foldl' ins empty xs.
-
-Definition mapKeys {a}
-   : (Data.IntSet.Internal.Key -> Data.IntSet.Internal.Key) ->
-     IntMap a -> IntMap a :=
-  fun f =>
-    fromList GHC.Base.∘ foldrWithKey (fun k x xs => cons (pair (f k) x) xs) nil.
-
-Fixpoint insertLookupWithKey {a} (arg_0__
-                               : (Data.IntSet.Internal.Key -> a -> a -> a)) (arg_1__
-                               : Data.IntSet.Internal.Key) (arg_2__ : a) (arg_3__ : IntMap a) : (option a *
-                                                                                                 IntMap a)%type
-           := match arg_0__, arg_1__, arg_2__, arg_3__ with
-              | f, k, x, (Bin p m l r as t) =>
-                  if nomatch k p m : bool then pair None (link k (Tip k x) p t) else
-                  if Data.IntSet.Internal.zero k m : bool
-                  then let 'pair found l' := insertLookupWithKey f k x l in
-                       pair found (Bin p m l' r) else
-                  let 'pair found r' := insertLookupWithKey f k x r in
-                  pair found (Bin p m l r')
-              | f, k, x, (Tip ky y as t) =>
-                  if k GHC.Base.== ky : bool then pair (Some y) (Tip k (f k x y)) else
-                  pair None (link k (Tip k x) ky t)
-              | _, k, x, Nil => pair None (Tip k x)
-              end.
-
-Fixpoint insertWithKey {a} (arg_0__ : (Data.IntSet.Internal.Key -> a -> a -> a))
-                       (arg_1__ : Data.IntSet.Internal.Key) (arg_2__ : a) (arg_3__ : IntMap a) : IntMap
-                                                                                                 a
-           := match arg_0__, arg_1__, arg_2__, arg_3__ with
-              | f, k, x, (Bin p m l r as t) =>
-                  if nomatch k p m : bool then link k (Tip k x) p t else
-                  if Data.IntSet.Internal.zero k m : bool
-                  then Bin p m (insertWithKey f k x l) r else
-                  Bin p m l (insertWithKey f k x r)
-              | f, k, x, (Tip ky y as t) =>
-                  if k GHC.Base.== ky : bool then Tip k (f k x y) else
-                  link k (Tip k x) ky t
-              | _, k, x, Nil => Tip k x
-              end.
-
-Definition fromListWithKey {a}
-   : (Data.IntSet.Internal.Key -> a -> a -> a) ->
-     list (Data.IntSet.Internal.Key * a)%type -> IntMap a :=
-  fun f xs =>
-    let ins :=
-      fun arg_0__ arg_1__ =>
-        match arg_0__, arg_1__ with
-        | t, pair k x => insertWithKey f k x t
-        end in
-    Data.Foldable.foldl' ins empty xs.
-
-Definition fromListWith {a}
-   : (a -> a -> a) -> list (Data.IntSet.Internal.Key * a)%type -> IntMap a :=
-  fun f xs =>
-    fromListWithKey (fun arg_0__ arg_1__ arg_2__ =>
-                       match arg_0__, arg_1__, arg_2__ with
-                       | _, x, y => f x y
-                       end) xs.
-
-Definition mapKeysWith {a}
-   : (a -> a -> a) ->
-     (Data.IntSet.Internal.Key -> Data.IntSet.Internal.Key) ->
-     IntMap a -> IntMap a :=
-  fun c f =>
-    fromListWith c GHC.Base.∘
-    foldrWithKey (fun k x xs => cons (pair (f k) x) xs) nil.
-
-Definition insertWith {a}
-   : (a -> a -> a) -> Data.IntSet.Internal.Key -> a -> IntMap a -> IntMap a :=
-  fun f k x t =>
-    insertWithKey (fun arg_0__ arg_1__ arg_2__ =>
-                     match arg_0__, arg_1__, arg_2__ with
-                     | _, x', y' => f x' y'
-                     end) k x t.
+Definition shorter : Mask -> Mask -> bool :=
+  fun m1 m2 => (m1) GHC.Base.> (m2).
 
 Definition mergeWithKey' {c} {a} {b}
    : (Prefix -> Mask -> IntMap c -> IntMap c -> IntMap c) ->
@@ -1177,207 +236,425 @@ Definition mergeWithKey' {c} {a} {b}
 Definition union {a} : IntMap a -> IntMap a -> IntMap a :=
   fun m1 m2 => mergeWithKey' Bin GHC.Base.const GHC.Base.id GHC.Base.id m1 m2.
 
-Definition split {a}
-   : Data.IntSet.Internal.Key -> IntMap a -> (IntMap a * IntMap a)%type :=
-  fun k t =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | k', (Bin p m l r as t') =>
-                     if nomatch k' p m : bool
-                     then if k' GHC.Base.> p : bool
-                          then pair t' Nil
-                          else pair Nil t' else
-                     if Data.IntSet.Internal.zero k' m : bool
-                     then let 'pair lt gt := go k' l in
-                          pair lt (union gt r) else
-                     let 'pair lt gt := go k' r in
-                     pair (union l lt) gt
-                 | k', (Tip ky _ as t') =>
-                     if k' GHC.Base.> ky : bool then (pair t' Nil) else
-                     if k' GHC.Base.< ky : bool then (pair Nil t') else
-                     (pair Nil Nil)
-                 | _, Nil => (pair Nil Nil)
-                 end in
-    let j_20__ := let 'pair lt gt := go k t in pair lt gt in
-    match t with
-    | Bin _ m l r =>
-        if m GHC.Base.< #0 : bool
-        then if k GHC.Base.>= #0 : bool
-             then let 'pair lt gt := go k l in
-                  let lt' := union r lt in pair lt' gt
-             else let 'pair lt gt := go k r in
-                  let gt' := union gt l in pair lt gt' else
-        j_20__
-    | _ => j_20__
-    end.
+Local Definition Semigroup__IntMap_op_zlzlzgzg__ {inst_a}
+   : (IntMap inst_a) -> (IntMap inst_a) -> (IntMap inst_a) :=
+  union.
 
-Definition splitLookup {a}
-   : Data.IntSet.Internal.Key ->
-     IntMap a -> (IntMap a * option a * IntMap a)%type :=
-  fun k t =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | k', (Bin p m l r as t') =>
-                     if nomatch k' p m : bool
-                     then if k' GHC.Base.> p : bool
-                          then Mk_SplitLookup t' None Nil
-                          else Mk_SplitLookup Nil None t' else
-                     if Data.IntSet.Internal.zero k' m : bool
-                     then mapGT (fun arg_2__ => union arg_2__ r) (go k' l) else
-                     mapLT (union l) (go k' r)
-                 | k', (Tip ky y as t') =>
-                     if k' GHC.Base.> ky : bool then Mk_SplitLookup t' None Nil else
-                     if k' GHC.Base.< ky : bool then Mk_SplitLookup Nil None t' else
-                     Mk_SplitLookup Nil (Some y) Nil
-                 | _, Nil => Mk_SplitLookup Nil None Nil
-                 end in
-    let 'Mk_SplitLookup lt fnd gt := (let j_12__ := go k t in
-                                        match t with
-                                        | Bin _ m l r =>
-                                            if m GHC.Base.< #0 : bool
-                                            then if k GHC.Base.>= #0 : bool
-                                                 then mapLT (union r) (go k l)
-                                                 else mapGT (fun arg_13__ => union arg_13__ l) (go k r) else
-                                            j_12__
-                                        | _ => j_12__
-                                        end) in
-    pair (pair lt fnd) gt.
+Program Instance Semigroup__IntMap {a} : GHC.Base.Semigroup (IntMap a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__IntMap_op_zlzlzgzg__ |}.
+
+Local Definition Monoid__IntMap_mappend {inst_a}
+   : (IntMap inst_a) -> (IntMap inst_a) -> (IntMap inst_a) :=
+  _GHC.Base.<<>>_.
+
+Definition empty {a} : IntMap a :=
+  Nil.
 
 Definition unions {f} {a} `{Data.Foldable.Foldable f}
    : f (IntMap a) -> IntMap a :=
   fun xs => Data.Foldable.foldl' union empty xs.
 
-Definition unionWithKey {a}
-   : (Data.IntSet.Internal.Key -> a -> a -> a) ->
-     IntMap a -> IntMap a -> IntMap a :=
-  fun f m1 m2 =>
-    mergeWithKey' Bin (fun arg_0__ arg_1__ =>
-                         match arg_0__, arg_1__ with
-                         | Tip k1 x1, Tip _k2 x2 => Tip k1 (f k1 x1 x2)
-                         | _, _ => GHC.Err.patternFailure
-                         end) GHC.Base.id GHC.Base.id m1 m2.
+Local Definition Monoid__IntMap_mconcat {inst_a}
+   : list (IntMap inst_a) -> (IntMap inst_a) :=
+  unions.
 
-Definition unionWith {a} : (a -> a -> a) -> IntMap a -> IntMap a -> IntMap a :=
-  fun f m1 m2 =>
-    unionWithKey (fun arg_0__ arg_1__ arg_2__ =>
-                    match arg_0__, arg_1__, arg_2__ with
-                    | _, x, y => f x y
-                    end) m1 m2.
+Local Definition Monoid__IntMap_mempty {inst_a} : (IntMap inst_a) :=
+  empty.
 
-Definition unionsWith {f} {a} `{Data.Foldable.Foldable f}
-   : (a -> a -> a) -> f (IntMap a) -> IntMap a :=
-  fun f ts => Data.Foldable.foldl' (unionWith f) empty ts.
+Program Instance Monoid__IntMap {a} : GHC.Base.Monoid (IntMap a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.mappend__ := Monoid__IntMap_mappend ;
+           GHC.Base.mconcat__ := Monoid__IntMap_mconcat ;
+           GHC.Base.mempty__ := Monoid__IntMap_mempty |}.
 
-Definition boolITE {a} : a -> a -> bool -> a :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | f, _, false => f
-    | _, t, true => t
-    end.
+Local Definition Foldable__IntMap_fold
+   : forall {m}, forall `{GHC.Base.Monoid m}, IntMap m -> m :=
+  fun {m} `{GHC.Base.Monoid m} =>
+    let fix go arg_0__
+              := match arg_0__ with
+                 | Nil => GHC.Base.mempty
+                 | Tip _ v => v
+                 | Bin _ _ l r => GHC.Base.mappend (go l) (go r)
+                 end in
+    go.
+
+Local Definition Foldable__IntMap_foldMap
+   : forall {m} {a}, forall `{GHC.Base.Monoid m}, (a -> m) -> IntMap a -> m :=
+  fun {m} {a} `{GHC.Base.Monoid m} =>
+    fun f t =>
+      let fix go arg_0__
+                := match arg_0__ with
+                   | Nil => GHC.Base.mempty
+                   | Tip _ v => f v
+                   | Bin _ _ l r => GHC.Base.mappend (go l) (go r)
+                   end in
+      go t.
+
+Definition foldl {a} {b} : (a -> b -> a) -> a -> IntMap b -> a :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Nil => z'
+                 | z', Tip _ x => f z' x
+                 | z', Bin _ _ l r => go (go z' l) r
+                 end in
+    fun t =>
+      match t with
+      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r
+      | _ => go z t
+      end.
+
+Local Definition Foldable__IntMap_foldl
+   : forall {b} {a}, (b -> a -> b) -> b -> IntMap a -> b :=
+  fun {b} {a} => foldl.
+
+Definition foldl' {a} {b} : (a -> b -> a) -> a -> IntMap b -> a :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Nil => z'
+                 | z', Tip _ x => f z' x
+                 | z', Bin _ _ l r => go (go z' l) r
+                 end in
+    fun t =>
+      match t with
+      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r
+      | _ => go z t
+      end.
+
+Local Definition Foldable__IntMap_foldl'
+   : forall {b} {a}, (b -> a -> b) -> b -> IntMap a -> b :=
+  fun {b} {a} => foldl'.
+
+Definition foldr {a} {b} : (a -> b -> b) -> b -> IntMap a -> b :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Nil => z'
+                 | z', Tip _ x => f x z'
+                 | z', Bin _ _ l r => go (go z' r) l
+                 end in
+    fun t =>
+      match t with
+      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
+      | _ => go z t
+      end.
+
+Local Definition Foldable__IntMap_foldr
+   : forall {a} {b}, (a -> b -> b) -> b -> IntMap a -> b :=
+  fun {a} {b} => foldr.
+
+Definition foldr' {a} {b} : (a -> b -> b) -> b -> IntMap a -> b :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Nil => z'
+                 | z', Tip _ x => f x z'
+                 | z', Bin _ _ l r => go (go z' r) l
+                 end in
+    fun t =>
+      match t with
+      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
+      | _ => go z t
+      end.
+
+Local Definition Foldable__IntMap_foldr'
+   : forall {a} {b}, (a -> b -> b) -> b -> IntMap a -> b :=
+  fun {a} {b} => foldr'.
+
+Definition size {a} : IntMap a -> Coq.Numbers.BinNums.N :=
+  let fix go arg_0__ arg_1__
+            := match arg_0__, arg_1__ with
+               | acc, Bin _ _ l r => go (go acc l) r
+               | acc, Tip _ _ => #1 GHC.Num.+ acc
+               | acc, Nil => acc
+               end in
+  go #0.
+
+Definition Foldable__IntMap_length : forall {a}, IntMap a -> GHC.Num.Int :=
+  fun {a} x => Coq.ZArith.BinInt.Z.of_N (size x).
+
+Definition null {a} : IntMap a -> bool :=
+  fun arg_0__ => match arg_0__ with | Nil => true | _ => false end.
+
+Local Definition Foldable__IntMap_null : forall {a}, IntMap a -> bool :=
+  fun {a} => null.
+
+Local Definition Foldable__IntMap_product
+   : forall {a}, forall `{GHC.Num.Num a}, IntMap a -> a :=
+  fun {a} `{GHC.Num.Num a} => foldl' _GHC.Num.*_ #1.
+
+Local Definition Foldable__IntMap_sum
+   : forall {a}, forall `{GHC.Num.Num a}, IntMap a -> a :=
+  fun {a} `{GHC.Num.Num a} => foldl' _GHC.Num.+_ #0.
+
+Definition elems {a} : IntMap a -> list a :=
+  foldr cons nil.
+
+Local Definition Foldable__IntMap_toList : forall {a}, IntMap a -> list a :=
+  fun {a} => elems.
+
+Program Instance Foldable__IntMap : Data.Foldable.Foldable IntMap :=
+  fun _ k__ =>
+    k__ {| Data.Foldable.fold__ := fun {m} `{GHC.Base.Monoid m} =>
+             Foldable__IntMap_fold ;
+           Data.Foldable.foldMap__ := fun {m} {a} `{GHC.Base.Monoid m} =>
+             Foldable__IntMap_foldMap ;
+           Data.Foldable.foldl__ := fun {b} {a} => Foldable__IntMap_foldl ;
+           Data.Foldable.foldl'__ := fun {b} {a} => Foldable__IntMap_foldl' ;
+           Data.Foldable.foldr__ := fun {a} {b} => Foldable__IntMap_foldr ;
+           Data.Foldable.foldr'__ := fun {a} {b} => Foldable__IntMap_foldr' ;
+           Data.Foldable.length__ := fun {a} => Foldable__IntMap_length ;
+           Data.Foldable.null__ := fun {a} => Foldable__IntMap_null ;
+           Data.Foldable.product__ := fun {a} `{GHC.Num.Num a} =>
+             Foldable__IntMap_product ;
+           Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__IntMap_sum ;
+           Data.Foldable.toList__ := fun {a} => Foldable__IntMap_toList |}.
+
+Definition traverseWithKey {t} {a} {b} `{GHC.Base.Applicative t}
+   : (Data.IntSet.Internal.Key -> a -> t b) -> IntMap a -> t (IntMap b) :=
+  fun f =>
+    let fix go arg_0__
+              := match arg_0__ with
+                 | Nil => GHC.Base.pure Nil
+                 | Tip k v => Tip k Data.Functor.<$> f k v
+                 | Bin p m l r => GHC.Base.liftA2 (Bin p m) (go l) (go r)
+                 end in
+    go.
+
+Local Definition Traversable__IntMap_traverse
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f}, (a -> f b) -> IntMap a -> f (IntMap b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+    fun f => traverseWithKey (fun arg_0__ => f).
+
+Local Definition Traversable__IntMap_mapM
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m}, (a -> m b) -> IntMap a -> m (IntMap b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__IntMap_traverse.
+
+Local Definition Traversable__IntMap_sequenceA
+   : forall {f} {a},
+     forall `{GHC.Base.Applicative f}, IntMap (f a) -> f (IntMap a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} =>
+    Traversable__IntMap_traverse GHC.Base.id.
+
+Local Definition Traversable__IntMap_sequence
+   : forall {m} {a}, forall `{GHC.Base.Monad m}, IntMap (m a) -> m (IntMap a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__IntMap_sequenceA.
+
+Definition map {a} {b} : (a -> b) -> IntMap a -> IntMap b :=
+  fun f =>
+    let fix go arg_0__
+              := match arg_0__ with
+                 | Bin p m l r => Bin p m (go l) (go r)
+                 | Tip k x => Tip k (f x)
+                 | Nil => Nil
+                 end in
+    go.
+
+Local Definition Functor__IntMap_fmap
+   : forall {a} {b}, (a -> b) -> IntMap a -> IntMap b :=
+  fun {a} {b} => map.
+
+Definition Functor__IntMap_op_zlzd__ {a} {b} :=
+  (@IntMap_op_zlzd__ a b).
+
+Program Instance Functor__IntMap : GHC.Base.Functor IntMap :=
+  fun _ k__ =>
+    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__IntMap_fmap ;
+           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__IntMap_op_zlzd__ |}.
+
+Program Instance Traversable__IntMap : Data.Traversable.Traversable IntMap :=
+  fun _ k__ =>
+    k__ {| Data.Traversable.mapM__ := fun {m} {a} {b} `{GHC.Base.Monad m} =>
+             Traversable__IntMap_mapM ;
+           Data.Traversable.sequence__ := fun {m} {a} `{GHC.Base.Monad m} =>
+             Traversable__IntMap_sequence ;
+           Data.Traversable.sequenceA__ := fun {f} {a} `{GHC.Base.Applicative f} =>
+             Traversable__IntMap_sequenceA ;
+           Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+             Traversable__IntMap_traverse |}.
+
+(* Skipping all instances of class `Control.DeepSeq.NFData', including
+   `Data.IntMap.Internal.NFData__IntMap' *)
+
+(* Skipping all instances of class `Data.Data.Data', including
+   `Data.IntMap.Internal.Data__IntMap' *)
+
+(* Skipping instance `Data.IntMap.Internal.Functor__WhenMissing' of class
+   `GHC.Base.Functor' *)
+
+(* Skipping instance `Data.IntMap.Internal.Category__WhenMissing' of class
+   `Control.Category.Category' *)
+
+(* Skipping instance `Data.IntMap.Internal.Applicative__WhenMissing' of class
+   `GHC.Base.Applicative' *)
+
+(* Skipping instance `Data.IntMap.Internal.Monad__WhenMissing' of class
+   `GHC.Base.Monad' *)
+
+(* Skipping instance `Data.IntMap.Internal.Functor__WhenMatched' of class
+   `GHC.Base.Functor' *)
+
+(* Skipping instance `Data.IntMap.Internal.Category__WhenMatched' of class
+   `Control.Category.Category' *)
+
+(* Skipping instance `Data.IntMap.Internal.Applicative__WhenMatched' of class
+   `GHC.Base.Applicative' *)
+
+(* Skipping instance `Data.IntMap.Internal.Monad__WhenMatched' of class
+   `GHC.Base.Monad' *)
+
+(* Skipping all instances of class `GHC.Exts.IsList', including
+   `Data.IntMap.Internal.IsList__IntMap' *)
+
+Fixpoint equal {a} `{GHC.Base.Eq_ a} (arg_0__ arg_1__ : IntMap a) : bool
+           := match arg_0__, arg_1__ with
+              | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
+                  andb (m1 GHC.Base.== m2) (andb (p1 GHC.Base.== p2) (andb (equal l1 l2) (equal r1
+                                                                            r2)))
+              | Tip kx x, Tip ky y => andb (kx GHC.Base.== ky) (x GHC.Base.== y)
+              | Nil, Nil => true
+              | _, _ => false
+              end.
+
+Local Definition Eq___IntMap_op_zeze__ {inst_a} `{GHC.Base.Eq_ inst_a}
+   : (IntMap inst_a) -> (IntMap inst_a) -> bool :=
+  fun t1 t2 => equal t1 t2.
+
+Fixpoint nequal {a} `{GHC.Base.Eq_ a} (arg_0__ arg_1__ : IntMap a) : bool
+           := match arg_0__, arg_1__ with
+              | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
+                  orb (m1 GHC.Base./= m2) (orb (p1 GHC.Base./= p2) (orb (nequal l1 l2) (nequal r1
+                                                                         r2)))
+              | Tip kx x, Tip ky y => orb (kx GHC.Base./= ky) (x GHC.Base./= y)
+              | Nil, Nil => false
+              | _, _ => true
+              end.
+
+Local Definition Eq___IntMap_op_zsze__ {inst_a} `{GHC.Base.Eq_ inst_a}
+   : (IntMap inst_a) -> (IntMap inst_a) -> bool :=
+  fun t1 t2 => nequal t1 t2.
+
+Program Instance Eq___IntMap {a} `{GHC.Base.Eq_ a} : GHC.Base.Eq_ (IntMap a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___IntMap_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___IntMap_op_zsze__ |}.
+
+(* Skipping instance `Data.IntMap.Internal.Eq1__IntMap' of class
+   `Data.Functor.Classes.Eq1' *)
+
+Definition foldrWithKey {a} {b}
+   : (Data.IntSet.Internal.Key -> a -> b -> b) -> b -> IntMap a -> b :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Nil => z'
+                 | z', Tip kx x => f kx x z'
+                 | z', Bin _ _ l r => go (go z' r) l
+                 end in
+    fun t =>
+      match t with
+      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
+      | _ => go z t
+      end.
+
+Definition toAscList {a}
+   : IntMap a -> list (Data.IntSet.Internal.Key * a)%type :=
+  foldrWithKey (fun k x xs => cons (pair k x) xs) nil.
+
+Definition toList {a} : IntMap a -> list (Data.IntSet.Internal.Key * a)%type :=
+  toAscList.
+
+Local Definition Ord__IntMap_compare {inst_a} `{GHC.Base.Ord inst_a}
+   : (IntMap inst_a) -> (IntMap inst_a) -> comparison :=
+  fun m1 m2 => GHC.Base.compare (toList m1) (toList m2).
+
+Local Definition Ord__IntMap_op_zl__ {inst_a} `{GHC.Base.Ord inst_a}
+   : (IntMap inst_a) -> (IntMap inst_a) -> bool :=
+  fun x y => Ord__IntMap_compare x y GHC.Base.== Lt.
+
+Local Definition Ord__IntMap_op_zlze__ {inst_a} `{GHC.Base.Ord inst_a}
+   : (IntMap inst_a) -> (IntMap inst_a) -> bool :=
+  fun x y => Ord__IntMap_compare x y GHC.Base./= Gt.
+
+Local Definition Ord__IntMap_op_zg__ {inst_a} `{GHC.Base.Ord inst_a}
+   : (IntMap inst_a) -> (IntMap inst_a) -> bool :=
+  fun x y => Ord__IntMap_compare x y GHC.Base.== Gt.
+
+Local Definition Ord__IntMap_op_zgze__ {inst_a} `{GHC.Base.Ord inst_a}
+   : (IntMap inst_a) -> (IntMap inst_a) -> bool :=
+  fun x y => Ord__IntMap_compare x y GHC.Base./= Lt.
+
+Local Definition Ord__IntMap_max {inst_a} `{GHC.Base.Ord inst_a}
+   : (IntMap inst_a) -> (IntMap inst_a) -> (IntMap inst_a) :=
+  fun x y => if Ord__IntMap_op_zlze__ x y : bool then y else x.
+
+Local Definition Ord__IntMap_min {inst_a} `{GHC.Base.Ord inst_a}
+   : (IntMap inst_a) -> (IntMap inst_a) -> (IntMap inst_a) :=
+  fun x y => if Ord__IntMap_op_zlze__ x y : bool then x else y.
+
+Program Instance Ord__IntMap {a} `{GHC.Base.Ord a} : GHC.Base.Ord (IntMap a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zl____ := Ord__IntMap_op_zl__ ;
+           GHC.Base.op_zlze____ := Ord__IntMap_op_zlze__ ;
+           GHC.Base.op_zg____ := Ord__IntMap_op_zg__ ;
+           GHC.Base.op_zgze____ := Ord__IntMap_op_zgze__ ;
+           GHC.Base.compare__ := Ord__IntMap_compare ;
+           GHC.Base.max__ := Ord__IntMap_max ;
+           GHC.Base.min__ := Ord__IntMap_min |}.
+
+(* Skipping instance `Data.IntMap.Internal.Ord1__IntMap' of class
+   `Data.Functor.Classes.Ord1' *)
+
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Data.IntMap.Internal.Show__IntMap' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Show1', including
+   `Data.IntMap.Internal.Show1__IntMap' *)
+
+(* Skipping all instances of class `GHC.Read.Read', including
+   `Data.IntMap.Internal.Read__IntMap' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Read1', including
+   `Data.IntMap.Internal.Read1__IntMap' *)
+
+(* Skipping definition `Data.IntMap.Internal.natFromInt' *)
+
+(* Skipping definition `Data.IntMap.Internal.intFromNat' *)
 
 Definition bitmapOf : Coq.Numbers.BinNums.N -> IntSetBitMap :=
   fun x =>
     Utils.Containers.Internal.BitUtil.shiftLL #1 (x Data.Bits..&.(**)
                                                   Data.IntSet.Internal.suffixBitMask).
 
-Definition binCheckRight {a}
-   : Prefix -> Mask -> IntMap a -> IntMap a -> IntMap a :=
-  fun arg_0__ arg_1__ arg_2__ arg_3__ =>
-    match arg_0__, arg_1__, arg_2__, arg_3__ with
-    | _, _, l, Nil => l
-    | p, m, l, r => Bin p m l r
-    end.
+(* Skipping definition `Data.IntMap.Internal.op_zn__' *)
 
-Definition binCheckLeft {a}
-   : Prefix -> Mask -> IntMap a -> IntMap a -> IntMap a :=
-  fun arg_0__ arg_1__ arg_2__ arg_3__ =>
-    match arg_0__, arg_1__, arg_2__, arg_3__ with
-    | _, _, Nil, r => r
-    | p, m, l, r => Bin p m l r
-    end.
+(* Skipping definition `Data.IntSet.Internal.mask' *)
 
-Fixpoint delete {a} (arg_0__ : Data.IntSet.Internal.Key) (arg_1__ : IntMap a)
-           : IntMap a
-           := match arg_0__, arg_1__ with
-              | k, (Bin p m l r as t) =>
-                  if nomatch k p m : bool then t else
-                  if Data.IntSet.Internal.zero k m : bool
-                  then binCheckLeft p m (delete k l) r else
-                  binCheckRight p m l (delete k r)
-              | k, (Tip ky _ as t) => if k GHC.Base.== ky : bool then Nil else t
-              | _k, Nil => Nil
-              end.
+(* Skipping definition `Data.IntSet.Internal.zero' *)
 
-Fixpoint updateLookupWithKey {a} (arg_0__
-                               : (Data.IntSet.Internal.Key -> a -> option a)) (arg_1__
-                               : Data.IntSet.Internal.Key) (arg_2__ : IntMap a) : (option a * IntMap a)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | f, k, (Bin p m l r as t) =>
-                  if nomatch k p m : bool then pair None t else
-                  if Data.IntSet.Internal.zero k m : bool
-                  then let 'pair found l' := updateLookupWithKey f k l in
-                       pair found (binCheckLeft p m l' r) else
-                  let 'pair found r' := updateLookupWithKey f k r in
-                  pair found (binCheckRight p m l r')
-              | f, k, (Tip ky y as t) =>
-                  if k GHC.Base.== ky : bool
-                  then match (f k y) with
-                       | Some y' => pair (Some y) (Tip ky y')
-                       | None => pair (Some y) Nil
-                       end else
-                  pair None t
-              | _, _, Nil => pair None Nil
-              end.
+Definition lookup {a} : Data.IntSet.Internal.Key -> IntMap a -> option a :=
+  fun k =>
+    let fix go arg_0__
+              := match arg_0__ with
+                 | Bin p m l r =>
+                     if nomatch k p m : bool then None else
+                     if Data.IntSet.Internal.zero k m : bool then go l else
+                     go r
+                 | Tip kx x => if k GHC.Base.== kx : bool then Some x else None
+                 | Nil => None
+                 end in
+    go.
 
-Fixpoint updatePrefix {a} (arg_0__ : IntSetPrefix) (arg_1__ : IntMap a) (arg_2__
-                        : (IntMap a -> IntMap a)) : IntMap a
-           := match arg_0__, arg_1__, arg_2__ with
-              | kp, (Bin p m l r as t), f =>
-                  if (m Data.Bits..&.(**) Data.IntSet.Internal.suffixBitMask) GHC.Base./=
-                     #0 : bool
-                  then if Coq.NArith.BinNat.N.ldiff p Data.IntSet.Internal.suffixBitMask
-                          GHC.Base.==
-                          kp : bool
-                       then f t
-                       else t else
-                  if nomatch kp p m : bool then t else
-                  if Data.IntSet.Internal.zero kp m : bool
-                  then binCheckLeft p m (updatePrefix kp l f) r else
-                  binCheckRight p m l (updatePrefix kp r f)
-              | kp, (Tip kx _ as t), f =>
-                  if Coq.NArith.BinNat.N.ldiff kx Data.IntSet.Internal.suffixBitMask GHC.Base.==
-                     kp : bool
-                  then f t else
-                  t
-              | _, Nil, _ => Nil
-              end.
+Definition op_znz3fU__ {a} : IntMap a -> Data.IntSet.Internal.Key -> option a :=
+  fun m k => lookup k m.
 
-Fixpoint updateWithKey {a} (arg_0__
-                         : (Data.IntSet.Internal.Key -> a -> option a)) (arg_1__
-                         : Data.IntSet.Internal.Key) (arg_2__ : IntMap a) : IntMap a
-           := match arg_0__, arg_1__, arg_2__ with
-              | f, k, (Bin p m l r as t) =>
-                  if nomatch k p m : bool then t else
-                  if Data.IntSet.Internal.zero k m : bool
-                  then binCheckLeft p m (updateWithKey f k l) r else
-                  binCheckRight p m l (updateWithKey f k r)
-              | f, k, (Tip ky y as t) =>
-                  if k GHC.Base.== ky : bool
-                  then match (f k y) with
-                       | Some y' => Tip ky y'
-                       | None => Nil
-                       end else
-                  t
-              | _, _, Nil => Nil
-              end.
+Notation "'_!?_'" := (op_znz3fU__).
 
-Definition update {a}
-   : (a -> option a) -> Data.IntSet.Internal.Key -> IntMap a -> IntMap a :=
-  fun f =>
-    updateWithKey (fun arg_0__ arg_1__ =>
-                     match arg_0__, arg_1__ with
-                     | _, x => f x
-                     end).
+Infix "!?" := (_!?_) (at level 99).
 
 Definition bin {a} : Prefix -> Mask -> IntMap a -> IntMap a -> IntMap a :=
   fun arg_0__ arg_1__ arg_2__ arg_3__ =>
@@ -1386,118 +663,6 @@ Definition bin {a} : Prefix -> Mask -> IntMap a -> IntMap a -> IntMap a :=
     | _, _, Nil, r => r
     | p, m, l, r => Bin p m l r
     end.
-
-Definition filterWithKey {a}
-   : (Data.IntSet.Internal.Key -> a -> bool) -> IntMap a -> IntMap a :=
-  fun predicate =>
-    let fix go arg_0__
-              := match arg_0__ with
-                 | Nil => Nil
-                 | (Tip k x as t) => if predicate k x : bool then t else Nil
-                 | Bin p m l r => bin p m (go l) (go r)
-                 end in
-    go.
-
-Definition filter {a} : (a -> bool) -> IntMap a -> IntMap a :=
-  fun p m =>
-    filterWithKey (fun arg_0__ arg_1__ =>
-                     match arg_0__, arg_1__ with
-                     | _, x => p x
-                     end) m.
-
-Definition filterMissing {f} {x} `{GHC.Base.Applicative f}
-   : (Data.IntSet.Internal.Key -> x -> bool) -> WhenMissing f x x :=
-  fun f =>
-    Mk_WhenMissing (fun m => GHC.Base.pure (filterWithKey f m)) (fun k x =>
-                      GHC.Base.pure (if f k x : bool then Some x else None)).
-
-Fixpoint filterWithKeyA {f} {a} `{GHC.Base.Applicative f} (arg_0__
-                          : (Data.IntSet.Internal.Key -> a -> f bool)) (arg_1__ : IntMap a) : f (IntMap
-                                                                                                 a)
-           := match arg_0__, arg_1__ with
-              | _, Nil => GHC.Base.pure Nil
-              | f, (Tip k x as t) =>
-                  (fun b => if b : bool then t else Nil) Data.Functor.<$> f k x
-              | f, Bin p m l r =>
-                  GHC.Base.liftA2 (bin p m) (filterWithKeyA f l) (filterWithKeyA f r)
-              end.
-
-Definition filterAMissing {f} {x} `{GHC.Base.Applicative f}
-   : (Data.IntSet.Internal.Key -> x -> f bool) -> WhenMissing f x x :=
-  fun f =>
-    Mk_WhenMissing (fun m => filterWithKeyA f m) (fun k x =>
-                      boolITE None (Some x) Data.Functor.<$> f k x).
-
-Definition intersection {a} {b} : IntMap a -> IntMap b -> IntMap a :=
-  fun m1 m2 =>
-    mergeWithKey' bin GHC.Base.const (GHC.Base.const Nil) (GHC.Base.const Nil) m1
-    m2.
-
-Definition intersectionWithKey {a} {b} {c}
-   : (Data.IntSet.Internal.Key -> a -> b -> c) ->
-     IntMap a -> IntMap b -> IntMap c :=
-  fun f m1 m2 =>
-    mergeWithKey' bin (fun arg_0__ arg_1__ =>
-                         match arg_0__, arg_1__ with
-                         | Tip k1 x1, Tip _k2 x2 => Tip k1 (f k1 x1 x2)
-                         | _, _ => GHC.Err.patternFailure
-                         end) (GHC.Base.const Nil) (GHC.Base.const Nil) m1 m2.
-
-Definition intersectionWith {a} {b} {c}
-   : (a -> b -> c) -> IntMap a -> IntMap b -> IntMap c :=
-  fun f m1 m2 =>
-    intersectionWithKey (fun arg_0__ arg_1__ arg_2__ =>
-                           match arg_0__, arg_1__, arg_2__ with
-                           | _, x, y => f x y
-                           end) m1 m2.
-
-Definition mapEitherWithKey {a} {b} {c}
-   : (Data.IntSet.Internal.Key -> a -> Data.Either.Either b c) ->
-     IntMap a -> (IntMap b * IntMap c)%type :=
-  fun f0 t0 =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | f, Bin p m l r =>
-                     let 'pair r1 r2 := go f r in
-                     let 'pair l1 l2 := go f l in
-                     pair (bin p m l1 r1) (bin p m l2 r2)
-                 | f, Tip k x =>
-                     match f k x with
-                     | Data.Either.Left y => (pair (Tip k y) Nil)
-                     | Data.Either.Right z => (pair Nil (Tip k z))
-                     end
-                 | _, Nil => (pair Nil Nil)
-                 end in
-    id (go f0 t0).
-
-Definition mapEither {a} {b} {c}
-   : (a -> Data.Either.Either b c) -> IntMap a -> (IntMap b * IntMap c)%type :=
-  fun f m =>
-    mapEitherWithKey (fun arg_0__ arg_1__ =>
-                        match arg_0__, arg_1__ with
-                        | _, x => f x
-                        end) m.
-
-Fixpoint mapMaybeWithKey {a} {b} (arg_0__
-                           : (Data.IntSet.Internal.Key -> a -> option b)) (arg_1__ : IntMap a) : IntMap b
-           := match arg_0__, arg_1__ with
-              | f, Bin p m l r => bin p m (mapMaybeWithKey f l) (mapMaybeWithKey f r)
-              | f, Tip k x => match f k x with | Some y => Tip k y | None => Nil end
-              | _, Nil => Nil
-              end.
-
-Definition mapMaybe {a} {b} : (a -> option b) -> IntMap a -> IntMap b :=
-  fun f =>
-    mapMaybeWithKey (fun arg_0__ arg_1__ =>
-                       match arg_0__, arg_1__ with
-                       | _, x => f x
-                       end).
-
-Definition mapMaybeMissing {f} {x} {y} `{GHC.Base.Applicative f}
-   : (Data.IntSet.Internal.Key -> x -> option y) -> WhenMissing f x y :=
-  fun f =>
-    Mk_WhenMissing (fun m => GHC.Base.pure (mapMaybeWithKey f m)) (fun k x =>
-                      GHC.Base.pure (f k x)).
 
 Definition mergeWithKey {a} {b} {c}
    : (Data.IntSet.Internal.Key -> a -> b -> option c) ->
@@ -1528,6 +693,384 @@ Notation "'_\\_'" := (op_zrzr__).
 
 Infix "\\" := (_\\_) (at level 99).
 
+(* Skipping definition `Data.IntMap.Internal.fromListConstr' *)
+
+(* Skipping definition `Data.IntMap.Internal.intMapDataType' *)
+
+Definition member {a} : Data.IntSet.Internal.Key -> IntMap a -> bool :=
+  fun k =>
+    let fix go arg_0__
+              := match arg_0__ with
+                 | Bin p m l r =>
+                     if nomatch k p m : bool then false else
+                     if Data.IntSet.Internal.zero k m : bool then go l else
+                     go r
+                 | Tip kx _ => k GHC.Base.== kx
+                 | Nil => false
+                 end in
+    go.
+
+Definition notMember {a} : Data.IntSet.Internal.Key -> IntMap a -> bool :=
+  fun k m => negb (member k m).
+
+(* Skipping definition `Data.IntMap.Internal.find' *)
+
+Definition findWithDefault {a}
+   : a -> Data.IntSet.Internal.Key -> IntMap a -> a :=
+  fun def k =>
+    let fix go arg_0__
+              := match arg_0__ with
+                 | Bin p m l r =>
+                     if nomatch k p m : bool then def else
+                     if Data.IntSet.Internal.zero k m : bool then go l else
+                     go r
+                 | Tip kx x => if k GHC.Base.== kx : bool then x else def
+                 | Nil => def
+                 end in
+    go.
+
+Fixpoint unsafeFindMax {a} (arg_0__ : IntMap a) : option
+                                                  (Data.IntSet.Internal.Key * a)%type
+           := match arg_0__ with
+              | Nil => None
+              | Tip ky y => Some (pair ky y)
+              | Bin _ _ _ r => unsafeFindMax r
+              end.
+
+Definition lookupLT {a}
+   : Data.IntSet.Internal.Key ->
+     IntMap a -> option (Data.IntSet.Internal.Key * a)%type :=
+  fun k t =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | def, Bin p m l r =>
+                     if nomatch k p m : bool
+                     then if k GHC.Base.< p : bool
+                          then unsafeFindMax def
+                          else unsafeFindMax r else
+                     if Data.IntSet.Internal.zero k m : bool then go def l else
+                     go l r
+                 | def, Tip ky y =>
+                     if k GHC.Base.<= ky : bool then unsafeFindMax def else
+                     Some (pair ky y)
+                 | def, Nil => unsafeFindMax def
+                 end in
+    let j_10__ := go Nil t in
+    match t with
+    | Bin _ m l r =>
+        if m GHC.Base.< #0 : bool
+        then if k GHC.Base.>= #0 : bool
+             then go r l
+             else go Nil r else
+        j_10__
+    | _ => j_10__
+    end.
+
+Fixpoint unsafeFindMin {a} (arg_0__ : IntMap a) : option
+                                                  (Data.IntSet.Internal.Key * a)%type
+           := match arg_0__ with
+              | Nil => None
+              | Tip ky y => Some (pair ky y)
+              | Bin _ _ l _ => unsafeFindMin l
+              end.
+
+Definition lookupGT {a}
+   : Data.IntSet.Internal.Key ->
+     IntMap a -> option (Data.IntSet.Internal.Key * a)%type :=
+  fun k t =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | def, Bin p m l r =>
+                     if nomatch k p m : bool
+                     then if k GHC.Base.< p : bool
+                          then unsafeFindMin l
+                          else unsafeFindMin def else
+                     if Data.IntSet.Internal.zero k m : bool then go r l else
+                     go def r
+                 | def, Tip ky y =>
+                     if k GHC.Base.>= ky : bool then unsafeFindMin def else
+                     Some (pair ky y)
+                 | def, Nil => unsafeFindMin def
+                 end in
+    let j_10__ := go Nil t in
+    match t with
+    | Bin _ m l r =>
+        if m GHC.Base.< #0 : bool
+        then if k GHC.Base.>= #0 : bool
+             then go Nil l
+             else go l r else
+        j_10__
+    | _ => j_10__
+    end.
+
+Definition lookupLE {a}
+   : Data.IntSet.Internal.Key ->
+     IntMap a -> option (Data.IntSet.Internal.Key * a)%type :=
+  fun k t =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | def, Bin p m l r =>
+                     if nomatch k p m : bool
+                     then if k GHC.Base.< p : bool
+                          then unsafeFindMax def
+                          else unsafeFindMax r else
+                     if Data.IntSet.Internal.zero k m : bool then go def l else
+                     go l r
+                 | def, Tip ky y =>
+                     if k GHC.Base.< ky : bool then unsafeFindMax def else
+                     Some (pair ky y)
+                 | def, Nil => unsafeFindMax def
+                 end in
+    let j_10__ := go Nil t in
+    match t with
+    | Bin _ m l r =>
+        if m GHC.Base.< #0 : bool
+        then if k GHC.Base.>= #0 : bool
+             then go r l
+             else go Nil r else
+        j_10__
+    | _ => j_10__
+    end.
+
+Definition lookupGE {a}
+   : Data.IntSet.Internal.Key ->
+     IntMap a -> option (Data.IntSet.Internal.Key * a)%type :=
+  fun k t =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | def, Bin p m l r =>
+                     if nomatch k p m : bool
+                     then if k GHC.Base.< p : bool
+                          then unsafeFindMin l
+                          else unsafeFindMin def else
+                     if Data.IntSet.Internal.zero k m : bool then go r l else
+                     go def r
+                 | def, Tip ky y =>
+                     if k GHC.Base.> ky : bool then unsafeFindMin def else
+                     Some (pair ky y)
+                 | def, Nil => unsafeFindMin def
+                 end in
+    let j_10__ := go Nil t in
+    match t with
+    | Bin _ m l r =>
+        if m GHC.Base.< #0 : bool
+        then if k GHC.Base.>= #0 : bool
+             then go Nil l
+             else go l r else
+        j_10__
+    | _ => j_10__
+    end.
+
+Definition singleton {a} : Data.IntSet.Internal.Key -> a -> IntMap a :=
+  fun k x => Tip k x.
+
+Fixpoint insert {a} (arg_0__ : Data.IntSet.Internal.Key) (arg_1__ : a) (arg_2__
+                  : IntMap a) : IntMap a
+           := match arg_0__, arg_1__, arg_2__ with
+              | k, x, (Bin p m l r as t) =>
+                  if nomatch k p m : bool then link k (Tip k x) p t else
+                  if Data.IntSet.Internal.zero k m : bool then Bin p m (insert k x l) r else
+                  Bin p m l (insert k x r)
+              | k, x, (Tip ky _ as t) =>
+                  if k GHC.Base.== ky : bool then Tip k x else
+                  link k (Tip k x) ky t
+              | k, x, Nil => Tip k x
+              end.
+
+Fixpoint insertWithKey {a} (arg_0__ : (Data.IntSet.Internal.Key -> a -> a -> a))
+                       (arg_1__ : Data.IntSet.Internal.Key) (arg_2__ : a) (arg_3__ : IntMap a) : IntMap
+                                                                                                 a
+           := match arg_0__, arg_1__, arg_2__, arg_3__ with
+              | f, k, x, (Bin p m l r as t) =>
+                  if nomatch k p m : bool then link k (Tip k x) p t else
+                  if Data.IntSet.Internal.zero k m : bool
+                  then Bin p m (insertWithKey f k x l) r else
+                  Bin p m l (insertWithKey f k x r)
+              | f, k, x, (Tip ky y as t) =>
+                  if k GHC.Base.== ky : bool then Tip k (f k x y) else
+                  link k (Tip k x) ky t
+              | _, k, x, Nil => Tip k x
+              end.
+
+Definition insertWith {a}
+   : (a -> a -> a) -> Data.IntSet.Internal.Key -> a -> IntMap a -> IntMap a :=
+  fun f k x t =>
+    insertWithKey (fun arg_0__ arg_1__ arg_2__ =>
+                     match arg_0__, arg_1__, arg_2__ with
+                     | _, x', y' => f x' y'
+                     end) k x t.
+
+Fixpoint insertLookupWithKey {a} (arg_0__
+                               : (Data.IntSet.Internal.Key -> a -> a -> a)) (arg_1__
+                               : Data.IntSet.Internal.Key) (arg_2__ : a) (arg_3__ : IntMap a) : (option a *
+                                                                                                 IntMap a)%type
+           := match arg_0__, arg_1__, arg_2__, arg_3__ with
+              | f, k, x, (Bin p m l r as t) =>
+                  if nomatch k p m : bool then pair None (link k (Tip k x) p t) else
+                  if Data.IntSet.Internal.zero k m : bool
+                  then let 'pair found l' := insertLookupWithKey f k x l in
+                       pair found (Bin p m l' r) else
+                  let 'pair found r' := insertLookupWithKey f k x r in
+                  pair found (Bin p m l r')
+              | f, k, x, (Tip ky y as t) =>
+                  if k GHC.Base.== ky : bool then pair (Some y) (Tip k (f k x y)) else
+                  pair None (link k (Tip k x) ky t)
+              | _, k, x, Nil => pair None (Tip k x)
+              end.
+
+Definition binCheckLeft {a}
+   : Prefix -> Mask -> IntMap a -> IntMap a -> IntMap a :=
+  fun arg_0__ arg_1__ arg_2__ arg_3__ =>
+    match arg_0__, arg_1__, arg_2__, arg_3__ with
+    | _, _, Nil, r => r
+    | p, m, l, r => Bin p m l r
+    end.
+
+Definition binCheckRight {a}
+   : Prefix -> Mask -> IntMap a -> IntMap a -> IntMap a :=
+  fun arg_0__ arg_1__ arg_2__ arg_3__ =>
+    match arg_0__, arg_1__, arg_2__, arg_3__ with
+    | _, _, l, Nil => l
+    | p, m, l, r => Bin p m l r
+    end.
+
+Fixpoint delete {a} (arg_0__ : Data.IntSet.Internal.Key) (arg_1__ : IntMap a)
+           : IntMap a
+           := match arg_0__, arg_1__ with
+              | k, (Bin p m l r as t) =>
+                  if nomatch k p m : bool then t else
+                  if Data.IntSet.Internal.zero k m : bool
+                  then binCheckLeft p m (delete k l) r else
+                  binCheckRight p m l (delete k r)
+              | k, (Tip ky _ as t) => if k GHC.Base.== ky : bool then Nil else t
+              | _k, Nil => Nil
+              end.
+
+Fixpoint adjustWithKey {a} (arg_0__ : (Data.IntSet.Internal.Key -> a -> a))
+                       (arg_1__ : Data.IntSet.Internal.Key) (arg_2__ : IntMap a) : IntMap a
+           := match arg_0__, arg_1__, arg_2__ with
+              | f, k, (Bin p m l r as t) =>
+                  if nomatch k p m : bool then t else
+                  if Data.IntSet.Internal.zero k m : bool
+                  then Bin p m (adjustWithKey f k l) r else
+                  Bin p m l (adjustWithKey f k r)
+              | f, k, (Tip ky y as t) => if k GHC.Base.== ky : bool then Tip ky (f k y) else t
+              | _, _, Nil => Nil
+              end.
+
+Definition adjust {a}
+   : (a -> a) -> Data.IntSet.Internal.Key -> IntMap a -> IntMap a :=
+  fun f k m =>
+    adjustWithKey (fun arg_0__ arg_1__ =>
+                     match arg_0__, arg_1__ with
+                     | _, x => f x
+                     end) k m.
+
+Fixpoint updateWithKey {a} (arg_0__
+                         : (Data.IntSet.Internal.Key -> a -> option a)) (arg_1__
+                         : Data.IntSet.Internal.Key) (arg_2__ : IntMap a) : IntMap a
+           := match arg_0__, arg_1__, arg_2__ with
+              | f, k, (Bin p m l r as t) =>
+                  if nomatch k p m : bool then t else
+                  if Data.IntSet.Internal.zero k m : bool
+                  then binCheckLeft p m (updateWithKey f k l) r else
+                  binCheckRight p m l (updateWithKey f k r)
+              | f, k, (Tip ky y as t) =>
+                  if k GHC.Base.== ky : bool
+                  then match (f k y) with
+                       | Some y' => Tip ky y'
+                       | None => Nil
+                       end else
+                  t
+              | _, _, Nil => Nil
+              end.
+
+Definition update {a}
+   : (a -> option a) -> Data.IntSet.Internal.Key -> IntMap a -> IntMap a :=
+  fun f =>
+    updateWithKey (fun arg_0__ arg_1__ =>
+                     match arg_0__, arg_1__ with
+                     | _, x => f x
+                     end).
+
+Fixpoint updateLookupWithKey {a} (arg_0__
+                               : (Data.IntSet.Internal.Key -> a -> option a)) (arg_1__
+                               : Data.IntSet.Internal.Key) (arg_2__ : IntMap a) : (option a * IntMap a)%type
+           := match arg_0__, arg_1__, arg_2__ with
+              | f, k, (Bin p m l r as t) =>
+                  if nomatch k p m : bool then pair None t else
+                  if Data.IntSet.Internal.zero k m : bool
+                  then let 'pair found l' := updateLookupWithKey f k l in
+                       pair found (binCheckLeft p m l' r) else
+                  let 'pair found r' := updateLookupWithKey f k r in
+                  pair found (binCheckRight p m l r')
+              | f, k, (Tip ky y as t) =>
+                  if k GHC.Base.== ky : bool
+                  then match (f k y) with
+                       | Some y' => pair (Some y) (Tip ky y')
+                       | None => pair (Some y) Nil
+                       end else
+                  pair None t
+              | _, _, Nil => pair None Nil
+              end.
+
+Fixpoint alter {a} (arg_0__ : (option a -> option a)) (arg_1__
+                 : Data.IntSet.Internal.Key) (arg_2__ : IntMap a) : IntMap a
+           := match arg_0__, arg_1__, arg_2__ with
+              | f, k, (Bin p m l r as t) =>
+                  if nomatch k p m : bool
+                  then match f None with
+                       | None => t
+                       | Some x => link k (Tip k x) p t
+                       end else
+                  if Data.IntSet.Internal.zero k m : bool
+                  then binCheckLeft p m (alter f k l) r else
+                  binCheckRight p m l (alter f k r)
+              | f, k, (Tip ky y as t) =>
+                  if k GHC.Base.== ky : bool
+                  then match f (Some y) with
+                       | Some x => Tip ky x
+                       | None => Nil
+                       end else
+                  match f None with
+                  | Some x => link k (Tip k x) ky t
+                  | None => Tip ky y
+                  end
+              | f, k, Nil => match f None with | Some x => Tip k x | None => Nil end
+              end.
+
+Definition alterF {f} {a} `{GHC.Base.Functor f}
+   : (option a -> f (option a)) ->
+     Data.IntSet.Internal.Key -> IntMap a -> f (IntMap a) :=
+  fun f k m =>
+    let mv := lookup k m in
+    (fun arg_1__ => arg_1__ Data.Functor.<$> f mv) (fun fres =>
+                                                      match fres with
+                                                      | None => Data.Maybe.maybe m (GHC.Base.const (delete k m)) mv
+                                                      | Some v' => insert k v' m
+                                                      end).
+
+Definition unionWithKey {a}
+   : (Data.IntSet.Internal.Key -> a -> a -> a) ->
+     IntMap a -> IntMap a -> IntMap a :=
+  fun f m1 m2 =>
+    mergeWithKey' Bin (fun arg_0__ arg_1__ =>
+                         match arg_0__, arg_1__ with
+                         | Tip k1 x1, Tip _k2 x2 => Tip k1 (f k1 x1 x2)
+                         | _, _ => GHC.Err.patternFailure
+                         end) GHC.Base.id GHC.Base.id m1 m2.
+
+Definition unionWith {a} : (a -> a -> a) -> IntMap a -> IntMap a -> IntMap a :=
+  fun f m1 m2 =>
+    unionWithKey (fun arg_0__ arg_1__ arg_2__ =>
+                    match arg_0__, arg_1__, arg_2__ with
+                    | _, x, y => f x y
+                    end) m1 m2.
+
+Definition unionsWith {f} {a} `{Data.Foldable.Foldable f}
+   : (a -> a -> a) -> f (IntMap a) -> IntMap a :=
+  fun f ts => Data.Foldable.foldl' (unionWith f) empty ts.
+
 Definition differenceWithKey {a} {b}
    : (Data.IntSet.Internal.Key -> a -> b -> option a) ->
      IntMap a -> IntMap b -> IntMap a :=
@@ -1541,103 +1084,28 @@ Definition differenceWith {a} {b}
                          | _, x, y => f x y
                          end) m1 m2.
 
-Definition partitionWithKey {a}
-   : (Data.IntSet.Internal.Key -> a -> bool) ->
-     IntMap a -> (IntMap a * IntMap a)%type :=
-  fun predicate0 t0 =>
-    let fix go predicate t
-              := match t with
-                 | Bin p m l r =>
-                     let 'pair r1 r2 := go predicate r in
-                     let 'pair l1 l2 := go predicate l in
-                     pair (bin p m l1 r1) (bin p m l2 r2)
-                 | Tip k x => if predicate k x : bool then (pair t Nil) else (pair Nil t)
-                 | Nil => (pair Nil Nil)
-                 end in
-    id (go predicate0 t0).
-
-Definition partition {a}
-   : (a -> bool) -> IntMap a -> (IntMap a * IntMap a)%type :=
-  fun p m =>
-    partitionWithKey (fun arg_0__ arg_1__ =>
-                        match arg_0__, arg_1__ with
-                        | _, x => p x
-                        end) m.
-
-Definition restrictBM {a} : IntSetBitMap -> IntMap a -> IntMap a :=
-  GHC.DeferredFix.deferredFix2 (fun restrictBM
-                                (arg_0__ : IntSetBitMap)
-                                (arg_1__ : IntMap a) =>
-                                  match arg_0__, arg_1__ with
-                                  | num_2__, _ =>
-                                      if num_2__ GHC.Base.== #0 : bool then Nil else
-                                      match arg_0__, arg_1__ with
-                                      | bm, Bin p m l r =>
-                                          let leftBits := bitmapOf (p Data.Bits..|.(**) m) GHC.Num.- #1 in
-                                          let bmL := bm Data.Bits..&.(**) leftBits in
-                                          let bmR := Data.Bits.xor bm bmL in
-                                          bin p m (restrictBM bmL l) (restrictBM bmR r)
-                                      | bm, (Tip k _ as t) =>
-                                          if Data.IntSet.Internal.member k (Data.IntSet.Internal.Tip
-                                                                          (Coq.NArith.BinNat.N.ldiff k
-                                                                                                     Data.IntSet.Internal.suffixBitMask)
-                                                                          bm) : bool
-                                          then t else
-                                          Nil
-                                      | _, Nil => Nil
-                                      end
-                                  end).
-
-Definition restrictKeys {a}
-   : IntMap a -> Data.IntSet.Internal.IntSet -> IntMap a :=
-  GHC.DeferredFix.deferredFix2 (fun restrictKeys
-                                (arg_0__ : IntMap a)
-                                (arg_1__ : Data.IntSet.Internal.IntSet) =>
-                                  match arg_0__, arg_1__ with
-                                  | (Bin p1 m1 l1 r1 as t1), (Data.IntSet.Internal.Bin p2 m2 l2 r2 as t2) =>
-                                      let intersection2 :=
-                                        if nomatch p1 p2 m2 : bool then Nil else
-                                        if Data.IntSet.Internal.zero p1 m2 : bool then restrictKeys t1 l2 else
-                                        restrictKeys t1 r2 in
-                                      let intersection1 :=
-                                        if nomatch p2 p1 m1 : bool then Nil else
-                                        if Data.IntSet.Internal.zero p2 m1 : bool then restrictKeys l1 t2 else
-                                        restrictKeys r1 t2 in
-                                      if shorter m1 m2 : bool then intersection1 else
-                                      if shorter m2 m1 : bool then intersection2 else
-                                      if p1 GHC.Base.== p2 : bool
-                                      then bin p1 m1 (restrictKeys l1 l2) (restrictKeys r1 r2) else
-                                      Nil
-                                  | (Bin p1 m1 _ _ as t1), Data.IntSet.Internal.Tip p2 bm2 =>
-                                      let maxbit :=
-                                        bitmapOf (p1 Data.Bits..|.(**) (m1 Data.Bits..|.(**) (m1 GHC.Num.- #1))) in
-                                      let le_maxbit := maxbit Data.Bits..|.(**) (maxbit GHC.Num.- #1) in
-                                      let minbit := bitmapOf p1 in
-                                      let ge_minbit := complement' (minbit GHC.Num.- #1) in
-                                      restrictBM ((bm2 Data.Bits..&.(**) ge_minbit) Data.Bits..&.(**) le_maxbit)
-                                      (lookupPrefix p2 t1)
-                                  | Bin _ _ _ _, Data.IntSet.Internal.Nil => Nil
-                                  | (Tip k1 _ as t1), t2 =>
-                                      if Data.IntSet.Internal.member k1 t2 : bool then t1 else
-                                      Nil
-                                  | Nil, _ => Nil
-                                  end).
-
-Definition traverseMaybeWithKey {f} {a} {b} `{GHC.Base.Applicative f}
-   : (Data.IntSet.Internal.Key -> a -> f (option b)) ->
-     IntMap a -> f (IntMap b) :=
-  fun f =>
-    let fix go arg_0__
-              := match arg_0__ with
-                 | Nil => GHC.Base.pure Nil
-                 | Tip k x => Data.Maybe.maybe Nil (Tip k) Data.Functor.<$> f k x
-                 | Bin p m l r => GHC.Base.liftA2 (bin p m) (go l) (go r)
-                 end in
-    go.
-
-Definition traverseMaybeMissing {f} {x} {y} `{GHC.Base.Applicative f}
-   : (Data.IntSet.Internal.Key -> x -> f (option y)) -> WhenMissing f x y :=
-  fun f => Mk_WhenMissing (traverseMaybeWithKey f) f.
+Fixpoint updatePrefix {a} (arg_0__ : IntSetPrefix) (arg_1__ : IntMap a) (arg_2__
+                        : (IntMap a -> IntMap a)) : IntMap a
+           := match arg_0__, arg_1__, arg_2__ with
+              | kp, (Bin p m l r as t), f =>
+                  if (m Data.Bits..&.(**) Data.IntSet.Internal.suffixBitMask) GHC.Base./=
+                     #0 : bool
+                  then if Coq.NArith.BinNat.N.ldiff p Data.IntSet.Internal.suffixBitMask
+                          GHC.Base.==
+                          kp : bool
+                       then f t
+                       else t else
+                  if nomatch kp p m : bool then t else
+                  if Data.IntSet.Internal.zero kp m : bool
+                  then binCheckLeft p m (updatePrefix kp l f) r else
+                  binCheckRight p m l (updatePrefix kp r f)
+              | kp, (Tip kx _ as t), f =>
+                  if Coq.NArith.BinNat.N.ldiff kx Data.IntSet.Internal.suffixBitMask GHC.Base.==
+                     kp : bool
+                  then f t else
+                  t
+              | _, Nil, _ => Nil
+              end.
 
 Definition withoutBM {a} : IntSetBitMap -> IntMap a -> IntMap a :=
   GHC.DeferredFix.deferredFix2 (fun withoutBM
@@ -1699,296 +1167,828 @@ Definition withoutKeys {a}
                                   | Nil, _ => Nil
                                   end).
 
-Definition assocs {a} : IntMap a -> list (Data.IntSet.Internal.Key * a)%type :=
-  toAscList.
+Definition intersection {a} {b} : IntMap a -> IntMap b -> IntMap a :=
+  fun m1 m2 =>
+    mergeWithKey' bin GHC.Base.const (GHC.Base.const Nil) (GHC.Base.const Nil) m1
+    m2.
 
-Definition alterF {f} {a} `{GHC.Base.Functor f}
-   : (option a -> f (option a)) ->
-     Data.IntSet.Internal.Key -> IntMap a -> f (IntMap a) :=
-  fun f k m =>
-    let mv := lookup k m in
-    (fun arg_1__ => arg_1__ Data.Functor.<$> f mv) (fun fres =>
-                                                      match fres with
-                                                      | None => Data.Maybe.maybe m (GHC.Base.const (delete k m)) mv
-                                                      | Some v' => insert k v' m
-                                                      end).
+Fixpoint lookupPrefix {a} (arg_0__ : IntSetPrefix) (arg_1__ : IntMap a) : IntMap
+                                                                          a
+           := match arg_0__, arg_1__ with
+              | kp, (Bin p m l r as t) =>
+                  if (m Data.Bits..&.(**) Data.IntSet.Internal.suffixBitMask) GHC.Base./=
+                     #0 : bool
+                  then if Coq.NArith.BinNat.N.ldiff p Data.IntSet.Internal.suffixBitMask
+                          GHC.Base.==
+                          kp : bool
+                       then t
+                       else Nil else
+                  if nomatch kp p m : bool then Nil else
+                  if Data.IntSet.Internal.zero kp m : bool then lookupPrefix kp l else
+                  lookupPrefix kp r
+              | kp, (Tip kx _ as t) =>
+                  if (Coq.NArith.BinNat.N.ldiff kx Data.IntSet.Internal.suffixBitMask) GHC.Base.==
+                     kp : bool
+                  then t else
+                  Nil
+              | _, Nil => Nil
+              end.
 
-Fixpoint alter {a} (arg_0__ : (option a -> option a)) (arg_1__
-                 : Data.IntSet.Internal.Key) (arg_2__ : IntMap a) : IntMap a
+Definition restrictBM {a} : IntSetBitMap -> IntMap a -> IntMap a :=
+  GHC.DeferredFix.deferredFix2 (fun restrictBM
+                                (arg_0__ : IntSetBitMap)
+                                (arg_1__ : IntMap a) =>
+                                  match arg_0__, arg_1__ with
+                                  | num_2__, _ =>
+                                      if num_2__ GHC.Base.== #0 : bool then Nil else
+                                      match arg_0__, arg_1__ with
+                                      | bm, Bin p m l r =>
+                                          let leftBits := bitmapOf (p Data.Bits..|.(**) m) GHC.Num.- #1 in
+                                          let bmL := bm Data.Bits..&.(**) leftBits in
+                                          let bmR := Data.Bits.xor bm bmL in
+                                          bin p m (restrictBM bmL l) (restrictBM bmR r)
+                                      | bm, (Tip k _ as t) =>
+                                          if Data.IntSet.Internal.member k (Data.IntSet.Internal.Tip
+                                                                          (Coq.NArith.BinNat.N.ldiff k
+                                                                                                     Data.IntSet.Internal.suffixBitMask)
+                                                                          bm) : bool
+                                          then t else
+                                          Nil
+                                      | _, Nil => Nil
+                                      end
+                                  end).
+
+Definition restrictKeys {a}
+   : IntMap a -> Data.IntSet.Internal.IntSet -> IntMap a :=
+  GHC.DeferredFix.deferredFix2 (fun restrictKeys
+                                (arg_0__ : IntMap a)
+                                (arg_1__ : Data.IntSet.Internal.IntSet) =>
+                                  match arg_0__, arg_1__ with
+                                  | (Bin p1 m1 l1 r1 as t1), (Data.IntSet.Internal.Bin p2 m2 l2 r2 as t2) =>
+                                      let intersection2 :=
+                                        if nomatch p1 p2 m2 : bool then Nil else
+                                        if Data.IntSet.Internal.zero p1 m2 : bool then restrictKeys t1 l2 else
+                                        restrictKeys t1 r2 in
+                                      let intersection1 :=
+                                        if nomatch p2 p1 m1 : bool then Nil else
+                                        if Data.IntSet.Internal.zero p2 m1 : bool then restrictKeys l1 t2 else
+                                        restrictKeys r1 t2 in
+                                      if shorter m1 m2 : bool then intersection1 else
+                                      if shorter m2 m1 : bool then intersection2 else
+                                      if p1 GHC.Base.== p2 : bool
+                                      then bin p1 m1 (restrictKeys l1 l2) (restrictKeys r1 r2) else
+                                      Nil
+                                  | (Bin p1 m1 _ _ as t1), Data.IntSet.Internal.Tip p2 bm2 =>
+                                      let maxbit :=
+                                        bitmapOf (p1 Data.Bits..|.(**) (m1 Data.Bits..|.(**) (m1 GHC.Num.- #1))) in
+                                      let le_maxbit := maxbit Data.Bits..|.(**) (maxbit GHC.Num.- #1) in
+                                      let minbit := bitmapOf p1 in
+                                      let ge_minbit := complement' (minbit GHC.Num.- #1) in
+                                      restrictBM ((bm2 Data.Bits..&.(**) ge_minbit) Data.Bits..&.(**) le_maxbit)
+                                      (lookupPrefix p2 t1)
+                                  | Bin _ _ _ _, Data.IntSet.Internal.Nil => Nil
+                                  | (Tip k1 _ as t1), t2 =>
+                                      if Data.IntSet.Internal.member k1 t2 : bool then t1 else
+                                      Nil
+                                  | Nil, _ => Nil
+                                  end).
+
+Definition intersectionWithKey {a} {b} {c}
+   : (Data.IntSet.Internal.Key -> a -> b -> c) ->
+     IntMap a -> IntMap b -> IntMap c :=
+  fun f m1 m2 =>
+    mergeWithKey' bin (fun arg_0__ arg_1__ =>
+                         match arg_0__, arg_1__ with
+                         | Tip k1 x1, Tip _k2 x2 => Tip k1 (f k1 x1 x2)
+                         | _, _ => GHC.Err.patternFailure
+                         end) (GHC.Base.const Nil) (GHC.Base.const Nil) m1 m2.
+
+Definition intersectionWith {a} {b} {c}
+   : (a -> b -> c) -> IntMap a -> IntMap b -> IntMap c :=
+  fun f m1 m2 =>
+    intersectionWithKey (fun arg_0__ arg_1__ arg_2__ =>
+                           match arg_0__, arg_1__, arg_2__ with
+                           | _, x, y => f x y
+                           end) m1 m2.
+
+Definition mapWhenMissing {f} {a} {b} {x} `{GHC.Base.Applicative f}
+  `{GHC.Base.Monad f}
+   : (a -> b) -> WhenMissing f x a -> WhenMissing f x b :=
+  fun f t =>
+    Mk_WhenMissing (fun m =>
+                      missingSubtree t m GHC.Base.>>= (fun m' => GHC.Base.pure (GHC.Base.fmap f m')))
+                   (fun k x =>
+                      missingKey t k x GHC.Base.>>= (fun q => (GHC.Base.pure (GHC.Base.fmap f q)))).
+
+Definition mapGentlyWhenMissing {f} {a} {b} {x} `{GHC.Base.Functor f}
+   : (a -> b) -> WhenMissing f x a -> WhenMissing f x b :=
+  fun f t =>
+    Mk_WhenMissing (fun m => GHC.Base.fmap f Data.Functor.<$> missingSubtree t m)
+                   (fun k x => GHC.Base.fmap f Data.Functor.<$> missingKey t k x).
+
+Definition runWhenMatched {f} {x} {y} {z}
+   : WhenMatched f x y z -> Data.IntSet.Internal.Key -> x -> y -> f (option z) :=
+  matchedKey.
+
+Definition zipWithMaybeAMatched {x} {y} {f} {z}
+   : (Data.IntSet.Internal.Key -> x -> y -> f (option z)) ->
+     WhenMatched f x y z :=
+  fun f => Mk_WhenMatched (fun k x y => f k x y).
+
+Definition mapGentlyWhenMatched {f} {a} {b} {x} {y} `{GHC.Base.Functor f}
+   : (a -> b) -> WhenMatched f x y a -> WhenMatched f x y b :=
+  fun f t =>
+    zipWithMaybeAMatched (fun k x y =>
+                            GHC.Base.fmap f Data.Functor.<$> runWhenMatched t k x y).
+
+Definition lmapWhenMissing {b} {a} {f} {x}
+   : (b -> a) -> WhenMissing f a x -> WhenMissing f b x :=
+  fun f t =>
+    Mk_WhenMissing (fun m => missingSubtree t (GHC.Base.fmap f m)) (fun k x =>
+                      missingKey t k (f x)).
+
+Definition contramapFirstWhenMatched {b} {a} {f} {y} {z}
+   : (b -> a) -> WhenMatched f a y z -> WhenMatched f b y z :=
+  fun f t => Mk_WhenMatched (fun k x y => runWhenMatched t k (f x) y).
+
+Definition contramapSecondWhenMatched {b} {a} {f} {x} {z}
+   : (b -> a) -> WhenMatched f x a z -> WhenMatched f x b z :=
+  fun f t => Mk_WhenMatched (fun k x y => runWhenMatched t k x (f y)).
+
+Definition runWhenMissing {f} {x} {y}
+   : WhenMissing f x y -> Data.IntSet.Internal.Key -> x -> f (option y) :=
+  missingKey.
+
+Definition mapWhenMatched {f} {a} {b} {x} {y} `{GHC.Base.Functor f}
+   : (a -> b) -> WhenMatched f x y a -> WhenMatched f x y b :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, Mk_WhenMatched g =>
+        Mk_WhenMatched (fun k x y => GHC.Base.fmap (GHC.Base.fmap f) (g k x y))
+    end.
+
+Definition zipWithMatched {f} {x} {y} {z} `{GHC.Base.Applicative f}
+   : (Data.IntSet.Internal.Key -> x -> y -> z) -> WhenMatched f x y z :=
+  fun f =>
+    Mk_WhenMatched (fun k x y => (GHC.Base.pure GHC.Base.∘ Some) (f k x y)).
+
+Definition zipWithAMatched {f} {x} {y} {z} `{GHC.Base.Applicative f}
+   : (Data.IntSet.Internal.Key -> x -> y -> f z) -> WhenMatched f x y z :=
+  fun f => Mk_WhenMatched (fun k x y => Some Data.Functor.<$> f k x y).
+
+Definition zipWithMaybeMatched {f} {x} {y} {z} `{GHC.Base.Applicative f}
+   : (Data.IntSet.Internal.Key -> x -> y -> option z) -> WhenMatched f x y z :=
+  fun f => Mk_WhenMatched (fun k x y => GHC.Base.pure (f k x y)).
+
+Definition dropMissing {f} {x} {y} `{GHC.Base.Applicative f}
+   : WhenMissing f x y :=
+  Mk_WhenMissing (GHC.Base.const (GHC.Base.pure Nil)) (fun arg_0__ arg_1__ =>
+                    GHC.Base.pure None).
+
+Definition preserveMissing {f} {x} `{GHC.Base.Applicative f}
+   : WhenMissing f x x :=
+  Mk_WhenMissing GHC.Base.pure (fun arg_0__ arg_1__ =>
+                    match arg_0__, arg_1__ with
+                    | _, v => GHC.Base.pure (Some v)
+                    end).
+
+Fixpoint mapWithKey {a} {b} (f : (Data.IntSet.Internal.Key -> a -> b)) (t
+                      : IntMap a) : IntMap b
+           := match t with
+              | Bin p m l r => Bin p m (mapWithKey f l) (mapWithKey f r)
+              | Tip k x => Tip k (f k x)
+              | Nil => Nil
+              end.
+
+Definition mapMissing {f} {x} {y} `{GHC.Base.Applicative f}
+   : (Data.IntSet.Internal.Key -> x -> y) -> WhenMissing f x y :=
+  fun f =>
+    Mk_WhenMissing (fun m => GHC.Base.pure (mapWithKey f m)) (fun k x =>
+                      GHC.Base.pure (Some (f k x))).
+
+Fixpoint mapMaybeWithKey {a} {b} (arg_0__
+                           : (Data.IntSet.Internal.Key -> a -> option b)) (arg_1__ : IntMap a) : IntMap b
+           := match arg_0__, arg_1__ with
+              | f, Bin p m l r => bin p m (mapMaybeWithKey f l) (mapMaybeWithKey f r)
+              | f, Tip k x => match f k x with | Some y => Tip k y | None => Nil end
+              | _, Nil => Nil
+              end.
+
+Definition mapMaybeMissing {f} {x} {y} `{GHC.Base.Applicative f}
+   : (Data.IntSet.Internal.Key -> x -> option y) -> WhenMissing f x y :=
+  fun f =>
+    Mk_WhenMissing (fun m => GHC.Base.pure (mapMaybeWithKey f m)) (fun k x =>
+                      GHC.Base.pure (f k x)).
+
+Definition filterWithKey {a}
+   : (Data.IntSet.Internal.Key -> a -> bool) -> IntMap a -> IntMap a :=
+  fun predicate =>
+    let fix go arg_0__
+              := match arg_0__ with
+                 | Nil => Nil
+                 | (Tip k x as t) => if predicate k x : bool then t else Nil
+                 | Bin p m l r => bin p m (go l) (go r)
+                 end in
+    go.
+
+Definition filterMissing {f} {x} `{GHC.Base.Applicative f}
+   : (Data.IntSet.Internal.Key -> x -> bool) -> WhenMissing f x x :=
+  fun f =>
+    Mk_WhenMissing (fun m => GHC.Base.pure (filterWithKey f m)) (fun k x =>
+                      GHC.Base.pure (if f k x : bool then Some x else None)).
+
+Definition boolITE {a} : a -> a -> bool -> a :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | f, _, false => f
+    | _, t, true => t
+    end.
+
+Fixpoint filterWithKeyA {f} {a} `{GHC.Base.Applicative f} (arg_0__
+                          : (Data.IntSet.Internal.Key -> a -> f bool)) (arg_1__ : IntMap a) : f (IntMap
+                                                                                                 a)
+           := match arg_0__, arg_1__ with
+              | _, Nil => GHC.Base.pure Nil
+              | f, (Tip k x as t) =>
+                  (fun b => if b : bool then t else Nil) Data.Functor.<$> f k x
+              | f, Bin p m l r =>
+                  GHC.Base.liftA2 (bin p m) (filterWithKeyA f l) (filterWithKeyA f r)
+              end.
+
+Definition filterAMissing {f} {x} `{GHC.Base.Applicative f}
+   : (Data.IntSet.Internal.Key -> x -> f bool) -> WhenMissing f x x :=
+  fun f =>
+    Mk_WhenMissing (fun m => filterWithKeyA f m) (fun k x =>
+                      boolITE None (Some x) Data.Functor.<$> f k x).
+
+Definition traverseMissing {f} {x} {y} `{GHC.Base.Applicative f}
+   : (Data.IntSet.Internal.Key -> x -> f y) -> WhenMissing f x y :=
+  fun f =>
+    Mk_WhenMissing (traverseWithKey f) (fun k x => Some Data.Functor.<$> f k x).
+
+Definition traverseMaybeWithKey {f} {a} {b} `{GHC.Base.Applicative f}
+   : (Data.IntSet.Internal.Key -> a -> f (option b)) ->
+     IntMap a -> f (IntMap b) :=
+  fun f =>
+    let fix go arg_0__
+              := match arg_0__ with
+                 | Nil => GHC.Base.pure Nil
+                 | Tip k x => Data.Maybe.maybe Nil (Tip k) Data.Functor.<$> f k x
+                 | Bin p m l r => GHC.Base.liftA2 (bin p m) (go l) (go r)
+                 end in
+    go.
+
+Definition traverseMaybeMissing {f} {x} {y} `{GHC.Base.Applicative f}
+   : (Data.IntSet.Internal.Key -> x -> f (option y)) -> WhenMissing f x y :=
+  fun f => Mk_WhenMissing (traverseMaybeWithKey f) f.
+
+(* Skipping definition `Data.IntMap.Internal.merge' *)
+
+(* Skipping definition `Data.IntMap.Internal.mergeA' *)
+
+(* Skipping definition `Data.IntMap.Internal.updateMinWithKey' *)
+
+(* Skipping definition `Data.IntMap.Internal.updateMaxWithKey' *)
+
+(* Skipping definition `Data.IntMap.Internal.maxViewWithKey' *)
+
+(* Skipping definition `Data.IntMap.Internal.maxViewWithKeySure' *)
+
+(* Skipping definition `Data.IntMap.Internal.minViewWithKey' *)
+
+(* Skipping definition `Data.IntMap.Internal.minViewWithKeySure' *)
+
+(* Skipping definition `Data.IntMap.Internal.updateMax' *)
+
+(* Skipping definition `Data.IntMap.Internal.updateMin' *)
+
+(* Skipping definition `Data.IntMap.Internal.maxView' *)
+
+(* Skipping definition `Data.IntMap.Internal.minView' *)
+
+(* Skipping definition `Data.IntMap.Internal.deleteFindMax' *)
+
+(* Skipping definition `Data.IntMap.Internal.deleteFindMin' *)
+
+Definition lookupMin {a}
+   : IntMap a -> option (Data.IntSet.Internal.Key * a)%type :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Nil => None
+    | Tip k v => Some (pair k v)
+    | Bin _ m l r =>
+        let fix go arg_2__
+                  := match arg_2__ with
+                     | Tip k v => Some (pair k v)
+                     | Bin _ _ l' _ => go l'
+                     | Nil => None
+                     end in
+        if m GHC.Base.< #0 : bool then go r else
+        go l
+    end.
+
+(* Skipping definition `Data.IntMap.Internal.findMin' *)
+
+Definition lookupMax {a}
+   : IntMap a -> option (Data.IntSet.Internal.Key * a)%type :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Nil => None
+    | Tip k v => Some (pair k v)
+    | Bin _ m l r =>
+        let fix go arg_2__
+                  := match arg_2__ with
+                     | Tip k v => Some (pair k v)
+                     | Bin _ _ _ r' => go r'
+                     | Nil => None
+                     end in
+        if m GHC.Base.< #0 : bool then go l else
+        go r
+    end.
+
+(* Skipping definition `Data.IntMap.Internal.findMax' *)
+
+(* Skipping definition `Data.IntMap.Internal.deleteMin' *)
+
+(* Skipping definition `Data.IntMap.Internal.deleteMax' *)
+
+Fixpoint submapCmp {a} {b} (arg_0__ : (a -> b -> bool)) (arg_1__ : IntMap a)
+                   (arg_2__ : IntMap b) : comparison
            := match arg_0__, arg_1__, arg_2__ with
-              | f, k, (Bin p m l r as t) =>
-                  if nomatch k p m : bool
-                  then match f None with
-                       | None => t
-                       | Some x => link k (Tip k x) p t
-                       end else
-                  if Data.IntSet.Internal.zero k m : bool
-                  then binCheckLeft p m (alter f k l) r else
-                  binCheckRight p m l (alter f k r)
-              | f, k, (Tip ky y as t) =>
-                  if k GHC.Base.== ky : bool
-                  then match f (Some y) with
-                       | Some x => Tip ky x
-                       | None => Nil
-                       end else
-                  match f None with
-                  | Some x => link k (Tip k x) ky t
-                  | None => Tip ky y
+              | predicate, (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
+                  let submapCmpEq :=
+                    match pair (submapCmp predicate l1 l2) (submapCmp predicate r1 r2) with
+                    | pair Gt _ => Gt
+                    | pair _ Gt => Gt
+                    | pair Eq Eq => Eq
+                    | _ => Lt
+                    end in
+                  let submapCmpLt :=
+                    if nomatch p1 p2 m2 : bool then Gt else
+                    if Data.IntSet.Internal.zero p1 m2 : bool then submapCmp predicate t1 l2 else
+                    submapCmp predicate t1 r2 in
+                  if shorter m1 m2 : bool then Gt else
+                  if shorter m2 m1 : bool then submapCmpLt else
+                  if p1 GHC.Base.== p2 : bool then submapCmpEq else
+                  Gt
+              | _, _, _ =>
+                  match arg_0__, arg_1__, arg_2__ with
+                  | _, Bin _ _ _ _, _ => Gt
+                  | predicate, Tip kx x, Tip ky y =>
+                      if andb (kx GHC.Base.== ky) (predicate x y) : bool then Eq else
+                      Gt
+                  | _, _, _ =>
+                      match arg_0__, arg_1__, arg_2__ with
+                      | predicate, Tip k x, t =>
+                          match lookup k t with
+                          | Some y => if predicate x y : bool then Lt else Gt
+                          | _ => Gt
+                          end
+                      | _, Nil, Nil => Eq
+                      | _, Nil, _ => Lt
+                      | _, _, _ => GHC.Err.patternFailure
+                      end
                   end
-              | f, k, Nil => match f None with | Some x => Tip k x | None => Nil end
               end.
 
-Fixpoint adjustWithKey {a} (arg_0__ : (Data.IntSet.Internal.Key -> a -> a))
-                       (arg_1__ : Data.IntSet.Internal.Key) (arg_2__ : IntMap a) : IntMap a
+Definition isProperSubmapOfBy {a} {b}
+   : (a -> b -> bool) -> IntMap a -> IntMap b -> bool :=
+  fun predicate t1 t2 =>
+    match submapCmp predicate t1 t2 with
+    | Lt => true
+    | _ => false
+    end.
+
+Definition isProperSubmapOf {a} `{GHC.Base.Eq_ a}
+   : IntMap a -> IntMap a -> bool :=
+  fun m1 m2 => isProperSubmapOfBy _GHC.Base.==_ m1 m2.
+
+Definition match_ : Data.IntSet.Internal.Key -> Prefix -> Mask -> bool :=
+  fun i p m => (Data.IntSet.Internal.mask i m) GHC.Base.== p.
+
+Fixpoint isSubmapOfBy {a} {b} (arg_0__ : (a -> b -> bool)) (arg_1__ : IntMap a)
+                      (arg_2__ : IntMap b) : bool
            := match arg_0__, arg_1__, arg_2__ with
-              | f, k, (Bin p m l r as t) =>
-                  if nomatch k p m : bool then t else
-                  if Data.IntSet.Internal.zero k m : bool
-                  then Bin p m (adjustWithKey f k l) r else
-                  Bin p m l (adjustWithKey f k r)
-              | f, k, (Tip ky y as t) => if k GHC.Base.== ky : bool then Tip ky (f k y) else t
-              | _, _, Nil => Nil
+              | predicate, (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
+                  if shorter m1 m2 : bool then false else
+                  if shorter m2 m1 : bool
+                  then andb (match_ p1 p2 m2) (if Data.IntSet.Internal.zero p1 m2 : bool
+                             then isSubmapOfBy predicate t1 l2
+                             else isSubmapOfBy predicate t1 r2) else
+                  andb (p1 GHC.Base.== p2) (andb (isSubmapOfBy predicate l1 l2) (isSubmapOfBy
+                                                  predicate r1 r2))
+              | _, _, _ =>
+                  match arg_0__, arg_1__, arg_2__ with
+                  | _, Bin _ _ _ _, _ => false
+                  | predicate, Tip k x, t =>
+                      match lookup k t with
+                      | Some y => predicate x y
+                      | None => false
+                      end
+                  | _, Nil, _ => true
+                  end
               end.
 
-Definition adjust {a}
-   : (a -> a) -> Data.IntSet.Internal.Key -> IntMap a -> IntMap a :=
-  fun f k m =>
-    adjustWithKey (fun arg_0__ arg_1__ =>
+Definition isSubmapOf {a} `{GHC.Base.Eq_ a} : IntMap a -> IntMap a -> bool :=
+  fun m1 m2 => isSubmapOfBy _GHC.Base.==_ m1 m2.
+
+Fixpoint mapAccumL {a} {b} {c} (f
+                     : (a -> Data.IntSet.Internal.Key -> b -> (a * c)%type)) (a0 : a) (t : IntMap b)
+           : (a * IntMap c)%type
+           := match t with
+              | Bin p m l r =>
+                  let 'pair a1 l' := mapAccumL f a0 l in
+                  let 'pair a2 r' := mapAccumL f a1 r in
+                  pair a2 (Bin p m l' r')
+              | Tip k x => let 'pair a' x' := f a0 k x in pair a' (Tip k x')
+              | Nil => pair a0 Nil
+              end.
+
+Definition mapAccumWithKey {a} {b} {c}
+   : (a -> Data.IntSet.Internal.Key -> b -> (a * c)%type) ->
+     a -> IntMap b -> (a * IntMap c)%type :=
+  fun f a t => mapAccumL f a t.
+
+Definition mapAccum {a} {b} {c}
+   : (a -> b -> (a * c)%type) -> a -> IntMap b -> (a * IntMap c)%type :=
+  fun f =>
+    mapAccumWithKey (fun arg_0__ arg_1__ arg_2__ =>
+                       match arg_0__, arg_1__, arg_2__ with
+                       | a', _, x => f a' x
+                       end).
+
+Fixpoint mapAccumRWithKey {a} {b} {c} (f
+                            : (a -> Data.IntSet.Internal.Key -> b -> (a * c)%type)) (a0 : a) (t : IntMap b)
+           : (a * IntMap c)%type
+           := match t with
+              | Bin p m l r =>
+                  let 'pair a1 r' := mapAccumRWithKey f a0 r in
+                  let 'pair a2 l' := mapAccumRWithKey f a1 l in
+                  pair a2 (Bin p m l' r')
+              | Tip k x => let 'pair a' x' := f a0 k x in pair a' (Tip k x')
+              | Nil => pair a0 Nil
+              end.
+
+Definition fromList {a}
+   : list (Data.IntSet.Internal.Key * a)%type -> IntMap a :=
+  fun xs =>
+    let ins :=
+      fun arg_0__ arg_1__ =>
+        match arg_0__, arg_1__ with
+        | t, pair k x => insert k x t
+        end in
+    Data.Foldable.foldl' ins empty xs.
+
+Definition mapKeys {a}
+   : (Data.IntSet.Internal.Key -> Data.IntSet.Internal.Key) ->
+     IntMap a -> IntMap a :=
+  fun f =>
+    fromList GHC.Base.∘ foldrWithKey (fun k x xs => cons (pair (f k) x) xs) nil.
+
+Definition fromListWithKey {a}
+   : (Data.IntSet.Internal.Key -> a -> a -> a) ->
+     list (Data.IntSet.Internal.Key * a)%type -> IntMap a :=
+  fun f xs =>
+    let ins :=
+      fun arg_0__ arg_1__ =>
+        match arg_0__, arg_1__ with
+        | t, pair k x => insertWithKey f k x t
+        end in
+    Data.Foldable.foldl' ins empty xs.
+
+Definition fromListWith {a}
+   : (a -> a -> a) -> list (Data.IntSet.Internal.Key * a)%type -> IntMap a :=
+  fun f xs =>
+    fromListWithKey (fun arg_0__ arg_1__ arg_2__ =>
+                       match arg_0__, arg_1__, arg_2__ with
+                       | _, x, y => f x y
+                       end) xs.
+
+Definition mapKeysWith {a}
+   : (a -> a -> a) ->
+     (Data.IntSet.Internal.Key -> Data.IntSet.Internal.Key) ->
+     IntMap a -> IntMap a :=
+  fun c f =>
+    fromListWith c GHC.Base.∘
+    foldrWithKey (fun k x xs => cons (pair (f k) x) xs) nil.
+
+(* Skipping definition `Data.IntMap.Internal.mapKeysMonotonic' *)
+
+Definition filter {a} : (a -> bool) -> IntMap a -> IntMap a :=
+  fun p m =>
+    filterWithKey (fun arg_0__ arg_1__ =>
                      match arg_0__, arg_1__ with
-                     | _, x => f x
-                     end) k m.
+                     | _, x => p x
+                     end) m.
 
-(* Skipping all instances of class `Data.Functor.Classes.Read1', including
-   `Data.IntMap.Internal.Read1__IntMap' *)
+Definition partitionWithKey {a}
+   : (Data.IntSet.Internal.Key -> a -> bool) ->
+     IntMap a -> (IntMap a * IntMap a)%type :=
+  fun predicate0 t0 =>
+    let fix go predicate t
+              := match t with
+                 | Bin p m l r =>
+                     let 'pair r1 r2 := go predicate r in
+                     let 'pair l1 l2 := go predicate l in
+                     pair (bin p m l1 r1) (bin p m l2 r2)
+                 | Tip k x => if predicate k x : bool then (pair t Nil) else (pair Nil t)
+                 | Nil => (pair Nil Nil)
+                 end in
+    id (go predicate0 t0).
 
-(* Skipping all instances of class `GHC.Read.Read', including
-   `Data.IntMap.Internal.Read__IntMap' *)
+Definition partition {a}
+   : (a -> bool) -> IntMap a -> (IntMap a * IntMap a)%type :=
+  fun p m =>
+    partitionWithKey (fun arg_0__ arg_1__ =>
+                        match arg_0__, arg_1__ with
+                        | _, x => p x
+                        end) m.
 
-(* Skipping all instances of class `Data.Functor.Classes.Show1', including
-   `Data.IntMap.Internal.Show1__IntMap' *)
+Definition mapMaybe {a} {b} : (a -> option b) -> IntMap a -> IntMap b :=
+  fun f =>
+    mapMaybeWithKey (fun arg_0__ arg_1__ =>
+                       match arg_0__, arg_1__ with
+                       | _, x => f x
+                       end).
 
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Data.IntMap.Internal.Show__IntMap' *)
+Definition mapEitherWithKey {a} {b} {c}
+   : (Data.IntSet.Internal.Key -> a -> Data.Either.Either b c) ->
+     IntMap a -> (IntMap b * IntMap c)%type :=
+  fun f0 t0 =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | f, Bin p m l r =>
+                     let 'pair r1 r2 := go f r in
+                     let 'pair l1 l2 := go f l in
+                     pair (bin p m l1 r1) (bin p m l2 r2)
+                 | f, Tip k x =>
+                     match f k x with
+                     | Data.Either.Left y => (pair (Tip k y) Nil)
+                     | Data.Either.Right z => (pair Nil (Tip k z))
+                     end
+                 | _, Nil => (pair Nil Nil)
+                 end in
+    id (go f0 t0).
 
-(* Skipping instance `Data.IntMap.Internal.Ord1__IntMap' of class
-   `Data.Functor.Classes.Ord1' *)
+Definition mapEither {a} {b} {c}
+   : (a -> Data.Either.Either b c) -> IntMap a -> (IntMap b * IntMap c)%type :=
+  fun f m =>
+    mapEitherWithKey (fun arg_0__ arg_1__ =>
+                        match arg_0__, arg_1__ with
+                        | _, x => f x
+                        end) m.
 
-Local Definition Ord__IntMap_compare {inst_a} `{GHC.Base.Ord inst_a}
-   : (IntMap inst_a) -> (IntMap inst_a) -> comparison :=
-  fun m1 m2 => GHC.Base.compare (toList m1) (toList m2).
+Definition split {a}
+   : Data.IntSet.Internal.Key -> IntMap a -> (IntMap a * IntMap a)%type :=
+  fun k t =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | k', (Bin p m l r as t') =>
+                     if nomatch k' p m : bool
+                     then if k' GHC.Base.> p : bool
+                          then pair t' Nil
+                          else pair Nil t' else
+                     if Data.IntSet.Internal.zero k' m : bool
+                     then let 'pair lt gt := go k' l in
+                          pair lt (union gt r) else
+                     let 'pair lt gt := go k' r in
+                     pair (union l lt) gt
+                 | k', (Tip ky _ as t') =>
+                     if k' GHC.Base.> ky : bool then (pair t' Nil) else
+                     if k' GHC.Base.< ky : bool then (pair Nil t') else
+                     (pair Nil Nil)
+                 | _, Nil => (pair Nil Nil)
+                 end in
+    let j_20__ := let 'pair lt gt := go k t in pair lt gt in
+    match t with
+    | Bin _ m l r =>
+        if m GHC.Base.< #0 : bool
+        then if k GHC.Base.>= #0 : bool
+             then let 'pair lt gt := go k l in
+                  let lt' := union r lt in pair lt' gt
+             else let 'pair lt gt := go k r in
+                  let gt' := union gt l in pair lt gt' else
+        j_20__
+    | _ => j_20__
+    end.
 
-Local Definition Ord__IntMap_op_zl__ {inst_a} `{GHC.Base.Ord inst_a}
-   : (IntMap inst_a) -> (IntMap inst_a) -> bool :=
-  fun x y => Ord__IntMap_compare x y GHC.Base.== Lt.
+Definition mapLT {a}
+   : (IntMap a -> IntMap a) -> SplitLookup a -> SplitLookup a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, Mk_SplitLookup lt fnd gt => Mk_SplitLookup (f lt) fnd gt
+    end.
 
-Local Definition Ord__IntMap_op_zlze__ {inst_a} `{GHC.Base.Ord inst_a}
-   : (IntMap inst_a) -> (IntMap inst_a) -> bool :=
-  fun x y => Ord__IntMap_compare x y GHC.Base./= Gt.
+Definition mapGT {a}
+   : (IntMap a -> IntMap a) -> SplitLookup a -> SplitLookup a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, Mk_SplitLookup lt fnd gt => Mk_SplitLookup lt fnd (f gt)
+    end.
 
-Local Definition Ord__IntMap_op_zg__ {inst_a} `{GHC.Base.Ord inst_a}
-   : (IntMap inst_a) -> (IntMap inst_a) -> bool :=
-  fun x y => Ord__IntMap_compare x y GHC.Base.== Gt.
+Definition splitLookup {a}
+   : Data.IntSet.Internal.Key ->
+     IntMap a -> (IntMap a * option a * IntMap a)%type :=
+  fun k t =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | k', (Bin p m l r as t') =>
+                     if nomatch k' p m : bool
+                     then if k' GHC.Base.> p : bool
+                          then Mk_SplitLookup t' None Nil
+                          else Mk_SplitLookup Nil None t' else
+                     if Data.IntSet.Internal.zero k' m : bool
+                     then mapGT (fun arg_2__ => union arg_2__ r) (go k' l) else
+                     mapLT (union l) (go k' r)
+                 | k', (Tip ky y as t') =>
+                     if k' GHC.Base.> ky : bool then Mk_SplitLookup t' None Nil else
+                     if k' GHC.Base.< ky : bool then Mk_SplitLookup Nil None t' else
+                     Mk_SplitLookup Nil (Some y) Nil
+                 | _, Nil => Mk_SplitLookup Nil None Nil
+                 end in
+    let 'Mk_SplitLookup lt fnd gt := (let j_12__ := go k t in
+                                        match t with
+                                        | Bin _ m l r =>
+                                            if m GHC.Base.< #0 : bool
+                                            then if k GHC.Base.>= #0 : bool
+                                                 then mapLT (union r) (go k l)
+                                                 else mapGT (fun arg_13__ => union arg_13__ l) (go k r) else
+                                            j_12__
+                                        | _ => j_12__
+                                        end) in
+    pair (pair lt fnd) gt.
 
-Local Definition Ord__IntMap_op_zgze__ {inst_a} `{GHC.Base.Ord inst_a}
-   : (IntMap inst_a) -> (IntMap inst_a) -> bool :=
-  fun x y => Ord__IntMap_compare x y GHC.Base./= Lt.
+Definition foldrWithKey' {a} {b}
+   : (Data.IntSet.Internal.Key -> a -> b -> b) -> b -> IntMap a -> b :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Nil => z'
+                 | z', Tip kx x => f kx x z'
+                 | z', Bin _ _ l r => go (go z' r) l
+                 end in
+    fun t =>
+      match t with
+      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
+      | _ => go z t
+      end.
 
-Local Definition Ord__IntMap_max {inst_a} `{GHC.Base.Ord inst_a}
-   : (IntMap inst_a) -> (IntMap inst_a) -> (IntMap inst_a) :=
-  fun x y => if Ord__IntMap_op_zlze__ x y : bool then y else x.
+Definition foldlWithKey {a} {b}
+   : (a -> Data.IntSet.Internal.Key -> b -> a) -> a -> IntMap b -> a :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Nil => z'
+                 | z', Tip kx x => f z' kx x
+                 | z', Bin _ _ l r => go (go z' l) r
+                 end in
+    fun t =>
+      match t with
+      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r
+      | _ => go z t
+      end.
 
-Local Definition Ord__IntMap_min {inst_a} `{GHC.Base.Ord inst_a}
-   : (IntMap inst_a) -> (IntMap inst_a) -> (IntMap inst_a) :=
-  fun x y => if Ord__IntMap_op_zlze__ x y : bool then x else y.
+Definition foldlWithKey' {a} {b}
+   : (a -> Data.IntSet.Internal.Key -> b -> a) -> a -> IntMap b -> a :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Nil => z'
+                 | z', Tip kx x => f z' kx x
+                 | z', Bin _ _ l r => go (go z' l) r
+                 end in
+    fun t =>
+      match t with
+      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r
+      | _ => go z t
+      end.
 
-Local Definition Eq___IntMap_op_zeze__ {inst_a} `{GHC.Base.Eq_ inst_a}
-   : (IntMap inst_a) -> (IntMap inst_a) -> bool :=
-  fun t1 t2 => equal t1 t2.
-
-Local Definition Eq___IntMap_op_zsze__ {inst_a} `{GHC.Base.Eq_ inst_a}
-   : (IntMap inst_a) -> (IntMap inst_a) -> bool :=
-  fun t1 t2 => nequal t1 t2.
-
-Program Instance Eq___IntMap {a} `{GHC.Base.Eq_ a} : GHC.Base.Eq_ (IntMap a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___IntMap_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___IntMap_op_zsze__ |}.
-
-Program Instance Ord__IntMap {a} `{GHC.Base.Ord a} : GHC.Base.Ord (IntMap a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zl____ := Ord__IntMap_op_zl__ ;
-           GHC.Base.op_zlze____ := Ord__IntMap_op_zlze__ ;
-           GHC.Base.op_zg____ := Ord__IntMap_op_zg__ ;
-           GHC.Base.op_zgze____ := Ord__IntMap_op_zgze__ ;
-           GHC.Base.compare__ := Ord__IntMap_compare ;
-           GHC.Base.max__ := Ord__IntMap_max ;
-           GHC.Base.min__ := Ord__IntMap_min |}.
-
-(* Skipping instance `Data.IntMap.Internal.Eq1__IntMap' of class
-   `Data.Functor.Classes.Eq1' *)
-
-(* Skipping all instances of class `GHC.Exts.IsList', including
-   `Data.IntMap.Internal.IsList__IntMap' *)
-
-(* Skipping all instances of class `Data.Data.Data', including
-   `Data.IntMap.Internal.Data__IntMap' *)
-
-(* Skipping all instances of class `Control.DeepSeq.NFData', including
-   `Data.IntMap.Internal.NFData__IntMap' *)
-
-Local Definition Traversable__IntMap_traverse
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f}, (a -> f b) -> IntMap a -> f (IntMap b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun f => traverseWithKey (fun arg_0__ => f).
-
-Local Definition Traversable__IntMap_mapM
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m}, (a -> m b) -> IntMap a -> m (IntMap b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__IntMap_traverse.
-
-Local Definition Traversable__IntMap_sequenceA
-   : forall {f} {a},
-     forall `{GHC.Base.Applicative f}, IntMap (f a) -> f (IntMap a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} =>
-    Traversable__IntMap_traverse GHC.Base.id.
-
-Local Definition Traversable__IntMap_sequence
-   : forall {m} {a}, forall `{GHC.Base.Monad m}, IntMap (m a) -> m (IntMap a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__IntMap_sequenceA.
-
-Local Definition Foldable__IntMap_fold
-   : forall {m}, forall `{GHC.Base.Monoid m}, IntMap m -> m :=
-  fun {m} `{GHC.Base.Monoid m} =>
+Definition foldMapWithKey {m} {a} `{GHC.Base.Monoid m}
+   : (Data.IntSet.Internal.Key -> a -> m) -> IntMap a -> m :=
+  fun f =>
     let fix go arg_0__
               := match arg_0__ with
                  | Nil => GHC.Base.mempty
-                 | Tip _ v => v
+                 | Tip kx x => f kx x
                  | Bin _ _ l r => GHC.Base.mappend (go l) (go r)
                  end in
     go.
 
-Local Definition Foldable__IntMap_foldMap
-   : forall {m} {a}, forall `{GHC.Base.Monoid m}, (a -> m) -> IntMap a -> m :=
-  fun {m} {a} `{GHC.Base.Monoid m} =>
-    fun f t =>
-      let fix go arg_0__
-                := match arg_0__ with
-                   | Nil => GHC.Base.mempty
-                   | Tip _ v => f v
-                   | Bin _ _ l r => GHC.Base.mappend (go l) (go r)
-                   end in
-      go t.
+Definition keys {a} : IntMap a -> list Data.IntSet.Internal.Key :=
+  foldrWithKey (fun arg_0__ arg_1__ arg_2__ =>
+                  match arg_0__, arg_1__, arg_2__ with
+                  | k, _, ks => cons k ks
+                  end) nil.
 
-Local Definition Foldable__IntMap_foldl
-   : forall {b} {a}, (b -> a -> b) -> b -> IntMap a -> b :=
-  fun {b} {a} => foldl.
+Definition assocs {a} : IntMap a -> list (Data.IntSet.Internal.Key * a)%type :=
+  toAscList.
 
-Local Definition Foldable__IntMap_foldl'
-   : forall {b} {a}, (b -> a -> b) -> b -> IntMap a -> b :=
-  fun {b} {a} => foldl'.
+Fixpoint keysSet {a} (arg_0__ : IntMap a) : Data.IntSet.Internal.IntSet
+           := match arg_0__ with
+              | Nil => Data.IntSet.Internal.Nil
+              | Tip kx _ => Data.IntSet.Internal.singleton kx
+              | Bin p m l r =>
+                  let fix computeBm arg_2__ arg_3__
+                            := match arg_2__, arg_3__ with
+                               | acc, Bin _ _ l' r' => computeBm (computeBm acc l') r'
+                               | acc, Tip kx _ => acc Data.Bits..|.(**) Data.IntSet.Internal.bitmapOf kx
+                               | _, Nil => GHC.Err.error (GHC.Base.hs_string__ "Data.IntSet.keysSet: Nil")
+                               end in
+                  if (m Data.Bits..&.(**) Data.IntSet.Internal.suffixBitMask) GHC.Base.==
+                     #0 : bool
+                  then Data.IntSet.Internal.Bin p m (keysSet l) (keysSet r) else
+                  Data.IntSet.Internal.Tip (Coq.NArith.BinNat.N.ldiff p
+                                                                      Data.IntSet.Internal.suffixBitMask) (computeBm
+                                                                                                           (computeBm #0
+                                                                                                            l) r)
+              end.
 
-Local Definition Foldable__IntMap_foldr
-   : forall {a} {b}, (a -> b -> b) -> b -> IntMap a -> b :=
-  fun {a} {b} => foldr.
+Fixpoint fromSet {a} (arg_0__ : (Data.IntSet.Internal.Key -> a)) (arg_1__
+                   : Data.IntSet.Internal.IntSet) : IntMap a
+           := match arg_0__, arg_1__ with
+              | _, Data.IntSet.Internal.Nil => Nil
+              | f, Data.IntSet.Internal.Bin p m l r => Bin p m (fromSet f l) (fromSet f r)
+              | f, Data.IntSet.Internal.Tip kx bm =>
+                  let buildTree :=
+                    GHC.DeferredFix.deferredFix4 (fun buildTree g prefix bmask bits =>
+                                                    let 'num_3__ := bits in
+                                                    if num_3__ GHC.Base.== #0 : bool then Tip prefix (g prefix) else
+                                                    let 'bits2 := Utils.Containers.Internal.BitUtil.shiftRL (bits) #1 in
+                                                    if (bmask Data.Bits..&.(**)
+                                                        ((Utils.Containers.Internal.BitUtil.shiftLL #1 bits2) GHC.Num.-
+                                                         #1)) GHC.Base.==
+                                                       #0 : bool
+                                                    then buildTree g (prefix GHC.Num.+ bits2)
+                                                         (Utils.Containers.Internal.BitUtil.shiftRL bmask bits2)
+                                                         bits2 else
+                                                    if ((Utils.Containers.Internal.BitUtil.shiftRL bmask bits2)
+                                                        Data.Bits..&.(**)
+                                                        ((Utils.Containers.Internal.BitUtil.shiftLL #1 bits2) GHC.Num.-
+                                                         #1)) GHC.Base.==
+                                                       #0 : bool
+                                                    then buildTree g prefix bmask bits2 else
+                                                    Bin prefix bits2 (buildTree g prefix bmask bits2) (buildTree g
+                                                                                                       (prefix GHC.Num.+
+                                                                                                        bits2)
+                                                                                                       (Utils.Containers.Internal.BitUtil.shiftRL
+                                                                                                        bmask bits2)
+                                                                                                       bits2)) in
+                  buildTree f kx bm (Data.IntSet.Internal.suffixBitMask GHC.Num.+ #1)
+              end.
 
-Local Definition Foldable__IntMap_foldr'
-   : forall {a} {b}, (a -> b -> b) -> b -> IntMap a -> b :=
-  fun {a} {b} => foldr'.
+Definition toDescList {a}
+   : IntMap a -> list (Data.IntSet.Internal.Key * a)%type :=
+  foldlWithKey (fun xs k x => cons (pair k x) xs) nil.
 
-Definition Foldable__IntMap_length : forall {a}, IntMap a -> GHC.Num.Int :=
-  fun {a} x => Coq.ZArith.BinInt.Z.of_N (size x).
+Definition foldrFB {a} {b}
+   : (Data.IntSet.Internal.Key -> a -> b -> b) -> b -> IntMap a -> b :=
+  foldrWithKey.
 
-Local Definition Foldable__IntMap_null : forall {a}, IntMap a -> bool :=
-  fun {a} => null.
+Definition foldlFB {a} {b}
+   : (a -> Data.IntSet.Internal.Key -> b -> a) -> a -> IntMap b -> a :=
+  foldlWithKey.
 
-Local Definition Foldable__IntMap_product
-   : forall {a}, forall `{GHC.Num.Num a}, IntMap a -> a :=
-  fun {a} `{GHC.Num.Num a} => foldl' _GHC.Num.*_ #1.
+(* Skipping definition `Data.IntMap.Internal.fromAscList' *)
 
-Local Definition Foldable__IntMap_sum
-   : forall {a}, forall `{GHC.Num.Num a}, IntMap a -> a :=
-  fun {a} `{GHC.Num.Num a} => foldl' _GHC.Num.+_ #0.
+(* Skipping definition `Data.IntMap.Internal.fromAscListWith' *)
 
-Local Definition Foldable__IntMap_toList : forall {a}, IntMap a -> list a :=
-  fun {a} => elems.
+(* Skipping definition `Data.IntMap.Internal.fromAscListWithKey' *)
 
-Program Instance Foldable__IntMap : Data.Foldable.Foldable IntMap :=
-  fun _ k__ =>
-    k__ {| Data.Foldable.fold__ := fun {m} `{GHC.Base.Monoid m} =>
-             Foldable__IntMap_fold ;
-           Data.Foldable.foldMap__ := fun {m} {a} `{GHC.Base.Monoid m} =>
-             Foldable__IntMap_foldMap ;
-           Data.Foldable.foldl__ := fun {b} {a} => Foldable__IntMap_foldl ;
-           Data.Foldable.foldl'__ := fun {b} {a} => Foldable__IntMap_foldl' ;
-           Data.Foldable.foldr__ := fun {a} {b} => Foldable__IntMap_foldr ;
-           Data.Foldable.foldr'__ := fun {a} {b} => Foldable__IntMap_foldr' ;
-           Data.Foldable.length__ := fun {a} => Foldable__IntMap_length ;
-           Data.Foldable.null__ := fun {a} => Foldable__IntMap_null ;
-           Data.Foldable.product__ := fun {a} `{GHC.Num.Num a} =>
-             Foldable__IntMap_product ;
-           Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__IntMap_sum ;
-           Data.Foldable.toList__ := fun {a} => Foldable__IntMap_toList |}.
+(* Skipping definition `Data.IntMap.Internal.fromDistinctAscList' *)
 
-Program Instance Traversable__IntMap : Data.Traversable.Traversable IntMap :=
-  fun _ k__ =>
-    k__ {| Data.Traversable.mapM__ := fun {m} {a} {b} `{GHC.Base.Monad m} =>
-             Traversable__IntMap_mapM ;
-           Data.Traversable.sequence__ := fun {m} {a} `{GHC.Base.Monad m} =>
-             Traversable__IntMap_sequence ;
-           Data.Traversable.sequenceA__ := fun {f} {a} `{GHC.Base.Applicative f} =>
-             Traversable__IntMap_sequenceA ;
-           Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-             Traversable__IntMap_traverse |}.
+Definition maskW : Nat -> Nat -> Prefix :=
+  fun i m => i Data.Bits..&.(**) (Data.Bits.xor (complement' (m GHC.Num.- #1)) m).
 
-Local Definition Semigroup__IntMap_op_zlzlzgzg__ {inst_a}
-   : (IntMap inst_a) -> (IntMap inst_a) -> (IntMap inst_a) :=
-  union.
+Definition splitRoot {a} : IntMap a -> list (IntMap a) :=
+  fun orig =>
+    match orig with
+    | Nil => nil
+    | (Tip _ _ as x) => cons x nil
+    | Bin _ m l r =>
+        if m GHC.Base.< #0 : bool then cons r (cons l nil) else
+        cons l (cons r nil)
+    end.
 
-Program Instance Semigroup__IntMap {a} : GHC.Base.Semigroup (IntMap a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__IntMap_op_zlzlzgzg__ |}.
+(* Skipping definition `Data.IntMap.Internal.showTree' *)
 
-Local Definition Monoid__IntMap_mappend {inst_a}
-   : (IntMap inst_a) -> (IntMap inst_a) -> (IntMap inst_a) :=
-  _GHC.Base.<<>>_.
+(* Skipping definition `Data.IntMap.Internal.showTreeWith' *)
 
-Local Definition Monoid__IntMap_mconcat {inst_a}
-   : list (IntMap inst_a) -> (IntMap inst_a) :=
-  unions.
+(* Skipping definition `Data.IntMap.Internal.showsTree' *)
 
-Local Definition Monoid__IntMap_mempty {inst_a} : (IntMap inst_a) :=
-  empty.
+(* Skipping definition `Data.IntMap.Internal.showsTreeHang' *)
 
-Program Instance Monoid__IntMap {a} : GHC.Base.Monoid (IntMap a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.mappend__ := Monoid__IntMap_mappend ;
-           GHC.Base.mconcat__ := Monoid__IntMap_mconcat ;
-           GHC.Base.mempty__ := Monoid__IntMap_mempty |}.
+(* Skipping definition `Data.IntMap.Internal.showBin' *)
 
-(* Skipping instance `Data.IntMap.Internal.Monad__WhenMissing' of class
-   `GHC.Base.Monad' *)
+(* Skipping definition `Data.IntMap.Internal.showWide' *)
 
-(* Skipping instance `Data.IntMap.Internal.Applicative__WhenMissing' of class
-   `GHC.Base.Applicative' *)
+(* Skipping definition `Data.IntMap.Internal.showsBars' *)
 
-(* Skipping instance `Data.IntMap.Internal.Category__WhenMissing' of class
-   `Control.Category.Category' *)
+Definition node : GHC.Base.String :=
+  GHC.Base.hs_string__ "+--".
 
-(* Skipping instance `Data.IntMap.Internal.Functor__WhenMissing' of class
-   `GHC.Base.Functor' *)
+(* Skipping definition `Data.IntMap.Internal.withBar' *)
 
-(* Skipping instance `Data.IntMap.Internal.Monad__WhenMatched' of class
-   `GHC.Base.Monad' *)
-
-(* Skipping instance `Data.IntMap.Internal.Applicative__WhenMatched' of class
-   `GHC.Base.Applicative' *)
-
-(* Skipping instance `Data.IntMap.Internal.Category__WhenMatched' of class
-   `Control.Category.Category' *)
-
-(* Skipping instance `Data.IntMap.Internal.Functor__WhenMatched' of class
-   `GHC.Base.Functor' *)
+(* Skipping definition `Data.IntMap.Internal.withEmpty' *)
 
 Module Notations.
 Notation "'_Data.IntMap.Internal.!?_'" := (op_znz3fU__).

--- a/examples/containers/lib/Data/IntSet/Internal.v
+++ b/examples/containers/lib/Data/IntSet/Internal.v
@@ -87,118 +87,10 @@ Require Import Coq.NArith.NArith.
 
 (* Converted value declarations: *)
 
-(* Skipping definition `Utils.Containers.Internal.BitUtil.lowestBitMask' *)
-
-Definition zero : Coq.Numbers.BinNums.N -> Mask -> bool :=
-  fun i m => ((i) Data.Bits..&.(**) (m)) GHC.Base.== #0.
-
-(* Skipping definition `Data.IntSet.Internal.withEmpty' *)
-
-(* Skipping definition `Data.IntSet.Internal.withBar' *)
-
-Definition tip : Prefix -> BitMap -> IntSet :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | _, num_2__ =>
-        if num_2__ GHC.Base.== #0 : bool then Nil else
-        match arg_0__, arg_1__ with
-        | kx, bm => Tip kx bm
-        end
-    end.
-
-Definition suffixBitMask :=
-  Coq.NArith.BinNat.N.ones 6.
-
-Definition suffixOf : Coq.Numbers.BinNums.N -> Coq.Numbers.BinNums.N :=
-  fun x => x Data.Bits..&.(**) suffixBitMask.
-
-Definition splitRoot : IntSet -> list IntSet :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Nil => nil
-    | (Tip _ _ as x) => cons x nil
-    | Bin _ m l r =>
-        if m GHC.Base.< #0 : bool then cons r (cons l nil) else
-        cons l (cons r nil)
-    end.
-
-Definition size : IntSet -> Coq.Numbers.BinNums.N :=
-  let fix go arg_0__ arg_1__
-            := match arg_0__, arg_1__ with
-               | acc, Bin _ _ l r => go (go acc l) r
-               | acc, Tip _ bm =>
-                   acc GHC.Num.+ Utils.Containers.Internal.BitUtil.bitcount #0 bm
-               | acc, Nil => acc
-               end in
-  go #0.
-
-(* Skipping definition `Data.IntSet.Internal.showsTreeHang' *)
-
-(* Skipping definition `Data.IntSet.Internal.showsTree' *)
-
-(* Skipping definition `Data.IntSet.Internal.showsBitMap' *)
-
-(* Skipping definition `Data.IntSet.Internal.showsBars' *)
-
-(* Skipping definition `Data.IntSet.Internal.showWide' *)
-
-(* Skipping definition `Data.IntSet.Internal.showTreeWith' *)
-
-(* Skipping definition `Data.IntSet.Internal.showTree' *)
-
-(* Skipping definition `Data.IntSet.Internal.showBitMap' *)
-
-(* Skipping definition `Data.IntSet.Internal.showBin' *)
-
-Definition shorter : Mask -> Mask -> bool :=
-  fun m1 m2 => (m1) GHC.Base.> (m2).
-
-Definition revNat : Nat -> Nat :=
-  fun x1 =>
-    let 'x2 := ((Utils.Containers.Internal.BitUtil.shiftRL x1 #1) Data.Bits..&.(**)
-                  #6148914691236517205) Data.Bits..|.(**)
-                 (Utils.Containers.Internal.BitUtil.shiftLL (x1 Data.Bits..&.(**)
-                                                             #6148914691236517205) #1) in
-    let 'x3 := ((Utils.Containers.Internal.BitUtil.shiftRL x2 #2) Data.Bits..&.(**)
-                  #3689348814741910323) Data.Bits..|.(**)
-                 (Utils.Containers.Internal.BitUtil.shiftLL (x2 Data.Bits..&.(**)
-                                                             #3689348814741910323) #2) in
-    let 'x4 := ((Utils.Containers.Internal.BitUtil.shiftRL x3 #4) Data.Bits..&.(**)
-                  #1085102592571150095) Data.Bits..|.(**)
-                 (Utils.Containers.Internal.BitUtil.shiftLL (x3 Data.Bits..&.(**)
-                                                             #1085102592571150095) #4) in
-    let 'x5 := ((Utils.Containers.Internal.BitUtil.shiftRL x4 #8) Data.Bits..&.(**)
-                  #71777214294589695) Data.Bits..|.(**)
-                 (Utils.Containers.Internal.BitUtil.shiftLL (x4 Data.Bits..&.(**)
-                                                             #71777214294589695) #8) in
-    let 'x6 := ((Utils.Containers.Internal.BitUtil.shiftRL x5 #16) Data.Bits..&.(**)
-                  #281470681808895) Data.Bits..|.(**)
-                 (Utils.Containers.Internal.BitUtil.shiftLL (x5 Data.Bits..&.(**)
-                                                             #281470681808895) #16) in
-    (Utils.Containers.Internal.BitUtil.shiftRL x6 #32) Data.Bits..|.(**)
-    (Utils.Containers.Internal.BitUtil.shiftLL x6 #32).
-
-Definition prefixOf : Coq.Numbers.BinNums.N -> Prefix :=
-  fun x => Coq.NArith.BinNat.N.ldiff x suffixBitMask.
-
-(* Skipping definition `Data.IntSet.Internal.prefixBitMask' *)
-
-Definition null : IntSet -> bool :=
-  fun arg_0__ => match arg_0__ with | Nil => true | _ => false end.
-
-(* Skipping definition `Data.IntSet.Internal.node' *)
-
-Fixpoint nequal (arg_0__ arg_1__ : IntSet) : bool
-           := match arg_0__, arg_1__ with
-              | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
-                  orb (m1 GHC.Base./= m2) (orb (p1 GHC.Base./= p2) (orb (nequal l1 l2) (nequal r1
-                                                                         r2)))
-              | Tip kx1 bm1, Tip kx2 bm2 => orb (kx1 GHC.Base./= kx2) (bm1 GHC.Base./= bm2)
-              | Nil, Nil => false
-              | _, _ => true
-              end.
-
-(* Skipping definition `Data.IntSet.Internal.natFromInt' *)
+Definition branchMask : Prefix -> Prefix -> Mask :=
+  fun p1 p2 =>
+    Coq.NArith.BinNat.N.pow 2 (Coq.NArith.BinNat.N.log2 (Coq.NArith.BinNat.N.lxor p1
+                                                                                  p2)).
 
 Definition maskW : Nat -> Nat -> Prefix :=
   fun i m => Coq.NArith.BinNat.N.ldiff i (2 * m - 1 % N).
@@ -206,362 +98,16 @@ Definition maskW : Nat -> Nat -> Prefix :=
 Definition mask : Coq.Numbers.BinNums.N -> Mask -> Prefix :=
   fun i m => maskW (i) (m).
 
-Definition match_ : Coq.Numbers.BinNums.N -> Prefix -> Mask -> bool :=
-  fun i p m => (mask i m) GHC.Base.== p.
-
-Definition nomatch : Coq.Numbers.BinNums.N -> Prefix -> Mask -> bool :=
-  fun i p m => (mask i m) GHC.Base./= p.
-
-Fixpoint subsetCmp (arg_0__ arg_1__ : IntSet) : comparison
-           := match arg_0__, arg_1__ with
-              | (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
-                  let subsetCmpEq :=
-                    match pair (subsetCmp l1 l2) (subsetCmp r1 r2) with
-                    | pair Gt _ => Gt
-                    | pair _ Gt => Gt
-                    | pair Eq Eq => Eq
-                    | _ => Lt
-                    end in
-                  let subsetCmpLt :=
-                    if nomatch p1 p2 m2 : bool then Gt else
-                    if zero p1 m2 : bool then subsetCmp t1 l2 else
-                    subsetCmp t1 r2 in
-                  if shorter m1 m2 : bool then Gt else
-                  if shorter m2 m1 : bool
-                  then match subsetCmpLt with
-                       | Gt => Gt
-                       | _ => Lt
-                       end else
-                  if p1 GHC.Base.== p2 : bool then subsetCmpEq else
-                  Gt
-              | _, _ =>
-                  match arg_0__, arg_1__ with
-                  | Bin _ _ _ _, _ => Gt
-                  | Tip kx1 bm1, Tip kx2 bm2 =>
-                      if kx1 GHC.Base./= kx2 : bool then Gt else
-                      if bm1 GHC.Base.== bm2 : bool then Eq else
-                      if Data.Bits.xor bm1 (bm1 Data.Bits..&.(**) bm2) GHC.Base.== #0 : bool
-                      then Lt else
-                      Gt
-                  | (Tip kx _ as t1), Bin p m l r =>
-                      if nomatch kx p m : bool then Gt else
-                      if zero kx m : bool then match subsetCmp t1 l with | Gt => Gt | _ => Lt end else
-                      match subsetCmp t1 r with
-                      | Gt => Gt
-                      | _ => Lt
-                      end
-                  | Tip _ _, Nil => Gt
-                  | Nil, Nil => Eq
-                  | Nil, _ => Lt
-                  end
-              end.
-
-Fixpoint isSubsetOf (arg_0__ arg_1__ : IntSet) : bool
-           := match arg_0__, arg_1__ with
-              | (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
-                  if shorter m1 m2 : bool then false else
-                  if shorter m2 m1 : bool
-                  then andb (match_ p1 p2 m2) (if zero p1 m2 : bool
-                             then isSubsetOf t1 l2
-                             else isSubsetOf t1 r2) else
-                  andb (p1 GHC.Base.== p2) (andb (isSubsetOf l1 l2) (isSubsetOf r1 r2))
-              | _, _ =>
-                  match arg_0__, arg_1__ with
-                  | Bin _ _ _ _, _ => false
-                  | Tip kx1 bm1, Tip kx2 bm2 =>
-                      andb (kx1 GHC.Base.== kx2) (Data.Bits.xor bm1 (bm1 Data.Bits..&.(**) bm2)
-                            GHC.Base.==
-                            #0)
-                  | (Tip kx _ as t1), Bin p m l r =>
-                      if nomatch kx p m : bool then false else
-                      if zero kx m : bool then isSubsetOf t1 l else
-                      isSubsetOf t1 r
-                  | Tip _ _, Nil => false
-                  | Nil, _ => true
-                  end
-              end.
-
-Definition isProperSubsetOf : IntSet -> IntSet -> bool :=
-  fun t1 t2 => match subsetCmp t1 t2 with | Lt => true | _ => false end.
-
-(* Skipping definition `Data.IntSet.Internal.intSetDataType' *)
-
-(* Skipping definition `Data.IntSet.Internal.intFromNat' *)
-
-Definition indexOfTheOnlyBit :=
-  fun x => Coq.NArith.BinNat.N.log2 x.
-
-Definition lowestBitSet : Nat -> Coq.Numbers.BinNums.N :=
-  fun x => indexOfTheOnlyBit (Utils.Containers.Internal.BitUtil.lowestBitMask x).
-
-Fixpoint unsafeFindMin (arg_0__ : IntSet) : option Key
-           := match arg_0__ with
-              | Nil => None
-              | Tip kx bm => Some (kx GHC.Num.+ lowestBitSet bm)
-              | Bin _ _ l _ => unsafeFindMin l
-              end.
-
-Definition highestBitSet : Nat -> Coq.Numbers.BinNums.N :=
-  fun x => indexOfTheOnlyBit (Utils.Containers.Internal.BitUtil.highestBitMask x).
-
-Fixpoint unsafeFindMax (arg_0__ : IntSet) : option Key
-           := match arg_0__ with
-              | Nil => None
-              | Tip kx bm => Some (kx GHC.Num.+ highestBitSet bm)
-              | Bin _ _ _ r => unsafeFindMax r
-              end.
-
-(* Skipping definition `Data.IntSet.Internal.fromListConstr' *)
-
-(* Skipping definition `Data.IntSet.Internal.fromDistinctAscList' *)
-
-(* Skipping definition `Data.IntSet.Internal.fromAscList' *)
-
-Definition revNatSafe n :=
-  Coq.NArith.BinNat.N.modulo (revNat n) (Coq.NArith.BinNat.N.pow 2 64).
-
-Program Definition foldrBits {a}
-           : Coq.Numbers.BinNums.N ->
-             (Coq.Numbers.BinNums.N -> a -> a) -> a -> Nat -> a :=
-          fun prefix f z bitmap =>
-            let go :=
-              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
-                               Coq.NArith.BinNat.N.to_nat arg_0__) _ (fun arg_0__ arg_1__ go =>
-                               match arg_0__, arg_1__ with
-                               | num_2__, acc =>
-                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
-                                   match arg_0__, arg_1__ with
-                                   | bm, acc =>
-                                       let bitmask := Utils.Containers.Internal.BitUtil.lowestBitMask bm in
-                                       let bi := indexOfTheOnlyBit bitmask in
-                                       go (Data.Bits.xor bm bitmask) ((f ((prefix GHC.Num.+ (#64 GHC.Num.- #1))
-                                                                          GHC.Num.-
-                                                                          bi)) acc)
-                                   end
-                               end) in
-            go (revNatSafe bitmap) z.
-Solve Obligations with (BitTerminationProofs.termination_foldl).
-
-Program Definition foldr'Bits {a}
-           : Coq.Numbers.BinNums.N ->
-             (Coq.Numbers.BinNums.N -> a -> a) -> a -> Nat -> a :=
-          fun prefix f z bitmap =>
-            let go :=
-              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
-                               Coq.NArith.BinNat.N.to_nat arg_0__) _ (fun arg_0__ arg_1__ go =>
-                               match arg_0__, arg_1__ with
-                               | num_2__, acc =>
-                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
-                                   match arg_0__, arg_1__ with
-                                   | bm, acc =>
-                                       let bitmask := Utils.Containers.Internal.BitUtil.lowestBitMask bm in
-                                       let bi := indexOfTheOnlyBit bitmask in
-                                       go (Data.Bits.xor bm bitmask) ((f ((prefix GHC.Num.+ (#64 GHC.Num.- #1))
-                                                                          GHC.Num.-
-                                                                          bi)) acc)
-                                   end
-                               end) in
-            go (revNatSafe bitmap) z.
-Solve Obligations with (BitTerminationProofs.termination_foldl).
-
-Definition foldr' {b} : (Key -> b -> b) -> b -> IntSet -> b :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx bm => foldr'Bits kx f z' bm
-                 | z', Bin _ _ l r => go (go z' r) l
-                 end in
-    fun t =>
-      match t with
-      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
-      | _ => go z t
-      end.
-
-Definition foldr {b} : (Key -> b -> b) -> b -> IntSet -> b :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx bm => foldrBits kx f z' bm
-                 | z', Bin _ _ l r => go (go z' r) l
-                 end in
-    fun t =>
-      match t with
-      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
-      | _ => go z t
-      end.
-
-Definition foldrFB {b} : (Key -> b -> b) -> b -> IntSet -> b :=
-  foldr.
-
-Definition toAscList : IntSet -> list Key :=
-  foldr cons nil.
-
-Definition toList : IntSet -> list Key :=
-  toAscList.
-
-Program Definition foldlBits {a}
-           : Coq.Numbers.BinNums.N ->
-             (a -> Coq.Numbers.BinNums.N -> a) -> a -> Nat -> a :=
-          fun prefix f z bitmap =>
-            let go :=
-              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
-                               Coq.NArith.BinNat.N.to_nat arg_0__) _ (fun arg_0__ arg_1__ go =>
-                               match arg_0__, arg_1__ with
-                               | num_2__, acc =>
-                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
-                                   match arg_0__, arg_1__ with
-                                   | bm, acc =>
-                                       let bitmask := Utils.Containers.Internal.BitUtil.lowestBitMask bm in
-                                       let bi := indexOfTheOnlyBit bitmask in
-                                       go (Data.Bits.xor bm bitmask) (f acc (prefix GHC.Num.+ bi))
-                                   end
-                               end) in
-            go bitmap z.
-Solve Obligations with (BitTerminationProofs.termination_foldl).
-
-Program Definition foldl'Bits {a}
-           : Coq.Numbers.BinNums.N ->
-             (a -> Coq.Numbers.BinNums.N -> a) -> a -> Nat -> a :=
-          fun prefix f z bitmap =>
-            let go :=
-              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
-                               Coq.NArith.BinNat.N.to_nat arg_0__) _ (fun arg_0__ arg_1__ go =>
-                               match arg_0__, arg_1__ with
-                               | num_2__, acc =>
-                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
-                                   match arg_0__, arg_1__ with
-                                   | bm, acc =>
-                                       let bitmask := Utils.Containers.Internal.BitUtil.lowestBitMask bm in
-                                       let bi := indexOfTheOnlyBit bitmask in
-                                       go (Data.Bits.xor bm bitmask) (f acc (prefix GHC.Num.+ bi))
-                                   end
-                               end) in
-            go bitmap z.
-Solve Obligations with (BitTerminationProofs.termination_foldl).
-
-Definition foldl' {a} : (a -> Key -> a) -> a -> IntSet -> a :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx bm => foldl'Bits kx f z' bm
-                 | z', Bin _ _ l r => go (go z' l) r
-                 end in
-    fun t =>
-      match t with
-      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r
-      | _ => go z t
-      end.
-
-Definition foldl {a} : (a -> Key -> a) -> a -> IntSet -> a :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx bm => foldlBits kx f z' bm
-                 | z', Bin _ _ l r => go (go z' l) r
-                 end in
-    fun t =>
-      match t with
-      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r
-      | _ => go z t
-      end.
-
-Definition foldlFB {a} : (a -> Key -> a) -> a -> IntSet -> a :=
-  foldl.
-
-Definition toDescList : IntSet -> list Key :=
-  foldl (GHC.Base.flip cons) nil.
-
-Definition fold {b} : (Key -> b -> b) -> b -> IntSet -> b :=
-  foldr.
-
-(* Skipping definition `Data.IntSet.Internal.findMin' *)
-
-(* Skipping definition `Data.IntSet.Internal.findMax' *)
-
-Fixpoint equal (arg_0__ arg_1__ : IntSet) : bool
-           := match arg_0__, arg_1__ with
-              | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
-                  andb (m1 GHC.Base.== m2) (andb (p1 GHC.Base.== p2) (andb (equal l1 l2) (equal r1
-                                                                            r2)))
-              | Tip kx1 bm1, Tip kx2 bm2 => andb (kx1 GHC.Base.== kx2) (bm1 GHC.Base.== bm2)
-              | Nil, Nil => true
-              | _, _ => false
-              end.
-
-Definition empty : IntSet :=
-  Nil.
-
-Definition elems : IntSet -> list Key :=
-  toAscList.
-
-Program Fixpoint disjoint (arg_0__ arg_1__ : IntSet) {measure (size_nat arg_0__
-                           +
-                           size_nat arg_1__)} : bool
-                   := match arg_0__, arg_1__ with
-                      | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
-                          let disjoint2 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then true else
-                            if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then disjoint t1 l2 else
-                            disjoint t1 r2 in
-                          let disjoint1 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then true else
-                            if Bool.Sumbool.sumbool_of_bool (zero p2 m1) then disjoint l1 t2 else
-                            disjoint r1 t2 in
-                          if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then disjoint1 else
-                          if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then disjoint2 else
-                          if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
-                          then andb (disjoint l1 l2) (disjoint r1 r2) else
-                          true
-                      | (Bin _ _ _ _ as t1), Tip kx2 bm2 =>
-                          let fix disjointBM arg_11__
-                                    := match arg_11__ with
-                                       | Bin p1 m1 l1 r1 =>
-                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx2 p1 m1) then true else
-                                           if Bool.Sumbool.sumbool_of_bool (zero kx2 m1) then disjointBM l1 else
-                                           disjointBM r1
-                                       | Tip kx1 bm1 =>
-                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
-                                           then (bm1 Data.Bits..&.(**) bm2) GHC.Base.== #0 else
-                                           true
-                                       | Nil => true
-                                       end in
-                          disjointBM t1
-                      | Bin _ _ _ _, Nil => true
-                      | Tip kx1 bm1, t2 =>
-                          let fix disjointBM arg_18__
-                                    := match arg_18__ with
-                                       | Bin p2 m2 l2 r2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx1 p2 m2) then true else
-                                           if Bool.Sumbool.sumbool_of_bool (zero kx1 m2) then disjointBM l2 else
-                                           disjointBM r2
-                                       | Tip kx2 bm2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
-                                           then (bm1 Data.Bits..&.(**) bm2) GHC.Base.== #0 else
-                                           true
-                                       | Nil => true
-                                       end in
-                          disjointBM t2
-                      | Nil, _ => true
-                      end.
-Solve Obligations with (termination_by_omega).
-
-(* Skipping definition `Data.IntSet.Internal.deleteFindMin' *)
-
-(* Skipping definition `Data.IntSet.Internal.deleteFindMax' *)
-
-Definition branchMask : Prefix -> Prefix -> Mask :=
-  fun p1 p2 =>
-    Coq.NArith.BinNat.N.pow 2 (Coq.NArith.BinNat.N.log2 (Coq.NArith.BinNat.N.lxor p1
-                                                                                  p2)).
+Definition zero : Coq.Numbers.BinNums.N -> Mask -> bool :=
+  fun i m => ((i) Data.Bits..&.(**) (m)) GHC.Base.== #0.
 
 Definition link : Prefix -> IntSet -> Prefix -> IntSet -> IntSet :=
   fun p1 t1 p2 t2 =>
     let m := branchMask p1 p2 in
     let p := mask p1 m in if zero p1 m : bool then Bin p m t1 t2 else Bin p m t2 t1.
+
+Definition nomatch : Coq.Numbers.BinNums.N -> Prefix -> Mask -> bool :=
+  fun i p m => (mask i m) GHC.Base./= p.
 
 Fixpoint insertBM (arg_0__ : Prefix) (arg_1__ : BitMap) (arg_2__ : IntSet)
            : IntSet
@@ -575,6 +121,9 @@ Fixpoint insertBM (arg_0__ : Prefix) (arg_1__ : BitMap) (arg_2__ : IntSet)
                   link kx (Tip kx bm) kx' t
               | kx, bm, Nil => Tip kx bm
               end.
+
+Definition shorter : Mask -> Mask -> bool :=
+  fun m1 m2 => (m1) GHC.Base.> (m2).
 
 Program Fixpoint union (arg_0__ arg_1__ : IntSet) {measure (size_nat arg_0__ +
                         size_nat arg_1__)} : IntSet
@@ -602,56 +151,365 @@ Program Fixpoint union (arg_0__ arg_1__ : IntSet) {measure (size_nat arg_0__ +
                       end.
 Solve Obligations with (termination_by_omega).
 
+Local Definition Semigroup__IntSet_op_zlzlzgzg__ : IntSet -> IntSet -> IntSet :=
+  union.
+
+Program Instance Semigroup__IntSet : GHC.Base.Semigroup IntSet :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__IntSet_op_zlzlzgzg__ |}.
+
+Local Definition Monoid__IntSet_mappend : IntSet -> IntSet -> IntSet :=
+  _GHC.Base.<<>>_.
+
+Definition empty : IntSet :=
+  Nil.
+
 Definition unions {f} `{Data.Foldable.Foldable f} : f IntSet -> IntSet :=
   fun xs => Data.Foldable.foldl' union empty xs.
+
+Local Definition Monoid__IntSet_mconcat : list IntSet -> IntSet :=
+  unions.
+
+Local Definition Monoid__IntSet_mempty : IntSet :=
+  empty.
+
+Program Instance Monoid__IntSet : GHC.Base.Monoid IntSet :=
+  fun _ k__ =>
+    k__ {| GHC.Base.mappend__ := Monoid__IntSet_mappend ;
+           GHC.Base.mconcat__ := Monoid__IntSet_mconcat ;
+           GHC.Base.mempty__ := Monoid__IntSet_mempty |}.
+
+(* Skipping all instances of class `Data.Data.Data', including
+   `Data.IntSet.Internal.Data__IntSet' *)
+
+(* Skipping all instances of class `GHC.Exts.IsList', including
+   `Data.IntSet.Internal.IsList__IntSet' *)
+
+Fixpoint equal (arg_0__ arg_1__ : IntSet) : bool
+           := match arg_0__, arg_1__ with
+              | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
+                  andb (m1 GHC.Base.== m2) (andb (p1 GHC.Base.== p2) (andb (equal l1 l2) (equal r1
+                                                                            r2)))
+              | Tip kx1 bm1, Tip kx2 bm2 => andb (kx1 GHC.Base.== kx2) (bm1 GHC.Base.== bm2)
+              | Nil, Nil => true
+              | _, _ => false
+              end.
+
+Local Definition Eq___IntSet_op_zeze__ : IntSet -> IntSet -> bool :=
+  fun t1 t2 => equal t1 t2.
+
+Fixpoint nequal (arg_0__ arg_1__ : IntSet) : bool
+           := match arg_0__, arg_1__ with
+              | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
+                  orb (m1 GHC.Base./= m2) (orb (p1 GHC.Base./= p2) (orb (nequal l1 l2) (nequal r1
+                                                                         r2)))
+              | Tip kx1 bm1, Tip kx2 bm2 => orb (kx1 GHC.Base./= kx2) (bm1 GHC.Base./= bm2)
+              | Nil, Nil => false
+              | _, _ => true
+              end.
+
+Local Definition Eq___IntSet_op_zsze__ : IntSet -> IntSet -> bool :=
+  fun t1 t2 => nequal t1 t2.
+
+Program Instance Eq___IntSet : GHC.Base.Eq_ IntSet :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___IntSet_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___IntSet_op_zsze__ |}.
+
+Definition indexOfTheOnlyBit :=
+  fun x => Coq.NArith.BinNat.N.log2 x.
+
+Definition revNat : Nat -> Nat :=
+  fun x1 =>
+    let 'x2 := ((Utils.Containers.Internal.BitUtil.shiftRL x1 #1) Data.Bits..&.(**)
+                  #6148914691236517205) Data.Bits..|.(**)
+                 (Utils.Containers.Internal.BitUtil.shiftLL (x1 Data.Bits..&.(**)
+                                                             #6148914691236517205) #1) in
+    let 'x3 := ((Utils.Containers.Internal.BitUtil.shiftRL x2 #2) Data.Bits..&.(**)
+                  #3689348814741910323) Data.Bits..|.(**)
+                 (Utils.Containers.Internal.BitUtil.shiftLL (x2 Data.Bits..&.(**)
+                                                             #3689348814741910323) #2) in
+    let 'x4 := ((Utils.Containers.Internal.BitUtil.shiftRL x3 #4) Data.Bits..&.(**)
+                  #1085102592571150095) Data.Bits..|.(**)
+                 (Utils.Containers.Internal.BitUtil.shiftLL (x3 Data.Bits..&.(**)
+                                                             #1085102592571150095) #4) in
+    let 'x5 := ((Utils.Containers.Internal.BitUtil.shiftRL x4 #8) Data.Bits..&.(**)
+                  #71777214294589695) Data.Bits..|.(**)
+                 (Utils.Containers.Internal.BitUtil.shiftLL (x4 Data.Bits..&.(**)
+                                                             #71777214294589695) #8) in
+    let 'x6 := ((Utils.Containers.Internal.BitUtil.shiftRL x5 #16) Data.Bits..&.(**)
+                  #281470681808895) Data.Bits..|.(**)
+                 (Utils.Containers.Internal.BitUtil.shiftLL (x5 Data.Bits..&.(**)
+                                                             #281470681808895) #16) in
+    (Utils.Containers.Internal.BitUtil.shiftRL x6 #32) Data.Bits..|.(**)
+    (Utils.Containers.Internal.BitUtil.shiftLL x6 #32).
+
+Definition revNatSafe n :=
+  Coq.NArith.BinNat.N.modulo (revNat n) (Coq.NArith.BinNat.N.pow 2 64).
+
+Program Definition foldrBits {a}
+           : Coq.Numbers.BinNums.N ->
+             (Coq.Numbers.BinNums.N -> a -> a) -> a -> Nat -> a :=
+          fun prefix f z bitmap =>
+            let go :=
+              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
+                               Coq.NArith.BinNat.N.to_nat arg_0__) _ (fun arg_0__ arg_1__ go =>
+                               match arg_0__, arg_1__ with
+                               | num_2__, acc =>
+                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
+                                   match arg_0__, arg_1__ with
+                                   | bm, acc =>
+                                       let bitmask := Utils.Containers.Internal.BitUtil.lowestBitMask bm in
+                                       let bi := indexOfTheOnlyBit bitmask in
+                                       go (Data.Bits.xor bm bitmask) ((f ((prefix GHC.Num.+ (#64 GHC.Num.- #1))
+                                                                          GHC.Num.-
+                                                                          bi)) acc)
+                                   end
+                               end) in
+            go (revNatSafe bitmap) z.
+Solve Obligations with (BitTerminationProofs.termination_foldl).
+
+Definition foldr {b} : (Key -> b -> b) -> b -> IntSet -> b :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Nil => z'
+                 | z', Tip kx bm => foldrBits kx f z' bm
+                 | z', Bin _ _ l r => go (go z' r) l
+                 end in
+    fun t =>
+      match t with
+      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
+      | _ => go z t
+      end.
+
+Definition toAscList : IntSet -> list Key :=
+  foldr cons nil.
+
+Local Definition Ord__IntSet_compare : IntSet -> IntSet -> comparison :=
+  fun s1 s2 => GHC.Base.compare (toAscList s1) (toAscList s2).
+
+Local Definition Ord__IntSet_op_zl__ : IntSet -> IntSet -> bool :=
+  fun x y => Ord__IntSet_compare x y GHC.Base.== Lt.
+
+Local Definition Ord__IntSet_op_zlze__ : IntSet -> IntSet -> bool :=
+  fun x y => Ord__IntSet_compare x y GHC.Base./= Gt.
+
+Local Definition Ord__IntSet_op_zg__ : IntSet -> IntSet -> bool :=
+  fun x y => Ord__IntSet_compare x y GHC.Base.== Gt.
+
+Local Definition Ord__IntSet_op_zgze__ : IntSet -> IntSet -> bool :=
+  fun x y => Ord__IntSet_compare x y GHC.Base./= Lt.
+
+Local Definition Ord__IntSet_max : IntSet -> IntSet -> IntSet :=
+  fun x y => if Ord__IntSet_op_zlze__ x y : bool then y else x.
+
+Local Definition Ord__IntSet_min : IntSet -> IntSet -> IntSet :=
+  fun x y => if Ord__IntSet_op_zlze__ x y : bool then x else y.
+
+Program Instance Ord__IntSet : GHC.Base.Ord IntSet :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zl____ := Ord__IntSet_op_zl__ ;
+           GHC.Base.op_zlze____ := Ord__IntSet_op_zlze__ ;
+           GHC.Base.op_zg____ := Ord__IntSet_op_zg__ ;
+           GHC.Base.op_zgze____ := Ord__IntSet_op_zgze__ ;
+           GHC.Base.compare__ := Ord__IntSet_compare ;
+           GHC.Base.max__ := Ord__IntSet_max ;
+           GHC.Base.min__ := Ord__IntSet_min |}.
+
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Data.IntSet.Internal.Show__IntSet' *)
+
+(* Skipping all instances of class `GHC.Read.Read', including
+   `Data.IntSet.Internal.Read__IntSet' *)
+
+(* Skipping all instances of class `Control.DeepSeq.NFData', including
+   `Data.IntSet.Internal.NFData__IntSet' *)
+
+(* Skipping definition `Data.IntSet.Internal.natFromInt' *)
+
+(* Skipping definition `Data.IntSet.Internal.intFromNat' *)
+
+Definition bin : Prefix -> Mask -> IntSet -> IntSet -> IntSet :=
+  fun arg_0__ arg_1__ arg_2__ arg_3__ =>
+    match arg_0__, arg_1__, arg_2__, arg_3__ with
+    | _, _, l, Nil => l
+    | _, _, Nil, r => r
+    | p, m, l, r => Bin p m l r
+    end.
+
+Definition tip : Prefix -> BitMap -> IntSet :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | _, num_2__ =>
+        if num_2__ GHC.Base.== #0 : bool then Nil else
+        match arg_0__, arg_1__ with
+        | kx, bm => Tip kx bm
+        end
+    end.
+
+Fixpoint deleteBM (arg_0__ : Prefix) (arg_1__ : BitMap) (arg_2__ : IntSet)
+           : IntSet
+           := match arg_0__, arg_1__, arg_2__ with
+              | kx, bm, (Bin p m l r as t) =>
+                  if nomatch kx p m : bool then t else
+                  if zero kx m : bool then bin p m (deleteBM kx bm l) r else
+                  bin p m l (deleteBM kx bm r)
+              | kx, bm, (Tip kx' bm' as t) =>
+                  if kx' GHC.Base.== kx : bool
+                  then tip kx (Data.Bits.xor bm' (bm' Data.Bits..&.(**) bm)) else
+                  t
+              | _, _, Nil => Nil
+              end.
+
+Program Fixpoint difference (arg_0__ arg_1__ : IntSet) {measure (size_nat
+                             arg_0__ +
+                             size_nat arg_1__)} : IntSet
+                   := match arg_0__, arg_1__ with
+                      | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
+                          let difference2 :=
+                            if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then t1 else
+                            if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then difference t1 l2 else
+                            difference t1 r2 in
+                          let difference1 :=
+                            if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then t1 else
+                            if Bool.Sumbool.sumbool_of_bool (zero p2 m1)
+                            then bin p1 m1 (difference l1 t2) r1 else
+                            bin p1 m1 l1 (difference r1 t2) in
+                          if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then difference1 else
+                          if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then difference2 else
+                          if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
+                          then bin p1 m1 (difference l1 l2) (difference r1 r2) else
+                          t1
+                      | (Bin _ _ _ _ as t), Tip kx bm => deleteBM kx bm t
+                      | (Bin _ _ _ _ as t), Nil => t
+                      | (Tip kx bm as t1), t2 =>
+                          let fix differenceTip arg_12__
+                                    := match arg_12__ with
+                                       | Bin p2 m2 l2 r2 =>
+                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx p2 m2) then t1 else
+                                           if Bool.Sumbool.sumbool_of_bool (zero kx m2) then differenceTip l2 else
+                                           differenceTip r2
+                                       | Tip kx2 bm2 =>
+                                           if Bool.Sumbool.sumbool_of_bool (kx GHC.Base.== kx2)
+                                           then tip kx (Data.Bits.xor bm (bm Data.Bits..&.(**) bm2)) else
+                                           t1
+                                       | Nil => t1
+                                       end in
+                          differenceTip t2
+                      | Nil, _ => Nil
+                      end.
+Solve Obligations with (termination_by_omega).
+
+Definition op_zrzr__ : IntSet -> IntSet -> IntSet :=
+  fun m1 m2 => difference m1 m2.
+
+Notation "'_\\_'" := (op_zrzr__).
+
+Infix "\\" := (_\\_) (at level 99).
+
+(* Skipping definition `Data.IntSet.Internal.fromListConstr' *)
+
+(* Skipping definition `Data.IntSet.Internal.intSetDataType' *)
+
+Definition null : IntSet -> bool :=
+  fun arg_0__ => match arg_0__ with | Nil => true | _ => false end.
+
+Definition size : IntSet -> Coq.Numbers.BinNums.N :=
+  let fix go arg_0__ arg_1__
+            := match arg_0__, arg_1__ with
+               | acc, Bin _ _ l r => go (go acc l) r
+               | acc, Tip _ bm =>
+                   acc GHC.Num.+ Utils.Containers.Internal.BitUtil.bitcount #0 bm
+               | acc, Nil => acc
+               end in
+  go #0.
 
 Definition bitmapOfSuffix : Coq.Numbers.BinNums.N -> BitMap :=
   fun s => Utils.Containers.Internal.BitUtil.shiftLL #1 s.
 
+Definition suffixBitMask :=
+  Coq.NArith.BinNat.N.ones 6.
+
+Definition suffixOf : Coq.Numbers.BinNums.N -> Coq.Numbers.BinNums.N :=
+  fun x => x Data.Bits..&.(**) suffixBitMask.
+
 Definition bitmapOf : Coq.Numbers.BinNums.N -> BitMap :=
   fun x => bitmapOfSuffix (suffixOf x).
 
-Definition insert : Key -> IntSet -> IntSet :=
-  fun x => insertBM (prefixOf x) (bitmapOf x).
+Definition prefixOf : Coq.Numbers.BinNums.N -> Prefix :=
+  fun x => Coq.NArith.BinNat.N.ldiff x suffixBitMask.
 
-Definition fromList : list Key -> IntSet :=
-  fun xs => let ins := fun t x => insert x t in Data.Foldable.foldl' ins empty xs.
+Definition member : Key -> IntSet -> bool :=
+  fun x =>
+    let fix go arg_0__
+              := match arg_0__ with
+                 | Bin p m l r =>
+                     if nomatch x p m : bool then false else
+                     if zero x m : bool then go l else
+                     go r
+                 | Tip y bm =>
+                     andb (prefixOf x GHC.Base.== y) ((bitmapOf x Data.Bits..&.(**) bm) GHC.Base./=
+                           #0)
+                 | Nil => false
+                 end in
+    go.
 
-Definition map : (Key -> Key) -> IntSet -> IntSet :=
-  fun f => fromList GHC.Base.∘ (GHC.Base.map f GHC.Base.∘ toList).
+Definition notMember : Key -> IntSet -> bool :=
+  fun k => negb GHC.Base.∘ member k.
 
-Definition lookupGE : Key -> IntSet -> option Key :=
+Definition highestBitSet : Nat -> Coq.Numbers.BinNums.N :=
+  fun x => indexOfTheOnlyBit (Utils.Containers.Internal.BitUtil.highestBitMask x).
+
+Fixpoint unsafeFindMax (arg_0__ : IntSet) : option Key
+           := match arg_0__ with
+              | Nil => None
+              | Tip kx bm => Some (kx GHC.Num.+ highestBitSet bm)
+              | Bin _ _ _ r => unsafeFindMax r
+              end.
+
+Definition lookupLT : Key -> IntSet -> option Key :=
   fun x t =>
     let fix go arg_0__ arg_1__
               := match arg_0__, arg_1__ with
                  | def, Bin p m l r =>
                      if nomatch x p m : bool
                      then if x GHC.Base.< p : bool
-                          then unsafeFindMin l
-                          else unsafeFindMin def else
-                     if zero x m : bool then go r l else
-                     go def r
+                          then unsafeFindMax def
+                          else unsafeFindMax r else
+                     if zero x m : bool then go def l else
+                     go l r
                  | def, Tip kx bm =>
-                     let maskGE :=
-                       (Coq.NArith.BinNat.N.ldiff (Coq.NArith.BinNat.N.ones (64 % N))
-                                                  (Coq.NArith.BinNat.N.pred (bitmapOf x))) Data.Bits..&.(**)
-                       bm in
-                     if prefixOf x GHC.Base.< kx : bool then Some (kx GHC.Num.+ lowestBitSet bm) else
-                     if andb (prefixOf x GHC.Base.== kx) (maskGE GHC.Base./= #0) : bool
-                     then Some (kx GHC.Num.+ lowestBitSet maskGE) else
-                     unsafeFindMin def
-                 | def, Nil => unsafeFindMin def
+                     let maskLT := (bitmapOf x GHC.Num.- #1) Data.Bits..&.(**) bm in
+                     if prefixOf x GHC.Base.> kx : bool
+                     then Some (kx GHC.Num.+ highestBitSet bm) else
+                     if andb (prefixOf x GHC.Base.== kx) (maskLT GHC.Base./= #0) : bool
+                     then Some (kx GHC.Num.+ highestBitSet maskLT) else
+                     unsafeFindMax def
+                 | def, Nil => unsafeFindMax def
                  end in
     let j_12__ := go Nil t in
     match t with
     | Bin _ m l r =>
         if m GHC.Base.< #0 : bool
         then if x GHC.Base.>= #0 : bool
-             then go Nil l
-             else go l r else
+             then go r l
+             else go Nil r else
         j_12__
     | _ => j_12__
     end.
+
+(* Skipping definition `Utils.Containers.Internal.BitUtil.lowestBitMask' *)
+
+Definition lowestBitSet : Nat -> Coq.Numbers.BinNums.N :=
+  fun x => indexOfTheOnlyBit (Utils.Containers.Internal.BitUtil.lowestBitMask x).
+
+Fixpoint unsafeFindMin (arg_0__ : IntSet) : option Key
+           := match arg_0__ with
+              | Nil => None
+              | Tip kx bm => Some (kx GHC.Num.+ lowestBitSet bm)
+              | Bin _ _ l _ => unsafeFindMin l
+              end.
 
 Definition lookupGT : Key -> IntSet -> option Key :=
   fun x t =>
@@ -721,57 +579,276 @@ Definition lookupLE : Key -> IntSet -> option Key :=
     | _ => j_12__
     end.
 
-Definition lookupLT : Key -> IntSet -> option Key :=
+Definition lookupGE : Key -> IntSet -> option Key :=
   fun x t =>
     let fix go arg_0__ arg_1__
               := match arg_0__, arg_1__ with
                  | def, Bin p m l r =>
                      if nomatch x p m : bool
                      then if x GHC.Base.< p : bool
-                          then unsafeFindMax def
-                          else unsafeFindMax r else
-                     if zero x m : bool then go def l else
-                     go l r
+                          then unsafeFindMin l
+                          else unsafeFindMin def else
+                     if zero x m : bool then go r l else
+                     go def r
                  | def, Tip kx bm =>
-                     let maskLT := (bitmapOf x GHC.Num.- #1) Data.Bits..&.(**) bm in
-                     if prefixOf x GHC.Base.> kx : bool
-                     then Some (kx GHC.Num.+ highestBitSet bm) else
-                     if andb (prefixOf x GHC.Base.== kx) (maskLT GHC.Base./= #0) : bool
-                     then Some (kx GHC.Num.+ highestBitSet maskLT) else
-                     unsafeFindMax def
-                 | def, Nil => unsafeFindMax def
+                     let maskGE :=
+                       (Coq.NArith.BinNat.N.ldiff (Coq.NArith.BinNat.N.ones (64 % N))
+                                                  (Coq.NArith.BinNat.N.pred (bitmapOf x))) Data.Bits..&.(**)
+                       bm in
+                     if prefixOf x GHC.Base.< kx : bool then Some (kx GHC.Num.+ lowestBitSet bm) else
+                     if andb (prefixOf x GHC.Base.== kx) (maskGE GHC.Base./= #0) : bool
+                     then Some (kx GHC.Num.+ lowestBitSet maskGE) else
+                     unsafeFindMin def
+                 | def, Nil => unsafeFindMin def
                  end in
     let j_12__ := go Nil t in
     match t with
     | Bin _ m l r =>
         if m GHC.Base.< #0 : bool
         then if x GHC.Base.>= #0 : bool
-             then go r l
-             else go Nil r else
+             then go Nil l
+             else go l r else
         j_12__
     | _ => j_12__
     end.
 
-Definition member : Key -> IntSet -> bool :=
-  fun x =>
-    let fix go arg_0__
-              := match arg_0__ with
-                 | Bin p m l r =>
-                     if nomatch x p m : bool then false else
-                     if zero x m : bool then go l else
-                     go r
-                 | Tip y bm =>
-                     andb (prefixOf x GHC.Base.== y) ((bitmapOf x Data.Bits..&.(**) bm) GHC.Base./=
-                           #0)
-                 | Nil => false
-                 end in
-    go.
-
-Definition notMember : Key -> IntSet -> bool :=
-  fun k => negb GHC.Base.∘ member k.
-
 Definition singleton : Key -> IntSet :=
   fun x => Tip (prefixOf x) (bitmapOf x).
+
+Definition insert : Key -> IntSet -> IntSet :=
+  fun x => insertBM (prefixOf x) (bitmapOf x).
+
+Definition delete : Key -> IntSet -> IntSet :=
+  fun x => deleteBM (prefixOf x) (bitmapOf x).
+
+Program Fixpoint intersection (arg_0__ arg_1__ : IntSet) {measure (size_nat
+                               arg_0__ +
+                               size_nat arg_1__)} : IntSet
+                   := match arg_0__, arg_1__ with
+                      | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
+                          let intersection2 :=
+                            if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then Nil else
+                            if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then intersection t1 l2 else
+                            intersection t1 r2 in
+                          let intersection1 :=
+                            if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then Nil else
+                            if Bool.Sumbool.sumbool_of_bool (zero p2 m1) then intersection l1 t2 else
+                            intersection r1 t2 in
+                          if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then intersection1 else
+                          if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then intersection2 else
+                          if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
+                          then bin p1 m1 (intersection l1 l2) (intersection r1 r2) else
+                          Nil
+                      | (Bin _ _ _ _ as t1), Tip kx2 bm2 =>
+                          let fix intersectBM arg_11__
+                                    := match arg_11__ with
+                                       | Bin p1 m1 l1 r1 =>
+                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx2 p1 m1) then Nil else
+                                           if Bool.Sumbool.sumbool_of_bool (zero kx2 m1) then intersectBM l1 else
+                                           intersectBM r1
+                                       | Tip kx1 bm1 =>
+                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
+                                           then tip kx1 (bm1 Data.Bits..&.(**) bm2) else
+                                           Nil
+                                       | Nil => Nil
+                                       end in
+                          intersectBM t1
+                      | Bin _ _ _ _, Nil => Nil
+                      | Tip kx1 bm1, t2 =>
+                          let fix intersectBM arg_18__
+                                    := match arg_18__ with
+                                       | Bin p2 m2 l2 r2 =>
+                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx1 p2 m2) then Nil else
+                                           if Bool.Sumbool.sumbool_of_bool (zero kx1 m2) then intersectBM l2 else
+                                           intersectBM r2
+                                       | Tip kx2 bm2 =>
+                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
+                                           then tip kx1 (bm1 Data.Bits..&.(**) bm2) else
+                                           Nil
+                                       | Nil => Nil
+                                       end in
+                          intersectBM t2
+                      | Nil, _ => Nil
+                      end.
+Solve Obligations with (termination_by_omega).
+
+Fixpoint subsetCmp (arg_0__ arg_1__ : IntSet) : comparison
+           := match arg_0__, arg_1__ with
+              | (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
+                  let subsetCmpEq :=
+                    match pair (subsetCmp l1 l2) (subsetCmp r1 r2) with
+                    | pair Gt _ => Gt
+                    | pair _ Gt => Gt
+                    | pair Eq Eq => Eq
+                    | _ => Lt
+                    end in
+                  let subsetCmpLt :=
+                    if nomatch p1 p2 m2 : bool then Gt else
+                    if zero p1 m2 : bool then subsetCmp t1 l2 else
+                    subsetCmp t1 r2 in
+                  if shorter m1 m2 : bool then Gt else
+                  if shorter m2 m1 : bool
+                  then match subsetCmpLt with
+                       | Gt => Gt
+                       | _ => Lt
+                       end else
+                  if p1 GHC.Base.== p2 : bool then subsetCmpEq else
+                  Gt
+              | _, _ =>
+                  match arg_0__, arg_1__ with
+                  | Bin _ _ _ _, _ => Gt
+                  | Tip kx1 bm1, Tip kx2 bm2 =>
+                      if kx1 GHC.Base./= kx2 : bool then Gt else
+                      if bm1 GHC.Base.== bm2 : bool then Eq else
+                      if Data.Bits.xor bm1 (bm1 Data.Bits..&.(**) bm2) GHC.Base.== #0 : bool
+                      then Lt else
+                      Gt
+                  | (Tip kx _ as t1), Bin p m l r =>
+                      if nomatch kx p m : bool then Gt else
+                      if zero kx m : bool then match subsetCmp t1 l with | Gt => Gt | _ => Lt end else
+                      match subsetCmp t1 r with
+                      | Gt => Gt
+                      | _ => Lt
+                      end
+                  | Tip _ _, Nil => Gt
+                  | Nil, Nil => Eq
+                  | Nil, _ => Lt
+                  end
+              end.
+
+Definition isProperSubsetOf : IntSet -> IntSet -> bool :=
+  fun t1 t2 => match subsetCmp t1 t2 with | Lt => true | _ => false end.
+
+Definition match_ : Coq.Numbers.BinNums.N -> Prefix -> Mask -> bool :=
+  fun i p m => (mask i m) GHC.Base.== p.
+
+Fixpoint isSubsetOf (arg_0__ arg_1__ : IntSet) : bool
+           := match arg_0__, arg_1__ with
+              | (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
+                  if shorter m1 m2 : bool then false else
+                  if shorter m2 m1 : bool
+                  then andb (match_ p1 p2 m2) (if zero p1 m2 : bool
+                             then isSubsetOf t1 l2
+                             else isSubsetOf t1 r2) else
+                  andb (p1 GHC.Base.== p2) (andb (isSubsetOf l1 l2) (isSubsetOf r1 r2))
+              | _, _ =>
+                  match arg_0__, arg_1__ with
+                  | Bin _ _ _ _, _ => false
+                  | Tip kx1 bm1, Tip kx2 bm2 =>
+                      andb (kx1 GHC.Base.== kx2) (Data.Bits.xor bm1 (bm1 Data.Bits..&.(**) bm2)
+                            GHC.Base.==
+                            #0)
+                  | (Tip kx _ as t1), Bin p m l r =>
+                      if nomatch kx p m : bool then false else
+                      if zero kx m : bool then isSubsetOf t1 l else
+                      isSubsetOf t1 r
+                  | Tip _ _, Nil => false
+                  | Nil, _ => true
+                  end
+              end.
+
+Program Fixpoint disjoint (arg_0__ arg_1__ : IntSet) {measure (size_nat arg_0__
+                           +
+                           size_nat arg_1__)} : bool
+                   := match arg_0__, arg_1__ with
+                      | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
+                          let disjoint2 :=
+                            if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then true else
+                            if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then disjoint t1 l2 else
+                            disjoint t1 r2 in
+                          let disjoint1 :=
+                            if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then true else
+                            if Bool.Sumbool.sumbool_of_bool (zero p2 m1) then disjoint l1 t2 else
+                            disjoint r1 t2 in
+                          if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then disjoint1 else
+                          if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then disjoint2 else
+                          if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
+                          then andb (disjoint l1 l2) (disjoint r1 r2) else
+                          true
+                      | (Bin _ _ _ _ as t1), Tip kx2 bm2 =>
+                          let fix disjointBM arg_11__
+                                    := match arg_11__ with
+                                       | Bin p1 m1 l1 r1 =>
+                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx2 p1 m1) then true else
+                                           if Bool.Sumbool.sumbool_of_bool (zero kx2 m1) then disjointBM l1 else
+                                           disjointBM r1
+                                       | Tip kx1 bm1 =>
+                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
+                                           then (bm1 Data.Bits..&.(**) bm2) GHC.Base.== #0 else
+                                           true
+                                       | Nil => true
+                                       end in
+                          disjointBM t1
+                      | Bin _ _ _ _, Nil => true
+                      | Tip kx1 bm1, t2 =>
+                          let fix disjointBM arg_18__
+                                    := match arg_18__ with
+                                       | Bin p2 m2 l2 r2 =>
+                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx1 p2 m2) then true else
+                                           if Bool.Sumbool.sumbool_of_bool (zero kx1 m2) then disjointBM l2 else
+                                           disjointBM r2
+                                       | Tip kx2 bm2 =>
+                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
+                                           then (bm1 Data.Bits..&.(**) bm2) GHC.Base.== #0 else
+                                           true
+                                       | Nil => true
+                                       end in
+                          disjointBM t2
+                      | Nil, _ => true
+                      end.
+Solve Obligations with (termination_by_omega).
+
+Program Definition foldl'Bits {a}
+           : Coq.Numbers.BinNums.N ->
+             (a -> Coq.Numbers.BinNums.N -> a) -> a -> Nat -> a :=
+          fun prefix f z bitmap =>
+            let go :=
+              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
+                               Coq.NArith.BinNat.N.to_nat arg_0__) _ (fun arg_0__ arg_1__ go =>
+                               match arg_0__, arg_1__ with
+                               | num_2__, acc =>
+                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
+                                   match arg_0__, arg_1__ with
+                                   | bm, acc =>
+                                       let bitmask := Utils.Containers.Internal.BitUtil.lowestBitMask bm in
+                                       let bi := indexOfTheOnlyBit bitmask in
+                                       go (Data.Bits.xor bm bitmask) (f acc (prefix GHC.Num.+ bi))
+                                   end
+                               end) in
+            go bitmap z.
+Solve Obligations with (BitTerminationProofs.termination_foldl).
+
+Fixpoint filter (predicate : (Key -> bool)) (t : IntSet) : IntSet
+           := let bitPred :=
+                fun kx bm bi =>
+                  if predicate (kx GHC.Num.+ bi) : bool
+                  then bm Data.Bits..|.(**) bitmapOfSuffix bi else
+                  bm in
+              match t with
+              | Bin p m l r => bin p m (filter predicate l) (filter predicate r)
+              | Tip kx bm => tip kx (foldl'Bits #0 (bitPred kx) #0 bm)
+              | Nil => Nil
+              end.
+
+Definition partition : (Key -> bool) -> IntSet -> (IntSet * IntSet)%type :=
+  fun predicate0 t0 =>
+    let fix go predicate t
+              := let bitPred :=
+                   fun kx bm bi =>
+                     if predicate (kx GHC.Num.+ bi) : bool
+                     then bm Data.Bits..|.(**) bitmapOfSuffix bi else
+                     bm in
+                 match t with
+                 | Bin p m l r =>
+                     let 'pair r1 r2 := go predicate r in
+                     let 'pair l1 l2 := go predicate l in
+                     pair (bin p m l1 r1) (bin p m l2 r2)
+                 | Tip kx bm =>
+                     let bm1 := foldl'Bits #0 (bitPred kx) #0 bm in
+                     pair (tip kx bm1) (tip kx (Data.Bits.xor bm bm1))
+                 | Nil => (pair Nil Nil)
+                 end in
+    id (go predicate0 t0).
 
 Definition split : Key -> IntSet -> (IntSet * IntSet)%type :=
   fun x t =>
@@ -853,140 +930,6 @@ Definition splitMember : Key -> IntSet -> (IntSet * bool * IntSet)%type :=
     | _ => j_22__
     end.
 
-Definition bin : Prefix -> Mask -> IntSet -> IntSet -> IntSet :=
-  fun arg_0__ arg_1__ arg_2__ arg_3__ =>
-    match arg_0__, arg_1__, arg_2__, arg_3__ with
-    | _, _, l, Nil => l
-    | _, _, Nil, r => r
-    | p, m, l, r => Bin p m l r
-    end.
-
-Fixpoint deleteBM (arg_0__ : Prefix) (arg_1__ : BitMap) (arg_2__ : IntSet)
-           : IntSet
-           := match arg_0__, arg_1__, arg_2__ with
-              | kx, bm, (Bin p m l r as t) =>
-                  if nomatch kx p m : bool then t else
-                  if zero kx m : bool then bin p m (deleteBM kx bm l) r else
-                  bin p m l (deleteBM kx bm r)
-              | kx, bm, (Tip kx' bm' as t) =>
-                  if kx' GHC.Base.== kx : bool
-                  then tip kx (Data.Bits.xor bm' (bm' Data.Bits..&.(**) bm)) else
-                  t
-              | _, _, Nil => Nil
-              end.
-
-Definition delete : Key -> IntSet -> IntSet :=
-  fun x => deleteBM (prefixOf x) (bitmapOf x).
-
-Program Fixpoint difference (arg_0__ arg_1__ : IntSet) {measure (size_nat
-                             arg_0__ +
-                             size_nat arg_1__)} : IntSet
-                   := match arg_0__, arg_1__ with
-                      | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
-                          let difference2 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then t1 else
-                            if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then difference t1 l2 else
-                            difference t1 r2 in
-                          let difference1 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then t1 else
-                            if Bool.Sumbool.sumbool_of_bool (zero p2 m1)
-                            then bin p1 m1 (difference l1 t2) r1 else
-                            bin p1 m1 l1 (difference r1 t2) in
-                          if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then difference1 else
-                          if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then difference2 else
-                          if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
-                          then bin p1 m1 (difference l1 l2) (difference r1 r2) else
-                          t1
-                      | (Bin _ _ _ _ as t), Tip kx bm => deleteBM kx bm t
-                      | (Bin _ _ _ _ as t), Nil => t
-                      | (Tip kx bm as t1), t2 =>
-                          let fix differenceTip arg_12__
-                                    := match arg_12__ with
-                                       | Bin p2 m2 l2 r2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx p2 m2) then t1 else
-                                           if Bool.Sumbool.sumbool_of_bool (zero kx m2) then differenceTip l2 else
-                                           differenceTip r2
-                                       | Tip kx2 bm2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (kx GHC.Base.== kx2)
-                                           then tip kx (Data.Bits.xor bm (bm Data.Bits..&.(**) bm2)) else
-                                           t1
-                                       | Nil => t1
-                                       end in
-                          differenceTip t2
-                      | Nil, _ => Nil
-                      end.
-Solve Obligations with (termination_by_omega).
-
-Definition op_zrzr__ : IntSet -> IntSet -> IntSet :=
-  fun m1 m2 => difference m1 m2.
-
-Notation "'_\\_'" := (op_zrzr__).
-
-Infix "\\" := (_\\_) (at level 99).
-
-Fixpoint filter (predicate : (Key -> bool)) (t : IntSet) : IntSet
-           := let bitPred :=
-                fun kx bm bi =>
-                  if predicate (kx GHC.Num.+ bi) : bool
-                  then bm Data.Bits..|.(**) bitmapOfSuffix bi else
-                  bm in
-              match t with
-              | Bin p m l r => bin p m (filter predicate l) (filter predicate r)
-              | Tip kx bm => tip kx (foldl'Bits #0 (bitPred kx) #0 bm)
-              | Nil => Nil
-              end.
-
-Program Fixpoint intersection (arg_0__ arg_1__ : IntSet) {measure (size_nat
-                               arg_0__ +
-                               size_nat arg_1__)} : IntSet
-                   := match arg_0__, arg_1__ with
-                      | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
-                          let intersection2 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then Nil else
-                            if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then intersection t1 l2 else
-                            intersection t1 r2 in
-                          let intersection1 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then Nil else
-                            if Bool.Sumbool.sumbool_of_bool (zero p2 m1) then intersection l1 t2 else
-                            intersection r1 t2 in
-                          if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then intersection1 else
-                          if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then intersection2 else
-                          if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
-                          then bin p1 m1 (intersection l1 l2) (intersection r1 r2) else
-                          Nil
-                      | (Bin _ _ _ _ as t1), Tip kx2 bm2 =>
-                          let fix intersectBM arg_11__
-                                    := match arg_11__ with
-                                       | Bin p1 m1 l1 r1 =>
-                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx2 p1 m1) then Nil else
-                                           if Bool.Sumbool.sumbool_of_bool (zero kx2 m1) then intersectBM l1 else
-                                           intersectBM r1
-                                       | Tip kx1 bm1 =>
-                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
-                                           then tip kx1 (bm1 Data.Bits..&.(**) bm2) else
-                                           Nil
-                                       | Nil => Nil
-                                       end in
-                          intersectBM t1
-                      | Bin _ _ _ _, Nil => Nil
-                      | Tip kx1 bm1, t2 =>
-                          let fix intersectBM arg_18__
-                                    := match arg_18__ with
-                                       | Bin p2 m2 l2 r2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx1 p2 m2) then Nil else
-                                           if Bool.Sumbool.sumbool_of_bool (zero kx1 m2) then intersectBM l2 else
-                                           intersectBM r2
-                                       | Tip kx2 bm2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
-                                           then tip kx1 (bm1 Data.Bits..&.(**) bm2) else
-                                           Nil
-                                       | Nil => Nil
-                                       end in
-                          intersectBM t2
-                      | Nil, _ => Nil
-                      end.
-Solve Obligations with (termination_by_omega).
-
 Definition maxView : IntSet -> option (Key * IntSet)%type :=
   fun t =>
     let fix go arg_0__
@@ -1008,9 +951,6 @@ Definition maxView : IntSet -> option (Key * IntSet)%type :=
         j_12__
     | _ => j_12__
     end.
-
-Definition deleteMax : IntSet -> IntSet :=
-  Data.Maybe.maybe Nil Data.Tuple.snd GHC.Base.∘ maxView.
 
 Definition minView : IntSet -> option (Key * IntSet)%type :=
   fun t =>
@@ -1034,107 +974,167 @@ Definition minView : IntSet -> option (Key * IntSet)%type :=
     | _ => j_12__
     end.
 
+(* Skipping definition `Data.IntSet.Internal.deleteFindMin' *)
+
+(* Skipping definition `Data.IntSet.Internal.deleteFindMax' *)
+
+(* Skipping definition `Data.IntSet.Internal.findMin' *)
+
+(* Skipping definition `Data.IntSet.Internal.findMax' *)
+
 Definition deleteMin : IntSet -> IntSet :=
   Data.Maybe.maybe Nil Data.Tuple.snd GHC.Base.∘ minView.
 
-Definition partition : (Key -> bool) -> IntSet -> (IntSet * IntSet)%type :=
-  fun predicate0 t0 =>
-    let fix go predicate t
-              := let bitPred :=
-                   fun kx bm bi =>
-                     if predicate (kx GHC.Num.+ bi) : bool
-                     then bm Data.Bits..|.(**) bitmapOfSuffix bi else
-                     bm in
-                 match t with
-                 | Bin p m l r =>
-                     let 'pair r1 r2 := go predicate r in
-                     let 'pair l1 l2 := go predicate l in
-                     pair (bin p m l1 r1) (bin p m l2 r2)
-                 | Tip kx bm =>
-                     let bm1 := foldl'Bits #0 (bitPred kx) #0 bm in
-                     pair (tip kx bm1) (tip kx (Data.Bits.xor bm bm1))
-                 | Nil => (pair Nil Nil)
+Definition deleteMax : IntSet -> IntSet :=
+  Data.Maybe.maybe Nil Data.Tuple.snd GHC.Base.∘ maxView.
+
+Definition fromList : list Key -> IntSet :=
+  fun xs => let ins := fun t x => insert x t in Data.Foldable.foldl' ins empty xs.
+
+Definition toList : IntSet -> list Key :=
+  toAscList.
+
+Definition map : (Key -> Key) -> IntSet -> IntSet :=
+  fun f => fromList GHC.Base.∘ (GHC.Base.map f GHC.Base.∘ toList).
+
+Definition fold {b} : (Key -> b -> b) -> b -> IntSet -> b :=
+  foldr.
+
+Program Definition foldr'Bits {a}
+           : Coq.Numbers.BinNums.N ->
+             (Coq.Numbers.BinNums.N -> a -> a) -> a -> Nat -> a :=
+          fun prefix f z bitmap =>
+            let go :=
+              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
+                               Coq.NArith.BinNat.N.to_nat arg_0__) _ (fun arg_0__ arg_1__ go =>
+                               match arg_0__, arg_1__ with
+                               | num_2__, acc =>
+                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
+                                   match arg_0__, arg_1__ with
+                                   | bm, acc =>
+                                       let bitmask := Utils.Containers.Internal.BitUtil.lowestBitMask bm in
+                                       let bi := indexOfTheOnlyBit bitmask in
+                                       go (Data.Bits.xor bm bitmask) ((f ((prefix GHC.Num.+ (#64 GHC.Num.- #1))
+                                                                          GHC.Num.-
+                                                                          bi)) acc)
+                                   end
+                               end) in
+            go (revNatSafe bitmap) z.
+Solve Obligations with (BitTerminationProofs.termination_foldl).
+
+Definition foldr' {b} : (Key -> b -> b) -> b -> IntSet -> b :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Nil => z'
+                 | z', Tip kx bm => foldr'Bits kx f z' bm
+                 | z', Bin _ _ l r => go (go z' r) l
                  end in
-    id (go predicate0 t0).
+    fun t =>
+      match t with
+      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
+      | _ => go z t
+      end.
 
-(* Skipping all instances of class `Control.DeepSeq.NFData', including
-   `Data.IntSet.Internal.NFData__IntSet' *)
+Program Definition foldlBits {a}
+           : Coq.Numbers.BinNums.N ->
+             (a -> Coq.Numbers.BinNums.N -> a) -> a -> Nat -> a :=
+          fun prefix f z bitmap =>
+            let go :=
+              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
+                               Coq.NArith.BinNat.N.to_nat arg_0__) _ (fun arg_0__ arg_1__ go =>
+                               match arg_0__, arg_1__ with
+                               | num_2__, acc =>
+                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
+                                   match arg_0__, arg_1__ with
+                                   | bm, acc =>
+                                       let bitmask := Utils.Containers.Internal.BitUtil.lowestBitMask bm in
+                                       let bi := indexOfTheOnlyBit bitmask in
+                                       go (Data.Bits.xor bm bitmask) (f acc (prefix GHC.Num.+ bi))
+                                   end
+                               end) in
+            go bitmap z.
+Solve Obligations with (BitTerminationProofs.termination_foldl).
 
-(* Skipping all instances of class `GHC.Read.Read', including
-   `Data.IntSet.Internal.Read__IntSet' *)
+Definition foldl {a} : (a -> Key -> a) -> a -> IntSet -> a :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Nil => z'
+                 | z', Tip kx bm => foldlBits kx f z' bm
+                 | z', Bin _ _ l r => go (go z' l) r
+                 end in
+    fun t =>
+      match t with
+      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r
+      | _ => go z t
+      end.
 
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Data.IntSet.Internal.Show__IntSet' *)
+Definition foldl' {a} : (a -> Key -> a) -> a -> IntSet -> a :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Nil => z'
+                 | z', Tip kx bm => foldl'Bits kx f z' bm
+                 | z', Bin _ _ l r => go (go z' l) r
+                 end in
+    fun t =>
+      match t with
+      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r
+      | _ => go z t
+      end.
 
-Local Definition Ord__IntSet_compare : IntSet -> IntSet -> comparison :=
-  fun s1 s2 => GHC.Base.compare (toAscList s1) (toAscList s2).
+Definition elems : IntSet -> list Key :=
+  toAscList.
 
-Local Definition Ord__IntSet_op_zl__ : IntSet -> IntSet -> bool :=
-  fun x y => Ord__IntSet_compare x y GHC.Base.== Lt.
+Definition toDescList : IntSet -> list Key :=
+  foldl (GHC.Base.flip cons) nil.
 
-Local Definition Ord__IntSet_op_zlze__ : IntSet -> IntSet -> bool :=
-  fun x y => Ord__IntSet_compare x y GHC.Base./= Gt.
+Definition foldrFB {b} : (Key -> b -> b) -> b -> IntSet -> b :=
+  foldr.
 
-Local Definition Ord__IntSet_op_zg__ : IntSet -> IntSet -> bool :=
-  fun x y => Ord__IntSet_compare x y GHC.Base.== Gt.
+Definition foldlFB {a} : (a -> Key -> a) -> a -> IntSet -> a :=
+  foldl.
 
-Local Definition Ord__IntSet_op_zgze__ : IntSet -> IntSet -> bool :=
-  fun x y => Ord__IntSet_compare x y GHC.Base./= Lt.
+(* Skipping definition `Data.IntSet.Internal.fromAscList' *)
 
-Local Definition Ord__IntSet_max : IntSet -> IntSet -> IntSet :=
-  fun x y => if Ord__IntSet_op_zlze__ x y : bool then y else x.
+(* Skipping definition `Data.IntSet.Internal.fromDistinctAscList' *)
 
-Local Definition Ord__IntSet_min : IntSet -> IntSet -> IntSet :=
-  fun x y => if Ord__IntSet_op_zlze__ x y : bool then x else y.
+(* Skipping definition `Data.IntSet.Internal.showTree' *)
 
-Local Definition Eq___IntSet_op_zeze__ : IntSet -> IntSet -> bool :=
-  fun t1 t2 => equal t1 t2.
+(* Skipping definition `Data.IntSet.Internal.showTreeWith' *)
 
-Local Definition Eq___IntSet_op_zsze__ : IntSet -> IntSet -> bool :=
-  fun t1 t2 => nequal t1 t2.
+(* Skipping definition `Data.IntSet.Internal.showsTree' *)
 
-Program Instance Eq___IntSet : GHC.Base.Eq_ IntSet :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___IntSet_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___IntSet_op_zsze__ |}.
+(* Skipping definition `Data.IntSet.Internal.showsTreeHang' *)
 
-Program Instance Ord__IntSet : GHC.Base.Ord IntSet :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zl____ := Ord__IntSet_op_zl__ ;
-           GHC.Base.op_zlze____ := Ord__IntSet_op_zlze__ ;
-           GHC.Base.op_zg____ := Ord__IntSet_op_zg__ ;
-           GHC.Base.op_zgze____ := Ord__IntSet_op_zgze__ ;
-           GHC.Base.compare__ := Ord__IntSet_compare ;
-           GHC.Base.max__ := Ord__IntSet_max ;
-           GHC.Base.min__ := Ord__IntSet_min |}.
+(* Skipping definition `Data.IntSet.Internal.showBin' *)
 
-(* Skipping all instances of class `Data.Data.Data', including
-   `Data.IntSet.Internal.Data__IntSet' *)
+(* Skipping definition `Data.IntSet.Internal.showWide' *)
 
-Local Definition Semigroup__IntSet_op_zlzlzgzg__ : IntSet -> IntSet -> IntSet :=
-  union.
+(* Skipping definition `Data.IntSet.Internal.showsBars' *)
 
-Program Instance Semigroup__IntSet : GHC.Base.Semigroup IntSet :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__IntSet_op_zlzlzgzg__ |}.
+(* Skipping definition `Data.IntSet.Internal.showsBitMap' *)
 
-Local Definition Monoid__IntSet_mappend : IntSet -> IntSet -> IntSet :=
-  _GHC.Base.<<>>_.
+(* Skipping definition `Data.IntSet.Internal.showBitMap' *)
 
-Local Definition Monoid__IntSet_mconcat : list IntSet -> IntSet :=
-  unions.
+(* Skipping definition `Data.IntSet.Internal.node' *)
 
-Local Definition Monoid__IntSet_mempty : IntSet :=
-  empty.
+(* Skipping definition `Data.IntSet.Internal.withBar' *)
 
-Program Instance Monoid__IntSet : GHC.Base.Monoid IntSet :=
-  fun _ k__ =>
-    k__ {| GHC.Base.mappend__ := Monoid__IntSet_mappend ;
-           GHC.Base.mconcat__ := Monoid__IntSet_mconcat ;
-           GHC.Base.mempty__ := Monoid__IntSet_mempty |}.
+(* Skipping definition `Data.IntSet.Internal.withEmpty' *)
 
-(* Skipping all instances of class `GHC.Exts.IsList', including
-   `Data.IntSet.Internal.IsList__IntSet' *)
+(* Skipping definition `Data.IntSet.Internal.prefixBitMask' *)
+
+Definition splitRoot : IntSet -> list IntSet :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Nil => nil
+    | (Tip _ _ as x) => cons x nil
+    | Bin _ m l r =>
+        if m GHC.Base.< #0 : bool then cons r (cons l nil) else
+        cons l (cons r nil)
+    end.
 
 Module Notations.
 Notation "'_Data.IntSet.Internal.\\_'" := (op_zrzr__).

--- a/examples/containers/lib/Data/IntSet/InternalWord.v
+++ b/examples/containers/lib/Data/IntSet/InternalWord.v
@@ -80,119 +80,16 @@ Ltac termination_by_omega :=
 
 (* Converted value declarations: *)
 
-(* Skipping definition `Data.IntSet.InternalWord.withEmpty' *)
-
-(* Skipping definition `Data.IntSet.InternalWord.withBar' *)
-
-Definition tip : Prefix -> BitMap -> IntSet :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | _, num_2__ =>
-        if num_2__ GHC.Base.== #0 : bool then Nil else
-        match arg_0__, arg_1__ with
-        | kx, bm => Tip kx bm
-        end
-    end.
-
-Definition suffixBitMask : IntWord.Int :=
-  #63.
-
-Definition suffixOf : IntWord.Int -> IntWord.Int :=
-  fun x => x Data.Bits..&.(**) suffixBitMask.
-
-Definition splitRoot : IntSet -> list IntSet :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Nil => nil
-    | (Tip _ _ as x) => cons x nil
-    | Bin _ m l r =>
-        if m GHC.Base.< #0 : bool then cons r (cons l nil) else
-        cons l (cons r nil)
-    end.
-
-Definition size : IntSet -> IntWord.Int :=
-  let fix go arg_0__ arg_1__
-            := match arg_0__, arg_1__ with
-               | acc, Bin _ _ l r => go (go acc l) r
-               | acc, Tip _ bm => acc GHC.Num.+ IntWord.bitcount #0 bm
-               | acc, Nil => acc
-               end in
-  go #0.
-
-(* Skipping definition `Data.IntSet.InternalWord.showsTreeHang' *)
-
-(* Skipping definition `Data.IntSet.InternalWord.showsTree' *)
-
-(* Skipping definition `Data.IntSet.InternalWord.showsBitMap' *)
-
-(* Skipping definition `Data.IntSet.InternalWord.showsBars' *)
-
-(* Skipping definition `Data.IntSet.InternalWord.showWide' *)
-
-(* Skipping definition `Data.IntSet.InternalWord.showTreeWith' *)
-
-(* Skipping definition `Data.IntSet.InternalWord.showTree' *)
-
-(* Skipping definition `Data.IntSet.InternalWord.showBitMap' *)
-
-(* Skipping definition `Data.IntSet.InternalWord.showBin' *)
-
-Definition revNat : Nat -> Nat :=
-  fun x1 =>
-    let 'x2 := ((IntWord.shiftRWord x1 #1) Data.Bits..&.(**) #6148914691236517205)
-                 Data.Bits..|.(**)
-                 (IntWord.shiftLWord (x1 Data.Bits..&.(**) #6148914691236517205) #1) in
-    let 'x3 := ((IntWord.shiftRWord x2 #2) Data.Bits..&.(**) #3689348814741910323)
-                 Data.Bits..|.(**)
-                 (IntWord.shiftLWord (x2 Data.Bits..&.(**) #3689348814741910323) #2) in
-    let 'x4 := ((IntWord.shiftRWord x3 #4) Data.Bits..&.(**) #1085102592571150095)
-                 Data.Bits..|.(**)
-                 (IntWord.shiftLWord (x3 Data.Bits..&.(**) #1085102592571150095) #4) in
-    let 'x5 := ((IntWord.shiftRWord x4 #8) Data.Bits..&.(**) #71777214294589695)
-                 Data.Bits..|.(**)
-                 (IntWord.shiftLWord (x4 Data.Bits..&.(**) #71777214294589695) #8) in
-    let 'x6 := ((IntWord.shiftRWord x5 #16) Data.Bits..&.(**) #281470681808895)
-                 Data.Bits..|.(**)
-                 (IntWord.shiftLWord (x5 Data.Bits..&.(**) #281470681808895) #16) in
-    (IntWord.shiftRWord x6 #32) Data.Bits..|.(**) (IntWord.shiftLWord x6 #32).
-
-Definition prefixBitMask : IntWord.Int :=
-  Data.Bits.complement suffixBitMask.
-
-Definition prefixOf : IntWord.Int -> Prefix :=
-  fun x => x Data.Bits..&.(**) prefixBitMask.
-
-Definition null : IntSet -> bool :=
-  fun arg_0__ => match arg_0__ with | Nil => true | _ => false end.
-
-(* Skipping definition `Data.IntSet.InternalWord.node' *)
-
-Fixpoint nequal (arg_0__ arg_1__ : IntSet) : bool
-           := match arg_0__, arg_1__ with
-              | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
-                  orb (m1 GHC.Base./= m2) (orb (p1 GHC.Base./= p2) (orb (nequal l1 l2) (nequal r1
-                                                                         r2)))
-              | Tip kx1 bm1, Tip kx2 bm2 => orb (kx1 GHC.Base./= kx2) (bm1 GHC.Base./= bm2)
-              | Nil, Nil => false
-              | _, _ => true
-              end.
+Definition intFromNat :=
+  IntWord.intFromWord.
 
 Definition natFromInt :=
   IntWord.wordFromInt.
 
-Definition shorter : Mask -> Mask -> bool :=
-  fun m1 m2 => (natFromInt m1) GHC.Base.> (natFromInt m2).
-
-Definition zero : IntWord.Int -> Mask -> bool :=
-  fun i m => ((natFromInt i) Data.Bits..&.(**) (natFromInt m)) GHC.Base.== #0.
-
-Definition lowestBitMask : Nat -> Nat :=
-  fun x => x Data.Bits..&.(**) GHC.Num.negate x.
-
-(* Skipping definition `Data.IntSet.InternalWord.intSetDataType' *)
-
-Definition intFromNat :=
-  IntWord.intFromWord.
+Definition branchMask : Prefix -> Prefix -> Mask :=
+  fun p1 p2 =>
+    intFromNat (IntWord.highestBitMask (Data.Bits.xor (natFromInt p1) (natFromInt
+                                                       p2))).
 
 Definition maskW : Nat -> Nat -> Prefix :=
   fun i m =>
@@ -202,351 +99,16 @@ Definition maskW : Nat -> Nat -> Prefix :=
 Definition mask : IntWord.Int -> Mask -> Prefix :=
   fun i m => maskW (natFromInt i) (natFromInt m).
 
-Definition match_ : IntWord.Int -> Prefix -> Mask -> bool :=
-  fun i p m => (mask i m) GHC.Base.== p.
-
-Definition nomatch : IntWord.Int -> Prefix -> Mask -> bool :=
-  fun i p m => (mask i m) GHC.Base./= p.
-
-Fixpoint isSubsetOf (arg_0__ arg_1__ : IntSet) : bool
-           := match arg_0__, arg_1__ with
-              | (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
-                  if shorter m1 m2 : bool then false else
-                  if shorter m2 m1 : bool
-                  then andb (match_ p1 p2 m2) (if zero p1 m2 : bool
-                             then isSubsetOf t1 l2
-                             else isSubsetOf t1 r2) else
-                  andb (p1 GHC.Base.== p2) (andb (isSubsetOf l1 l2) (isSubsetOf r1 r2))
-              | _, _ =>
-                  match arg_0__, arg_1__ with
-                  | Bin _ _ _ _, _ => false
-                  | Tip kx1 bm1, Tip kx2 bm2 =>
-                      andb (kx1 GHC.Base.== kx2) ((bm1 Data.Bits..&.(**) Data.Bits.complement bm2)
-                            GHC.Base.==
-                            #0)
-                  | (Tip kx _ as t1), Bin p m l r =>
-                      if nomatch kx p m : bool then false else
-                      if zero kx m : bool then isSubsetOf t1 l else
-                      isSubsetOf t1 r
-                  | Tip _ _, Nil => false
-                  | Nil, _ => true
-                  end
-              end.
-
-Fixpoint subsetCmp (arg_0__ arg_1__ : IntSet) : comparison
-           := match arg_0__, arg_1__ with
-              | (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
-                  let subsetCmpEq :=
-                    match pair (subsetCmp l1 l2) (subsetCmp r1 r2) with
-                    | pair Gt _ => Gt
-                    | pair _ Gt => Gt
-                    | pair Eq Eq => Eq
-                    | _ => Lt
-                    end in
-                  let subsetCmpLt :=
-                    if nomatch p1 p2 m2 : bool then Gt else
-                    if zero p1 m2 : bool then subsetCmp t1 l2 else
-                    subsetCmp t1 r2 in
-                  if shorter m1 m2 : bool then Gt else
-                  if shorter m2 m1 : bool
-                  then match subsetCmpLt with
-                       | Gt => Gt
-                       | _ => Lt
-                       end else
-                  if p1 GHC.Base.== p2 : bool then subsetCmpEq else
-                  Gt
-              | _, _ =>
-                  match arg_0__, arg_1__ with
-                  | Bin _ _ _ _, _ => Gt
-                  | Tip kx1 bm1, Tip kx2 bm2 =>
-                      if kx1 GHC.Base./= kx2 : bool then Gt else
-                      if bm1 GHC.Base.== bm2 : bool then Eq else
-                      if (bm1 Data.Bits..&.(**) Data.Bits.complement bm2) GHC.Base.== #0 : bool
-                      then Lt else
-                      Gt
-                  | (Tip kx _ as t1), Bin p m l r =>
-                      if nomatch kx p m : bool then Gt else
-                      if zero kx m : bool then match subsetCmp t1 l with | Gt => Gt | _ => Lt end else
-                      match subsetCmp t1 r with
-                      | Gt => Gt
-                      | _ => Lt
-                      end
-                  | Tip _ _, Nil => Gt
-                  | Nil, Nil => Eq
-                  | Nil, _ => Lt
-                  end
-              end.
-
-Definition isProperSubsetOf : IntSet -> IntSet -> bool :=
-  fun t1 t2 => match subsetCmp t1 t2 with | Lt => true | _ => false end.
-
-Definition indexOfTheOnlyBit :=
-  IntWord.indexOfTheOnlyBit.
-
-Definition lowestBitSet : Nat -> IntWord.Int :=
-  fun x => indexOfTheOnlyBit (lowestBitMask x).
-
-Fixpoint unsafeFindMin (arg_0__ : IntSet) : option Key
-           := match arg_0__ with
-              | Nil => None
-              | Tip kx bm => Some (kx GHC.Num.+ lowestBitSet bm)
-              | Bin _ _ l _ => unsafeFindMin l
-              end.
-
-Definition highestBitSet : Nat -> IntWord.Int :=
-  fun x => indexOfTheOnlyBit (IntWord.highestBitMask x).
-
-Fixpoint unsafeFindMax (arg_0__ : IntSet) : option Key
-           := match arg_0__ with
-              | Nil => None
-              | Tip kx bm => Some (kx GHC.Num.+ highestBitSet bm)
-              | Bin _ _ _ r => unsafeFindMax r
-              end.
-
-(* Skipping definition `Data.IntSet.InternalWord.fromListConstr' *)
-
-(* Skipping definition `Data.IntSet.InternalWord.fromDistinctAscList' *)
-
-(* Skipping definition `Data.IntSet.InternalWord.fromAscList' *)
-
-Program Definition foldrBits {a}
-           : IntWord.Int -> (IntWord.Int -> a -> a) -> a -> Nat -> a :=
-          fun prefix f z bitmap =>
-            let go :=
-              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
-                               IntWord.wordTonat arg_0__) _ (fun arg_0__ arg_1__ go =>
-                               match arg_0__, arg_1__ with
-                               | num_2__, acc =>
-                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
-                                   match arg_0__, arg_1__ with
-                                   | bm, acc =>
-                                       let bitmask := lowestBitMask bm in
-                                       let bi := indexOfTheOnlyBit bitmask in
-                                       go (Data.Bits.xor bm bitmask) ((f ((prefix GHC.Num.+ (#64 GHC.Num.- #1))
-                                                                          GHC.Num.-
-                                                                          bi)) acc)
-                                   end
-                               end) in
-            go (revNat bitmap) z.
-Admit Obligations.
-
-Program Definition foldr'Bits {a}
-           : IntWord.Int -> (IntWord.Int -> a -> a) -> a -> Nat -> a :=
-          fun prefix f z bitmap =>
-            let go :=
-              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
-                               IntWord.wordTonat arg_0__) _ (fun arg_0__ arg_1__ go =>
-                               match arg_0__, arg_1__ with
-                               | num_2__, acc =>
-                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
-                                   match arg_0__, arg_1__ with
-                                   | bm, acc =>
-                                       let bitmask := lowestBitMask bm in
-                                       let bi := indexOfTheOnlyBit bitmask in
-                                       go (Data.Bits.xor bm bitmask) ((f ((prefix GHC.Num.+ (#64 GHC.Num.- #1))
-                                                                          GHC.Num.-
-                                                                          bi)) acc)
-                                   end
-                               end) in
-            go (revNat bitmap) z.
-Admit Obligations.
-
-Definition foldr' {b} : (Key -> b -> b) -> b -> IntSet -> b :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx bm => foldr'Bits kx f z' bm
-                 | z', Bin _ _ l r => go (go z' r) l
-                 end in
-    fun t =>
-      match t with
-      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
-      | _ => go z t
-      end.
-
-Definition foldr {b} : (Key -> b -> b) -> b -> IntSet -> b :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx bm => foldrBits kx f z' bm
-                 | z', Bin _ _ l r => go (go z' r) l
-                 end in
-    fun t =>
-      match t with
-      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
-      | _ => go z t
-      end.
-
-Definition foldrFB {b} : (Key -> b -> b) -> b -> IntSet -> b :=
-  foldr.
-
-Definition toAscList : IntSet -> list Key :=
-  foldr cons nil.
-
-Definition toList : IntSet -> list Key :=
-  toAscList.
-
-Program Definition foldlBits {a}
-           : IntWord.Int -> (a -> IntWord.Int -> a) -> a -> Nat -> a :=
-          fun prefix f z bitmap =>
-            let go :=
-              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
-                               IntWord.wordTonat arg_0__) _ (fun arg_0__ arg_1__ go =>
-                               match arg_0__, arg_1__ with
-                               | num_2__, acc =>
-                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
-                                   match arg_0__, arg_1__ with
-                                   | bm, acc =>
-                                       let bitmask := lowestBitMask bm in
-                                       let bi := indexOfTheOnlyBit bitmask in
-                                       go (Data.Bits.xor bm bitmask) (f acc (prefix GHC.Num.+ bi))
-                                   end
-                               end) in
-            go bitmap z.
-Admit Obligations.
-
-Program Definition foldl'Bits {a}
-           : IntWord.Int -> (a -> IntWord.Int -> a) -> a -> Nat -> a :=
-          fun prefix f z bitmap =>
-            let go :=
-              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
-                               IntWord.wordTonat arg_0__) _ (fun arg_0__ arg_1__ go =>
-                               match arg_0__, arg_1__ with
-                               | num_2__, acc =>
-                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
-                                   match arg_0__, arg_1__ with
-                                   | bm, acc =>
-                                       let bitmask := lowestBitMask bm in
-                                       let bi := indexOfTheOnlyBit bitmask in
-                                       go (Data.Bits.xor bm bitmask) (f acc (prefix GHC.Num.+ bi))
-                                   end
-                               end) in
-            go bitmap z.
-Admit Obligations.
-
-Definition foldl' {a} : (a -> Key -> a) -> a -> IntSet -> a :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx bm => foldl'Bits kx f z' bm
-                 | z', Bin _ _ l r => go (go z' l) r
-                 end in
-    fun t =>
-      match t with
-      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r
-      | _ => go z t
-      end.
-
-Definition foldl {a} : (a -> Key -> a) -> a -> IntSet -> a :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Nil => z'
-                 | z', Tip kx bm => foldlBits kx f z' bm
-                 | z', Bin _ _ l r => go (go z' l) r
-                 end in
-    fun t =>
-      match t with
-      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r
-      | _ => go z t
-      end.
-
-Definition foldlFB {a} : (a -> Key -> a) -> a -> IntSet -> a :=
-  foldl.
-
-Definition toDescList : IntSet -> list Key :=
-  foldl (GHC.Base.flip cons) nil.
-
-Definition fold {b} : (Key -> b -> b) -> b -> IntSet -> b :=
-  foldr.
-
-(* Skipping definition `Data.IntSet.InternalWord.findMin' *)
-
-(* Skipping definition `Data.IntSet.InternalWord.findMax' *)
-
-Fixpoint equal (arg_0__ arg_1__ : IntSet) : bool
-           := match arg_0__, arg_1__ with
-              | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
-                  andb (m1 GHC.Base.== m2) (andb (p1 GHC.Base.== p2) (andb (equal l1 l2) (equal r1
-                                                                            r2)))
-              | Tip kx1 bm1, Tip kx2 bm2 => andb (kx1 GHC.Base.== kx2) (bm1 GHC.Base.== bm2)
-              | Nil, Nil => true
-              | _, _ => false
-              end.
-
-Definition empty : IntSet :=
-  Nil.
-
-Definition elems : IntSet -> list Key :=
-  toAscList.
-
-Program Fixpoint disjoint (arg_0__ arg_1__ : IntSet) {measure (size_nat arg_0__
-                           +
-                           size_nat arg_1__)} : bool
-                   := match arg_0__, arg_1__ with
-                      | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
-                          let disjoint2 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then true else
-                            if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then disjoint t1 l2 else
-                            disjoint t1 r2 in
-                          let disjoint1 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then true else
-                            if Bool.Sumbool.sumbool_of_bool (zero p2 m1) then disjoint l1 t2 else
-                            disjoint r1 t2 in
-                          if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then disjoint1 else
-                          if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then disjoint2 else
-                          if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
-                          then andb (disjoint l1 l2) (disjoint r1 r2) else
-                          true
-                      | (Bin _ _ _ _ as t1), Tip kx2 bm2 =>
-                          let fix disjointBM arg_11__
-                                    := match arg_11__ with
-                                       | Bin p1 m1 l1 r1 =>
-                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx2 p1 m1) then true else
-                                           if Bool.Sumbool.sumbool_of_bool (zero kx2 m1) then disjointBM l1 else
-                                           disjointBM r1
-                                       | Tip kx1 bm1 =>
-                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
-                                           then (bm1 Data.Bits..&.(**) bm2) GHC.Base.== #0 else
-                                           true
-                                       | Nil => true
-                                       end in
-                          disjointBM t1
-                      | Bin _ _ _ _, Nil => true
-                      | Tip kx1 bm1, t2 =>
-                          let fix disjointBM arg_18__
-                                    := match arg_18__ with
-                                       | Bin p2 m2 l2 r2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx1 p2 m2) then true else
-                                           if Bool.Sumbool.sumbool_of_bool (zero kx1 m2) then disjointBM l2 else
-                                           disjointBM r2
-                                       | Tip kx2 bm2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
-                                           then (bm1 Data.Bits..&.(**) bm2) GHC.Base.== #0 else
-                                           true
-                                       | Nil => true
-                                       end in
-                          disjointBM t2
-                      | Nil, _ => true
-                      end.
-Solve Obligations with (termination_by_omega).
-
-(* Skipping definition `Data.IntSet.InternalWord.deleteFindMin' *)
-
-(* Skipping definition `Data.IntSet.InternalWord.deleteFindMax' *)
-
-Definition branchMask : Prefix -> Prefix -> Mask :=
-  fun p1 p2 =>
-    intFromNat (IntWord.highestBitMask (Data.Bits.xor (natFromInt p1) (natFromInt
-                                                       p2))).
+Definition zero : IntWord.Int -> Mask -> bool :=
+  fun i m => ((natFromInt i) Data.Bits..&.(**) (natFromInt m)) GHC.Base.== #0.
 
 Definition link : Prefix -> IntSet -> Prefix -> IntSet -> IntSet :=
   fun p1 t1 p2 t2 =>
     let m := branchMask p1 p2 in
     let p := mask p1 m in if zero p1 m : bool then Bin p m t1 t2 else Bin p m t2 t1.
+
+Definition nomatch : IntWord.Int -> Prefix -> Mask -> bool :=
+  fun i p m => (mask i m) GHC.Base./= p.
 
 Fixpoint insertBM (arg_0__ : Prefix) (arg_1__ : BitMap) (arg_2__ : IntSet)
            : IntSet
@@ -560,6 +122,9 @@ Fixpoint insertBM (arg_0__ : Prefix) (arg_1__ : BitMap) (arg_2__ : IntSet)
                   link kx (Tip kx bm) kx' t
               | kx, bm, Nil => Tip kx bm
               end.
+
+Definition shorter : Mask -> Mask -> bool :=
+  fun m1 m2 => (natFromInt m1) GHC.Base.> (natFromInt m2).
 
 Program Fixpoint union (arg_0__ arg_1__ : IntSet) {measure (size_nat arg_0__ +
                         size_nat arg_1__)} : IntSet
@@ -587,53 +152,354 @@ Program Fixpoint union (arg_0__ arg_1__ : IntSet) {measure (size_nat arg_0__ +
                       end.
 Solve Obligations with (termination_by_omega).
 
+Local Definition Semigroup__IntSet_op_zlzlzgzg__ : IntSet -> IntSet -> IntSet :=
+  union.
+
+Program Instance Semigroup__IntSet : GHC.Base.Semigroup IntSet :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__IntSet_op_zlzlzgzg__ |}.
+
+Local Definition Monoid__IntSet_mappend : IntSet -> IntSet -> IntSet :=
+  _GHC.Base.<<>>_.
+
+Definition empty : IntSet :=
+  Nil.
+
 Definition unions {f} `{Data.Foldable.Foldable f} : f IntSet -> IntSet :=
   fun xs => Data.Foldable.foldl' union empty xs.
+
+Local Definition Monoid__IntSet_mconcat : list IntSet -> IntSet :=
+  unions.
+
+Local Definition Monoid__IntSet_mempty : IntSet :=
+  empty.
+
+Program Instance Monoid__IntSet : GHC.Base.Monoid IntSet :=
+  fun _ k__ =>
+    k__ {| GHC.Base.mappend__ := Monoid__IntSet_mappend ;
+           GHC.Base.mconcat__ := Monoid__IntSet_mconcat ;
+           GHC.Base.mempty__ := Monoid__IntSet_mempty |}.
+
+(* Skipping all instances of class `Data.Data.Data', including
+   `Data.IntSet.InternalWord.Data__IntSet' *)
+
+(* Skipping all instances of class `GHC.Exts.IsList', including
+   `Data.IntSet.InternalWord.IsList__IntSet' *)
+
+Fixpoint equal (arg_0__ arg_1__ : IntSet) : bool
+           := match arg_0__, arg_1__ with
+              | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
+                  andb (m1 GHC.Base.== m2) (andb (p1 GHC.Base.== p2) (andb (equal l1 l2) (equal r1
+                                                                            r2)))
+              | Tip kx1 bm1, Tip kx2 bm2 => andb (kx1 GHC.Base.== kx2) (bm1 GHC.Base.== bm2)
+              | Nil, Nil => true
+              | _, _ => false
+              end.
+
+Local Definition Eq___IntSet_op_zeze__ : IntSet -> IntSet -> bool :=
+  fun t1 t2 => equal t1 t2.
+
+Fixpoint nequal (arg_0__ arg_1__ : IntSet) : bool
+           := match arg_0__, arg_1__ with
+              | Bin p1 m1 l1 r1, Bin p2 m2 l2 r2 =>
+                  orb (m1 GHC.Base./= m2) (orb (p1 GHC.Base./= p2) (orb (nequal l1 l2) (nequal r1
+                                                                         r2)))
+              | Tip kx1 bm1, Tip kx2 bm2 => orb (kx1 GHC.Base./= kx2) (bm1 GHC.Base./= bm2)
+              | Nil, Nil => false
+              | _, _ => true
+              end.
+
+Local Definition Eq___IntSet_op_zsze__ : IntSet -> IntSet -> bool :=
+  fun t1 t2 => nequal t1 t2.
+
+Program Instance Eq___IntSet : GHC.Base.Eq_ IntSet :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___IntSet_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___IntSet_op_zsze__ |}.
+
+Definition indexOfTheOnlyBit :=
+  IntWord.indexOfTheOnlyBit.
+
+Definition lowestBitMask : Nat -> Nat :=
+  fun x => x Data.Bits..&.(**) GHC.Num.negate x.
+
+Definition revNat : Nat -> Nat :=
+  fun x1 =>
+    let 'x2 := ((IntWord.shiftRWord x1 #1) Data.Bits..&.(**) #6148914691236517205)
+                 Data.Bits..|.(**)
+                 (IntWord.shiftLWord (x1 Data.Bits..&.(**) #6148914691236517205) #1) in
+    let 'x3 := ((IntWord.shiftRWord x2 #2) Data.Bits..&.(**) #3689348814741910323)
+                 Data.Bits..|.(**)
+                 (IntWord.shiftLWord (x2 Data.Bits..&.(**) #3689348814741910323) #2) in
+    let 'x4 := ((IntWord.shiftRWord x3 #4) Data.Bits..&.(**) #1085102592571150095)
+                 Data.Bits..|.(**)
+                 (IntWord.shiftLWord (x3 Data.Bits..&.(**) #1085102592571150095) #4) in
+    let 'x5 := ((IntWord.shiftRWord x4 #8) Data.Bits..&.(**) #71777214294589695)
+                 Data.Bits..|.(**)
+                 (IntWord.shiftLWord (x4 Data.Bits..&.(**) #71777214294589695) #8) in
+    let 'x6 := ((IntWord.shiftRWord x5 #16) Data.Bits..&.(**) #281470681808895)
+                 Data.Bits..|.(**)
+                 (IntWord.shiftLWord (x5 Data.Bits..&.(**) #281470681808895) #16) in
+    (IntWord.shiftRWord x6 #32) Data.Bits..|.(**) (IntWord.shiftLWord x6 #32).
+
+Program Definition foldrBits {a}
+           : IntWord.Int -> (IntWord.Int -> a -> a) -> a -> Nat -> a :=
+          fun prefix f z bitmap =>
+            let go :=
+              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
+                               IntWord.wordTonat arg_0__) _ (fun arg_0__ arg_1__ go =>
+                               match arg_0__, arg_1__ with
+                               | num_2__, acc =>
+                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
+                                   match arg_0__, arg_1__ with
+                                   | bm, acc =>
+                                       let bitmask := lowestBitMask bm in
+                                       let bi := indexOfTheOnlyBit bitmask in
+                                       go (Data.Bits.xor bm bitmask) ((f ((prefix GHC.Num.+ (#64 GHC.Num.- #1))
+                                                                          GHC.Num.-
+                                                                          bi)) acc)
+                                   end
+                               end) in
+            go (revNat bitmap) z.
+Admit Obligations.
+
+Definition foldr {b} : (Key -> b -> b) -> b -> IntSet -> b :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Nil => z'
+                 | z', Tip kx bm => foldrBits kx f z' bm
+                 | z', Bin _ _ l r => go (go z' r) l
+                 end in
+    fun t =>
+      match t with
+      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
+      | _ => go z t
+      end.
+
+Definition toAscList : IntSet -> list Key :=
+  foldr cons nil.
+
+Local Definition Ord__IntSet_compare : IntSet -> IntSet -> comparison :=
+  fun s1 s2 => GHC.Base.compare (toAscList s1) (toAscList s2).
+
+Local Definition Ord__IntSet_op_zl__ : IntSet -> IntSet -> bool :=
+  fun x y => Ord__IntSet_compare x y GHC.Base.== Lt.
+
+Local Definition Ord__IntSet_op_zlze__ : IntSet -> IntSet -> bool :=
+  fun x y => Ord__IntSet_compare x y GHC.Base./= Gt.
+
+Local Definition Ord__IntSet_op_zg__ : IntSet -> IntSet -> bool :=
+  fun x y => Ord__IntSet_compare x y GHC.Base.== Gt.
+
+Local Definition Ord__IntSet_op_zgze__ : IntSet -> IntSet -> bool :=
+  fun x y => Ord__IntSet_compare x y GHC.Base./= Lt.
+
+Local Definition Ord__IntSet_max : IntSet -> IntSet -> IntSet :=
+  fun x y => if Ord__IntSet_op_zlze__ x y : bool then y else x.
+
+Local Definition Ord__IntSet_min : IntSet -> IntSet -> IntSet :=
+  fun x y => if Ord__IntSet_op_zlze__ x y : bool then x else y.
+
+Program Instance Ord__IntSet : GHC.Base.Ord IntSet :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zl____ := Ord__IntSet_op_zl__ ;
+           GHC.Base.op_zlze____ := Ord__IntSet_op_zlze__ ;
+           GHC.Base.op_zg____ := Ord__IntSet_op_zg__ ;
+           GHC.Base.op_zgze____ := Ord__IntSet_op_zgze__ ;
+           GHC.Base.compare__ := Ord__IntSet_compare ;
+           GHC.Base.max__ := Ord__IntSet_max ;
+           GHC.Base.min__ := Ord__IntSet_min |}.
+
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Data.IntSet.InternalWord.Show__IntSet' *)
+
+(* Skipping all instances of class `GHC.Read.Read', including
+   `Data.IntSet.InternalWord.Read__IntSet' *)
+
+(* Skipping all instances of class `Control.DeepSeq.NFData', including
+   `Data.IntSet.InternalWord.NFData__IntSet' *)
+
+Definition bin : Prefix -> Mask -> IntSet -> IntSet -> IntSet :=
+  fun arg_0__ arg_1__ arg_2__ arg_3__ =>
+    match arg_0__, arg_1__, arg_2__, arg_3__ with
+    | _, _, l, Nil => l
+    | _, _, Nil, r => r
+    | p, m, l, r => Bin p m l r
+    end.
+
+Definition tip : Prefix -> BitMap -> IntSet :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | _, num_2__ =>
+        if num_2__ GHC.Base.== #0 : bool then Nil else
+        match arg_0__, arg_1__ with
+        | kx, bm => Tip kx bm
+        end
+    end.
+
+Fixpoint deleteBM (arg_0__ : Prefix) (arg_1__ : BitMap) (arg_2__ : IntSet)
+           : IntSet
+           := match arg_0__, arg_1__, arg_2__ with
+              | kx, bm, (Bin p m l r as t) =>
+                  if nomatch kx p m : bool then t else
+                  if zero kx m : bool then bin p m (deleteBM kx bm l) r else
+                  bin p m l (deleteBM kx bm r)
+              | kx, bm, (Tip kx' bm' as t) =>
+                  if kx' GHC.Base.== kx : bool
+                  then tip kx (bm' Data.Bits..&.(**) Data.Bits.complement bm) else
+                  t
+              | _, _, Nil => Nil
+              end.
+
+Program Fixpoint difference (arg_0__ arg_1__ : IntSet) {measure (size_nat
+                             arg_0__ +
+                             size_nat arg_1__)} : IntSet
+                   := match arg_0__, arg_1__ with
+                      | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
+                          let difference2 :=
+                            if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then t1 else
+                            if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then difference t1 l2 else
+                            difference t1 r2 in
+                          let difference1 :=
+                            if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then t1 else
+                            if Bool.Sumbool.sumbool_of_bool (zero p2 m1)
+                            then bin p1 m1 (difference l1 t2) r1 else
+                            bin p1 m1 l1 (difference r1 t2) in
+                          if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then difference1 else
+                          if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then difference2 else
+                          if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
+                          then bin p1 m1 (difference l1 l2) (difference r1 r2) else
+                          t1
+                      | (Bin _ _ _ _ as t), Tip kx bm => deleteBM kx bm t
+                      | (Bin _ _ _ _ as t), Nil => t
+                      | (Tip kx bm as t1), t2 =>
+                          let fix differenceTip arg_12__
+                                    := match arg_12__ with
+                                       | Bin p2 m2 l2 r2 =>
+                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx p2 m2) then t1 else
+                                           if Bool.Sumbool.sumbool_of_bool (zero kx m2) then differenceTip l2 else
+                                           differenceTip r2
+                                       | Tip kx2 bm2 =>
+                                           if Bool.Sumbool.sumbool_of_bool (kx GHC.Base.== kx2)
+                                           then tip kx (bm Data.Bits..&.(**) Data.Bits.complement bm2) else
+                                           t1
+                                       | Nil => t1
+                                       end in
+                          differenceTip t2
+                      | Nil, _ => Nil
+                      end.
+Solve Obligations with (termination_by_omega).
+
+Definition op_zrzr__ : IntSet -> IntSet -> IntSet :=
+  fun m1 m2 => difference m1 m2.
+
+Notation "'_\\_'" := (op_zrzr__).
+
+Infix "\\" := (_\\_) (at level 99).
+
+(* Skipping definition `Data.IntSet.InternalWord.fromListConstr' *)
+
+(* Skipping definition `Data.IntSet.InternalWord.intSetDataType' *)
+
+Definition null : IntSet -> bool :=
+  fun arg_0__ => match arg_0__ with | Nil => true | _ => false end.
+
+Definition size : IntSet -> IntWord.Int :=
+  let fix go arg_0__ arg_1__
+            := match arg_0__, arg_1__ with
+               | acc, Bin _ _ l r => go (go acc l) r
+               | acc, Tip _ bm => acc GHC.Num.+ IntWord.bitcount #0 bm
+               | acc, Nil => acc
+               end in
+  go #0.
 
 Definition bitmapOfSuffix : IntWord.Int -> BitMap :=
   fun s => IntWord.shiftLWord #1 s.
 
+Definition suffixBitMask : IntWord.Int :=
+  #63.
+
+Definition suffixOf : IntWord.Int -> IntWord.Int :=
+  fun x => x Data.Bits..&.(**) suffixBitMask.
+
 Definition bitmapOf : IntWord.Int -> BitMap :=
   fun x => bitmapOfSuffix (suffixOf x).
 
-Definition insert : Key -> IntSet -> IntSet :=
-  fun x => insertBM (prefixOf x) (bitmapOf x).
+Definition prefixBitMask : IntWord.Int :=
+  Data.Bits.complement suffixBitMask.
 
-Definition fromList : list Key -> IntSet :=
-  fun xs => let ins := fun t x => insert x t in Data.Foldable.foldl' ins empty xs.
+Definition prefixOf : IntWord.Int -> Prefix :=
+  fun x => x Data.Bits..&.(**) prefixBitMask.
 
-Definition map : (Key -> Key) -> IntSet -> IntSet :=
-  fun f => fromList GHC.Base.∘ (GHC.Base.map f GHC.Base.∘ toList).
+Definition member : Key -> IntSet -> bool :=
+  fun x =>
+    let fix go arg_0__
+              := match arg_0__ with
+                 | Bin p m l r =>
+                     if nomatch x p m : bool then false else
+                     if zero x m : bool then go l else
+                     go r
+                 | Tip y bm =>
+                     andb (prefixOf x GHC.Base.== y) ((bitmapOf x Data.Bits..&.(**) bm) GHC.Base./=
+                           #0)
+                 | Nil => false
+                 end in
+    go.
 
-Definition lookupGE : Key -> IntSet -> option Key :=
+Definition notMember : Key -> IntSet -> bool :=
+  fun k => negb GHC.Base.∘ member k.
+
+Definition highestBitSet : Nat -> IntWord.Int :=
+  fun x => indexOfTheOnlyBit (IntWord.highestBitMask x).
+
+Fixpoint unsafeFindMax (arg_0__ : IntSet) : option Key
+           := match arg_0__ with
+              | Nil => None
+              | Tip kx bm => Some (kx GHC.Num.+ highestBitSet bm)
+              | Bin _ _ _ r => unsafeFindMax r
+              end.
+
+Definition lookupLT : Key -> IntSet -> option Key :=
   fun x t =>
     let fix go arg_0__ arg_1__
               := match arg_0__, arg_1__ with
                  | def, Bin p m l r =>
                      if nomatch x p m : bool
                      then if x GHC.Base.< p : bool
-                          then unsafeFindMin l
-                          else unsafeFindMin def else
-                     if zero x m : bool then go r l else
-                     go def r
+                          then unsafeFindMax def
+                          else unsafeFindMax r else
+                     if zero x m : bool then go def l else
+                     go l r
                  | def, Tip kx bm =>
-                     let maskGE := (GHC.Num.negate (bitmapOf x)) Data.Bits..&.(**) bm in
-                     if prefixOf x GHC.Base.< kx : bool then Some (kx GHC.Num.+ lowestBitSet bm) else
-                     if andb (prefixOf x GHC.Base.== kx) (maskGE GHC.Base./= #0) : bool
-                     then Some (kx GHC.Num.+ lowestBitSet maskGE) else
-                     unsafeFindMin def
-                 | def, Nil => unsafeFindMin def
+                     let maskLT := (bitmapOf x GHC.Num.- #1) Data.Bits..&.(**) bm in
+                     if prefixOf x GHC.Base.> kx : bool
+                     then Some (kx GHC.Num.+ highestBitSet bm) else
+                     if andb (prefixOf x GHC.Base.== kx) (maskLT GHC.Base./= #0) : bool
+                     then Some (kx GHC.Num.+ highestBitSet maskLT) else
+                     unsafeFindMax def
+                 | def, Nil => unsafeFindMax def
                  end in
     let j_12__ := go Nil t in
     match t with
     | Bin _ m l r =>
         if m GHC.Base.< #0 : bool
         then if x GHC.Base.>= #0 : bool
-             then go Nil l
-             else go l r else
+             then go r l
+             else go Nil r else
         j_12__
     | _ => j_12__
     end.
+
+Definition lowestBitSet : Nat -> IntWord.Int :=
+  fun x => indexOfTheOnlyBit (lowestBitMask x).
+
+Fixpoint unsafeFindMin (arg_0__ : IntSet) : option Key
+           := match arg_0__ with
+              | Nil => None
+              | Tip kx bm => Some (kx GHC.Num.+ lowestBitSet bm)
+              | Bin _ _ l _ => unsafeFindMin l
+              end.
 
 Definition lookupGT : Key -> IntSet -> option Key :=
   fun x t =>
@@ -698,57 +564,272 @@ Definition lookupLE : Key -> IntSet -> option Key :=
     | _ => j_12__
     end.
 
-Definition lookupLT : Key -> IntSet -> option Key :=
+Definition lookupGE : Key -> IntSet -> option Key :=
   fun x t =>
     let fix go arg_0__ arg_1__
               := match arg_0__, arg_1__ with
                  | def, Bin p m l r =>
                      if nomatch x p m : bool
                      then if x GHC.Base.< p : bool
-                          then unsafeFindMax def
-                          else unsafeFindMax r else
-                     if zero x m : bool then go def l else
-                     go l r
+                          then unsafeFindMin l
+                          else unsafeFindMin def else
+                     if zero x m : bool then go r l else
+                     go def r
                  | def, Tip kx bm =>
-                     let maskLT := (bitmapOf x GHC.Num.- #1) Data.Bits..&.(**) bm in
-                     if prefixOf x GHC.Base.> kx : bool
-                     then Some (kx GHC.Num.+ highestBitSet bm) else
-                     if andb (prefixOf x GHC.Base.== kx) (maskLT GHC.Base./= #0) : bool
-                     then Some (kx GHC.Num.+ highestBitSet maskLT) else
-                     unsafeFindMax def
-                 | def, Nil => unsafeFindMax def
+                     let maskGE := (GHC.Num.negate (bitmapOf x)) Data.Bits..&.(**) bm in
+                     if prefixOf x GHC.Base.< kx : bool then Some (kx GHC.Num.+ lowestBitSet bm) else
+                     if andb (prefixOf x GHC.Base.== kx) (maskGE GHC.Base./= #0) : bool
+                     then Some (kx GHC.Num.+ lowestBitSet maskGE) else
+                     unsafeFindMin def
+                 | def, Nil => unsafeFindMin def
                  end in
     let j_12__ := go Nil t in
     match t with
     | Bin _ m l r =>
         if m GHC.Base.< #0 : bool
         then if x GHC.Base.>= #0 : bool
-             then go r l
-             else go Nil r else
+             then go Nil l
+             else go l r else
         j_12__
     | _ => j_12__
     end.
 
-Definition member : Key -> IntSet -> bool :=
-  fun x =>
-    let fix go arg_0__
-              := match arg_0__ with
-                 | Bin p m l r =>
-                     if nomatch x p m : bool then false else
-                     if zero x m : bool then go l else
-                     go r
-                 | Tip y bm =>
-                     andb (prefixOf x GHC.Base.== y) ((bitmapOf x Data.Bits..&.(**) bm) GHC.Base./=
-                           #0)
-                 | Nil => false
-                 end in
-    go.
-
-Definition notMember : Key -> IntSet -> bool :=
-  fun k => negb GHC.Base.∘ member k.
-
 Definition singleton : Key -> IntSet :=
   fun x => Tip (prefixOf x) (bitmapOf x).
+
+Definition insert : Key -> IntSet -> IntSet :=
+  fun x => insertBM (prefixOf x) (bitmapOf x).
+
+Definition delete : Key -> IntSet -> IntSet :=
+  fun x => deleteBM (prefixOf x) (bitmapOf x).
+
+Program Fixpoint intersection (arg_0__ arg_1__ : IntSet) {measure (size_nat
+                               arg_0__ +
+                               size_nat arg_1__)} : IntSet
+                   := match arg_0__, arg_1__ with
+                      | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
+                          let intersection2 :=
+                            if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then Nil else
+                            if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then intersection t1 l2 else
+                            intersection t1 r2 in
+                          let intersection1 :=
+                            if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then Nil else
+                            if Bool.Sumbool.sumbool_of_bool (zero p2 m1) then intersection l1 t2 else
+                            intersection r1 t2 in
+                          if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then intersection1 else
+                          if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then intersection2 else
+                          if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
+                          then bin p1 m1 (intersection l1 l2) (intersection r1 r2) else
+                          Nil
+                      | (Bin _ _ _ _ as t1), Tip kx2 bm2 =>
+                          let fix intersectBM arg_11__
+                                    := match arg_11__ with
+                                       | Bin p1 m1 l1 r1 =>
+                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx2 p1 m1) then Nil else
+                                           if Bool.Sumbool.sumbool_of_bool (zero kx2 m1) then intersectBM l1 else
+                                           intersectBM r1
+                                       | Tip kx1 bm1 =>
+                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
+                                           then tip kx1 (bm1 Data.Bits..&.(**) bm2) else
+                                           Nil
+                                       | Nil => Nil
+                                       end in
+                          intersectBM t1
+                      | Bin _ _ _ _, Nil => Nil
+                      | Tip kx1 bm1, t2 =>
+                          let fix intersectBM arg_18__
+                                    := match arg_18__ with
+                                       | Bin p2 m2 l2 r2 =>
+                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx1 p2 m2) then Nil else
+                                           if Bool.Sumbool.sumbool_of_bool (zero kx1 m2) then intersectBM l2 else
+                                           intersectBM r2
+                                       | Tip kx2 bm2 =>
+                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
+                                           then tip kx1 (bm1 Data.Bits..&.(**) bm2) else
+                                           Nil
+                                       | Nil => Nil
+                                       end in
+                          intersectBM t2
+                      | Nil, _ => Nil
+                      end.
+Solve Obligations with (termination_by_omega).
+
+Fixpoint subsetCmp (arg_0__ arg_1__ : IntSet) : comparison
+           := match arg_0__, arg_1__ with
+              | (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
+                  let subsetCmpEq :=
+                    match pair (subsetCmp l1 l2) (subsetCmp r1 r2) with
+                    | pair Gt _ => Gt
+                    | pair _ Gt => Gt
+                    | pair Eq Eq => Eq
+                    | _ => Lt
+                    end in
+                  let subsetCmpLt :=
+                    if nomatch p1 p2 m2 : bool then Gt else
+                    if zero p1 m2 : bool then subsetCmp t1 l2 else
+                    subsetCmp t1 r2 in
+                  if shorter m1 m2 : bool then Gt else
+                  if shorter m2 m1 : bool
+                  then match subsetCmpLt with
+                       | Gt => Gt
+                       | _ => Lt
+                       end else
+                  if p1 GHC.Base.== p2 : bool then subsetCmpEq else
+                  Gt
+              | _, _ =>
+                  match arg_0__, arg_1__ with
+                  | Bin _ _ _ _, _ => Gt
+                  | Tip kx1 bm1, Tip kx2 bm2 =>
+                      if kx1 GHC.Base./= kx2 : bool then Gt else
+                      if bm1 GHC.Base.== bm2 : bool then Eq else
+                      if (bm1 Data.Bits..&.(**) Data.Bits.complement bm2) GHC.Base.== #0 : bool
+                      then Lt else
+                      Gt
+                  | (Tip kx _ as t1), Bin p m l r =>
+                      if nomatch kx p m : bool then Gt else
+                      if zero kx m : bool then match subsetCmp t1 l with | Gt => Gt | _ => Lt end else
+                      match subsetCmp t1 r with
+                      | Gt => Gt
+                      | _ => Lt
+                      end
+                  | Tip _ _, Nil => Gt
+                  | Nil, Nil => Eq
+                  | Nil, _ => Lt
+                  end
+              end.
+
+Definition isProperSubsetOf : IntSet -> IntSet -> bool :=
+  fun t1 t2 => match subsetCmp t1 t2 with | Lt => true | _ => false end.
+
+Definition match_ : IntWord.Int -> Prefix -> Mask -> bool :=
+  fun i p m => (mask i m) GHC.Base.== p.
+
+Fixpoint isSubsetOf (arg_0__ arg_1__ : IntSet) : bool
+           := match arg_0__, arg_1__ with
+              | (Bin p1 m1 l1 r1 as t1), Bin p2 m2 l2 r2 =>
+                  if shorter m1 m2 : bool then false else
+                  if shorter m2 m1 : bool
+                  then andb (match_ p1 p2 m2) (if zero p1 m2 : bool
+                             then isSubsetOf t1 l2
+                             else isSubsetOf t1 r2) else
+                  andb (p1 GHC.Base.== p2) (andb (isSubsetOf l1 l2) (isSubsetOf r1 r2))
+              | _, _ =>
+                  match arg_0__, arg_1__ with
+                  | Bin _ _ _ _, _ => false
+                  | Tip kx1 bm1, Tip kx2 bm2 =>
+                      andb (kx1 GHC.Base.== kx2) ((bm1 Data.Bits..&.(**) Data.Bits.complement bm2)
+                            GHC.Base.==
+                            #0)
+                  | (Tip kx _ as t1), Bin p m l r =>
+                      if nomatch kx p m : bool then false else
+                      if zero kx m : bool then isSubsetOf t1 l else
+                      isSubsetOf t1 r
+                  | Tip _ _, Nil => false
+                  | Nil, _ => true
+                  end
+              end.
+
+Program Fixpoint disjoint (arg_0__ arg_1__ : IntSet) {measure (size_nat arg_0__
+                           +
+                           size_nat arg_1__)} : bool
+                   := match arg_0__, arg_1__ with
+                      | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
+                          let disjoint2 :=
+                            if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then true else
+                            if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then disjoint t1 l2 else
+                            disjoint t1 r2 in
+                          let disjoint1 :=
+                            if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then true else
+                            if Bool.Sumbool.sumbool_of_bool (zero p2 m1) then disjoint l1 t2 else
+                            disjoint r1 t2 in
+                          if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then disjoint1 else
+                          if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then disjoint2 else
+                          if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
+                          then andb (disjoint l1 l2) (disjoint r1 r2) else
+                          true
+                      | (Bin _ _ _ _ as t1), Tip kx2 bm2 =>
+                          let fix disjointBM arg_11__
+                                    := match arg_11__ with
+                                       | Bin p1 m1 l1 r1 =>
+                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx2 p1 m1) then true else
+                                           if Bool.Sumbool.sumbool_of_bool (zero kx2 m1) then disjointBM l1 else
+                                           disjointBM r1
+                                       | Tip kx1 bm1 =>
+                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
+                                           then (bm1 Data.Bits..&.(**) bm2) GHC.Base.== #0 else
+                                           true
+                                       | Nil => true
+                                       end in
+                          disjointBM t1
+                      | Bin _ _ _ _, Nil => true
+                      | Tip kx1 bm1, t2 =>
+                          let fix disjointBM arg_18__
+                                    := match arg_18__ with
+                                       | Bin p2 m2 l2 r2 =>
+                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx1 p2 m2) then true else
+                                           if Bool.Sumbool.sumbool_of_bool (zero kx1 m2) then disjointBM l2 else
+                                           disjointBM r2
+                                       | Tip kx2 bm2 =>
+                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
+                                           then (bm1 Data.Bits..&.(**) bm2) GHC.Base.== #0 else
+                                           true
+                                       | Nil => true
+                                       end in
+                          disjointBM t2
+                      | Nil, _ => true
+                      end.
+Solve Obligations with (termination_by_omega).
+
+Program Definition foldl'Bits {a}
+           : IntWord.Int -> (a -> IntWord.Int -> a) -> a -> Nat -> a :=
+          fun prefix f z bitmap =>
+            let go :=
+              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
+                               IntWord.wordTonat arg_0__) _ (fun arg_0__ arg_1__ go =>
+                               match arg_0__, arg_1__ with
+                               | num_2__, acc =>
+                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
+                                   match arg_0__, arg_1__ with
+                                   | bm, acc =>
+                                       let bitmask := lowestBitMask bm in
+                                       let bi := indexOfTheOnlyBit bitmask in
+                                       go (Data.Bits.xor bm bitmask) (f acc (prefix GHC.Num.+ bi))
+                                   end
+                               end) in
+            go bitmap z.
+Admit Obligations.
+
+Fixpoint filter (predicate : (Key -> bool)) (t : IntSet) : IntSet
+           := let bitPred :=
+                fun kx bm bi =>
+                  if predicate (kx GHC.Num.+ bi) : bool
+                  then bm Data.Bits..|.(**) bitmapOfSuffix bi else
+                  bm in
+              match t with
+              | Bin p m l r => bin p m (filter predicate l) (filter predicate r)
+              | Tip kx bm => tip kx (foldl'Bits #0 (bitPred kx) #0 bm)
+              | Nil => Nil
+              end.
+
+Definition partition : (Key -> bool) -> IntSet -> (IntSet * IntSet)%type :=
+  fun predicate0 t0 =>
+    let fix go predicate t
+              := let bitPred :=
+                   fun kx bm bi =>
+                     if predicate (kx GHC.Num.+ bi) : bool
+                     then bm Data.Bits..|.(**) bitmapOfSuffix bi else
+                     bm in
+                 match t with
+                 | Bin p m l r =>
+                     let 'pair r1 r2 := go predicate r in
+                     let 'pair l1 l2 := go predicate l in
+                     pair (bin p m l1 r1) (bin p m l2 r2)
+                 | Tip kx bm =>
+                     let bm1 := foldl'Bits #0 (bitPred kx) #0 bm in
+                     pair (tip kx bm1) (tip kx (Data.Bits.xor bm bm1))
+                 | Nil => (pair Nil Nil)
+                 end in
+    id (go predicate0 t0).
 
 Definition split : Key -> IntSet -> (IntSet * IntSet)%type :=
   fun x t =>
@@ -824,140 +905,6 @@ Definition splitMember : Key -> IntSet -> (IntSet * bool * IntSet)%type :=
     | _ => j_22__
     end.
 
-Definition bin : Prefix -> Mask -> IntSet -> IntSet -> IntSet :=
-  fun arg_0__ arg_1__ arg_2__ arg_3__ =>
-    match arg_0__, arg_1__, arg_2__, arg_3__ with
-    | _, _, l, Nil => l
-    | _, _, Nil, r => r
-    | p, m, l, r => Bin p m l r
-    end.
-
-Fixpoint deleteBM (arg_0__ : Prefix) (arg_1__ : BitMap) (arg_2__ : IntSet)
-           : IntSet
-           := match arg_0__, arg_1__, arg_2__ with
-              | kx, bm, (Bin p m l r as t) =>
-                  if nomatch kx p m : bool then t else
-                  if zero kx m : bool then bin p m (deleteBM kx bm l) r else
-                  bin p m l (deleteBM kx bm r)
-              | kx, bm, (Tip kx' bm' as t) =>
-                  if kx' GHC.Base.== kx : bool
-                  then tip kx (bm' Data.Bits..&.(**) Data.Bits.complement bm) else
-                  t
-              | _, _, Nil => Nil
-              end.
-
-Definition delete : Key -> IntSet -> IntSet :=
-  fun x => deleteBM (prefixOf x) (bitmapOf x).
-
-Program Fixpoint difference (arg_0__ arg_1__ : IntSet) {measure (size_nat
-                             arg_0__ +
-                             size_nat arg_1__)} : IntSet
-                   := match arg_0__, arg_1__ with
-                      | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
-                          let difference2 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then t1 else
-                            if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then difference t1 l2 else
-                            difference t1 r2 in
-                          let difference1 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then t1 else
-                            if Bool.Sumbool.sumbool_of_bool (zero p2 m1)
-                            then bin p1 m1 (difference l1 t2) r1 else
-                            bin p1 m1 l1 (difference r1 t2) in
-                          if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then difference1 else
-                          if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then difference2 else
-                          if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
-                          then bin p1 m1 (difference l1 l2) (difference r1 r2) else
-                          t1
-                      | (Bin _ _ _ _ as t), Tip kx bm => deleteBM kx bm t
-                      | (Bin _ _ _ _ as t), Nil => t
-                      | (Tip kx bm as t1), t2 =>
-                          let fix differenceTip arg_12__
-                                    := match arg_12__ with
-                                       | Bin p2 m2 l2 r2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx p2 m2) then t1 else
-                                           if Bool.Sumbool.sumbool_of_bool (zero kx m2) then differenceTip l2 else
-                                           differenceTip r2
-                                       | Tip kx2 bm2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (kx GHC.Base.== kx2)
-                                           then tip kx (bm Data.Bits..&.(**) Data.Bits.complement bm2) else
-                                           t1
-                                       | Nil => t1
-                                       end in
-                          differenceTip t2
-                      | Nil, _ => Nil
-                      end.
-Solve Obligations with (termination_by_omega).
-
-Definition op_zrzr__ : IntSet -> IntSet -> IntSet :=
-  fun m1 m2 => difference m1 m2.
-
-Notation "'_\\_'" := (op_zrzr__).
-
-Infix "\\" := (_\\_) (at level 99).
-
-Fixpoint filter (predicate : (Key -> bool)) (t : IntSet) : IntSet
-           := let bitPred :=
-                fun kx bm bi =>
-                  if predicate (kx GHC.Num.+ bi) : bool
-                  then bm Data.Bits..|.(**) bitmapOfSuffix bi else
-                  bm in
-              match t with
-              | Bin p m l r => bin p m (filter predicate l) (filter predicate r)
-              | Tip kx bm => tip kx (foldl'Bits #0 (bitPred kx) #0 bm)
-              | Nil => Nil
-              end.
-
-Program Fixpoint intersection (arg_0__ arg_1__ : IntSet) {measure (size_nat
-                               arg_0__ +
-                               size_nat arg_1__)} : IntSet
-                   := match arg_0__, arg_1__ with
-                      | (Bin p1 m1 l1 r1 as t1), (Bin p2 m2 l2 r2 as t2) =>
-                          let intersection2 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p1 p2 m2) then Nil else
-                            if Bool.Sumbool.sumbool_of_bool (zero p1 m2) then intersection t1 l2 else
-                            intersection t1 r2 in
-                          let intersection1 :=
-                            if Bool.Sumbool.sumbool_of_bool (nomatch p2 p1 m1) then Nil else
-                            if Bool.Sumbool.sumbool_of_bool (zero p2 m1) then intersection l1 t2 else
-                            intersection r1 t2 in
-                          if Bool.Sumbool.sumbool_of_bool (shorter m1 m2) then intersection1 else
-                          if Bool.Sumbool.sumbool_of_bool (shorter m2 m1) then intersection2 else
-                          if Bool.Sumbool.sumbool_of_bool (p1 GHC.Base.== p2)
-                          then bin p1 m1 (intersection l1 l2) (intersection r1 r2) else
-                          Nil
-                      | (Bin _ _ _ _ as t1), Tip kx2 bm2 =>
-                          let fix intersectBM arg_11__
-                                    := match arg_11__ with
-                                       | Bin p1 m1 l1 r1 =>
-                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx2 p1 m1) then Nil else
-                                           if Bool.Sumbool.sumbool_of_bool (zero kx2 m1) then intersectBM l1 else
-                                           intersectBM r1
-                                       | Tip kx1 bm1 =>
-                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
-                                           then tip kx1 (bm1 Data.Bits..&.(**) bm2) else
-                                           Nil
-                                       | Nil => Nil
-                                       end in
-                          intersectBM t1
-                      | Bin _ _ _ _, Nil => Nil
-                      | Tip kx1 bm1, t2 =>
-                          let fix intersectBM arg_18__
-                                    := match arg_18__ with
-                                       | Bin p2 m2 l2 r2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (nomatch kx1 p2 m2) then Nil else
-                                           if Bool.Sumbool.sumbool_of_bool (zero kx1 m2) then intersectBM l2 else
-                                           intersectBM r2
-                                       | Tip kx2 bm2 =>
-                                           if Bool.Sumbool.sumbool_of_bool (kx1 GHC.Base.== kx2)
-                                           then tip kx1 (bm1 Data.Bits..&.(**) bm2) else
-                                           Nil
-                                       | Nil => Nil
-                                       end in
-                          intersectBM t2
-                      | Nil, _ => Nil
-                      end.
-Solve Obligations with (termination_by_omega).
-
 Definition maxView : IntSet -> option (Key * IntSet)%type :=
   fun t =>
     let fix go arg_0__
@@ -979,9 +926,6 @@ Definition maxView : IntSet -> option (Key * IntSet)%type :=
         j_12__
     | _ => j_12__
     end.
-
-Definition deleteMax : IntSet -> IntSet :=
-  Data.Maybe.maybe Nil Data.Tuple.snd GHC.Base.∘ maxView.
 
 Definition minView : IntSet -> option (Key * IntSet)%type :=
   fun t =>
@@ -1005,107 +949,163 @@ Definition minView : IntSet -> option (Key * IntSet)%type :=
     | _ => j_12__
     end.
 
+(* Skipping definition `Data.IntSet.InternalWord.deleteFindMin' *)
+
+(* Skipping definition `Data.IntSet.InternalWord.deleteFindMax' *)
+
+(* Skipping definition `Data.IntSet.InternalWord.findMin' *)
+
+(* Skipping definition `Data.IntSet.InternalWord.findMax' *)
+
 Definition deleteMin : IntSet -> IntSet :=
   Data.Maybe.maybe Nil Data.Tuple.snd GHC.Base.∘ minView.
 
-Definition partition : (Key -> bool) -> IntSet -> (IntSet * IntSet)%type :=
-  fun predicate0 t0 =>
-    let fix go predicate t
-              := let bitPred :=
-                   fun kx bm bi =>
-                     if predicate (kx GHC.Num.+ bi) : bool
-                     then bm Data.Bits..|.(**) bitmapOfSuffix bi else
-                     bm in
-                 match t with
-                 | Bin p m l r =>
-                     let 'pair r1 r2 := go predicate r in
-                     let 'pair l1 l2 := go predicate l in
-                     pair (bin p m l1 r1) (bin p m l2 r2)
-                 | Tip kx bm =>
-                     let bm1 := foldl'Bits #0 (bitPred kx) #0 bm in
-                     pair (tip kx bm1) (tip kx (Data.Bits.xor bm bm1))
-                 | Nil => (pair Nil Nil)
+Definition deleteMax : IntSet -> IntSet :=
+  Data.Maybe.maybe Nil Data.Tuple.snd GHC.Base.∘ maxView.
+
+Definition fromList : list Key -> IntSet :=
+  fun xs => let ins := fun t x => insert x t in Data.Foldable.foldl' ins empty xs.
+
+Definition toList : IntSet -> list Key :=
+  toAscList.
+
+Definition map : (Key -> Key) -> IntSet -> IntSet :=
+  fun f => fromList GHC.Base.∘ (GHC.Base.map f GHC.Base.∘ toList).
+
+Definition fold {b} : (Key -> b -> b) -> b -> IntSet -> b :=
+  foldr.
+
+Program Definition foldr'Bits {a}
+           : IntWord.Int -> (IntWord.Int -> a -> a) -> a -> Nat -> a :=
+          fun prefix f z bitmap =>
+            let go :=
+              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
+                               IntWord.wordTonat arg_0__) _ (fun arg_0__ arg_1__ go =>
+                               match arg_0__, arg_1__ with
+                               | num_2__, acc =>
+                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
+                                   match arg_0__, arg_1__ with
+                                   | bm, acc =>
+                                       let bitmask := lowestBitMask bm in
+                                       let bi := indexOfTheOnlyBit bitmask in
+                                       go (Data.Bits.xor bm bitmask) ((f ((prefix GHC.Num.+ (#64 GHC.Num.- #1))
+                                                                          GHC.Num.-
+                                                                          bi)) acc)
+                                   end
+                               end) in
+            go (revNat bitmap) z.
+Admit Obligations.
+
+Definition foldr' {b} : (Key -> b -> b) -> b -> IntSet -> b :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Nil => z'
+                 | z', Tip kx bm => foldr'Bits kx f z' bm
+                 | z', Bin _ _ l r => go (go z' r) l
                  end in
-    id (go predicate0 t0).
+    fun t =>
+      match t with
+      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z l) r else go (go z r) l
+      | _ => go z t
+      end.
 
-(* Skipping all instances of class `Control.DeepSeq.NFData', including
-   `Data.IntSet.InternalWord.NFData__IntSet' *)
+Program Definition foldlBits {a}
+           : IntWord.Int -> (a -> IntWord.Int -> a) -> a -> Nat -> a :=
+          fun prefix f z bitmap =>
+            let go :=
+              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
+                               IntWord.wordTonat arg_0__) _ (fun arg_0__ arg_1__ go =>
+                               match arg_0__, arg_1__ with
+                               | num_2__, acc =>
+                                   if Bool.Sumbool.sumbool_of_bool (num_2__ GHC.Base.== #0) then acc else
+                                   match arg_0__, arg_1__ with
+                                   | bm, acc =>
+                                       let bitmask := lowestBitMask bm in
+                                       let bi := indexOfTheOnlyBit bitmask in
+                                       go (Data.Bits.xor bm bitmask) (f acc (prefix GHC.Num.+ bi))
+                                   end
+                               end) in
+            go bitmap z.
+Admit Obligations.
 
-(* Skipping all instances of class `GHC.Read.Read', including
-   `Data.IntSet.InternalWord.Read__IntSet' *)
+Definition foldl {a} : (a -> Key -> a) -> a -> IntSet -> a :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Nil => z'
+                 | z', Tip kx bm => foldlBits kx f z' bm
+                 | z', Bin _ _ l r => go (go z' l) r
+                 end in
+    fun t =>
+      match t with
+      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r
+      | _ => go z t
+      end.
 
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Data.IntSet.InternalWord.Show__IntSet' *)
+Definition foldl' {a} : (a -> Key -> a) -> a -> IntSet -> a :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Nil => z'
+                 | z', Tip kx bm => foldl'Bits kx f z' bm
+                 | z', Bin _ _ l r => go (go z' l) r
+                 end in
+    fun t =>
+      match t with
+      | Bin _ m l r => if m GHC.Base.< #0 : bool then go (go z r) l else go (go z l) r
+      | _ => go z t
+      end.
 
-Local Definition Ord__IntSet_compare : IntSet -> IntSet -> comparison :=
-  fun s1 s2 => GHC.Base.compare (toAscList s1) (toAscList s2).
+Definition elems : IntSet -> list Key :=
+  toAscList.
 
-Local Definition Ord__IntSet_op_zl__ : IntSet -> IntSet -> bool :=
-  fun x y => Ord__IntSet_compare x y GHC.Base.== Lt.
+Definition toDescList : IntSet -> list Key :=
+  foldl (GHC.Base.flip cons) nil.
 
-Local Definition Ord__IntSet_op_zlze__ : IntSet -> IntSet -> bool :=
-  fun x y => Ord__IntSet_compare x y GHC.Base./= Gt.
+Definition foldrFB {b} : (Key -> b -> b) -> b -> IntSet -> b :=
+  foldr.
 
-Local Definition Ord__IntSet_op_zg__ : IntSet -> IntSet -> bool :=
-  fun x y => Ord__IntSet_compare x y GHC.Base.== Gt.
+Definition foldlFB {a} : (a -> Key -> a) -> a -> IntSet -> a :=
+  foldl.
 
-Local Definition Ord__IntSet_op_zgze__ : IntSet -> IntSet -> bool :=
-  fun x y => Ord__IntSet_compare x y GHC.Base./= Lt.
+(* Skipping definition `Data.IntSet.InternalWord.fromAscList' *)
 
-Local Definition Ord__IntSet_max : IntSet -> IntSet -> IntSet :=
-  fun x y => if Ord__IntSet_op_zlze__ x y : bool then y else x.
+(* Skipping definition `Data.IntSet.InternalWord.fromDistinctAscList' *)
 
-Local Definition Ord__IntSet_min : IntSet -> IntSet -> IntSet :=
-  fun x y => if Ord__IntSet_op_zlze__ x y : bool then x else y.
+(* Skipping definition `Data.IntSet.InternalWord.showTree' *)
 
-Local Definition Eq___IntSet_op_zeze__ : IntSet -> IntSet -> bool :=
-  fun t1 t2 => equal t1 t2.
+(* Skipping definition `Data.IntSet.InternalWord.showTreeWith' *)
 
-Local Definition Eq___IntSet_op_zsze__ : IntSet -> IntSet -> bool :=
-  fun t1 t2 => nequal t1 t2.
+(* Skipping definition `Data.IntSet.InternalWord.showsTree' *)
 
-Program Instance Eq___IntSet : GHC.Base.Eq_ IntSet :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___IntSet_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___IntSet_op_zsze__ |}.
+(* Skipping definition `Data.IntSet.InternalWord.showsTreeHang' *)
 
-Program Instance Ord__IntSet : GHC.Base.Ord IntSet :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zl____ := Ord__IntSet_op_zl__ ;
-           GHC.Base.op_zlze____ := Ord__IntSet_op_zlze__ ;
-           GHC.Base.op_zg____ := Ord__IntSet_op_zg__ ;
-           GHC.Base.op_zgze____ := Ord__IntSet_op_zgze__ ;
-           GHC.Base.compare__ := Ord__IntSet_compare ;
-           GHC.Base.max__ := Ord__IntSet_max ;
-           GHC.Base.min__ := Ord__IntSet_min |}.
+(* Skipping definition `Data.IntSet.InternalWord.showBin' *)
 
-(* Skipping all instances of class `Data.Data.Data', including
-   `Data.IntSet.InternalWord.Data__IntSet' *)
+(* Skipping definition `Data.IntSet.InternalWord.showWide' *)
 
-Local Definition Semigroup__IntSet_op_zlzlzgzg__ : IntSet -> IntSet -> IntSet :=
-  union.
+(* Skipping definition `Data.IntSet.InternalWord.showsBars' *)
 
-Program Instance Semigroup__IntSet : GHC.Base.Semigroup IntSet :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__IntSet_op_zlzlzgzg__ |}.
+(* Skipping definition `Data.IntSet.InternalWord.showsBitMap' *)
 
-Local Definition Monoid__IntSet_mappend : IntSet -> IntSet -> IntSet :=
-  _GHC.Base.<<>>_.
+(* Skipping definition `Data.IntSet.InternalWord.showBitMap' *)
 
-Local Definition Monoid__IntSet_mconcat : list IntSet -> IntSet :=
-  unions.
+(* Skipping definition `Data.IntSet.InternalWord.node' *)
 
-Local Definition Monoid__IntSet_mempty : IntSet :=
-  empty.
+(* Skipping definition `Data.IntSet.InternalWord.withBar' *)
 
-Program Instance Monoid__IntSet : GHC.Base.Monoid IntSet :=
-  fun _ k__ =>
-    k__ {| GHC.Base.mappend__ := Monoid__IntSet_mappend ;
-           GHC.Base.mconcat__ := Monoid__IntSet_mconcat ;
-           GHC.Base.mempty__ := Monoid__IntSet_mempty |}.
+(* Skipping definition `Data.IntSet.InternalWord.withEmpty' *)
 
-(* Skipping all instances of class `GHC.Exts.IsList', including
-   `Data.IntSet.InternalWord.IsList__IntSet' *)
+Definition splitRoot : IntSet -> list IntSet :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Nil => nil
+    | (Tip _ _ as x) => cons x nil
+    | Bin _ m l r =>
+        if m GHC.Base.< #0 : bool then cons r (cons l nil) else
+        cons l (cons r nil)
+    end.
 
 Module Notations.
 Notation "'_Data.IntSet.InternalWord.\\_'" := (op_zrzr__).

--- a/examples/containers/lib/Data/Map/Internal.v
+++ b/examples/containers/lib/Data/Map/Internal.v
@@ -158,571 +158,55 @@ Fixpoint functor__Map_op_zlzd__ {inst_k} {a} {b} (f: a) (m:(Map inst_k) b):
 
 (* Converted value declarations: *)
 
-Definition zipWithMaybeMatched {f} {k} {x} {y} {z} `{GHC.Base.Applicative f}
-   : (k -> x -> y -> option z) -> WhenMatched f k x y z :=
-  fun f => Mk_WhenMatched (fun k x y => GHC.Base.pure (f k x y)).
-
-Definition zipWithMaybeAMatched {k} {x} {y} {f} {z}
-   : (k -> x -> y -> f (option z)) -> WhenMatched f k x y z :=
-  fun f => Mk_WhenMatched (fun k x y => f k x y).
-
-Definition zipWithMatched {f} {k} {x} {y} {z} `{GHC.Base.Applicative f}
-   : (k -> x -> y -> z) -> WhenMatched f k x y z :=
-  fun f =>
-    Mk_WhenMatched (fun k x y => (GHC.Base.pure GHC.Base.∘ Some) (f k x y)).
-
-Definition zipWithAMatched {f} {k} {x} {y} {z} `{GHC.Base.Applicative f}
-   : (k -> x -> y -> f z) -> WhenMatched f k x y z :=
-  fun f => Mk_WhenMatched (fun k x y => Some Data.Functor.<$> f k x y).
-
-Definition traverseWithKey {t} {k} {a} {b} `{GHC.Base.Applicative t}
-   : (k -> a -> t b) -> Map k a -> t (Map k b) :=
-  fun f =>
-    let fix go arg_0__
-              := match arg_0__ with
-                 | Tip => GHC.Base.pure Tip
-                 | Bin num_1__ k v _ _ =>
-                     if num_1__ GHC.Base.== #1 : bool
-                     then (fun v' => Bin #1 k v' Tip Tip) Data.Functor.<$> f k v else
-                     match arg_0__ with
-                     | Bin s k v l r =>
-                         GHC.Base.liftA3 (GHC.Base.flip (Bin s k)) (go l) (f k v) (go r)
-                     | _ => GHC.Err.patternFailure
-                     end
-                 end in
-    go.
-
-Definition traverseMissing {f} {k} {x} {y} `{GHC.Base.Applicative f}
-   : (k -> x -> f y) -> WhenMissing f k x y :=
-  fun f =>
-    Mk_WhenMissing (traverseWithKey f) (fun k x => Some Data.Functor.<$> f k x).
-
-Definition size {k} {a} : Map k a -> GHC.Num.Int :=
-  fun arg_0__ => match arg_0__ with | Tip => #0 | Bin sz _ _ _ _ => sz end.
-
-Definition singleton {k} {a} : k -> a -> Map k a :=
-  fun k x => Bin #1 k x Tip Tip.
-
-Definition splitRoot {k} {b} : Map k b -> list (Map k b) :=
-  fun orig =>
-    match orig with
-    | Tip => nil
-    | Bin _ k v l r => cons l (cons (singleton k v) (cons r nil))
-    end.
-
-Definition runWhenMissing {f} {k} {x} {y}
-   : WhenMissing f k x y -> k -> x -> f (option y) :=
-  missingKey.
-
-Definition runWhenMatched {f} {k} {x} {y} {z}
-   : WhenMatched f k x y z -> k -> x -> y -> f (option z) :=
-  matchedKey.
-
-(* Skipping definition `Data.Map.Internal.replaceAlong' *)
+Definition delta : GHC.Num.Int :=
+  #3.
 
 Definition ratio : GHC.Num.Int :=
   #2.
 
-Definition preserveMissing {f} {k} {x} `{GHC.Base.Applicative f}
-   : WhenMissing f k x x :=
-  Mk_WhenMissing GHC.Base.pure (fun arg_0__ arg_1__ =>
-                    match arg_0__, arg_1__ with
-                    | _, v => GHC.Base.pure (Some v)
-                    end).
+Definition size {k} {a} : Map k a -> GHC.Num.Int :=
+  fun arg_0__ => match arg_0__ with | Tip => #0 | Bin sz _ _ _ _ => sz end.
 
-(* Skipping definition `Data.Map.Internal.op_zn__' *)
-
-Definition null {k} {a} : Map k a -> bool :=
-  fun arg_0__ => match arg_0__ with | Tip => true | Bin _ _ _ _ _ => false end.
-
-Definition member {k} {a} `{GHC.Base.Ord k} : k -> Map k a -> bool :=
-  let fix go arg_0__ arg_1__
-            := match arg_0__, arg_1__ with
-               | _, Tip => false
-               | k, Bin _ kx _ l r =>
-                   match GHC.Base.compare k kx with
-                   | Lt => go k l
-                   | Gt => go k r
-                   | Eq => true
-                   end
-               end in
-  go.
-
-Definition notMember {k} {a} `{GHC.Base.Ord k} : k -> Map k a -> bool :=
-  fun k m => negb (member k m).
-
-Fixpoint mapWithKey {k} {a} {b} (arg_0__ : (k -> a -> b)) (arg_1__ : Map k a)
-           : Map k b
-           := match arg_0__, arg_1__ with
-              | _, Tip => Tip
-              | f, Bin sx kx x l r => Bin sx kx (f kx x) (mapWithKey f l) (mapWithKey f r)
-              end.
-
-Definition map {a} {b} {k} : (a -> b) -> Map k a -> Map k b :=
-  fun f =>
-    let fix go arg_0__
-              := match arg_0__ with
-                 | Tip => Tip
-                 | Bin sx kx x l r => Bin sx kx (f x) (go l) (go r)
-                 end in
-    go.
-
-Local Definition Functor__Map_fmap {inst_k}
-   : forall {a} {b}, (a -> b) -> (Map inst_k) a -> (Map inst_k) b :=
-  fun {a} {b} => fun f m => map f m.
-
-Local Definition Functor__Map_op_zlzd__ {k : Type} {a : Type} {b : Type} :=
-  (@functor__Map_op_zlzd__ k a b).
-
-Program Instance Functor__Map {k} : GHC.Base.Functor (Map k) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Map_fmap ;
-           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Map_op_zlzd__ |}.
-
-Definition mapWhenMissing {f} {a} {b} {k} {x} `{GHC.Base.Applicative f}
-  `{GHC.Base.Monad f}
-   : (a -> b) -> WhenMissing f k x a -> WhenMissing f k x b :=
-  fun f t =>
-    Mk_WhenMissing (fun m =>
-                      missingSubtree t m GHC.Base.>>= (fun m' => GHC.Base.pure (GHC.Base.fmap f m')))
-                   (fun k x =>
-                      missingKey t k x GHC.Base.>>= (fun q => (GHC.Base.pure (GHC.Base.fmap f q)))).
-
-Definition mapWhenMatched {f} {a} {b} {k} {x} {y} `{GHC.Base.Functor f}
-   : (a -> b) -> WhenMatched f k x y a -> WhenMatched f k x y b :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, Mk_WhenMatched g =>
-        Mk_WhenMatched (fun k x y => GHC.Base.fmap (GHC.Base.fmap f) (g k x y))
+Definition balanceL {k} {a} : k -> a -> Map k a -> Map k a -> Map k a :=
+  fun k x l r =>
+    match r with
+    | Tip =>
+        match l with
+        | Tip => Bin #1 k x Tip Tip
+        | Bin _ _ _ Tip Tip => Bin #2 k x l Tip
+        | Bin _ lk lx Tip (Bin _ lrk lrx _ _) =>
+            Bin #3 lrk lrx (Bin #1 lk lx Tip Tip) (Bin #1 k x Tip Tip)
+        | Bin _ lk lx (Bin _ _ _ _ _ as ll) Tip => Bin #3 lk lx ll (Bin #1 k x Tip Tip)
+        | Bin ls lk lx (Bin lls _ _ _ _ as ll) (Bin lrs lrk lrx lrl lrr as lr) =>
+            if lrs GHC.Base.< (ratio GHC.Num.* lls) : bool
+            then Bin (#1 GHC.Num.+ ls) lk lx ll (Bin (#1 GHC.Num.+ lrs) k x lr Tip) else
+            Bin (#1 GHC.Num.+ ls) lrk lrx (Bin ((#1 GHC.Num.+ lls) GHC.Num.+ size lrl) lk lx
+                                           ll lrl) (Bin (#1 GHC.Num.+ size lrr) k x lrr Tip)
+        end
+    | Bin rs _ _ _ _ =>
+        match l with
+        | Tip => Bin (#1 GHC.Num.+ rs) k x Tip r
+        | Bin ls lk lx ll lr =>
+            if ls GHC.Base.> (delta GHC.Num.* rs) : bool
+            then let scrut_9__ := pair ll lr in
+                 match scrut_9__ with
+                 | pair (Bin lls _ _ _ _) (Bin lrs lrk lrx lrl lrr) =>
+                     if lrs GHC.Base.< (ratio GHC.Num.* lls) : bool
+                     then Bin ((#1 GHC.Num.+ ls) GHC.Num.+ rs) lk lx ll (Bin ((#1 GHC.Num.+ rs)
+                                                                              GHC.Num.+
+                                                                              lrs) k x lr r) else
+                     Bin ((#1 GHC.Num.+ ls) GHC.Num.+ rs) lrk lrx (Bin ((#1 GHC.Num.+ lls) GHC.Num.+
+                                                                        size lrl) lk lx ll lrl) (Bin ((#1 GHC.Num.+ rs)
+                                                                                                      GHC.Num.+
+                                                                                                      size lrr) k x lrr
+                                                                                                 r)
+                 | _ =>
+                     let 'pair _ _ := scrut_9__ in
+                     GHC.Err.error (GHC.Base.hs_string__ "Failure in Data.Map.balanceL")
+                 end else
+            Bin ((#1 GHC.Num.+ ls) GHC.Num.+ rs) k x l r
+        end
     end.
-
-Definition mapMissing {f} {k} {x} {y} `{GHC.Base.Applicative f}
-   : (k -> x -> y) -> WhenMissing f k x y :=
-  fun f =>
-    Mk_WhenMissing (fun m => GHC.Base.pure (mapWithKey f m)) (fun k x =>
-                      GHC.Base.pure (Some (f k x))).
-
-Fixpoint mapKeysMonotonic {k1} {k2} {a} (arg_0__ : (k1 -> k2)) (arg_1__
-                            : Map k1 a) : Map k2 a
-           := match arg_0__, arg_1__ with
-              | _, Tip => Tip
-              | f, Bin sz k x l r =>
-                  Bin sz (f k) x (mapKeysMonotonic f l) (mapKeysMonotonic f r)
-              end.
-
-Definition mapGentlyWhenMissing {f} {a} {b} {k} {x} `{GHC.Base.Functor f}
-   : (a -> b) -> WhenMissing f k x a -> WhenMissing f k x b :=
-  fun f t =>
-    Mk_WhenMissing (fun m => GHC.Base.fmap f Data.Functor.<$> missingSubtree t m)
-                   (fun k x => GHC.Base.fmap f Data.Functor.<$> missingKey t k x).
-
-Definition mapGentlyWhenMatched {f} {a} {b} {k} {x} {y} `{GHC.Base.Functor f}
-   : (a -> b) -> WhenMatched f k x y a -> WhenMatched f k x y b :=
-  fun f t =>
-    zipWithMaybeAMatched (fun k x y =>
-                            GHC.Base.fmap f Data.Functor.<$> runWhenMatched t k x y).
-
-(* Skipping definition `Data.Map.Internal.mapDataType' *)
-
-Fixpoint mapAccumRWithKey {a} {k} {b} {c} (arg_0__
-                            : (a -> k -> b -> (a * c)%type)) (arg_1__ : a) (arg_2__ : Map k b) : (a *
-                                                                                                  Map k c)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, a, Tip => pair a Tip
-              | f, a, Bin sx kx x l r =>
-                  let 'pair a1 r' := mapAccumRWithKey f a r in
-                  let 'pair a2 x' := f a1 kx x in
-                  let 'pair a3 l' := mapAccumRWithKey f a2 l in
-                  pair a3 (Bin sx kx x' l' r')
-              end.
-
-Fixpoint mapAccumL {a} {k} {b} {c} (arg_0__ : (a -> k -> b -> (a * c)%type))
-                   (arg_1__ : a) (arg_2__ : Map k b) : (a * Map k c)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, a, Tip => pair a Tip
-              | f, a, Bin sx kx x l r =>
-                  let 'pair a1 l' := mapAccumL f a l in
-                  let 'pair a2 x' := f a1 kx x in
-                  let 'pair a3 r' := mapAccumL f a2 r in
-                  pair a3 (Bin sx kx x' l' r')
-              end.
-
-Definition mapAccumWithKey {a} {k} {b} {c}
-   : (a -> k -> b -> (a * c)%type) -> a -> Map k b -> (a * Map k c)%type :=
-  fun f a t => mapAccumL f a t.
-
-Definition mapAccum {a} {b} {c} {k}
-   : (a -> b -> (a * c)%type) -> a -> Map k b -> (a * Map k c)%type :=
-  fun f a m =>
-    mapAccumWithKey (fun arg_0__ arg_1__ arg_2__ =>
-                       match arg_0__, arg_1__, arg_2__ with
-                       | a', _, x' => f a' x'
-                       end) a m.
-
-(* Skipping definition `Data.Map.Internal.lookupTrace' *)
-
-Fixpoint lookupMinSure {k} {a} (arg_0__ : k) (arg_1__ : a) (arg_2__ : Map k a)
-           : (k * a)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | k, a, Tip => pair k a
-              | _, _, Bin _ k a l _ => lookupMinSure k a l
-              end.
-
-Definition lookupMin {k} {a} : Map k a -> option (k * a)%type :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Tip => None
-    | Bin _ k x l _ => Some (lookupMinSure k x l)
-    end.
-
-Fixpoint lookupMaxSure {k} {a} (arg_0__ : k) (arg_1__ : a) (arg_2__ : Map k a)
-           : (k * a)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | k, a, Tip => pair k a
-              | _, _, Bin _ k a _ r => lookupMaxSure k a r
-              end.
-
-Definition lookupMax {k} {a} : Map k a -> option (k * a)%type :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Tip => None
-    | Bin _ k x _ r => Some (lookupMaxSure k x r)
-    end.
-
-Definition lookupLT {k} {v} `{GHC.Base.Ord k}
-   : k -> Map k v -> option (k * v)%type :=
-  let fix goJust arg_0__ arg_1__ arg_2__ arg_3__
-            := match arg_0__, arg_1__, arg_2__, arg_3__ with
-               | _, kx', x', Tip => Some (pair kx' x')
-               | k, kx', x', Bin _ kx x l r =>
-                   if k GHC.Base.<= kx : bool then goJust k kx' x' l else
-                   goJust k kx x r
-               end in
-  let fix goNothing arg_8__ arg_9__
-            := match arg_8__, arg_9__ with
-               | _, Tip => None
-               | k, Bin _ kx x l r =>
-                   if k GHC.Base.<= kx : bool then goNothing k l else
-                   goJust k kx x r
-               end in
-  goNothing.
-
-Definition lookupLE {k} {v} `{GHC.Base.Ord k}
-   : k -> Map k v -> option (k * v)%type :=
-  let fix goJust arg_0__ arg_1__ arg_2__ arg_3__
-            := match arg_0__, arg_1__, arg_2__, arg_3__ with
-               | _, kx', x', Tip => Some (pair kx' x')
-               | k, kx', x', Bin _ kx x l r =>
-                   match GHC.Base.compare k kx with
-                   | Lt => goJust k kx' x' l
-                   | Eq => Some (pair kx x)
-                   | Gt => goJust k kx x r
-                   end
-               end in
-  let fix goNothing arg_12__ arg_13__
-            := match arg_12__, arg_13__ with
-               | _, Tip => None
-               | k, Bin _ kx x l r =>
-                   match GHC.Base.compare k kx with
-                   | Lt => goNothing k l
-                   | Eq => Some (pair kx x)
-                   | Gt => goJust k kx x r
-                   end
-               end in
-  goNothing.
-
-Definition lookupIndex {k} {a} `{GHC.Base.Ord k}
-   : k -> Map k a -> option GHC.Num.Int :=
-  let go {k} {a} `{GHC.Base.Ord k}
-   : GHC.Num.Int -> k -> Map k a -> option GHC.Num.Int :=
-    fix go (arg_0__ : GHC.Num.Int) (arg_1__ : k) (arg_2__ : Map k a) : option
-                                                                       GHC.Num.Int
-          := match arg_0__, arg_1__, arg_2__ with
-             | _, _, Tip => None
-             | idx, k, Bin _ kx _ l r =>
-                 match GHC.Base.compare k kx with
-                 | Lt => go idx k l
-                 | Gt => go ((idx GHC.Num.+ size l) GHC.Num.+ #1) k r
-                 | Eq => Some (idx GHC.Num.+ size l)
-                 end
-             end in
-  go #0.
-
-Definition lookupGT {k} {v} `{GHC.Base.Ord k}
-   : k -> Map k v -> option (k * v)%type :=
-  let fix goJust arg_0__ arg_1__ arg_2__ arg_3__
-            := match arg_0__, arg_1__, arg_2__, arg_3__ with
-               | _, kx', x', Tip => Some (pair kx' x')
-               | k, kx', x', Bin _ kx x l r =>
-                   if k GHC.Base.< kx : bool then goJust k kx x l else
-                   goJust k kx' x' r
-               end in
-  let fix goNothing arg_8__ arg_9__
-            := match arg_8__, arg_9__ with
-               | _, Tip => None
-               | k, Bin _ kx x l r =>
-                   if k GHC.Base.< kx : bool then goJust k kx x l else
-                   goNothing k r
-               end in
-  goNothing.
-
-Definition lookupGE {k} {v} `{GHC.Base.Ord k}
-   : k -> Map k v -> option (k * v)%type :=
-  let fix goJust arg_0__ arg_1__ arg_2__ arg_3__
-            := match arg_0__, arg_1__, arg_2__, arg_3__ with
-               | _, kx', x', Tip => Some (pair kx' x')
-               | k, kx', x', Bin _ kx x l r =>
-                   match GHC.Base.compare k kx with
-                   | Lt => goJust k kx x l
-                   | Eq => Some (pair kx x)
-                   | Gt => goJust k kx' x' r
-                   end
-               end in
-  let fix goNothing arg_12__ arg_13__
-            := match arg_12__, arg_13__ with
-               | _, Tip => None
-               | k, Bin _ kx x l r =>
-                   match GHC.Base.compare k kx with
-                   | Lt => goJust k kx x l
-                   | Eq => Some (pair kx x)
-                   | Gt => goNothing k r
-                   end
-               end in
-  goNothing.
-
-Definition lookup {k} {a} `{GHC.Base.Ord k} : k -> Map k a -> option a :=
-  let fix go arg_0__ arg_1__
-            := match arg_0__, arg_1__ with
-               | _, Tip => None
-               | k, Bin _ kx x l r =>
-                   match GHC.Base.compare k kx with
-                   | Lt => go k l
-                   | Gt => go k r
-                   | Eq => Some x
-                   end
-               end in
-  go.
-
-Definition op_znz3fU__ {k} {a} `{GHC.Base.Ord k} : Map k a -> k -> option a :=
-  fun m k => lookup k m.
-
-Notation "'_!?_'" := (op_znz3fU__).
-
-Infix "!?" := (_!?_) (at level 99).
-
-Definition lmapWhenMissing {b} {a} {f} {k} {x}
-   : (b -> a) -> WhenMissing f k a x -> WhenMissing f k b x :=
-  fun f t =>
-    Mk_WhenMissing (fun m => missingSubtree t (GHC.Base.fmap f m)) (fun k x =>
-                      missingKey t k (f x)).
-
-Fixpoint keysSet {k} {a} (arg_0__ : Map k a) : Data.Set.Internal.Set_ k
-           := match arg_0__ with
-              | Tip => Data.Set.Internal.Tip
-              | Bin sz kx _ l r => Data.Set.Internal.Bin sz kx (keysSet l) (keysSet r)
-              end.
-
-(* Skipping definition `Data.Map.Internal.insertAlong' *)
-
-Fixpoint fromSet {k} {a} (arg_0__ : (k -> a)) (arg_1__
-                   : Data.Set.Internal.Set_ k) : Map k a
-           := match arg_0__, arg_1__ with
-              | _, Data.Set.Internal.Tip => Tip
-              | f, Data.Set.Internal.Bin sz x l r =>
-                  Bin sz x (f x) (fromSet f l) (fromSet f r)
-              end.
-
-(* Skipping definition `Data.Map.Internal.fromListConstr' *)
-
-Definition foldrWithKey' {k} {a} {b}
-   : (k -> a -> b -> b) -> b -> Map k a -> b :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ kx x l r => go (f kx x (go z' r)) l
-                 end in
-    go z.
-
-Definition foldrWithKey {k} {a} {b} : (k -> a -> b -> b) -> b -> Map k a -> b :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ kx x l r => go (f kx x (go z' r)) l
-                 end in
-    go z.
-
-Definition keys {k} {a} : Map k a -> list k :=
-  foldrWithKey (fun arg_0__ arg_1__ arg_2__ =>
-                  match arg_0__, arg_1__, arg_2__ with
-                  | k, _, ks => cons k ks
-                  end) nil.
-
-Definition toAscList {k} {a} : Map k a -> list (k * a)%type :=
-  foldrWithKey (fun k x xs => cons (pair k x) xs) nil.
-
-Definition toList {k} {a} : Map k a -> list (k * a)%type :=
-  toAscList.
-
-Definition foldrFB {k} {a} {b} : (k -> a -> b -> b) -> b -> Map k a -> b :=
-  foldrWithKey.
-
-Definition foldr' {a} {b} {k} : (a -> b -> b) -> b -> Map k a -> b :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ _ x l r => go (f x (go z' r)) l
-                 end in
-    go z.
-
-Definition foldr {a} {b} {k} : (a -> b -> b) -> b -> Map k a -> b :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ _ x l r => go (f x (go z' r)) l
-                 end in
-    go z.
-
-Definition foldlWithKey' {a} {k} {b}
-   : (a -> k -> b -> a) -> a -> Map k b -> a :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ kx x l r => go (f (go z' l) kx x) r
-                 end in
-    go z.
-
-Definition foldlWithKey {a} {k} {b} : (a -> k -> b -> a) -> a -> Map k b -> a :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ kx x l r => go (f (go z' l) kx x) r
-                 end in
-    go z.
-
-Definition toDescList {k} {a} : Map k a -> list (k * a)%type :=
-  foldlWithKey (fun xs k x => cons (pair k x) xs) nil.
-
-Definition foldlFB {a} {k} {b} : (a -> k -> b -> a) -> a -> Map k b -> a :=
-  foldlWithKey.
-
-Definition foldl' {a} {b} {k} : (a -> b -> a) -> a -> Map k b -> a :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ _ x l r => go (f (go z' l) x) r
-                 end in
-    go z.
-
-Definition foldl {a} {b} {k} : (a -> b -> a) -> a -> Map k b -> a :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ _ x l r => go (f (go z' l) x) r
-                 end in
-    go z.
-
-Definition foldMapWithKey {m} {k} {a} `{GHC.Base.Monoid m}
-   : (k -> a -> m) -> Map k a -> m :=
-  fun f =>
-    let fix go arg_0__
-              := match arg_0__ with
-                 | Tip => GHC.Base.mempty
-                 | Bin num_1__ k v _ _ =>
-                     if num_1__ GHC.Base.== #1 : bool then f k v else
-                     match arg_0__ with
-                     | Bin _ k v l r => GHC.Base.mappend (go l) (GHC.Base.mappend (f k v) (go r))
-                     | _ => GHC.Err.patternFailure
-                     end
-                 end in
-    go.
-
-Definition findWithDefault {k} {a} `{GHC.Base.Ord k} : a -> k -> Map k a -> a :=
-  let fix go arg_0__ arg_1__ arg_2__
-            := match arg_0__, arg_1__, arg_2__ with
-               | def, _, Tip => def
-               | def, k, Bin _ kx x l r =>
-                   match GHC.Base.compare k kx with
-                   | Lt => go def k l
-                   | Gt => go def k r
-                   | Eq => x
-                   end
-               end in
-  go.
-
-(* Skipping definition `Data.Map.Internal.findMin' *)
-
-(* Skipping definition `Data.Map.Internal.findMax' *)
-
-Definition findIndex {k} {a} `{GHC.Base.Ord k} : k -> Map k a -> GHC.Num.Int :=
-  let go {k} {a} `{GHC.Base.Ord k} : GHC.Num.Int -> k -> Map k a -> GHC.Num.Int :=
-    fix go (arg_0__ : GHC.Num.Int) (arg_1__ : k) (arg_2__ : Map k a) : GHC.Num.Int
-          := match arg_0__, arg_1__, arg_2__ with
-             | _, _, Tip =>
-                 GHC.Err.error (GHC.Base.hs_string__ "Map.findIndex: element is not in the map")
-             | idx, k, Bin _ kx _ l r =>
-                 match GHC.Base.compare k kx with
-                 | Lt => go idx k l
-                 | Gt => go ((idx GHC.Num.+ size l) GHC.Num.+ #1) k r
-                 | Eq => idx GHC.Num.+ size l
-                 end
-             end in
-  go #0.
-
-(* Skipping definition `Data.Map.Internal.find' *)
-
-Definition empty {k} {a} : Map k a :=
-  Tip.
-
-Definition elems {k} {a} : Map k a -> list a :=
-  foldr cons nil.
-
-(* Skipping definition `Data.Map.Internal.elemAt' *)
-
-Definition dropMissing {f} {k} {x} {y} `{GHC.Base.Applicative f}
-   : WhenMissing f k x y :=
-  Mk_WhenMissing (GHC.Base.const (GHC.Base.pure Tip)) (fun arg_0__ arg_1__ =>
-                    GHC.Base.pure None).
-
-(* Skipping definition `Data.Map.Internal.differenceWithKey' *)
-
-(* Skipping definition `Data.Map.Internal.differenceWith' *)
-
-Definition delta : GHC.Num.Int :=
-  #3.
-
-(* Skipping definition `Data.Map.Internal.deleteFindMin' *)
-
-(* Skipping definition `Data.Map.Internal.deleteFindMax' *)
-
-(* Skipping definition `Data.Map.Internal.deleteAlong' *)
-
-Definition contramapSecondWhenMatched {b} {a} {f} {k} {x} {z}
-   : (b -> a) -> WhenMatched f k x a z -> WhenMatched f k x b z :=
-  fun f t => Mk_WhenMatched (fun k x y => runWhenMatched t k x (f y)).
-
-Definition contramapFirstWhenMatched {b} {a} {f} {k} {y} {z}
-   : (b -> a) -> WhenMatched f k a y z -> WhenMatched f k b y z :=
-  fun f t => Mk_WhenMatched (fun k x y => runWhenMatched t k (f x) y).
-
-Definition boolITE {a} : a -> a -> bool -> a :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | f, _, false => f
-    | _, t, true => t
-    end.
-
-(* Skipping definition `Data.Map.Internal.bogus' *)
-
-Definition bin {k} {a} : k -> a -> Map k a -> Map k a -> Map k a :=
-  fun k x l r => Bin ((size l GHC.Num.+ size r) GHC.Num.+ #1) k x l r.
 
 Definition balanceR {k} {a} : k -> a -> Map k a -> Map k a -> Map k a :=
   fun k x l r =>
@@ -766,111 +250,8 @@ Definition balanceR {k} {a} : k -> a -> Map k a -> Map k a -> Map k a :=
         end
     end.
 
-Fixpoint deleteMin {k} {a} (arg_0__ : Map k a) : Map k a
-           := match arg_0__ with
-              | Bin _ _ _ Tip r => r
-              | Bin _ kx x l r => balanceR kx x (deleteMin l) r
-              | Tip => Tip
-              end.
-
-Fixpoint insertMax {k} {a} (kx : k) (x : a) (t : Map k a) : Map k a
-           := match t with
-              | Tip => singleton kx x
-              | Bin _ ky y l r => balanceR ky y l (insertMax kx x r)
-              end.
-
-Definition minViewSure {k} {a} : k -> a -> Map k a -> Map k a -> MinView k a :=
-  let fix go arg_0__ arg_1__ arg_2__ arg_3__
-            := match arg_0__, arg_1__, arg_2__, arg_3__ with
-               | k, x, Tip, r => Mk_MinView k x r
-               | k, x, Bin _ kl xl ll lr, r =>
-                   let 'Mk_MinView km xm l' := go kl xl ll lr in
-                   Mk_MinView km xm (balanceR k x l' r)
-               end in
-  go.
-
-Definition minViewWithKey {k} {a}
-   : Map k a -> option ((k * a)%type * Map k a)%type :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Tip => None
-    | Bin _ k x l r =>
-        Some (let 'Mk_MinView km xm t := minViewSure k x l r in pair (pair km xm) t)
-    end.
-
-Definition minView {k} {a} : Map k a -> option (a * Map k a)%type :=
-  fun t =>
-    match minViewWithKey t with
-    | None => None
-    | Some (pair (pair _ x) t') => Some (pair x t')
-    end.
-
-Fixpoint updateMinWithKey {k} {a} (arg_0__ : (k -> a -> option a)) (arg_1__
-                            : Map k a) : Map k a
-           := match arg_0__, arg_1__ with
-              | _, Tip => Tip
-              | f, Bin sx kx x Tip r =>
-                  match f kx x with
-                  | None => r
-                  | Some x' => Bin sx kx x' Tip r
-                  end
-              | f, Bin _ kx x l r => balanceR kx x (updateMinWithKey f l) r
-              end.
-
-Definition updateMin {a} {k} : (a -> option a) -> Map k a -> Map k a :=
-  fun f m =>
-    updateMinWithKey (fun arg_0__ arg_1__ =>
-                        match arg_0__, arg_1__ with
-                        | _, x => f x
-                        end) m.
-
-Definition balanceL {k} {a} : k -> a -> Map k a -> Map k a -> Map k a :=
-  fun k x l r =>
-    match r with
-    | Tip =>
-        match l with
-        | Tip => Bin #1 k x Tip Tip
-        | Bin _ _ _ Tip Tip => Bin #2 k x l Tip
-        | Bin _ lk lx Tip (Bin _ lrk lrx _ _) =>
-            Bin #3 lrk lrx (Bin #1 lk lx Tip Tip) (Bin #1 k x Tip Tip)
-        | Bin _ lk lx (Bin _ _ _ _ _ as ll) Tip => Bin #3 lk lx ll (Bin #1 k x Tip Tip)
-        | Bin ls lk lx (Bin lls _ _ _ _ as ll) (Bin lrs lrk lrx lrl lrr as lr) =>
-            if lrs GHC.Base.< (ratio GHC.Num.* lls) : bool
-            then Bin (#1 GHC.Num.+ ls) lk lx ll (Bin (#1 GHC.Num.+ lrs) k x lr Tip) else
-            Bin (#1 GHC.Num.+ ls) lrk lrx (Bin ((#1 GHC.Num.+ lls) GHC.Num.+ size lrl) lk lx
-                                           ll lrl) (Bin (#1 GHC.Num.+ size lrr) k x lrr Tip)
-        end
-    | Bin rs _ _ _ _ =>
-        match l with
-        | Tip => Bin (#1 GHC.Num.+ rs) k x Tip r
-        | Bin ls lk lx ll lr =>
-            if ls GHC.Base.> (delta GHC.Num.* rs) : bool
-            then let scrut_9__ := pair ll lr in
-                 match scrut_9__ with
-                 | pair (Bin lls _ _ _ _) (Bin lrs lrk lrx lrl lrr) =>
-                     if lrs GHC.Base.< (ratio GHC.Num.* lls) : bool
-                     then Bin ((#1 GHC.Num.+ ls) GHC.Num.+ rs) lk lx ll (Bin ((#1 GHC.Num.+ rs)
-                                                                              GHC.Num.+
-                                                                              lrs) k x lr r) else
-                     Bin ((#1 GHC.Num.+ ls) GHC.Num.+ rs) lrk lrx (Bin ((#1 GHC.Num.+ lls) GHC.Num.+
-                                                                        size lrl) lk lx ll lrl) (Bin ((#1 GHC.Num.+ rs)
-                                                                                                      GHC.Num.+
-                                                                                                      size lrr) k x lrr
-                                                                                                 r)
-                 | _ =>
-                     let 'pair _ _ := scrut_9__ in
-                     GHC.Err.error (GHC.Base.hs_string__ "Failure in Data.Map.balanceL")
-                 end else
-            Bin ((#1 GHC.Num.+ ls) GHC.Num.+ rs) k x l r
-        end
-    end.
-
-Fixpoint deleteMax {k} {a} (arg_0__ : Map k a) : Map k a
-           := match arg_0__ with
-              | Bin _ _ _ l Tip => l
-              | Bin _ kx x l r => balanceL kx x l (deleteMax r)
-              | Tip => Tip
-              end.
+Definition singleton {k} {a} : k -> a -> Map k a :=
+  fun k x => Bin #1 k x Tip Tip.
 
 Definition insert {k} {a} `{GHC.Base.Ord k} : k -> a -> Map k a -> Map k a :=
   fun kx0 =>
@@ -898,34 +279,6 @@ Definition insert {k} {a} `{GHC.Base.Ord k} : k -> a -> Map k a -> Map k a :=
                end in
     go kx0 kx0.
 
-Definition insertLookupWithKey {k} {a} `{GHC.Base.Ord k}
-   : (k -> a -> a -> a) -> k -> a -> Map k a -> (option a * Map k a)%type :=
-  fun f0 k0 x0 =>
-    let go {k} {a} `{GHC.Base.Ord k}
-     : (k -> a -> a -> a) -> k -> a -> Map k a -> prod (option a) (Map k a) :=
-      fix go (arg_0__ : (k -> a -> a -> a)) (arg_1__ : k) (arg_2__ : a) (arg_3__
-               : Map k a) : prod (option a) (Map k a)
-            := match arg_0__, arg_1__, arg_2__, arg_3__ with
-               | _, kx, x, Tip => (pair None (singleton kx x))
-               | f, kx, x, Bin sy ky y l r =>
-                   match GHC.Base.compare kx ky with
-                   | Lt =>
-                       let 'pair found l' := go f kx x l in
-                       let t' := balanceL ky y l' r in (pair found t')
-                   | Gt =>
-                       let 'pair found r' := go f kx x r in
-                       let t' := balanceR ky y l r' in (pair found t')
-                   | Eq => (pair (Some y) (Bin sy kx (f kx x y) l r))
-                   end
-               end in
-    id GHC.Base.∘ go f0 k0 x0.
-
-Fixpoint insertMin {k} {a} (kx : k) (x : a) (t : Map k a) : Map k a
-           := match t with
-              | Tip => singleton kx x
-              | Bin _ ky y l r => balanceL ky y (insertMin kx x l) r
-              end.
-
 Definition insertR {k} {a} `{GHC.Base.Ord k} : k -> a -> Map k a -> Map k a :=
   fun kx0 =>
     let go {k} {a} `{GHC.Base.Ord k} : k -> k -> a -> Map k a -> Map k a :=
@@ -947,97 +300,20 @@ Definition insertR {k} {a} `{GHC.Base.Ord k} : k -> a -> Map k a -> Map k a :=
                end in
     go kx0 kx0.
 
-Definition insertWith {k} {a} `{GHC.Base.Ord k}
-   : (a -> a -> a) -> k -> a -> Map k a -> Map k a :=
-  let go {k} {a} `{GHC.Base.Ord k}
-   : (a -> a -> a) -> k -> a -> Map k a -> Map k a :=
-    fix go (arg_0__ : (a -> a -> a)) (arg_1__ : k) (arg_2__ : a) (arg_3__ : Map k a)
-          : Map k a
-          := match arg_0__, arg_1__, arg_2__, arg_3__ with
-             | _, kx, x, Tip => singleton kx x
-             | f, kx, x, Bin sy ky y l r =>
-                 match GHC.Base.compare kx ky with
-                 | Lt => balanceL ky y (go f kx x l) r
-                 | Gt => balanceR ky y l (go f kx x r)
-                 | Eq => Bin sy kx (f x y) l r
-                 end
-             end in
-  go.
+Definition bin {k} {a} : k -> a -> Map k a -> Map k a -> Map k a :=
+  fun k x l r => Bin ((size l GHC.Num.+ size r) GHC.Num.+ #1) k x l r.
 
-Definition insertWithKey {k} {a} `{GHC.Base.Ord k}
-   : (k -> a -> a -> a) -> k -> a -> Map k a -> Map k a :=
-  let go {k} {a} `{GHC.Base.Ord k}
-   : (k -> a -> a -> a) -> k -> a -> Map k a -> Map k a :=
-    fix go (arg_0__ : (k -> a -> a -> a)) (arg_1__ : k) (arg_2__ : a) (arg_3__
-             : Map k a) : Map k a
-          := match arg_0__, arg_1__, arg_2__, arg_3__ with
-             | _, kx, x, Tip => singleton kx x
-             | f, kx, x, Bin sy ky y l r =>
-                 match GHC.Base.compare kx ky with
-                 | Lt => balanceL ky y (go f kx x l) r
-                 | Gt => balanceR ky y l (go f kx x r)
-                 | Eq => Bin sy kx (f kx x y) l r
-                 end
-             end in
-  go.
+Fixpoint insertMax {k} {a} (kx : k) (x : a) (t : Map k a) : Map k a
+           := match t with
+              | Tip => singleton kx x
+              | Bin _ ky y l r => balanceR ky y l (insertMax kx x r)
+              end.
 
-Definition fromListWithKey {k} {a} `{GHC.Base.Ord k}
-   : (k -> a -> a -> a) -> list (k * a)%type -> Map k a :=
-  fun f xs =>
-    let ins :=
-      fun arg_0__ arg_1__ =>
-        match arg_0__, arg_1__ with
-        | t, pair k x => insertWithKey f k x t
-        end in
-    Data.Foldable.foldl' ins empty xs.
-
-Definition fromListWith {k} {a} `{GHC.Base.Ord k}
-   : (a -> a -> a) -> list (k * a)%type -> Map k a :=
-  fun f xs =>
-    fromListWithKey (fun arg_0__ arg_1__ arg_2__ =>
-                       match arg_0__, arg_1__, arg_2__ with
-                       | _, x, y => f x y
-                       end) xs.
-
-Definition mapKeysWith {k2} {a} {k1} `{GHC.Base.Ord k2}
-   : (a -> a -> a) -> (k1 -> k2) -> Map k1 a -> Map k2 a :=
-  fun c f =>
-    fromListWith c GHC.Base.∘
-    foldrWithKey (fun k x xs => cons (pair (f k) x) xs) nil.
-
-Definition insertWithKeyR {k} {a} `{GHC.Base.Ord k}
-   : (k -> a -> a -> a) -> k -> a -> Map k a -> Map k a :=
-  let go {k} {a} `{GHC.Base.Ord k}
-   : (k -> a -> a -> a) -> k -> a -> Map k a -> Map k a :=
-    fix go (arg_0__ : (k -> a -> a -> a)) (arg_1__ : k) (arg_2__ : a) (arg_3__
-             : Map k a) : Map k a
-          := match arg_0__, arg_1__, arg_2__, arg_3__ with
-             | _, kx, x, Tip => singleton kx x
-             | f, kx, x, Bin sy ky y l r =>
-                 match GHC.Base.compare kx ky with
-                 | Lt => balanceL ky y (go f kx x l) r
-                 | Gt => balanceR ky y l (go f kx x r)
-                 | Eq => Bin sy ky (f ky y x) l r
-                 end
-             end in
-  go.
-
-Definition insertWithR {k} {a} `{GHC.Base.Ord k}
-   : (a -> a -> a) -> k -> a -> Map k a -> Map k a :=
-  let go {k} {a} `{GHC.Base.Ord k}
-   : (a -> a -> a) -> k -> a -> Map k a -> Map k a :=
-    fix go (arg_0__ : (a -> a -> a)) (arg_1__ : k) (arg_2__ : a) (arg_3__ : Map k a)
-          : Map k a
-          := match arg_0__, arg_1__, arg_2__, arg_3__ with
-             | _, kx, x, Tip => singleton kx x
-             | f, kx, x, Bin sy ky y l r =>
-                 match GHC.Base.compare kx ky with
-                 | Lt => balanceL ky y (go f kx x l) r
-                 | Gt => balanceR ky y l (go f kx x r)
-                 | Eq => Bin sy ky (f y x) l r
-                 end
-             end in
-  go.
+Fixpoint insertMin {k} {a} (kx : k) (x : a) (t : Map k a) : Map k a
+           := match t with
+              | Tip => singleton kx x
+              | Bin _ ky y l r => balanceL ky y (insertMin kx x l) r
+              end.
 
 Program Fixpoint link {k} {a} (arg_0__ : k) (arg_1__ : a) (arg_2__ arg_3__
                         : Map k a) {measure (Nat.add (map_size arg_2__) (map_size arg_3__))} : Map k a
@@ -1053,277 +329,6 @@ Program Fixpoint link {k} {a} (arg_0__ : k) (arg_1__ : a) (arg_2__ arg_3__
                       end.
 Solve Obligations with (termination_by_omega).
 
-Definition drop {k} {a} : GHC.Num.Int -> Map k a -> Map k a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | i, m =>
-        if i GHC.Base.>= size m : bool then Tip else
-        match arg_0__, arg_1__ with
-        | i0, m0 =>
-            let fix go arg_2__ arg_3__
-                      := match arg_2__, arg_3__ with
-                         | i, m =>
-                             if i GHC.Base.<= #0 : bool then m else
-                             match arg_2__, arg_3__ with
-                             | _, Tip => Tip
-                             | i, Bin _ kx x l r =>
-                                 let sizeL := size l in
-                                 match GHC.Base.compare i sizeL with
-                                 | Lt => link kx x (go i l) r
-                                 | Gt => go ((i GHC.Num.- sizeL) GHC.Num.- #1) r
-                                 | Eq => insertMin kx x r
-                                 end
-                             end
-                         end in
-            go i0 m0
-        end
-    end.
-
-Fixpoint dropWhileAntitone {k} {a} (arg_0__ : (k -> bool)) (arg_1__ : Map k a)
-           : Map k a
-           := match arg_0__, arg_1__ with
-              | _, Tip => Tip
-              | p, Bin _ kx x l r =>
-                  if p kx : bool then dropWhileAntitone p r else
-                  link kx x (dropWhileAntitone p l) r
-              end.
-
-Definition fromDistinctAscList {k} {a} : list (k * a)%type -> Map k a :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | nil => Tip
-    | cons (pair kx0 x0) xs0 =>
-        let create :=
-          GHC.DeferredFix.deferredFix2 (fun create arg_1__ arg_2__ =>
-                                          match arg_1__, arg_2__ with
-                                          | _, nil => (pair Tip nil)
-                                          | s, (cons x' xs' as xs) =>
-                                              if s GHC.Base.== #1 : bool
-                                              then let 'pair kx x := x' in
-                                                   (pair (Bin #1 kx x Tip Tip) xs') else
-                                              match create (Data.Bits.shiftR s #1) xs with
-                                              | (pair _ nil as res) => res
-                                              | pair l (cons (pair ky y) ys) =>
-                                                  let 'pair r zs := create (Data.Bits.shiftR s #1) ys in
-                                                  (pair (link ky y l r) zs)
-                                              end
-                                          end) in
-        let go :=
-          GHC.DeferredFix.deferredFix3 (fun go arg_15__ arg_16__ arg_17__ =>
-                                          match arg_15__, arg_16__, arg_17__ with
-                                          | _, t, nil => t
-                                          | s, l, cons (pair kx x) xs =>
-                                              let 'pair r ys := create s xs in
-                                              let t' := link kx x l r in go (Data.Bits.shiftL s #1) t' ys
-                                          end) in
-        go (#1 : GHC.Num.Int) (Bin #1 kx0 x0 Tip Tip) xs0
-    end.
-
-Definition fromAscList {k} {a} `{GHC.Base.Eq_ k}
-   : list (k * a)%type -> Map k a :=
-  fun xs =>
-    let fix combineEq' arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z, nil => cons z nil
-                 | (pair kz _ as z), cons (pair kx xx as x) xs' =>
-                     if kx GHC.Base.== kz : bool then combineEq' (pair kx xx) xs' else
-                     cons z (combineEq' x xs')
-                 end in
-    let combineEq :=
-      fun xs' =>
-        match xs' with
-        | nil => nil
-        | cons x nil => cons x nil
-        | cons x xx => combineEq' x xx
-        end in
-    fromDistinctAscList (combineEq xs).
-
-Definition fromAscListWithKey {k} {a} `{GHC.Base.Eq_ k}
-   : (k -> a -> a -> a) -> list (k * a)%type -> Map k a :=
-  fun f xs =>
-    let fix combineEq' arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z, nil => cons z nil
-                 | (pair kz zz as z), cons (pair kx xx as x) xs' =>
-                     if kx GHC.Base.== kz : bool
-                     then let yy := f kx xx zz in combineEq' (pair kx yy) xs' else
-                     cons z (combineEq' x xs')
-                 end in
-    let combineEq :=
-      fun arg_7__ arg_8__ =>
-        match arg_7__, arg_8__ with
-        | _, xs' =>
-            match xs' with
-            | nil => nil
-            | cons x nil => cons x nil
-            | cons x xx => combineEq' x xx
-            end
-        end in
-    fromDistinctAscList (combineEq f xs).
-
-Definition fromAscListWith {k} {a} `{GHC.Base.Eq_ k}
-   : (a -> a -> a) -> list (k * a)%type -> Map k a :=
-  fun f xs =>
-    fromAscListWithKey (fun arg_0__ arg_1__ arg_2__ =>
-                          match arg_0__, arg_1__, arg_2__ with
-                          | _, x, y => f x y
-                          end) xs.
-
-Definition fromDistinctDescList {k} {a} : list (k * a)%type -> Map k a :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | nil => Tip
-    | cons (pair kx0 x0) xs0 =>
-        let create :=
-          GHC.DeferredFix.deferredFix2 (fun create arg_1__ arg_2__ =>
-                                          match arg_1__, arg_2__ with
-                                          | _, nil => (pair Tip nil)
-                                          | s, (cons x' xs' as xs) =>
-                                              if s GHC.Base.== #1 : bool
-                                              then let 'pair kx x := x' in
-                                                   (pair (Bin #1 kx x Tip Tip) xs') else
-                                              match create (Data.Bits.shiftR s #1) xs with
-                                              | (pair _ nil as res) => res
-                                              | pair r (cons (pair ky y) ys) =>
-                                                  let 'pair l zs := create (Data.Bits.shiftR s #1) ys in
-                                                  (pair (link ky y l r) zs)
-                                              end
-                                          end) in
-        let go :=
-          GHC.DeferredFix.deferredFix3 (fun go arg_15__ arg_16__ arg_17__ =>
-                                          match arg_15__, arg_16__, arg_17__ with
-                                          | _, t, nil => t
-                                          | s, r, cons (pair kx x) xs =>
-                                              let 'pair l ys := create s xs in
-                                              let t' := link kx x l r in go (Data.Bits.shiftL s #1) t' ys
-                                          end) in
-        go (#1 : GHC.Num.Int) (Bin #1 kx0 x0 Tip Tip) xs0
-    end.
-
-Definition fromDescList {k} {a} `{GHC.Base.Eq_ k}
-   : list (k * a)%type -> Map k a :=
-  fun xs =>
-    let fix combineEq' arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z, nil => cons z nil
-                 | (pair kz _ as z), cons (pair kx xx as x) xs' =>
-                     if kx GHC.Base.== kz : bool then combineEq' (pair kx xx) xs' else
-                     cons z (combineEq' x xs')
-                 end in
-    let combineEq :=
-      fun xs' =>
-        match xs' with
-        | nil => nil
-        | cons x nil => cons x nil
-        | cons x xx => combineEq' x xx
-        end in
-    fromDistinctDescList (combineEq xs).
-
-Definition fromDescListWithKey {k} {a} `{GHC.Base.Eq_ k}
-   : (k -> a -> a -> a) -> list (k * a)%type -> Map k a :=
-  fun f xs =>
-    let fix combineEq' arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z, nil => cons z nil
-                 | (pair kz zz as z), cons (pair kx xx as x) xs' =>
-                     if kx GHC.Base.== kz : bool
-                     then let yy := f kx xx zz in combineEq' (pair kx yy) xs' else
-                     cons z (combineEq' x xs')
-                 end in
-    let combineEq :=
-      fun arg_7__ arg_8__ =>
-        match arg_7__, arg_8__ with
-        | _, xs' =>
-            match xs' with
-            | nil => nil
-            | cons x nil => cons x nil
-            | cons x xx => combineEq' x xx
-            end
-        end in
-    fromDistinctDescList (combineEq f xs).
-
-Definition fromDescListWith {k} {a} `{GHC.Base.Eq_ k}
-   : (a -> a -> a) -> list (k * a)%type -> Map k a :=
-  fun f xs =>
-    fromDescListWithKey (fun arg_0__ arg_1__ arg_2__ =>
-                           match arg_0__, arg_1__, arg_2__ with
-                           | _, x, y => f x y
-                           end) xs.
-
-Definition fromList {k} {a} `{GHC.Base.Ord k} : list (k * a)%type -> Map k a :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | nil => Tip
-    | cons (pair kx x) nil => Bin #1 kx x Tip Tip
-    | cons (pair kx0 x0) xs0 =>
-        let fromList' :=
-          fun t0 xs =>
-            let ins :=
-              fun arg_2__ arg_3__ =>
-                match arg_2__, arg_3__ with
-                | t, pair k x => insert k x t
-                end in
-            Data.Foldable.foldl' ins t0 xs in
-        let not_ordered :=
-          fun arg_7__ arg_8__ =>
-            match arg_7__, arg_8__ with
-            | _, nil => false
-            | kx, cons (pair ky _) _ => kx GHC.Base.>= ky
-            end in
-        let create :=
-          GHC.DeferredFix.deferredFix2 (fun create arg_11__ arg_12__ =>
-                                          match arg_11__, arg_12__ with
-                                          | _, nil => pair (pair Tip nil) nil
-                                          | s, (cons xp xss as xs) =>
-                                              if s GHC.Base.== #1 : bool
-                                              then let 'pair kx x := xp in
-                                                   if not_ordered kx xss : bool
-                                                   then pair (pair (Bin #1 kx x Tip Tip) nil) xss else
-                                                   pair (pair (Bin #1 kx x Tip Tip) xss) nil else
-                                              match create (Data.Bits.shiftR s #1) xs with
-                                              | (pair (pair _ nil) _ as res) => res
-                                              | pair (pair l (cons (pair ky y) nil)) zs =>
-                                                  pair (pair (insertMax ky y l) nil) zs
-                                              | pair (pair l (cons (pair ky y) yss as ys)) _ =>
-                                                  if not_ordered ky yss : bool then pair (pair l nil) ys else
-                                                  let 'pair (pair r zs) ws := create (Data.Bits.shiftR s #1) yss in
-                                                  pair (pair (link ky y l r) zs) ws
-                                              end
-                                          end) in
-        let go :=
-          GHC.DeferredFix.deferredFix3 (fun go arg_28__ arg_29__ arg_30__ =>
-                                          match arg_28__, arg_29__, arg_30__ with
-                                          | _, t, nil => t
-                                          | _, t, cons (pair kx x) nil => insertMax kx x t
-                                          | s, l, (cons (pair kx x) xss as xs) =>
-                                              if not_ordered kx xss : bool then fromList' l xs else
-                                              match create s xss with
-                                              | pair (pair r ys) nil => go (Data.Bits.shiftL s #1) (link kx x l r) ys
-                                              | pair (pair r _) ys => fromList' (link kx x l r) ys
-                                              end
-                                          end) in
-        if not_ordered kx0 xs0 : bool then fromList' (Bin #1 kx0 x0 Tip Tip) xs0 else
-        go (#1 : GHC.Num.Int) (Bin #1 kx0 x0 Tip Tip) xs0
-    end.
-
-Definition mapKeys {k2} {k1} {a} `{GHC.Base.Ord k2}
-   : (k1 -> k2) -> Map k1 a -> Map k2 a :=
-  fun f =>
-    fromList GHC.Base.∘ foldrWithKey (fun k x xs => cons (pair (f k) x) xs) nil.
-
-Definition spanAntitone {k} {a}
-   : (k -> bool) -> Map k a -> (Map k a * Map k a)%type :=
-  fun p0 m =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | _, Tip => pair Tip Tip
-                 | p, Bin _ kx x l r =>
-                     if p kx : bool then let 'pair u v := go p r in pair (link kx x l u) v else
-                     let 'pair u v := go p l in
-                     pair u (link kx x v r)
-                 end in
-    id (go p0 m).
-
 Definition split {k} {a} `{GHC.Base.Ord k}
    : k -> Map k a -> (Map k a * Map k a)%type :=
   fun k0 t0 =>
@@ -1338,137 +343,6 @@ Definition split {k} {a} `{GHC.Base.Ord k}
                      end
                  end in
     id (go k0 t0).
-
-Definition splitAt {k} {a}
-   : GHC.Num.Int -> Map k a -> (Map k a * Map k a)%type :=
-  fun i0 m0 =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | i, m =>
-                     if i GHC.Base.<= #0 : bool then pair Tip m else
-                     match arg_0__, arg_1__ with
-                     | _, Tip => pair Tip Tip
-                     | i, Bin _ kx x l r =>
-                         let sizeL := size l in
-                         match GHC.Base.compare i sizeL with
-                         | Lt => let 'pair ll lr := go i l in pair ll (link kx x lr r)
-                         | Gt =>
-                             let 'pair rl rr := go ((i GHC.Num.- sizeL) GHC.Num.- #1) r in
-                             pair (link kx x l rl) rr
-                         | Eq => pair l (insertMin kx x r)
-                         end
-                     end
-                 end in
-    if i0 GHC.Base.>= size m0 : bool then pair m0 Tip else
-    id (go i0 m0).
-
-Definition splitLookup {k} {a} `{GHC.Base.Ord k}
-   : k -> Map k a -> (Map k a * option a * Map k a)%type :=
-  fun k0 m =>
-    let go {k} {a} `{GHC.Base.Ord k}
-     : k -> Map k a -> StrictTriple (Map k a) (option a) (Map k a) :=
-      fix go (k0 : k) (t : Map k a) : StrictTriple (Map k a) (option a) (Map k a)
-            := match t with
-               | Tip => Mk_StrictTriple Tip None Tip
-               | Bin _ kx x l r =>
-                   match GHC.Base.compare k0 kx with
-                   | Lt =>
-                       let 'Mk_StrictTriple lt z gt := go k0 l in
-                       let gt' := link kx x gt r in Mk_StrictTriple lt z gt'
-                   | Gt =>
-                       let 'Mk_StrictTriple lt z gt := go k0 r in
-                       let lt' := link kx x l lt in Mk_StrictTriple lt' z gt
-                   | Eq => Mk_StrictTriple l (Some x) r
-                   end
-               end in
-    let 'Mk_StrictTriple l mv r := go k0 m in
-    pair (pair l mv) r.
-
-Fixpoint submap' {a} {b} {c} `{GHC.Base.Ord a} (arg_0__ : (b -> c -> bool))
-                 (arg_1__ : Map a b) (arg_2__ : Map a c) : bool
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, Tip, _ => true
-              | _, _, Tip => false
-              | f, Bin _ kx x l r, t =>
-                  let 'pair (pair lt found) gt := splitLookup kx t in
-                  match found with
-                  | None => false
-                  | Some y => andb (f x y) (andb (submap' f l lt) (submap' f r gt))
-                  end
-              end.
-
-Definition isProperSubmapOfBy {k} {a} {b} `{GHC.Base.Ord k}
-   : (a -> b -> bool) -> Map k a -> Map k b -> bool :=
-  fun f t1 t2 => andb (size t1 GHC.Base.< size t2) (submap' f t1 t2).
-
-Definition isProperSubmapOf {k} {a} `{GHC.Base.Ord k} `{GHC.Base.Eq_ a}
-   : Map k a -> Map k a -> bool :=
-  fun m1 m2 => isProperSubmapOfBy _GHC.Base.==_ m1 m2.
-
-Definition isSubmapOfBy {k} {a} {b} `{GHC.Base.Ord k}
-   : (a -> b -> bool) -> Map k a -> Map k b -> bool :=
-  fun f t1 t2 => andb (size t1 GHC.Base.<= size t2) (submap' f t1 t2).
-
-Definition isSubmapOf {k} {a} `{GHC.Base.Ord k} `{GHC.Base.Eq_ a}
-   : Map k a -> Map k a -> bool :=
-  fun m1 m2 => isSubmapOfBy _GHC.Base.==_ m1 m2.
-
-Definition splitMember {k} {a} `{GHC.Base.Ord k}
-   : k -> Map k a -> (Map k a * bool * Map k a)%type :=
-  fun k0 m =>
-    let go {k} {a} `{GHC.Base.Ord k}
-     : k -> Map k a -> StrictTriple (Map k a) bool (Map k a) :=
-      fix go (k0 : k) (t : Map k a) : StrictTriple (Map k a) bool (Map k a)
-            := match t with
-               | Tip => Mk_StrictTriple Tip false Tip
-               | Bin _ kx x l r =>
-                   match GHC.Base.compare k0 kx with
-                   | Lt =>
-                       let 'Mk_StrictTriple lt z gt := go k0 l in
-                       let gt' := link kx x gt r in Mk_StrictTriple lt z gt'
-                   | Gt =>
-                       let 'Mk_StrictTriple lt z gt := go k0 r in
-                       let lt' := link kx x l lt in Mk_StrictTriple lt' z gt
-                   | Eq => Mk_StrictTriple l true r
-                   end
-               end in
-    let 'Mk_StrictTriple l mv r := go k0 m in
-    pair (pair l mv) r.
-
-Definition take {k} {a} : GHC.Num.Int -> Map k a -> Map k a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | i, m =>
-        if i GHC.Base.>= size m : bool then m else
-        match arg_0__, arg_1__ with
-        | i0, m0 =>
-            let fix go arg_2__ arg_3__
-                      := match arg_2__, arg_3__ with
-                         | i, _ =>
-                             if i GHC.Base.<= #0 : bool then Tip else
-                             match arg_2__, arg_3__ with
-                             | _, Tip => Tip
-                             | i, Bin _ kx x l r =>
-                                 let sizeL := size l in
-                                 match GHC.Base.compare i sizeL with
-                                 | Lt => go i l
-                                 | Gt => link kx x l (go ((i GHC.Num.- sizeL) GHC.Num.- #1) r)
-                                 | Eq => l
-                                 end
-                             end
-                         end in
-            go i0 m0
-        end
-    end.
-
-Fixpoint takeWhileAntitone {k} {a} (arg_0__ : (k -> bool)) (arg_1__ : Map k a)
-           : Map k a
-           := match arg_0__, arg_1__ with
-              | _, Tip => Tip
-              | p, Bin _ kx x l r =>
-                  if p kx : bool then link kx x l (takeWhileAntitone p r) else
-                  takeWhileAntitone p l
-              end.
 
 Fixpoint union {k} {a} `{GHC.Base.Ord k} (arg_0__ arg_1__ : Map k a) : Map k a
            := match arg_0__, arg_1__ with
@@ -1486,48 +360,473 @@ Fixpoint union {k} {a} `{GHC.Base.Ord k} (arg_0__ arg_1__ : Map k a) : Map k a
                   link k1 x1 l1l2 r1r2
               end.
 
+Local Definition Semigroup__Map_op_zlzlzgzg__ {inst_k} {inst_v} `{(GHC.Base.Ord
+   inst_k)}
+   : (Map inst_k inst_v) -> (Map inst_k inst_v) -> (Map inst_k inst_v) :=
+  union.
+
+Program Instance Semigroup__Map {k} {v} `{(GHC.Base.Ord k)}
+   : GHC.Base.Semigroup (Map k v) :=
+  fun _ k__ => k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__Map_op_zlzlzgzg__ |}.
+
+Local Definition Monoid__Map_mappend {inst_k} {inst_v} `{(GHC.Base.Ord inst_k)}
+   : (Map inst_k inst_v) -> (Map inst_k inst_v) -> (Map inst_k inst_v) :=
+  _GHC.Base.<<>>_.
+
+Definition empty {k} {a} : Map k a :=
+  Tip.
+
 Definition unions {f} {k} {a} `{Data.Foldable.Foldable f} `{GHC.Base.Ord k}
    : f (Map k a) -> Map k a :=
   fun ts => Data.Foldable.foldl' union empty ts.
 
-Fixpoint unionWith {k} {a} `{GHC.Base.Ord k} (arg_0__ : (a -> a -> a)) (arg_1__
-                    arg_2__
-                     : Map k a) : Map k a
-           := match arg_0__, arg_1__, arg_2__ with
-              | _f, t1, Tip => t1
-              | f, t1, Bin _ k x Tip Tip => insertWithR f k x t1
-              | f, Bin _ k x Tip Tip, t2 => insertWith f k x t2
-              | _f, Tip, t2 => t2
-              | f, Bin _ k1 x1 l1 r1, t2 =>
-                  let 'pair (pair l2 mb) r2 := splitLookup k1 t2 in
-                  let r1r2 := unionWith f r1 r2 in
-                  let l1l2 := unionWith f l1 l2 in
-                  match mb with
-                  | None => link k1 x1 l1l2 r1r2
-                  | Some x2 => link k1 (f x1 x2) l1l2 r1r2
-                  end
-              end.
+Local Definition Monoid__Map_mconcat {inst_k} {inst_v} `{(GHC.Base.Ord inst_k)}
+   : list (Map inst_k inst_v) -> (Map inst_k inst_v) :=
+  unions.
 
-Definition unionsWith {f} {k} {a} `{Data.Foldable.Foldable f} `{GHC.Base.Ord k}
-   : (a -> a -> a) -> f (Map k a) -> Map k a :=
-  fun f ts => Data.Foldable.foldl' (unionWith f) empty ts.
+Local Definition Monoid__Map_mempty {inst_k} {inst_v} `{(GHC.Base.Ord inst_k)}
+   : (Map inst_k inst_v) :=
+  empty.
 
-Fixpoint unionWithKey {k} {a} `{GHC.Base.Ord k} (arg_0__ : (k -> a -> a -> a))
-                      (arg_1__ arg_2__ : Map k a) : Map k a
-           := match arg_0__, arg_1__, arg_2__ with
-              | _f, t1, Tip => t1
-              | f, t1, Bin _ k x Tip Tip => insertWithKeyR f k x t1
-              | f, Bin _ k x Tip Tip, t2 => insertWithKey f k x t2
-              | _f, Tip, t2 => t2
-              | f, Bin _ k1 x1 l1 r1, t2 =>
-                  let 'pair (pair l2 mb) r2 := splitLookup k1 t2 in
-                  let r1r2 := unionWithKey f r1 r2 in
-                  let l1l2 := unionWithKey f l1 l2 in
-                  match mb with
-                  | None => link k1 x1 l1l2 r1r2
-                  | Some x2 => link k1 (f k1 x1 x2) l1l2 r1r2
-                  end
-              end.
+Program Instance Monoid__Map {k} {v} `{(GHC.Base.Ord k)}
+   : GHC.Base.Monoid (Map k v) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.mappend__ := Monoid__Map_mappend ;
+           GHC.Base.mconcat__ := Monoid__Map_mconcat ;
+           GHC.Base.mempty__ := Monoid__Map_mempty |}.
+
+(* Skipping all instances of class `Data.Data.Data', including
+   `Data.Map.Internal.Data__Map' *)
+
+Definition map {a} {b} {k} : (a -> b) -> Map k a -> Map k b :=
+  fun f =>
+    let fix go arg_0__
+              := match arg_0__ with
+                 | Tip => Tip
+                 | Bin sx kx x l r => Bin sx kx (f x) (go l) (go r)
+                 end in
+    go.
+
+Local Definition Functor__Map_fmap {inst_k}
+   : forall {a} {b}, (a -> b) -> (Map inst_k) a -> (Map inst_k) b :=
+  fun {a} {b} => fun f m => map f m.
+
+Local Definition Functor__Map_op_zlzd__ {k : Type} {a : Type} {b : Type} :=
+  (@functor__Map_op_zlzd__ k a b).
+
+Program Instance Functor__Map {k} : GHC.Base.Functor (Map k) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Map_fmap ;
+           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Map_op_zlzd__ |}.
+
+Definition mapWhenMissing {f} {a} {b} {k} {x} `{GHC.Base.Applicative f}
+  `{GHC.Base.Monad f}
+   : (a -> b) -> WhenMissing f k x a -> WhenMissing f k x b :=
+  fun f t =>
+    Mk_WhenMissing (fun m =>
+                      missingSubtree t m GHC.Base.>>= (fun m' => GHC.Base.pure (GHC.Base.fmap f m')))
+                   (fun k x =>
+                      missingKey t k x GHC.Base.>>= (fun q => (GHC.Base.pure (GHC.Base.fmap f q)))).
+
+Local Definition Functor__WhenMissing_fmap {inst_f} {inst_k} {inst_x}
+  `{GHC.Base.Applicative inst_f} `{GHC.Base.Monad inst_f}
+   : forall {a} {b},
+     (a -> b) ->
+     (WhenMissing inst_f inst_k inst_x) a -> (WhenMissing inst_f inst_k inst_x) b :=
+  fun {a} {b} => mapWhenMissing.
+
+Local Definition Functor__WhenMissing_op_zlzd__ {inst_f} {inst_k} {inst_x}
+  `{GHC.Base.Applicative inst_f} `{GHC.Base.Monad inst_f}
+   : forall {a} {b},
+     a ->
+     (WhenMissing inst_f inst_k inst_x) b -> (WhenMissing inst_f inst_k inst_x) a :=
+  fun {a} {b} => Functor__WhenMissing_fmap GHC.Base.∘ GHC.Base.const.
+
+Program Instance Functor__WhenMissing {f} {k} {x} `{GHC.Base.Applicative f}
+  `{GHC.Base.Monad f}
+   : GHC.Base.Functor (WhenMissing f k x) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__WhenMissing_fmap ;
+           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__WhenMissing_op_zlzd__ |}.
+
+(* Skipping instance `Data.Map.Internal.Category__WhenMissing' of class
+   `Control.Category.Category' *)
+
+(* Skipping instance `Data.Map.Internal.Applicative__WhenMissing' of class
+   `GHC.Base.Applicative' *)
+
+(* Skipping instance `Data.Map.Internal.Monad__WhenMissing' of class
+   `GHC.Base.Monad' *)
+
+Definition mapWhenMatched {f} {a} {b} {k} {x} {y} `{GHC.Base.Functor f}
+   : (a -> b) -> WhenMatched f k x y a -> WhenMatched f k x y b :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, Mk_WhenMatched g =>
+        Mk_WhenMatched (fun k x y => GHC.Base.fmap (GHC.Base.fmap f) (g k x y))
+    end.
+
+Local Definition Functor__WhenMatched_fmap {inst_f} {inst_k} {inst_x} {inst_y}
+  `{GHC.Base.Functor inst_f}
+   : forall {a} {b},
+     (a -> b) ->
+     (WhenMatched inst_f inst_k inst_x inst_y) a ->
+     (WhenMatched inst_f inst_k inst_x inst_y) b :=
+  fun {a} {b} => mapWhenMatched.
+
+Local Definition Functor__WhenMatched_op_zlzd__ {inst_f} {inst_k} {inst_x}
+  {inst_y} `{GHC.Base.Functor inst_f}
+   : forall {a} {b},
+     a ->
+     (WhenMatched inst_f inst_k inst_x inst_y) b ->
+     (WhenMatched inst_f inst_k inst_x inst_y) a :=
+  fun {a} {b} => Functor__WhenMatched_fmap GHC.Base.∘ GHC.Base.const.
+
+Program Instance Functor__WhenMatched {f} {k} {x} {y} `{GHC.Base.Functor f}
+   : GHC.Base.Functor (WhenMatched f k x y) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__WhenMatched_fmap ;
+           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__WhenMatched_op_zlzd__ |}.
+
+(* Skipping instance `Data.Map.Internal.Category__WhenMatched' of class
+   `Control.Category.Category' *)
+
+(* Skipping instance `Data.Map.Internal.Applicative__WhenMatched' of class
+   `GHC.Base.Applicative' *)
+
+(* Skipping instance `Data.Map.Internal.Monad__WhenMatched' of class
+   `GHC.Base.Monad' *)
+
+(* Skipping all instances of class `GHC.Exts.IsList', including
+   `Data.Map.Internal.IsList__Map' *)
+
+Definition foldrWithKey {k} {a} {b} : (k -> a -> b -> b) -> b -> Map k a -> b :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Tip => z'
+                 | z', Bin _ kx x l r => go (f kx x (go z' r)) l
+                 end in
+    go z.
+
+Definition toAscList {k} {a} : Map k a -> list (k * a)%type :=
+  foldrWithKey (fun k x xs => cons (pair k x) xs) nil.
+
+Local Definition Eq___Map_op_zeze__ {inst_k} {inst_a} `{GHC.Base.Eq_ inst_k}
+  `{GHC.Base.Eq_ inst_a}
+   : (Map inst_k inst_a) -> (Map inst_k inst_a) -> bool :=
+  fun t1 t2 =>
+    andb (size t1 GHC.Base.== size t2) (toAscList t1 GHC.Base.== toAscList t2).
+
+Local Definition Eq___Map_op_zsze__ {inst_k} {inst_a} `{GHC.Base.Eq_ inst_k}
+  `{GHC.Base.Eq_ inst_a}
+   : (Map inst_k inst_a) -> (Map inst_k inst_a) -> bool :=
+  fun x y => negb (Eq___Map_op_zeze__ x y).
+
+Program Instance Eq___Map {k} {a} `{GHC.Base.Eq_ k} `{GHC.Base.Eq_ a}
+   : GHC.Base.Eq_ (Map k a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___Map_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___Map_op_zsze__ |}.
+
+Local Definition Ord__Map_compare {inst_k} {inst_v} `{GHC.Base.Ord inst_k}
+  `{GHC.Base.Ord inst_v}
+   : (Map inst_k inst_v) -> (Map inst_k inst_v) -> comparison :=
+  fun m1 m2 => GHC.Base.compare (toAscList m1) (toAscList m2).
+
+Local Definition Ord__Map_op_zl__ {inst_k} {inst_v} `{GHC.Base.Ord inst_k}
+  `{GHC.Base.Ord inst_v}
+   : (Map inst_k inst_v) -> (Map inst_k inst_v) -> bool :=
+  fun x y => Ord__Map_compare x y GHC.Base.== Lt.
+
+Local Definition Ord__Map_op_zlze__ {inst_k} {inst_v} `{GHC.Base.Ord inst_k}
+  `{GHC.Base.Ord inst_v}
+   : (Map inst_k inst_v) -> (Map inst_k inst_v) -> bool :=
+  fun x y => Ord__Map_compare x y GHC.Base./= Gt.
+
+Local Definition Ord__Map_op_zg__ {inst_k} {inst_v} `{GHC.Base.Ord inst_k}
+  `{GHC.Base.Ord inst_v}
+   : (Map inst_k inst_v) -> (Map inst_k inst_v) -> bool :=
+  fun x y => Ord__Map_compare x y GHC.Base.== Gt.
+
+Local Definition Ord__Map_op_zgze__ {inst_k} {inst_v} `{GHC.Base.Ord inst_k}
+  `{GHC.Base.Ord inst_v}
+   : (Map inst_k inst_v) -> (Map inst_k inst_v) -> bool :=
+  fun x y => Ord__Map_compare x y GHC.Base./= Lt.
+
+Local Definition Ord__Map_max {inst_k} {inst_v} `{GHC.Base.Ord inst_k}
+  `{GHC.Base.Ord inst_v}
+   : (Map inst_k inst_v) -> (Map inst_k inst_v) -> (Map inst_k inst_v) :=
+  fun x y => if Ord__Map_op_zlze__ x y : bool then y else x.
+
+Local Definition Ord__Map_min {inst_k} {inst_v} `{GHC.Base.Ord inst_k}
+  `{GHC.Base.Ord inst_v}
+   : (Map inst_k inst_v) -> (Map inst_k inst_v) -> (Map inst_k inst_v) :=
+  fun x y => if Ord__Map_op_zlze__ x y : bool then x else y.
+
+Program Instance Ord__Map {k} {v} `{GHC.Base.Ord k} `{GHC.Base.Ord v}
+   : GHC.Base.Ord (Map k v) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zl____ := Ord__Map_op_zl__ ;
+           GHC.Base.op_zlze____ := Ord__Map_op_zlze__ ;
+           GHC.Base.op_zg____ := Ord__Map_op_zg__ ;
+           GHC.Base.op_zgze____ := Ord__Map_op_zgze__ ;
+           GHC.Base.compare__ := Ord__Map_compare ;
+           GHC.Base.max__ := Ord__Map_max ;
+           GHC.Base.min__ := Ord__Map_min |}.
+
+Definition toList {k} {a} : Map k a -> list (k * a)%type :=
+  toAscList.
+
+Local Definition Eq2__Map_liftEq2
+   : forall {a} {b} {c} {d},
+     (a -> b -> bool) -> (c -> d -> bool) -> Map a c -> Map b d -> bool :=
+  fun {a} {b} {c} {d} =>
+    fun eqk eqv m n =>
+      andb (size m GHC.Base.== size n) (Data.Functor.Classes.liftEq
+            (Data.Functor.Classes.liftEq2 eqk eqv) (toList m) (toList n)).
+
+Program Instance Eq2__Map : Data.Functor.Classes.Eq2 Map :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftEq2__ := fun {a} {b} {c} {d} =>
+             Eq2__Map_liftEq2 |}.
+
+(* Skipping instance `Data.Map.Internal.Eq1__Map' of class
+   `Data.Functor.Classes.Eq1' *)
+
+Local Definition Ord2__Map_liftCompare2
+   : forall {a} {b} {c} {d},
+     (a -> b -> comparison) ->
+     (c -> d -> comparison) -> Map a c -> Map b d -> comparison :=
+  fun {a} {b} {c} {d} =>
+    fun cmpk cmpv m n =>
+      Data.Functor.Classes.liftCompare (Data.Functor.Classes.liftCompare2 cmpk cmpv)
+      (toList m) (toList n).
+
+Program Instance Ord2__Map : Data.Functor.Classes.Ord2 Map :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftCompare2__ := fun {a} {b} {c} {d} =>
+             Ord2__Map_liftCompare2 |}.
+
+(* Skipping instance `Data.Map.Internal.Ord1__Map' of class
+   `Data.Functor.Classes.Ord1' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Show2', including
+   `Data.Map.Internal.Show2__Map' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Show1', including
+   `Data.Map.Internal.Show1__Map' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Read1', including
+   `Data.Map.Internal.Read1__Map' *)
+
+Definition traverseWithKey {t} {k} {a} {b} `{GHC.Base.Applicative t}
+   : (k -> a -> t b) -> Map k a -> t (Map k b) :=
+  fun f =>
+    let fix go arg_0__
+              := match arg_0__ with
+                 | Tip => GHC.Base.pure Tip
+                 | Bin num_1__ k v _ _ =>
+                     if num_1__ GHC.Base.== #1 : bool
+                     then (fun v' => Bin #1 k v' Tip Tip) Data.Functor.<$> f k v else
+                     match arg_0__ with
+                     | Bin s k v l r =>
+                         GHC.Base.liftA3 (GHC.Base.flip (Bin s k)) (go l) (f k v) (go r)
+                     | _ => GHC.Err.patternFailure
+                     end
+                 end in
+    go.
+
+Local Definition Traversable__Map_traverse {inst_k}
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f},
+     (a -> f b) -> (Map inst_k) a -> f ((Map inst_k) b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+    fun f => traverseWithKey (fun arg_0__ => f).
+
+Local Definition Traversable__Map_mapM {inst_k}
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m},
+     (a -> m b) -> (Map inst_k) a -> m ((Map inst_k) b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Map_traverse.
+
+Local Definition Traversable__Map_sequenceA {inst_k}
+   : forall {f} {a},
+     forall `{GHC.Base.Applicative f}, (Map inst_k) (f a) -> f ((Map inst_k) a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} => Traversable__Map_traverse GHC.Base.id.
+
+Local Definition Traversable__Map_sequence {inst_k}
+   : forall {m} {a},
+     forall `{GHC.Base.Monad m}, (Map inst_k) (m a) -> m ((Map inst_k) a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Map_sequenceA.
+
+Local Definition Foldable__Map_fold {inst_k}
+   : forall {m}, forall `{GHC.Base.Monoid m}, (Map inst_k) m -> m :=
+  fun {m} `{GHC.Base.Monoid m} =>
+    let fix go arg_0__
+              := match arg_0__ with
+                 | Tip => GHC.Base.mempty
+                 | Bin num_1__ _ v _ _ =>
+                     if num_1__ GHC.Base.== #1 : bool then v else
+                     match arg_0__ with
+                     | Bin _ _ v l r => GHC.Base.mappend (go l) (GHC.Base.mappend v (go r))
+                     | _ => GHC.Err.patternFailure
+                     end
+                 end in
+    go.
+
+Local Definition Foldable__Map_foldMap {inst_k}
+   : forall {m} {a},
+     forall `{GHC.Base.Monoid m}, (a -> m) -> (Map inst_k) a -> m :=
+  fun {m} {a} `{GHC.Base.Monoid m} =>
+    fun f t =>
+      let fix go arg_0__
+                := match arg_0__ with
+                   | Tip => GHC.Base.mempty
+                   | Bin num_1__ _ v _ _ =>
+                       if num_1__ GHC.Base.== #1 : bool then f v else
+                       match arg_0__ with
+                       | Bin _ _ v l r => GHC.Base.mappend (go l) (GHC.Base.mappend (f v) (go r))
+                       | _ => GHC.Err.patternFailure
+                       end
+                   end in
+      go t.
+
+Definition foldl {a} {b} {k} : (a -> b -> a) -> a -> Map k b -> a :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Tip => z'
+                 | z', Bin _ _ x l r => go (f (go z' l) x) r
+                 end in
+    go z.
+
+Local Definition Foldable__Map_foldl {inst_k}
+   : forall {b} {a}, (b -> a -> b) -> b -> (Map inst_k) a -> b :=
+  fun {b} {a} => foldl.
+
+Definition foldl' {a} {b} {k} : (a -> b -> a) -> a -> Map k b -> a :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Tip => z'
+                 | z', Bin _ _ x l r => go (f (go z' l) x) r
+                 end in
+    go z.
+
+Local Definition Foldable__Map_foldl' {inst_k}
+   : forall {b} {a}, (b -> a -> b) -> b -> (Map inst_k) a -> b :=
+  fun {b} {a} => foldl'.
+
+Definition foldr {a} {b} {k} : (a -> b -> b) -> b -> Map k a -> b :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Tip => z'
+                 | z', Bin _ _ x l r => go (f x (go z' r)) l
+                 end in
+    go z.
+
+Local Definition Foldable__Map_foldr {inst_k}
+   : forall {a} {b}, (a -> b -> b) -> b -> (Map inst_k) a -> b :=
+  fun {a} {b} => foldr.
+
+Definition foldr' {a} {b} {k} : (a -> b -> b) -> b -> Map k a -> b :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Tip => z'
+                 | z', Bin _ _ x l r => go (f x (go z' r)) l
+                 end in
+    go z.
+
+Local Definition Foldable__Map_foldr' {inst_k}
+   : forall {a} {b}, (a -> b -> b) -> b -> (Map inst_k) a -> b :=
+  fun {a} {b} => foldr'.
+
+Local Definition Foldable__Map_length {inst_k}
+   : forall {a}, (Map inst_k) a -> GHC.Num.Int :=
+  fun {a} => size.
+
+Definition null {k} {a} : Map k a -> bool :=
+  fun arg_0__ => match arg_0__ with | Tip => true | Bin _ _ _ _ _ => false end.
+
+Local Definition Foldable__Map_null {inst_k}
+   : forall {a}, (Map inst_k) a -> bool :=
+  fun {a} => null.
+
+Local Definition Foldable__Map_product {inst_k}
+   : forall {a}, forall `{GHC.Num.Num a}, (Map inst_k) a -> a :=
+  fun {a} `{GHC.Num.Num a} => foldl' _GHC.Num.*_ #1.
+
+Local Definition Foldable__Map_sum {inst_k}
+   : forall {a}, forall `{GHC.Num.Num a}, (Map inst_k) a -> a :=
+  fun {a} `{GHC.Num.Num a} => foldl' _GHC.Num.+_ #0.
+
+Definition elems {k} {a} : Map k a -> list a :=
+  foldr cons nil.
+
+Local Definition Foldable__Map_toList {inst_k}
+   : forall {a}, (Map inst_k) a -> list a :=
+  fun {a} => elems.
+
+Program Instance Foldable__Map {k} : Data.Foldable.Foldable (Map k) :=
+  fun _ k__ =>
+    k__ {| Data.Foldable.fold__ := fun {m} `{GHC.Base.Monoid m} =>
+             Foldable__Map_fold ;
+           Data.Foldable.foldMap__ := fun {m} {a} `{GHC.Base.Monoid m} =>
+             Foldable__Map_foldMap ;
+           Data.Foldable.foldl__ := fun {b} {a} => Foldable__Map_foldl ;
+           Data.Foldable.foldl'__ := fun {b} {a} => Foldable__Map_foldl' ;
+           Data.Foldable.foldr__ := fun {a} {b} => Foldable__Map_foldr ;
+           Data.Foldable.foldr'__ := fun {a} {b} => Foldable__Map_foldr' ;
+           Data.Foldable.length__ := fun {a} => Foldable__Map_length ;
+           Data.Foldable.null__ := fun {a} => Foldable__Map_null ;
+           Data.Foldable.product__ := fun {a} `{GHC.Num.Num a} => Foldable__Map_product ;
+           Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Map_sum ;
+           Data.Foldable.toList__ := fun {a} => Foldable__Map_toList |}.
+
+Program Instance Traversable__Map {k} : Data.Traversable.Traversable (Map k) :=
+  fun _ k__ =>
+    k__ {| Data.Traversable.mapM__ := fun {m} {a} {b} `{GHC.Base.Monad m} =>
+             Traversable__Map_mapM ;
+           Data.Traversable.sequence__ := fun {m} {a} `{GHC.Base.Monad m} =>
+             Traversable__Map_sequence ;
+           Data.Traversable.sequenceA__ := fun {f} {a} `{GHC.Base.Applicative f} =>
+             Traversable__Map_sequenceA ;
+           Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+             Traversable__Map_traverse |}.
+
+(* Skipping all instances of class `Control.DeepSeq.NFData', including
+   `Data.Map.Internal.NFData__Map' *)
+
+(* Skipping all instances of class `GHC.Read.Read', including
+   `Data.Map.Internal.Read__Map' *)
+
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Data.Map.Internal.Show__Map' *)
+
+(* Skipping definition `Data.Map.Internal.op_zn__' *)
+
+Definition lookup {k} {a} `{GHC.Base.Ord k} : k -> Map k a -> option a :=
+  let fix go arg_0__ arg_1__
+            := match arg_0__, arg_1__ with
+               | _, Tip => None
+               | k, Bin _ kx x l r =>
+                   match GHC.Base.compare k kx with
+                   | Lt => go k l
+                   | Gt => go k r
+                   | Eq => Some x
+                   end
+               end in
+  go.
+
+Definition op_znz3fU__ {k} {a} `{GHC.Base.Ord k} : Map k a -> k -> option a :=
+  fun m k => lookup k m.
+
+Notation "'_!?_'" := (op_znz3fU__).
+
+Infix "!?" := (_!?_) (at level 99).
 
 Definition maxViewSure {k} {a} : k -> a -> Map k a -> Map k a -> MaxView k a :=
   let fix go arg_0__ arg_1__ arg_2__ arg_3__
@@ -1536,6 +835,16 @@ Definition maxViewSure {k} {a} : k -> a -> Map k a -> Map k a -> MaxView k a :=
                | k, x, l, Bin _ kr xr rl rr =>
                    let 'Mk_MaxView km xm r' := go kr xr rl rr in
                    Mk_MaxView km xm (balanceL k x l r')
+               end in
+  go.
+
+Definition minViewSure {k} {a} : k -> a -> Map k a -> Map k a -> MinView k a :=
+  let fix go arg_0__ arg_1__ arg_2__ arg_3__
+            := match arg_0__, arg_1__, arg_2__, arg_3__ with
+               | k, x, Tip, r => Mk_MinView k x r
+               | k, x, Bin _ kl xl ll lr, r =>
+                   let 'Mk_MinView km xm l' := go kl xl ll lr in
+                   Mk_MinView km xm (balanceR k x l' r)
                end in
   go.
 
@@ -1551,38 +860,6 @@ Definition glue {k} {a} : Map k a -> Map k a -> Map k a :=
         let 'Mk_MinView km m r' := minViewSure kr xr rl rr in
         balanceL km m l r'
     end.
-
-Definition delete {k} {a} `{GHC.Base.Ord k} : k -> Map k a -> Map k a :=
-  let go {k} {a} `{GHC.Base.Ord k} : k -> Map k a -> Map k a :=
-    fix go (arg_0__ : k) (arg_1__ : Map k a) : Map k a
-          := match arg_0__, arg_1__ with
-             | _, Tip => Tip
-             | k, (Bin _ kx x l r as t) =>
-                 match GHC.Base.compare k kx with
-                 | Lt =>
-                     let l' := go k l in
-                     if Utils.Containers.Internal.PtrEquality.ptrEq l' l : bool then t else
-                     balanceR kx x l' r
-                 | Gt =>
-                     let r' := go k r in
-                     if Utils.Containers.Internal.PtrEquality.ptrEq r' r : bool then t else
-                     balanceL kx x l r'
-                 | Eq => glue l r
-                 end
-             end in
-  go.
-
-Fixpoint deleteAt {k} {a} (i : GHC.Num.Int) (t : Map k a) : Map k a
-           := match t with
-              | Tip => GHC.Err.error (GHC.Base.hs_string__ "Map.deleteAt: index out of range")
-              | Bin _ kx x l r =>
-                  let sizeL := size l in
-                  match GHC.Base.compare i sizeL with
-                  | Lt => balanceR kx x (deleteAt i l) r
-                  | Gt => balanceL kx x l (deleteAt ((i GHC.Num.- sizeL) GHC.Num.- #1) r)
-                  | Eq => glue l r
-                  end
-              end.
 
 Program Fixpoint link2 {k} {a} (arg_0__ arg_1__ : Map k a) {measure (Nat.add
                         (map_size arg_0__) (map_size arg_1__))} : Map k a
@@ -1619,328 +896,282 @@ Notation "'_\\_'" := (op_zrzr__).
 
 Infix "\\" := (_\\_) (at level 99).
 
-Fixpoint filterWithKey {k} {a} (arg_0__ : (k -> a -> bool)) (arg_1__ : Map k a)
-           : Map k a
-           := match arg_0__, arg_1__ with
-              | _, Tip => Tip
-              | p, (Bin _ kx x l r as t) =>
-                  let pr := filterWithKey p r in
-                  let pl := filterWithKey p l in
-                  if p kx x : bool
-                  then if andb (Utils.Containers.Internal.PtrEquality.ptrEq pl l)
-                               (Utils.Containers.Internal.PtrEquality.ptrEq pr r) : bool
-                       then t
-                       else link kx x pl pr else
-                  link2 pl pr
-              end.
+(* Skipping definition `Data.Map.Internal.fromListConstr' *)
 
-Definition filter {a} {k} : (a -> bool) -> Map k a -> Map k a :=
-  fun p m =>
-    filterWithKey (fun arg_0__ arg_1__ =>
-                     match arg_0__, arg_1__ with
-                     | _, x => p x
-                     end) m.
+(* Skipping definition `Data.Map.Internal.mapDataType' *)
 
-Definition filterMissing {f} {k} {x} `{GHC.Base.Applicative f}
-   : (k -> x -> bool) -> WhenMissing f k x x :=
-  fun f =>
-    Mk_WhenMissing (fun m => GHC.Base.pure (filterWithKey f m)) (fun k x =>
-                      GHC.Base.pure (if f k x : bool then Some x else None)).
-
-Fixpoint filterWithKeyA {f} {k} {a} `{GHC.Base.Applicative f} (arg_0__
-                          : (k -> a -> f bool)) (arg_1__ : Map k a) : f (Map k a)
-           := match arg_0__, arg_1__ with
-              | _, Tip => GHC.Base.pure Tip
-              | p, (Bin _ kx x l r as t) =>
-                  let combine :=
-                    fun arg_3__ arg_4__ arg_5__ =>
-                      match arg_3__, arg_4__, arg_5__ with
-                      | true, pl, pr =>
-                          if andb (Utils.Containers.Internal.PtrEquality.ptrEq pl l)
-                                  (Utils.Containers.Internal.PtrEquality.ptrEq pr r) : bool
-                          then t else
-                          link kx x pl pr
-                      | false, pl, pr => link2 pl pr
-                      end in
-                  GHC.Base.liftA3 combine (p kx x) (filterWithKeyA p l) (filterWithKeyA p r)
-              end.
-
-Definition filterAMissing {f} {k} {x} `{GHC.Base.Applicative f}
-   : (k -> x -> f bool) -> WhenMissing f k x x :=
-  fun f =>
-    Mk_WhenMissing (fun m => filterWithKeyA f m) (fun k x =>
-                      boolITE None (Some x) Data.Functor.<$> f k x).
-
-Fixpoint intersection {k} {a} {b} `{GHC.Base.Ord k} (arg_0__ : Map k a) (arg_1__
-                        : Map k b) : Map k a
-           := match arg_0__, arg_1__ with
-              | Tip, _ => Tip
-              | _, Tip => Tip
-              | (Bin _ k x l1 r1 as t1), t2 =>
-                  let 'pair (pair l2 mb) r2 := splitMember k t2 in
-                  let l1l2 := intersection l1 l2 in
-                  let r1r2 := intersection r1 r2 in
-                  if mb : bool
-                  then if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1l2 l1)
-                               (Utils.Containers.Internal.PtrEquality.ptrEq r1r2 r1) : bool
-                       then t1
-                       else link k x l1l2 r1r2 else
-                  link2 l1l2 r1r2
-              end.
-
-Fixpoint intersectionWith {k} {a} {b} {c} `{GHC.Base.Ord k} (arg_0__
-                            : (a -> b -> c)) (arg_1__ : Map k a) (arg_2__ : Map k b) : Map k c
-           := match arg_0__, arg_1__, arg_2__ with
-              | _f, Tip, _ => Tip
-              | _f, _, Tip => Tip
-              | f, Bin _ k x1 l1 r1, t2 =>
-                  let 'pair (pair l2 mb) r2 := splitLookup k t2 in
-                  let l1l2 := intersectionWith f l1 l2 in
-                  let r1r2 := intersectionWith f r1 r2 in
-                  match mb with
-                  | Some x2 => link k (f x1 x2) l1l2 r1r2
-                  | None => link2 l1l2 r1r2
-                  end
-              end.
-
-Fixpoint intersectionWithKey {k} {a} {b} {c} `{GHC.Base.Ord k} (arg_0__
-                               : (k -> a -> b -> c)) (arg_1__ : Map k a) (arg_2__ : Map k b) : Map k c
-           := match arg_0__, arg_1__, arg_2__ with
-              | _f, Tip, _ => Tip
-              | _f, _, Tip => Tip
-              | f, Bin _ k x1 l1 r1, t2 =>
-                  let 'pair (pair l2 mb) r2 := splitLookup k t2 in
-                  let l1l2 := intersectionWithKey f l1 l2 in
-                  let r1r2 := intersectionWithKey f r1 r2 in
-                  match mb with
-                  | Some x2 => link k (f k x1 x2) l1l2 r1r2
-                  | None => link2 l1l2 r1r2
-                  end
-              end.
-
-Definition mapEitherWithKey {k} {a} {b} {c}
-   : (k -> a -> Data.Either.Either b c) -> Map k a -> (Map k b * Map k c)%type :=
-  fun f0 t0 =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | _, Tip => (pair Tip Tip)
-                 | f, Bin _ kx x l r =>
-                     let 'pair r1 r2 := go f r in
-                     let 'pair l1 l2 := go f l in
-                     match f kx x with
-                     | Data.Either.Left y => pair (link kx y l1 r1) (link2 l2 r2)
-                     | Data.Either.Right z => pair (link2 l1 r1) (link kx z l2 r2)
-                     end
-                 end in
-    id (go f0 t0).
-
-Definition mapEither {a} {b} {c} {k}
-   : (a -> Data.Either.Either b c) -> Map k a -> (Map k b * Map k c)%type :=
-  fun f m =>
-    mapEitherWithKey (fun arg_0__ arg_1__ =>
-                        match arg_0__, arg_1__ with
-                        | _, x => f x
-                        end) m.
-
-Fixpoint mapMaybeWithKey {k} {a} {b} (arg_0__ : (k -> a -> option b)) (arg_1__
-                           : Map k a) : Map k b
-           := match arg_0__, arg_1__ with
-              | _, Tip => Tip
-              | f, Bin _ kx x l r =>
-                  match f kx x with
-                  | Some y => link kx y (mapMaybeWithKey f l) (mapMaybeWithKey f r)
-                  | None => link2 (mapMaybeWithKey f l) (mapMaybeWithKey f r)
-                  end
-              end.
-
-Definition mapMaybe {a} {b} {k} : (a -> option b) -> Map k a -> Map k b :=
-  fun f =>
-    mapMaybeWithKey (fun arg_0__ arg_1__ =>
-                       match arg_0__, arg_1__ with
-                       | _, x => f x
-                       end).
-
-Definition mapMaybeMissing {f} {k} {x} {y} `{GHC.Base.Applicative f}
-   : (k -> x -> option y) -> WhenMissing f k x y :=
-  fun f =>
-    Mk_WhenMissing (fun m => GHC.Base.pure (mapMaybeWithKey f m)) (fun k x =>
-                      GHC.Base.pure (f k x)).
-
-Definition mergeA {f} {k} {a} {c} {b} `{GHC.Base.Applicative f} `{GHC.Base.Ord
-  k}
-   : WhenMissing f k a c ->
-     WhenMissing f k b c ->
-     WhenMatched f k a b c -> Map k a -> Map k b -> f (Map k c) :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | Mk_WhenMissing g1t g1k, Mk_WhenMissing g2t _, Mk_WhenMatched f =>
-        let fix go arg_3__ arg_4__
-                  := match arg_3__, arg_4__ with
-                     | t1, Tip => g1t t1
-                     | Tip, t2 => g2t t2
-                     | Bin _ kx x1 l1 r1, t2 =>
-                         let 'pair (pair l2 mx2) r2 := splitLookup kx t2 in
-                         let r1r2 := go r1 r2 in
-                         let l1l2 := go l1 l2 in
-                         match mx2 with
-                         | None =>
-                             GHC.Base.liftA3 (fun l' mx' r' => Data.Maybe.maybe link2 (link kx) mx' l' r')
-                             l1l2 (g1k kx x1) r1r2
-                         | Some x2 =>
-                             GHC.Base.liftA3 (fun l' mx' r' => Data.Maybe.maybe link2 (link kx) mx' l' r')
-                             l1l2 (f kx x1 x2) r1r2
-                         end
-                     end in
-        go
-    end.
-
-Definition merge {k} {a} {c} {b} `{GHC.Base.Ord k}
-   : SimpleWhenMissing k a c ->
-     SimpleWhenMissing k b c ->
-     SimpleWhenMatched k a b c -> Map k a -> Map k b -> Map k c :=
-  fun g1 g2 f m1 m2 => Data.Functor.Identity.runIdentity (mergeA g1 g2 f m1 m2).
-
-Definition mergeWithKey {k} {a} {b} {c} `{GHC.Base.Ord k}
-   : (k -> a -> b -> option c) ->
-     (Map k a -> Map k c) -> (Map k b -> Map k c) -> Map k a -> Map k b -> Map k c :=
-  fun f g1 g2 =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | Tip, t2 => g2 t2
-                 | t1, Tip => g1 t1
-                 | Bin _ kx x l1 r1, t2 =>
-                     let 'pair (pair l2 found) r2 := splitLookup kx t2 in
-                     let l' := go l1 l2 in
-                     let r' := go r1 r2 in
-                     match found with
-                     | None =>
-                         match g1 (singleton kx x) with
-                         | Tip => link2 l' r'
-                         | Bin _ _ x' Tip Tip => link kx x' l' r'
-                         | _ =>
-                             GHC.Err.error (GHC.Base.hs_string__
-                                            "mergeWithKey: Given function only1 does not fulfill required conditions (see documentation)")
-                         end
-                     | Some x2 =>
-                         match f kx x x2 with
-                         | None => link2 l' r'
-                         | Some x' => link kx x' l' r'
-                         end
-                     end
-                 end in
-    go.
-
-Definition partitionWithKey {k} {a}
-   : (k -> a -> bool) -> Map k a -> (Map k a * Map k a)%type :=
-  fun p0 t0 =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | _, Tip => (pair Tip Tip)
-                 | p, (Bin _ kx x l r as t) =>
-                     let 'pair r1 r2 := go p r in
-                     let 'pair l1 l2 := go p l in
-                     if p kx x : bool
-                     then pair (if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1 l)
-                                        (Utils.Containers.Internal.PtrEquality.ptrEq r1 r) : bool
-                                then t
-                                else link kx x l1 r1) (link2 l2 r2) else
-                     pair (link2 l1 r1) (if andb (Utils.Containers.Internal.PtrEquality.ptrEq l2 l)
-                                                 (Utils.Containers.Internal.PtrEquality.ptrEq r2 r) : bool
-                           then t
-                           else link kx x l2 r2)
-                 end in
-    id (go p0 t0).
-
-Definition partition {a} {k}
-   : (a -> bool) -> Map k a -> (Map k a * Map k a)%type :=
-  fun p m =>
-    partitionWithKey (fun arg_0__ arg_1__ =>
-                        match arg_0__, arg_1__ with
-                        | _, x => p x
-                        end) m.
-
-Fixpoint restrictKeys {k} {a} `{GHC.Base.Ord k} (arg_0__ : Map k a) (arg_1__
-                        : Data.Set.Internal.Set_ k) : Map k a
-           := match arg_0__, arg_1__ with
-              | Tip, _ => Tip
-              | _, Data.Set.Internal.Tip => Tip
-              | (Bin _ k x l1 r1 as m), s =>
-                  let 'pair (pair l2 b) r2 := Data.Set.Internal.splitMember k s in
-                  let l1l2 := restrictKeys l1 l2 in
-                  let r1r2 := restrictKeys r1 r2 in
-                  if b : bool
-                  then if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1l2 l1)
-                               (Utils.Containers.Internal.PtrEquality.ptrEq r1r2 r1) : bool
-                       then m
-                       else link k x l1l2 r1r2 else
-                  link2 l1l2 r1r2
-              end.
-
-Definition traverseMaybeWithKey {f} {k} {a} {b} `{GHC.Base.Applicative f}
-   : (k -> a -> f (option b)) -> Map k a -> f (Map k b) :=
+Definition member {k} {a} `{GHC.Base.Ord k} : k -> Map k a -> bool :=
   let fix go arg_0__ arg_1__
             := match arg_0__, arg_1__ with
-               | _, Tip => GHC.Base.pure Tip
-               | f, Bin _ kx x Tip Tip =>
-                   Data.Maybe.maybe Tip (fun x' => Bin #1 kx x' Tip Tip) Data.Functor.<$> f kx x
-               | f, Bin _ kx x l r =>
-                   let combine :=
-                     fun l' mx r' =>
-                       match mx with
-                       | None => link2 l' r'
-                       | Some x' => link kx x' l' r'
-                       end in
-                   GHC.Base.liftA3 combine (go f l) (f kx x) (go f r)
+               | _, Tip => false
+               | k, Bin _ kx _ l r =>
+                   match GHC.Base.compare k kx with
+                   | Lt => go k l
+                   | Gt => go k r
+                   | Eq => true
+                   end
                end in
   go.
 
-Definition traverseMaybeMissing {f} {k} {x} {y} `{GHC.Base.Applicative f}
-   : (k -> x -> f (option y)) -> WhenMissing f k x y :=
-  fun f => Mk_WhenMissing (traverseMaybeWithKey f) f.
+Definition notMember {k} {a} `{GHC.Base.Ord k} : k -> Map k a -> bool :=
+  fun k m => negb (member k m).
 
-Fixpoint withoutKeys {k} {a} `{GHC.Base.Ord k} (arg_0__ : Map k a) (arg_1__
-                       : Data.Set.Internal.Set_ k) : Map k a
-           := match arg_0__, arg_1__ with
-              | Tip, _ => Tip
-              | m, Data.Set.Internal.Tip => m
-              | m, Data.Set.Internal.Bin _ k ls rs =>
-                  let 'pair (pair lm b) rm := splitMember k m in
-                  let rm' := withoutKeys rm rs in
-                  let lm' := withoutKeys lm ls in
-                  if andb (negb b) (andb (Utils.Containers.Internal.PtrEquality.ptrEq lm' lm)
-                                         (Utils.Containers.Internal.PtrEquality.ptrEq rm' rm)) : bool
-                  then m else
-                  link2 lm' rm'
-              end.
+(* Skipping definition `Data.Map.Internal.find' *)
 
-Definition maxViewWithKey {k} {a}
-   : Map k a -> option ((k * a)%type * Map k a)%type :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Tip => None
-    | Bin _ k x l r =>
-        Some (let 'Mk_MaxView km xm t := maxViewSure k x l r in pair (pair km xm) t)
-    end.
+Definition findWithDefault {k} {a} `{GHC.Base.Ord k} : a -> k -> Map k a -> a :=
+  let fix go arg_0__ arg_1__ arg_2__
+            := match arg_0__, arg_1__, arg_2__ with
+               | def, _, Tip => def
+               | def, k, Bin _ kx x l r =>
+                   match GHC.Base.compare k kx with
+                   | Lt => go def k l
+                   | Gt => go def k r
+                   | Eq => x
+                   end
+               end in
+  go.
 
-Definition maxView {k} {a} : Map k a -> option (a * Map k a)%type :=
-  fun t =>
-    match maxViewWithKey t with
-    | None => None
-    | Some (pair (pair _ x) t') => Some (pair x t')
-    end.
+Definition lookupLT {k} {v} `{GHC.Base.Ord k}
+   : k -> Map k v -> option (k * v)%type :=
+  let fix goJust arg_0__ arg_1__ arg_2__ arg_3__
+            := match arg_0__, arg_1__, arg_2__, arg_3__ with
+               | _, kx', x', Tip => Some (pair kx' x')
+               | k, kx', x', Bin _ kx x l r =>
+                   if k GHC.Base.<= kx : bool then goJust k kx' x' l else
+                   goJust k kx x r
+               end in
+  let fix goNothing arg_8__ arg_9__
+            := match arg_8__, arg_9__ with
+               | _, Tip => None
+               | k, Bin _ kx x l r =>
+                   if k GHC.Base.<= kx : bool then goNothing k l else
+                   goJust k kx x r
+               end in
+  goNothing.
 
-Fixpoint updateAt {k} {a} (f : (k -> a -> option a)) (i : GHC.Num.Int) (t
-                    : Map k a) : Map k a
-           := match t with
-              | Tip => GHC.Err.error (GHC.Base.hs_string__ "Map.updateAt: index out of range")
-              | Bin sx kx x l r =>
-                  let sizeL := size l in
-                  match GHC.Base.compare i sizeL with
-                  | Lt => balanceR kx x (updateAt f i l) r
-                  | Gt => balanceL kx x l (updateAt f ((i GHC.Num.- sizeL) GHC.Num.- #1) r)
-                  | Eq => match f kx x with | Some x' => Bin sx kx x' l r | None => glue l r end
-                  end
-              end.
+Definition lookupGT {k} {v} `{GHC.Base.Ord k}
+   : k -> Map k v -> option (k * v)%type :=
+  let fix goJust arg_0__ arg_1__ arg_2__ arg_3__
+            := match arg_0__, arg_1__, arg_2__, arg_3__ with
+               | _, kx', x', Tip => Some (pair kx' x')
+               | k, kx', x', Bin _ kx x l r =>
+                   if k GHC.Base.< kx : bool then goJust k kx x l else
+                   goJust k kx' x' r
+               end in
+  let fix goNothing arg_8__ arg_9__
+            := match arg_8__, arg_9__ with
+               | _, Tip => None
+               | k, Bin _ kx x l r =>
+                   if k GHC.Base.< kx : bool then goJust k kx x l else
+                   goNothing k r
+               end in
+  goNothing.
+
+Definition lookupLE {k} {v} `{GHC.Base.Ord k}
+   : k -> Map k v -> option (k * v)%type :=
+  let fix goJust arg_0__ arg_1__ arg_2__ arg_3__
+            := match arg_0__, arg_1__, arg_2__, arg_3__ with
+               | _, kx', x', Tip => Some (pair kx' x')
+               | k, kx', x', Bin _ kx x l r =>
+                   match GHC.Base.compare k kx with
+                   | Lt => goJust k kx' x' l
+                   | Eq => Some (pair kx x)
+                   | Gt => goJust k kx x r
+                   end
+               end in
+  let fix goNothing arg_12__ arg_13__
+            := match arg_12__, arg_13__ with
+               | _, Tip => None
+               | k, Bin _ kx x l r =>
+                   match GHC.Base.compare k kx with
+                   | Lt => goNothing k l
+                   | Eq => Some (pair kx x)
+                   | Gt => goJust k kx x r
+                   end
+               end in
+  goNothing.
+
+Definition lookupGE {k} {v} `{GHC.Base.Ord k}
+   : k -> Map k v -> option (k * v)%type :=
+  let fix goJust arg_0__ arg_1__ arg_2__ arg_3__
+            := match arg_0__, arg_1__, arg_2__, arg_3__ with
+               | _, kx', x', Tip => Some (pair kx' x')
+               | k, kx', x', Bin _ kx x l r =>
+                   match GHC.Base.compare k kx with
+                   | Lt => goJust k kx x l
+                   | Eq => Some (pair kx x)
+                   | Gt => goJust k kx' x' r
+                   end
+               end in
+  let fix goNothing arg_12__ arg_13__
+            := match arg_12__, arg_13__ with
+               | _, Tip => None
+               | k, Bin _ kx x l r =>
+                   match GHC.Base.compare k kx with
+                   | Lt => goJust k kx x l
+                   | Eq => Some (pair kx x)
+                   | Gt => goNothing k r
+                   end
+               end in
+  goNothing.
+
+Definition insertWith {k} {a} `{GHC.Base.Ord k}
+   : (a -> a -> a) -> k -> a -> Map k a -> Map k a :=
+  let go {k} {a} `{GHC.Base.Ord k}
+   : (a -> a -> a) -> k -> a -> Map k a -> Map k a :=
+    fix go (arg_0__ : (a -> a -> a)) (arg_1__ : k) (arg_2__ : a) (arg_3__ : Map k a)
+          : Map k a
+          := match arg_0__, arg_1__, arg_2__, arg_3__ with
+             | _, kx, x, Tip => singleton kx x
+             | f, kx, x, Bin sy ky y l r =>
+                 match GHC.Base.compare kx ky with
+                 | Lt => balanceL ky y (go f kx x l) r
+                 | Gt => balanceR ky y l (go f kx x r)
+                 | Eq => Bin sy kx (f x y) l r
+                 end
+             end in
+  go.
+
+Definition insertWithR {k} {a} `{GHC.Base.Ord k}
+   : (a -> a -> a) -> k -> a -> Map k a -> Map k a :=
+  let go {k} {a} `{GHC.Base.Ord k}
+   : (a -> a -> a) -> k -> a -> Map k a -> Map k a :=
+    fix go (arg_0__ : (a -> a -> a)) (arg_1__ : k) (arg_2__ : a) (arg_3__ : Map k a)
+          : Map k a
+          := match arg_0__, arg_1__, arg_2__, arg_3__ with
+             | _, kx, x, Tip => singleton kx x
+             | f, kx, x, Bin sy ky y l r =>
+                 match GHC.Base.compare kx ky with
+                 | Lt => balanceL ky y (go f kx x l) r
+                 | Gt => balanceR ky y l (go f kx x r)
+                 | Eq => Bin sy ky (f y x) l r
+                 end
+             end in
+  go.
+
+Definition insertWithKey {k} {a} `{GHC.Base.Ord k}
+   : (k -> a -> a -> a) -> k -> a -> Map k a -> Map k a :=
+  let go {k} {a} `{GHC.Base.Ord k}
+   : (k -> a -> a -> a) -> k -> a -> Map k a -> Map k a :=
+    fix go (arg_0__ : (k -> a -> a -> a)) (arg_1__ : k) (arg_2__ : a) (arg_3__
+             : Map k a) : Map k a
+          := match arg_0__, arg_1__, arg_2__, arg_3__ with
+             | _, kx, x, Tip => singleton kx x
+             | f, kx, x, Bin sy ky y l r =>
+                 match GHC.Base.compare kx ky with
+                 | Lt => balanceL ky y (go f kx x l) r
+                 | Gt => balanceR ky y l (go f kx x r)
+                 | Eq => Bin sy kx (f kx x y) l r
+                 end
+             end in
+  go.
+
+Definition insertWithKeyR {k} {a} `{GHC.Base.Ord k}
+   : (k -> a -> a -> a) -> k -> a -> Map k a -> Map k a :=
+  let go {k} {a} `{GHC.Base.Ord k}
+   : (k -> a -> a -> a) -> k -> a -> Map k a -> Map k a :=
+    fix go (arg_0__ : (k -> a -> a -> a)) (arg_1__ : k) (arg_2__ : a) (arg_3__
+             : Map k a) : Map k a
+          := match arg_0__, arg_1__, arg_2__, arg_3__ with
+             | _, kx, x, Tip => singleton kx x
+             | f, kx, x, Bin sy ky y l r =>
+                 match GHC.Base.compare kx ky with
+                 | Lt => balanceL ky y (go f kx x l) r
+                 | Gt => balanceR ky y l (go f kx x r)
+                 | Eq => Bin sy ky (f ky y x) l r
+                 end
+             end in
+  go.
+
+Definition insertLookupWithKey {k} {a} `{GHC.Base.Ord k}
+   : (k -> a -> a -> a) -> k -> a -> Map k a -> (option a * Map k a)%type :=
+  fun f0 k0 x0 =>
+    let go {k} {a} `{GHC.Base.Ord k}
+     : (k -> a -> a -> a) -> k -> a -> Map k a -> prod (option a) (Map k a) :=
+      fix go (arg_0__ : (k -> a -> a -> a)) (arg_1__ : k) (arg_2__ : a) (arg_3__
+               : Map k a) : prod (option a) (Map k a)
+            := match arg_0__, arg_1__, arg_2__, arg_3__ with
+               | _, kx, x, Tip => (pair None (singleton kx x))
+               | f, kx, x, Bin sy ky y l r =>
+                   match GHC.Base.compare kx ky with
+                   | Lt =>
+                       let 'pair found l' := go f kx x l in
+                       let t' := balanceL ky y l' r in (pair found t')
+                   | Gt =>
+                       let 'pair found r' := go f kx x r in
+                       let t' := balanceR ky y l r' in (pair found t')
+                   | Eq => (pair (Some y) (Bin sy kx (f kx x y) l r))
+                   end
+               end in
+    id GHC.Base.∘ go f0 k0 x0.
+
+Definition delete {k} {a} `{GHC.Base.Ord k} : k -> Map k a -> Map k a :=
+  let go {k} {a} `{GHC.Base.Ord k} : k -> Map k a -> Map k a :=
+    fix go (arg_0__ : k) (arg_1__ : Map k a) : Map k a
+          := match arg_0__, arg_1__ with
+             | _, Tip => Tip
+             | k, (Bin _ kx x l r as t) =>
+                 match GHC.Base.compare k kx with
+                 | Lt =>
+                     let l' := go k l in
+                     if Utils.Containers.Internal.PtrEquality.ptrEq l' l : bool then t else
+                     balanceR kx x l' r
+                 | Gt =>
+                     let r' := go k r in
+                     if Utils.Containers.Internal.PtrEquality.ptrEq r' r : bool then t else
+                     balanceL kx x l r'
+                 | Eq => glue l r
+                 end
+             end in
+  go.
+
+Definition adjustWithKey {k} {a} `{GHC.Base.Ord k}
+   : (k -> a -> a) -> k -> Map k a -> Map k a :=
+  let go {k} {a} `{GHC.Base.Ord k} : (k -> a -> a) -> k -> Map k a -> Map k a :=
+    fix go (arg_0__ : (k -> a -> a)) (arg_1__ : k) (arg_2__ : Map k a) : Map k a
+          := match arg_0__, arg_1__, arg_2__ with
+             | _, _, Tip => Tip
+             | f, k, Bin sx kx x l r =>
+                 match GHC.Base.compare k kx with
+                 | Lt => Bin sx kx x (go f k l) r
+                 | Gt => Bin sx kx x l (go f k r)
+                 | Eq => Bin sx kx (f kx x) l r
+                 end
+             end in
+  go.
+
+Definition adjust {k} {a} `{GHC.Base.Ord k}
+   : (a -> a) -> k -> Map k a -> Map k a :=
+  fun f =>
+    adjustWithKey (fun arg_0__ arg_1__ =>
+                     match arg_0__, arg_1__ with
+                     | _, x => f x
+                     end).
+
+Definition updateWithKey {k} {a} `{GHC.Base.Ord k}
+   : (k -> a -> option a) -> k -> Map k a -> Map k a :=
+  let go {k} {a} `{GHC.Base.Ord k}
+   : (k -> a -> option a) -> k -> Map k a -> Map k a :=
+    fix go (arg_0__ : (k -> a -> option a)) (arg_1__ : k) (arg_2__ : Map k a) : Map
+                                                                                k a
+          := match arg_0__, arg_1__, arg_2__ with
+             | _, _, Tip => Tip
+             | f, k, Bin sx kx x l r =>
+                 match GHC.Base.compare k kx with
+                 | Lt => balanceR kx x (go f k l) r
+                 | Gt => balanceL kx x l (go f k r)
+                 | Eq => match f kx x with | Some x' => Bin sx kx x' l r | None => glue l r end
+                 end
+             end in
+  go.
+
+Definition update {k} {a} `{GHC.Base.Ord k}
+   : (a -> option a) -> k -> Map k a -> Map k a :=
+  fun f =>
+    updateWithKey (fun arg_0__ arg_1__ =>
+                     match arg_0__, arg_1__ with
+                     | _, x => f x
+                     end).
 
 Definition updateLookupWithKey {k} {a} `{GHC.Base.Ord k}
    : (k -> a -> option a) -> k -> Map k a -> (option a * Map k a)%type :=
@@ -1967,50 +1198,6 @@ Definition updateLookupWithKey {k} {a} `{GHC.Base.Ord k}
                    end
                end in
     id GHC.Base.∘ go f0 k0.
-
-Fixpoint updateMaxWithKey {k} {a} (arg_0__ : (k -> a -> option a)) (arg_1__
-                            : Map k a) : Map k a
-           := match arg_0__, arg_1__ with
-              | _, Tip => Tip
-              | f, Bin sx kx x l Tip =>
-                  match f kx x with
-                  | None => l
-                  | Some x' => Bin sx kx x' l Tip
-                  end
-              | f, Bin _ kx x l r => balanceL kx x l (updateMaxWithKey f r)
-              end.
-
-Definition updateMax {a} {k} : (a -> option a) -> Map k a -> Map k a :=
-  fun f m =>
-    updateMaxWithKey (fun arg_0__ arg_1__ =>
-                        match arg_0__, arg_1__ with
-                        | _, x => f x
-                        end) m.
-
-Definition updateWithKey {k} {a} `{GHC.Base.Ord k}
-   : (k -> a -> option a) -> k -> Map k a -> Map k a :=
-  let go {k} {a} `{GHC.Base.Ord k}
-   : (k -> a -> option a) -> k -> Map k a -> Map k a :=
-    fix go (arg_0__ : (k -> a -> option a)) (arg_1__ : k) (arg_2__ : Map k a) : Map
-                                                                                k a
-          := match arg_0__, arg_1__, arg_2__ with
-             | _, _, Tip => Tip
-             | f, k, Bin sx kx x l r =>
-                 match GHC.Base.compare k kx with
-                 | Lt => balanceR kx x (go f k l) r
-                 | Gt => balanceL kx x l (go f k r)
-                 | Eq => match f kx x with | Some x' => Bin sx kx x' l r | None => glue l r end
-                 end
-             end in
-  go.
-
-Definition update {k} {a} `{GHC.Base.Ord k}
-   : (a -> option a) -> k -> Map k a -> Map k a :=
-  fun f =>
-    updateWithKey (fun arg_0__ arg_1__ =>
-                     match arg_0__, arg_1__ with
-                     | _, x => f x
-                     end).
 
 Definition balance {k} {a} : k -> a -> Map k a -> Map k a -> Map k a :=
   fun k x l r =>
@@ -2082,6 +1269,41 @@ Definition balance {k} {a} : k -> a -> Map k a -> Map k a -> Map k a :=
         end
     end.
 
+Definition alter {k} {a} `{GHC.Base.Ord k}
+   : (option a -> option a) -> k -> Map k a -> Map k a :=
+  let go {k} {a} `{GHC.Base.Ord k}
+   : (option a -> option a) -> k -> Map k a -> Map k a :=
+    fix go (arg_0__ : (option a -> option a)) (arg_1__ : k) (arg_2__ : Map k a)
+          : Map k a
+          := match arg_0__, arg_1__, arg_2__ with
+             | f, k, Tip => match f None with | None => Tip | Some x => singleton k x end
+             | f, k, Bin sx kx x l r =>
+                 match GHC.Base.compare k kx with
+                 | Lt => balance kx x (go f k l) r
+                 | Gt => balance kx x l (go f k r)
+                 | Eq =>
+                     match f (Some x) with
+                     | Some x' => Bin sx kx x' l r
+                     | None => glue l r
+                     end
+                 end
+             end in
+  go.
+
+(* Skipping definition `Data.Map.Internal.alterF' *)
+
+(* Skipping definition `Data.Map.Internal.atKeyImpl' *)
+
+(* Skipping definition `Data.Map.Internal.lookupTrace' *)
+
+(* Skipping definition `Data.Map.Internal.insertAlong' *)
+
+(* Skipping definition `Data.Map.Internal.deleteAlong' *)
+
+(* Skipping definition `Data.Map.Internal.bogus' *)
+
+(* Skipping definition `Data.Map.Internal.replaceAlong' *)
+
 Definition atKeyPlain {k} {a} `{GHC.Base.Ord k}
    : AreWeStrict -> k -> (option a -> option a) -> Map k a -> Map k a :=
   fun strict k0 f0 t =>
@@ -2133,8 +1355,6 @@ Definition atKeyPlain {k} {a} `{GHC.Base.Ord k}
     | AltSame => t
     end.
 
-(* Skipping definition `Data.Map.Internal.atKeyImpl' *)
-
 Definition atKeyIdentity {k} {a} `{GHC.Base.Ord k}
    : k ->
      (option a -> Data.Functor.Identity.Identity (option a)) ->
@@ -2142,381 +1362,1161 @@ Definition atKeyIdentity {k} {a} `{GHC.Base.Ord k}
   fun k f t =>
     Data.Functor.Identity.Mk_Identity (atKeyPlain Lazy k (GHC.Prim.coerce f) t).
 
-Definition assocs {k} {a} : Map k a -> list (k * a)%type :=
-  fun m => toAscList m.
+Definition findIndex {k} {a} `{GHC.Base.Ord k} : k -> Map k a -> GHC.Num.Int :=
+  let go {k} {a} `{GHC.Base.Ord k} : GHC.Num.Int -> k -> Map k a -> GHC.Num.Int :=
+    fix go (arg_0__ : GHC.Num.Int) (arg_1__ : k) (arg_2__ : Map k a) : GHC.Num.Int
+          := match arg_0__, arg_1__, arg_2__ with
+             | _, _, Tip =>
+                 GHC.Err.error (GHC.Base.hs_string__ "Map.findIndex: element is not in the map")
+             | idx, k, Bin _ kx _ l r =>
+                 match GHC.Base.compare k kx with
+                 | Lt => go idx k l
+                 | Gt => go ((idx GHC.Num.+ size l) GHC.Num.+ #1) k r
+                 | Eq => idx GHC.Num.+ size l
+                 end
+             end in
+  go #0.
 
-(* Skipping definition `Data.Map.Internal.alterF' *)
-
-Definition alter {k} {a} `{GHC.Base.Ord k}
-   : (option a -> option a) -> k -> Map k a -> Map k a :=
+Definition lookupIndex {k} {a} `{GHC.Base.Ord k}
+   : k -> Map k a -> option GHC.Num.Int :=
   let go {k} {a} `{GHC.Base.Ord k}
-   : (option a -> option a) -> k -> Map k a -> Map k a :=
-    fix go (arg_0__ : (option a -> option a)) (arg_1__ : k) (arg_2__ : Map k a)
-          : Map k a
+   : GHC.Num.Int -> k -> Map k a -> option GHC.Num.Int :=
+    fix go (arg_0__ : GHC.Num.Int) (arg_1__ : k) (arg_2__ : Map k a) : option
+                                                                       GHC.Num.Int
           := match arg_0__, arg_1__, arg_2__ with
-             | f, k, Tip => match f None with | None => Tip | Some x => singleton k x end
-             | f, k, Bin sx kx x l r =>
+             | _, _, Tip => None
+             | idx, k, Bin _ kx _ l r =>
                  match GHC.Base.compare k kx with
-                 | Lt => balance kx x (go f k l) r
-                 | Gt => balance kx x l (go f k r)
-                 | Eq =>
-                     match f (Some x) with
-                     | Some x' => Bin sx kx x' l r
-                     | None => glue l r
-                     end
+                 | Lt => go idx k l
+                 | Gt => go ((idx GHC.Num.+ size l) GHC.Num.+ #1) k r
+                 | Eq => Some (idx GHC.Num.+ size l)
                  end
              end in
-  go.
+  go #0.
 
-Definition adjustWithKey {k} {a} `{GHC.Base.Ord k}
-   : (k -> a -> a) -> k -> Map k a -> Map k a :=
-  let go {k} {a} `{GHC.Base.Ord k} : (k -> a -> a) -> k -> Map k a -> Map k a :=
-    fix go (arg_0__ : (k -> a -> a)) (arg_1__ : k) (arg_2__ : Map k a) : Map k a
-          := match arg_0__, arg_1__, arg_2__ with
-             | _, _, Tip => Tip
-             | f, k, Bin sx kx x l r =>
-                 match GHC.Base.compare k kx with
-                 | Lt => Bin sx kx x (go f k l) r
-                 | Gt => Bin sx kx x l (go f k r)
-                 | Eq => Bin sx kx (f kx x) l r
-                 end
-             end in
-  go.
+(* Skipping definition `Data.Map.Internal.elemAt' *)
 
-Definition adjust {k} {a} `{GHC.Base.Ord k}
-   : (a -> a) -> k -> Map k a -> Map k a :=
-  fun f =>
-    adjustWithKey (fun arg_0__ arg_1__ =>
+Definition take {k} {a} : GHC.Num.Int -> Map k a -> Map k a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | i, m =>
+        if i GHC.Base.>= size m : bool then m else
+        match arg_0__, arg_1__ with
+        | i0, m0 =>
+            let fix go arg_2__ arg_3__
+                      := match arg_2__, arg_3__ with
+                         | i, _ =>
+                             if i GHC.Base.<= #0 : bool then Tip else
+                             match arg_2__, arg_3__ with
+                             | _, Tip => Tip
+                             | i, Bin _ kx x l r =>
+                                 let sizeL := size l in
+                                 match GHC.Base.compare i sizeL with
+                                 | Lt => go i l
+                                 | Gt => link kx x l (go ((i GHC.Num.- sizeL) GHC.Num.- #1) r)
+                                 | Eq => l
+                                 end
+                             end
+                         end in
+            go i0 m0
+        end
+    end.
+
+Definition drop {k} {a} : GHC.Num.Int -> Map k a -> Map k a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | i, m =>
+        if i GHC.Base.>= size m : bool then Tip else
+        match arg_0__, arg_1__ with
+        | i0, m0 =>
+            let fix go arg_2__ arg_3__
+                      := match arg_2__, arg_3__ with
+                         | i, m =>
+                             if i GHC.Base.<= #0 : bool then m else
+                             match arg_2__, arg_3__ with
+                             | _, Tip => Tip
+                             | i, Bin _ kx x l r =>
+                                 let sizeL := size l in
+                                 match GHC.Base.compare i sizeL with
+                                 | Lt => link kx x (go i l) r
+                                 | Gt => go ((i GHC.Num.- sizeL) GHC.Num.- #1) r
+                                 | Eq => insertMin kx x r
+                                 end
+                             end
+                         end in
+            go i0 m0
+        end
+    end.
+
+Definition splitAt {k} {a}
+   : GHC.Num.Int -> Map k a -> (Map k a * Map k a)%type :=
+  fun i0 m0 =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | i, m =>
+                     if i GHC.Base.<= #0 : bool then pair Tip m else
                      match arg_0__, arg_1__ with
-                     | _, x => f x
-                     end).
+                     | _, Tip => pair Tip Tip
+                     | i, Bin _ kx x l r =>
+                         let sizeL := size l in
+                         match GHC.Base.compare i sizeL with
+                         | Lt => let 'pair ll lr := go i l in pair ll (link kx x lr r)
+                         | Gt =>
+                             let 'pair rl rr := go ((i GHC.Num.- sizeL) GHC.Num.- #1) r in
+                             pair (link kx x l rl) rr
+                         | Eq => pair l (insertMin kx x r)
+                         end
+                     end
+                 end in
+    if i0 GHC.Base.>= size m0 : bool then pair m0 Tip else
+    id (go i0 m0).
 
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Data.Map.Internal.Show__Map' *)
+Fixpoint updateAt {k} {a} (f : (k -> a -> option a)) (i : GHC.Num.Int) (t
+                    : Map k a) : Map k a
+           := match t with
+              | Tip => GHC.Err.error (GHC.Base.hs_string__ "Map.updateAt: index out of range")
+              | Bin sx kx x l r =>
+                  let sizeL := size l in
+                  match GHC.Base.compare i sizeL with
+                  | Lt => balanceR kx x (updateAt f i l) r
+                  | Gt => balanceL kx x l (updateAt f ((i GHC.Num.- sizeL) GHC.Num.- #1) r)
+                  | Eq => match f kx x with | Some x' => Bin sx kx x' l r | None => glue l r end
+                  end
+              end.
 
-(* Skipping all instances of class `GHC.Read.Read', including
-   `Data.Map.Internal.Read__Map' *)
+Fixpoint deleteAt {k} {a} (i : GHC.Num.Int) (t : Map k a) : Map k a
+           := match t with
+              | Tip => GHC.Err.error (GHC.Base.hs_string__ "Map.deleteAt: index out of range")
+              | Bin _ kx x l r =>
+                  let sizeL := size l in
+                  match GHC.Base.compare i sizeL with
+                  | Lt => balanceR kx x (deleteAt i l) r
+                  | Gt => balanceL kx x l (deleteAt ((i GHC.Num.- sizeL) GHC.Num.- #1) r)
+                  | Eq => glue l r
+                  end
+              end.
 
-(* Skipping all instances of class `Control.DeepSeq.NFData', including
-   `Data.Map.Internal.NFData__Map' *)
+Fixpoint lookupMinSure {k} {a} (arg_0__ : k) (arg_1__ : a) (arg_2__ : Map k a)
+           : (k * a)%type
+           := match arg_0__, arg_1__, arg_2__ with
+              | k, a, Tip => pair k a
+              | _, _, Bin _ k a l _ => lookupMinSure k a l
+              end.
 
-Local Definition Foldable__Map_fold {inst_k}
-   : forall {m}, forall `{GHC.Base.Monoid m}, (Map inst_k) m -> m :=
-  fun {m} `{GHC.Base.Monoid m} =>
+Definition lookupMin {k} {a} : Map k a -> option (k * a)%type :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Tip => None
+    | Bin _ k x l _ => Some (lookupMinSure k x l)
+    end.
+
+(* Skipping definition `Data.Map.Internal.findMin' *)
+
+Fixpoint lookupMaxSure {k} {a} (arg_0__ : k) (arg_1__ : a) (arg_2__ : Map k a)
+           : (k * a)%type
+           := match arg_0__, arg_1__, arg_2__ with
+              | k, a, Tip => pair k a
+              | _, _, Bin _ k a _ r => lookupMaxSure k a r
+              end.
+
+Definition lookupMax {k} {a} : Map k a -> option (k * a)%type :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Tip => None
+    | Bin _ k x _ r => Some (lookupMaxSure k x r)
+    end.
+
+(* Skipping definition `Data.Map.Internal.findMax' *)
+
+Fixpoint deleteMin {k} {a} (arg_0__ : Map k a) : Map k a
+           := match arg_0__ with
+              | Bin _ _ _ Tip r => r
+              | Bin _ kx x l r => balanceR kx x (deleteMin l) r
+              | Tip => Tip
+              end.
+
+Fixpoint deleteMax {k} {a} (arg_0__ : Map k a) : Map k a
+           := match arg_0__ with
+              | Bin _ _ _ l Tip => l
+              | Bin _ kx x l r => balanceL kx x l (deleteMax r)
+              | Tip => Tip
+              end.
+
+Fixpoint updateMinWithKey {k} {a} (arg_0__ : (k -> a -> option a)) (arg_1__
+                            : Map k a) : Map k a
+           := match arg_0__, arg_1__ with
+              | _, Tip => Tip
+              | f, Bin sx kx x Tip r =>
+                  match f kx x with
+                  | None => r
+                  | Some x' => Bin sx kx x' Tip r
+                  end
+              | f, Bin _ kx x l r => balanceR kx x (updateMinWithKey f l) r
+              end.
+
+Definition updateMin {a} {k} : (a -> option a) -> Map k a -> Map k a :=
+  fun f m =>
+    updateMinWithKey (fun arg_0__ arg_1__ =>
+                        match arg_0__, arg_1__ with
+                        | _, x => f x
+                        end) m.
+
+Fixpoint updateMaxWithKey {k} {a} (arg_0__ : (k -> a -> option a)) (arg_1__
+                            : Map k a) : Map k a
+           := match arg_0__, arg_1__ with
+              | _, Tip => Tip
+              | f, Bin sx kx x l Tip =>
+                  match f kx x with
+                  | None => l
+                  | Some x' => Bin sx kx x' l Tip
+                  end
+              | f, Bin _ kx x l r => balanceL kx x l (updateMaxWithKey f r)
+              end.
+
+Definition updateMax {a} {k} : (a -> option a) -> Map k a -> Map k a :=
+  fun f m =>
+    updateMaxWithKey (fun arg_0__ arg_1__ =>
+                        match arg_0__, arg_1__ with
+                        | _, x => f x
+                        end) m.
+
+Definition minViewWithKey {k} {a}
+   : Map k a -> option ((k * a)%type * Map k a)%type :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Tip => None
+    | Bin _ k x l r =>
+        Some (let 'Mk_MinView km xm t := minViewSure k x l r in pair (pair km xm) t)
+    end.
+
+Definition maxViewWithKey {k} {a}
+   : Map k a -> option ((k * a)%type * Map k a)%type :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Tip => None
+    | Bin _ k x l r =>
+        Some (let 'Mk_MaxView km xm t := maxViewSure k x l r in pair (pair km xm) t)
+    end.
+
+Definition minView {k} {a} : Map k a -> option (a * Map k a)%type :=
+  fun t =>
+    match minViewWithKey t with
+    | None => None
+    | Some (pair (pair _ x) t') => Some (pair x t')
+    end.
+
+Definition maxView {k} {a} : Map k a -> option (a * Map k a)%type :=
+  fun t =>
+    match maxViewWithKey t with
+    | None => None
+    | Some (pair (pair _ x) t') => Some (pair x t')
+    end.
+
+Definition splitLookup {k} {a} `{GHC.Base.Ord k}
+   : k -> Map k a -> (Map k a * option a * Map k a)%type :=
+  fun k0 m =>
+    let go {k} {a} `{GHC.Base.Ord k}
+     : k -> Map k a -> StrictTriple (Map k a) (option a) (Map k a) :=
+      fix go (k0 : k) (t : Map k a) : StrictTriple (Map k a) (option a) (Map k a)
+            := match t with
+               | Tip => Mk_StrictTriple Tip None Tip
+               | Bin _ kx x l r =>
+                   match GHC.Base.compare k0 kx with
+                   | Lt =>
+                       let 'Mk_StrictTriple lt z gt := go k0 l in
+                       let gt' := link kx x gt r in Mk_StrictTriple lt z gt'
+                   | Gt =>
+                       let 'Mk_StrictTriple lt z gt := go k0 r in
+                       let lt' := link kx x l lt in Mk_StrictTriple lt' z gt
+                   | Eq => Mk_StrictTriple l (Some x) r
+                   end
+               end in
+    let 'Mk_StrictTriple l mv r := go k0 m in
+    pair (pair l mv) r.
+
+Fixpoint unionWith {k} {a} `{GHC.Base.Ord k} (arg_0__ : (a -> a -> a)) (arg_1__
+                    arg_2__
+                     : Map k a) : Map k a
+           := match arg_0__, arg_1__, arg_2__ with
+              | _f, t1, Tip => t1
+              | f, t1, Bin _ k x Tip Tip => insertWithR f k x t1
+              | f, Bin _ k x Tip Tip, t2 => insertWith f k x t2
+              | _f, Tip, t2 => t2
+              | f, Bin _ k1 x1 l1 r1, t2 =>
+                  let 'pair (pair l2 mb) r2 := splitLookup k1 t2 in
+                  let r1r2 := unionWith f r1 r2 in
+                  let l1l2 := unionWith f l1 l2 in
+                  match mb with
+                  | None => link k1 x1 l1l2 r1r2
+                  | Some x2 => link k1 (f x1 x2) l1l2 r1r2
+                  end
+              end.
+
+Definition unionsWith {f} {k} {a} `{Data.Foldable.Foldable f} `{GHC.Base.Ord k}
+   : (a -> a -> a) -> f (Map k a) -> Map k a :=
+  fun f ts => Data.Foldable.foldl' (unionWith f) empty ts.
+
+Fixpoint unionWithKey {k} {a} `{GHC.Base.Ord k} (arg_0__ : (k -> a -> a -> a))
+                      (arg_1__ arg_2__ : Map k a) : Map k a
+           := match arg_0__, arg_1__, arg_2__ with
+              | _f, t1, Tip => t1
+              | f, t1, Bin _ k x Tip Tip => insertWithKeyR f k x t1
+              | f, Bin _ k x Tip Tip, t2 => insertWithKey f k x t2
+              | _f, Tip, t2 => t2
+              | f, Bin _ k1 x1 l1 r1, t2 =>
+                  let 'pair (pair l2 mb) r2 := splitLookup k1 t2 in
+                  let r1r2 := unionWithKey f r1 r2 in
+                  let l1l2 := unionWithKey f l1 l2 in
+                  match mb with
+                  | None => link k1 x1 l1l2 r1r2
+                  | Some x2 => link k1 (f k1 x1 x2) l1l2 r1r2
+                  end
+              end.
+
+Definition splitMember {k} {a} `{GHC.Base.Ord k}
+   : k -> Map k a -> (Map k a * bool * Map k a)%type :=
+  fun k0 m =>
+    let go {k} {a} `{GHC.Base.Ord k}
+     : k -> Map k a -> StrictTriple (Map k a) bool (Map k a) :=
+      fix go (k0 : k) (t : Map k a) : StrictTriple (Map k a) bool (Map k a)
+            := match t with
+               | Tip => Mk_StrictTriple Tip false Tip
+               | Bin _ kx x l r =>
+                   match GHC.Base.compare k0 kx with
+                   | Lt =>
+                       let 'Mk_StrictTriple lt z gt := go k0 l in
+                       let gt' := link kx x gt r in Mk_StrictTriple lt z gt'
+                   | Gt =>
+                       let 'Mk_StrictTriple lt z gt := go k0 r in
+                       let lt' := link kx x l lt in Mk_StrictTriple lt' z gt
+                   | Eq => Mk_StrictTriple l true r
+                   end
+               end in
+    let 'Mk_StrictTriple l mv r := go k0 m in
+    pair (pair l mv) r.
+
+Fixpoint withoutKeys {k} {a} `{GHC.Base.Ord k} (arg_0__ : Map k a) (arg_1__
+                       : Data.Set.Internal.Set_ k) : Map k a
+           := match arg_0__, arg_1__ with
+              | Tip, _ => Tip
+              | m, Data.Set.Internal.Tip => m
+              | m, Data.Set.Internal.Bin _ k ls rs =>
+                  let 'pair (pair lm b) rm := splitMember k m in
+                  let rm' := withoutKeys rm rs in
+                  let lm' := withoutKeys lm ls in
+                  if andb (negb b) (andb (Utils.Containers.Internal.PtrEquality.ptrEq lm' lm)
+                                         (Utils.Containers.Internal.PtrEquality.ptrEq rm' rm)) : bool
+                  then m else
+                  link2 lm' rm'
+              end.
+
+(* Skipping definition `Data.Map.Internal.differenceWith' *)
+
+(* Skipping definition `Data.Map.Internal.differenceWithKey' *)
+
+Fixpoint intersection {k} {a} {b} `{GHC.Base.Ord k} (arg_0__ : Map k a) (arg_1__
+                        : Map k b) : Map k a
+           := match arg_0__, arg_1__ with
+              | Tip, _ => Tip
+              | _, Tip => Tip
+              | (Bin _ k x l1 r1 as t1), t2 =>
+                  let 'pair (pair l2 mb) r2 := splitMember k t2 in
+                  let l1l2 := intersection l1 l2 in
+                  let r1r2 := intersection r1 r2 in
+                  if mb : bool
+                  then if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1l2 l1)
+                               (Utils.Containers.Internal.PtrEquality.ptrEq r1r2 r1) : bool
+                       then t1
+                       else link k x l1l2 r1r2 else
+                  link2 l1l2 r1r2
+              end.
+
+Fixpoint restrictKeys {k} {a} `{GHC.Base.Ord k} (arg_0__ : Map k a) (arg_1__
+                        : Data.Set.Internal.Set_ k) : Map k a
+           := match arg_0__, arg_1__ with
+              | Tip, _ => Tip
+              | _, Data.Set.Internal.Tip => Tip
+              | (Bin _ k x l1 r1 as m), s =>
+                  let 'pair (pair l2 b) r2 := Data.Set.Internal.splitMember k s in
+                  let l1l2 := restrictKeys l1 l2 in
+                  let r1r2 := restrictKeys r1 r2 in
+                  if b : bool
+                  then if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1l2 l1)
+                               (Utils.Containers.Internal.PtrEquality.ptrEq r1r2 r1) : bool
+                       then m
+                       else link k x l1l2 r1r2 else
+                  link2 l1l2 r1r2
+              end.
+
+Fixpoint intersectionWith {k} {a} {b} {c} `{GHC.Base.Ord k} (arg_0__
+                            : (a -> b -> c)) (arg_1__ : Map k a) (arg_2__ : Map k b) : Map k c
+           := match arg_0__, arg_1__, arg_2__ with
+              | _f, Tip, _ => Tip
+              | _f, _, Tip => Tip
+              | f, Bin _ k x1 l1 r1, t2 =>
+                  let 'pair (pair l2 mb) r2 := splitLookup k t2 in
+                  let l1l2 := intersectionWith f l1 l2 in
+                  let r1r2 := intersectionWith f r1 r2 in
+                  match mb with
+                  | Some x2 => link k (f x1 x2) l1l2 r1r2
+                  | None => link2 l1l2 r1r2
+                  end
+              end.
+
+Fixpoint intersectionWithKey {k} {a} {b} {c} `{GHC.Base.Ord k} (arg_0__
+                               : (k -> a -> b -> c)) (arg_1__ : Map k a) (arg_2__ : Map k b) : Map k c
+           := match arg_0__, arg_1__, arg_2__ with
+              | _f, Tip, _ => Tip
+              | _f, _, Tip => Tip
+              | f, Bin _ k x1 l1 r1, t2 =>
+                  let 'pair (pair l2 mb) r2 := splitLookup k t2 in
+                  let l1l2 := intersectionWithKey f l1 l2 in
+                  let r1r2 := intersectionWithKey f r1 r2 in
+                  match mb with
+                  | Some x2 => link k (f k x1 x2) l1l2 r1r2
+                  | None => link2 l1l2 r1r2
+                  end
+              end.
+
+Definition mapGentlyWhenMissing {f} {a} {b} {k} {x} `{GHC.Base.Functor f}
+   : (a -> b) -> WhenMissing f k x a -> WhenMissing f k x b :=
+  fun f t =>
+    Mk_WhenMissing (fun m => GHC.Base.fmap f Data.Functor.<$> missingSubtree t m)
+                   (fun k x => GHC.Base.fmap f Data.Functor.<$> missingKey t k x).
+
+Definition runWhenMatched {f} {k} {x} {y} {z}
+   : WhenMatched f k x y z -> k -> x -> y -> f (option z) :=
+  matchedKey.
+
+Definition zipWithMaybeAMatched {k} {x} {y} {f} {z}
+   : (k -> x -> y -> f (option z)) -> WhenMatched f k x y z :=
+  fun f => Mk_WhenMatched (fun k x y => f k x y).
+
+Definition mapGentlyWhenMatched {f} {a} {b} {k} {x} {y} `{GHC.Base.Functor f}
+   : (a -> b) -> WhenMatched f k x y a -> WhenMatched f k x y b :=
+  fun f t =>
+    zipWithMaybeAMatched (fun k x y =>
+                            GHC.Base.fmap f Data.Functor.<$> runWhenMatched t k x y).
+
+Definition lmapWhenMissing {b} {a} {f} {k} {x}
+   : (b -> a) -> WhenMissing f k a x -> WhenMissing f k b x :=
+  fun f t =>
+    Mk_WhenMissing (fun m => missingSubtree t (GHC.Base.fmap f m)) (fun k x =>
+                      missingKey t k (f x)).
+
+Definition contramapFirstWhenMatched {b} {a} {f} {k} {y} {z}
+   : (b -> a) -> WhenMatched f k a y z -> WhenMatched f k b y z :=
+  fun f t => Mk_WhenMatched (fun k x y => runWhenMatched t k (f x) y).
+
+Definition contramapSecondWhenMatched {b} {a} {f} {k} {x} {z}
+   : (b -> a) -> WhenMatched f k x a z -> WhenMatched f k x b z :=
+  fun f t => Mk_WhenMatched (fun k x y => runWhenMatched t k x (f y)).
+
+Definition runWhenMissing {f} {k} {x} {y}
+   : WhenMissing f k x y -> k -> x -> f (option y) :=
+  missingKey.
+
+Definition zipWithMatched {f} {k} {x} {y} {z} `{GHC.Base.Applicative f}
+   : (k -> x -> y -> z) -> WhenMatched f k x y z :=
+  fun f =>
+    Mk_WhenMatched (fun k x y => (GHC.Base.pure GHC.Base.∘ Some) (f k x y)).
+
+Definition zipWithAMatched {f} {k} {x} {y} {z} `{GHC.Base.Applicative f}
+   : (k -> x -> y -> f z) -> WhenMatched f k x y z :=
+  fun f => Mk_WhenMatched (fun k x y => Some Data.Functor.<$> f k x y).
+
+Definition zipWithMaybeMatched {f} {k} {x} {y} {z} `{GHC.Base.Applicative f}
+   : (k -> x -> y -> option z) -> WhenMatched f k x y z :=
+  fun f => Mk_WhenMatched (fun k x y => GHC.Base.pure (f k x y)).
+
+Definition dropMissing {f} {k} {x} {y} `{GHC.Base.Applicative f}
+   : WhenMissing f k x y :=
+  Mk_WhenMissing (GHC.Base.const (GHC.Base.pure Tip)) (fun arg_0__ arg_1__ =>
+                    GHC.Base.pure None).
+
+Definition preserveMissing {f} {k} {x} `{GHC.Base.Applicative f}
+   : WhenMissing f k x x :=
+  Mk_WhenMissing GHC.Base.pure (fun arg_0__ arg_1__ =>
+                    match arg_0__, arg_1__ with
+                    | _, v => GHC.Base.pure (Some v)
+                    end).
+
+Fixpoint mapWithKey {k} {a} {b} (arg_0__ : (k -> a -> b)) (arg_1__ : Map k a)
+           : Map k b
+           := match arg_0__, arg_1__ with
+              | _, Tip => Tip
+              | f, Bin sx kx x l r => Bin sx kx (f kx x) (mapWithKey f l) (mapWithKey f r)
+              end.
+
+Definition mapMissing {f} {k} {x} {y} `{GHC.Base.Applicative f}
+   : (k -> x -> y) -> WhenMissing f k x y :=
+  fun f =>
+    Mk_WhenMissing (fun m => GHC.Base.pure (mapWithKey f m)) (fun k x =>
+                      GHC.Base.pure (Some (f k x))).
+
+Fixpoint mapMaybeWithKey {k} {a} {b} (arg_0__ : (k -> a -> option b)) (arg_1__
+                           : Map k a) : Map k b
+           := match arg_0__, arg_1__ with
+              | _, Tip => Tip
+              | f, Bin _ kx x l r =>
+                  match f kx x with
+                  | Some y => link kx y (mapMaybeWithKey f l) (mapMaybeWithKey f r)
+                  | None => link2 (mapMaybeWithKey f l) (mapMaybeWithKey f r)
+                  end
+              end.
+
+Definition mapMaybeMissing {f} {k} {x} {y} `{GHC.Base.Applicative f}
+   : (k -> x -> option y) -> WhenMissing f k x y :=
+  fun f =>
+    Mk_WhenMissing (fun m => GHC.Base.pure (mapMaybeWithKey f m)) (fun k x =>
+                      GHC.Base.pure (f k x)).
+
+Fixpoint filterWithKey {k} {a} (arg_0__ : (k -> a -> bool)) (arg_1__ : Map k a)
+           : Map k a
+           := match arg_0__, arg_1__ with
+              | _, Tip => Tip
+              | p, (Bin _ kx x l r as t) =>
+                  let pr := filterWithKey p r in
+                  let pl := filterWithKey p l in
+                  if p kx x : bool
+                  then if andb (Utils.Containers.Internal.PtrEquality.ptrEq pl l)
+                               (Utils.Containers.Internal.PtrEquality.ptrEq pr r) : bool
+                       then t
+                       else link kx x pl pr else
+                  link2 pl pr
+              end.
+
+Definition filterMissing {f} {k} {x} `{GHC.Base.Applicative f}
+   : (k -> x -> bool) -> WhenMissing f k x x :=
+  fun f =>
+    Mk_WhenMissing (fun m => GHC.Base.pure (filterWithKey f m)) (fun k x =>
+                      GHC.Base.pure (if f k x : bool then Some x else None)).
+
+Definition boolITE {a} : a -> a -> bool -> a :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | f, _, false => f
+    | _, t, true => t
+    end.
+
+Fixpoint filterWithKeyA {f} {k} {a} `{GHC.Base.Applicative f} (arg_0__
+                          : (k -> a -> f bool)) (arg_1__ : Map k a) : f (Map k a)
+           := match arg_0__, arg_1__ with
+              | _, Tip => GHC.Base.pure Tip
+              | p, (Bin _ kx x l r as t) =>
+                  let combine :=
+                    fun arg_3__ arg_4__ arg_5__ =>
+                      match arg_3__, arg_4__, arg_5__ with
+                      | true, pl, pr =>
+                          if andb (Utils.Containers.Internal.PtrEquality.ptrEq pl l)
+                                  (Utils.Containers.Internal.PtrEquality.ptrEq pr r) : bool
+                          then t else
+                          link kx x pl pr
+                      | false, pl, pr => link2 pl pr
+                      end in
+                  GHC.Base.liftA3 combine (p kx x) (filterWithKeyA p l) (filterWithKeyA p r)
+              end.
+
+Definition filterAMissing {f} {k} {x} `{GHC.Base.Applicative f}
+   : (k -> x -> f bool) -> WhenMissing f k x x :=
+  fun f =>
+    Mk_WhenMissing (fun m => filterWithKeyA f m) (fun k x =>
+                      boolITE None (Some x) Data.Functor.<$> f k x).
+
+Definition traverseMissing {f} {k} {x} {y} `{GHC.Base.Applicative f}
+   : (k -> x -> f y) -> WhenMissing f k x y :=
+  fun f =>
+    Mk_WhenMissing (traverseWithKey f) (fun k x => Some Data.Functor.<$> f k x).
+
+Definition traverseMaybeWithKey {f} {k} {a} {b} `{GHC.Base.Applicative f}
+   : (k -> a -> f (option b)) -> Map k a -> f (Map k b) :=
+  let fix go arg_0__ arg_1__
+            := match arg_0__, arg_1__ with
+               | _, Tip => GHC.Base.pure Tip
+               | f, Bin _ kx x Tip Tip =>
+                   Data.Maybe.maybe Tip (fun x' => Bin #1 kx x' Tip Tip) Data.Functor.<$> f kx x
+               | f, Bin _ kx x l r =>
+                   let combine :=
+                     fun l' mx r' =>
+                       match mx with
+                       | None => link2 l' r'
+                       | Some x' => link kx x' l' r'
+                       end in
+                   GHC.Base.liftA3 combine (go f l) (f kx x) (go f r)
+               end in
+  go.
+
+Definition traverseMaybeMissing {f} {k} {x} {y} `{GHC.Base.Applicative f}
+   : (k -> x -> f (option y)) -> WhenMissing f k x y :=
+  fun f => Mk_WhenMissing (traverseMaybeWithKey f) f.
+
+Definition mergeA {f} {k} {a} {c} {b} `{GHC.Base.Applicative f} `{GHC.Base.Ord
+  k}
+   : WhenMissing f k a c ->
+     WhenMissing f k b c ->
+     WhenMatched f k a b c -> Map k a -> Map k b -> f (Map k c) :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | Mk_WhenMissing g1t g1k, Mk_WhenMissing g2t _, Mk_WhenMatched f =>
+        let fix go arg_3__ arg_4__
+                  := match arg_3__, arg_4__ with
+                     | t1, Tip => g1t t1
+                     | Tip, t2 => g2t t2
+                     | Bin _ kx x1 l1 r1, t2 =>
+                         let 'pair (pair l2 mx2) r2 := splitLookup kx t2 in
+                         let r1r2 := go r1 r2 in
+                         let l1l2 := go l1 l2 in
+                         match mx2 with
+                         | None =>
+                             GHC.Base.liftA3 (fun l' mx' r' => Data.Maybe.maybe link2 (link kx) mx' l' r')
+                             l1l2 (g1k kx x1) r1r2
+                         | Some x2 =>
+                             GHC.Base.liftA3 (fun l' mx' r' => Data.Maybe.maybe link2 (link kx) mx' l' r')
+                             l1l2 (f kx x1 x2) r1r2
+                         end
+                     end in
+        go
+    end.
+
+Definition merge {k} {a} {c} {b} `{GHC.Base.Ord k}
+   : SimpleWhenMissing k a c ->
+     SimpleWhenMissing k b c ->
+     SimpleWhenMatched k a b c -> Map k a -> Map k b -> Map k c :=
+  fun g1 g2 f m1 m2 => Data.Functor.Identity.runIdentity (mergeA g1 g2 f m1 m2).
+
+Definition mergeWithKey {k} {a} {b} {c} `{GHC.Base.Ord k}
+   : (k -> a -> b -> option c) ->
+     (Map k a -> Map k c) -> (Map k b -> Map k c) -> Map k a -> Map k b -> Map k c :=
+  fun f g1 g2 =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | Tip, t2 => g2 t2
+                 | t1, Tip => g1 t1
+                 | Bin _ kx x l1 r1, t2 =>
+                     let 'pair (pair l2 found) r2 := splitLookup kx t2 in
+                     let l' := go l1 l2 in
+                     let r' := go r1 r2 in
+                     match found with
+                     | None =>
+                         match g1 (singleton kx x) with
+                         | Tip => link2 l' r'
+                         | Bin _ _ x' Tip Tip => link kx x' l' r'
+                         | _ =>
+                             GHC.Err.error (GHC.Base.hs_string__
+                                            "mergeWithKey: Given function only1 does not fulfill required conditions (see documentation)")
+                         end
+                     | Some x2 =>
+                         match f kx x x2 with
+                         | None => link2 l' r'
+                         | Some x' => link kx x' l' r'
+                         end
+                     end
+                 end in
+    go.
+
+Fixpoint submap' {a} {b} {c} `{GHC.Base.Ord a} (arg_0__ : (b -> c -> bool))
+                 (arg_1__ : Map a b) (arg_2__ : Map a c) : bool
+           := match arg_0__, arg_1__, arg_2__ with
+              | _, Tip, _ => true
+              | _, _, Tip => false
+              | f, Bin _ kx x l r, t =>
+                  let 'pair (pair lt found) gt := splitLookup kx t in
+                  match found with
+                  | None => false
+                  | Some y => andb (f x y) (andb (submap' f l lt) (submap' f r gt))
+                  end
+              end.
+
+Definition isSubmapOfBy {k} {a} {b} `{GHC.Base.Ord k}
+   : (a -> b -> bool) -> Map k a -> Map k b -> bool :=
+  fun f t1 t2 => andb (size t1 GHC.Base.<= size t2) (submap' f t1 t2).
+
+Definition isSubmapOf {k} {a} `{GHC.Base.Ord k} `{GHC.Base.Eq_ a}
+   : Map k a -> Map k a -> bool :=
+  fun m1 m2 => isSubmapOfBy _GHC.Base.==_ m1 m2.
+
+Definition isProperSubmapOfBy {k} {a} {b} `{GHC.Base.Ord k}
+   : (a -> b -> bool) -> Map k a -> Map k b -> bool :=
+  fun f t1 t2 => andb (size t1 GHC.Base.< size t2) (submap' f t1 t2).
+
+Definition isProperSubmapOf {k} {a} `{GHC.Base.Ord k} `{GHC.Base.Eq_ a}
+   : Map k a -> Map k a -> bool :=
+  fun m1 m2 => isProperSubmapOfBy _GHC.Base.==_ m1 m2.
+
+Definition filter {a} {k} : (a -> bool) -> Map k a -> Map k a :=
+  fun p m =>
+    filterWithKey (fun arg_0__ arg_1__ =>
+                     match arg_0__, arg_1__ with
+                     | _, x => p x
+                     end) m.
+
+Fixpoint takeWhileAntitone {k} {a} (arg_0__ : (k -> bool)) (arg_1__ : Map k a)
+           : Map k a
+           := match arg_0__, arg_1__ with
+              | _, Tip => Tip
+              | p, Bin _ kx x l r =>
+                  if p kx : bool then link kx x l (takeWhileAntitone p r) else
+                  takeWhileAntitone p l
+              end.
+
+Fixpoint dropWhileAntitone {k} {a} (arg_0__ : (k -> bool)) (arg_1__ : Map k a)
+           : Map k a
+           := match arg_0__, arg_1__ with
+              | _, Tip => Tip
+              | p, Bin _ kx x l r =>
+                  if p kx : bool then dropWhileAntitone p r else
+                  link kx x (dropWhileAntitone p l) r
+              end.
+
+Definition spanAntitone {k} {a}
+   : (k -> bool) -> Map k a -> (Map k a * Map k a)%type :=
+  fun p0 m =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | _, Tip => pair Tip Tip
+                 | p, Bin _ kx x l r =>
+                     if p kx : bool then let 'pair u v := go p r in pair (link kx x l u) v else
+                     let 'pair u v := go p l in
+                     pair u (link kx x v r)
+                 end in
+    id (go p0 m).
+
+Definition partitionWithKey {k} {a}
+   : (k -> a -> bool) -> Map k a -> (Map k a * Map k a)%type :=
+  fun p0 t0 =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | _, Tip => (pair Tip Tip)
+                 | p, (Bin _ kx x l r as t) =>
+                     let 'pair r1 r2 := go p r in
+                     let 'pair l1 l2 := go p l in
+                     if p kx x : bool
+                     then pair (if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1 l)
+                                        (Utils.Containers.Internal.PtrEquality.ptrEq r1 r) : bool
+                                then t
+                                else link kx x l1 r1) (link2 l2 r2) else
+                     pair (link2 l1 r1) (if andb (Utils.Containers.Internal.PtrEquality.ptrEq l2 l)
+                                                 (Utils.Containers.Internal.PtrEquality.ptrEq r2 r) : bool
+                           then t
+                           else link kx x l2 r2)
+                 end in
+    id (go p0 t0).
+
+Definition partition {a} {k}
+   : (a -> bool) -> Map k a -> (Map k a * Map k a)%type :=
+  fun p m =>
+    partitionWithKey (fun arg_0__ arg_1__ =>
+                        match arg_0__, arg_1__ with
+                        | _, x => p x
+                        end) m.
+
+Definition mapMaybe {a} {b} {k} : (a -> option b) -> Map k a -> Map k b :=
+  fun f =>
+    mapMaybeWithKey (fun arg_0__ arg_1__ =>
+                       match arg_0__, arg_1__ with
+                       | _, x => f x
+                       end).
+
+Definition mapEitherWithKey {k} {a} {b} {c}
+   : (k -> a -> Data.Either.Either b c) -> Map k a -> (Map k b * Map k c)%type :=
+  fun f0 t0 =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | _, Tip => (pair Tip Tip)
+                 | f, Bin _ kx x l r =>
+                     let 'pair r1 r2 := go f r in
+                     let 'pair l1 l2 := go f l in
+                     match f kx x with
+                     | Data.Either.Left y => pair (link kx y l1 r1) (link2 l2 r2)
+                     | Data.Either.Right z => pair (link2 l1 r1) (link kx z l2 r2)
+                     end
+                 end in
+    id (go f0 t0).
+
+Definition mapEither {a} {b} {c} {k}
+   : (a -> Data.Either.Either b c) -> Map k a -> (Map k b * Map k c)%type :=
+  fun f m =>
+    mapEitherWithKey (fun arg_0__ arg_1__ =>
+                        match arg_0__, arg_1__ with
+                        | _, x => f x
+                        end) m.
+
+Fixpoint mapAccumL {a} {k} {b} {c} (arg_0__ : (a -> k -> b -> (a * c)%type))
+                   (arg_1__ : a) (arg_2__ : Map k b) : (a * Map k c)%type
+           := match arg_0__, arg_1__, arg_2__ with
+              | _, a, Tip => pair a Tip
+              | f, a, Bin sx kx x l r =>
+                  let 'pair a1 l' := mapAccumL f a l in
+                  let 'pair a2 x' := f a1 kx x in
+                  let 'pair a3 r' := mapAccumL f a2 r in
+                  pair a3 (Bin sx kx x' l' r')
+              end.
+
+Definition mapAccumWithKey {a} {k} {b} {c}
+   : (a -> k -> b -> (a * c)%type) -> a -> Map k b -> (a * Map k c)%type :=
+  fun f a t => mapAccumL f a t.
+
+Definition mapAccum {a} {b} {c} {k}
+   : (a -> b -> (a * c)%type) -> a -> Map k b -> (a * Map k c)%type :=
+  fun f a m =>
+    mapAccumWithKey (fun arg_0__ arg_1__ arg_2__ =>
+                       match arg_0__, arg_1__, arg_2__ with
+                       | a', _, x' => f a' x'
+                       end) a m.
+
+Fixpoint mapAccumRWithKey {a} {k} {b} {c} (arg_0__
+                            : (a -> k -> b -> (a * c)%type)) (arg_1__ : a) (arg_2__ : Map k b) : (a *
+                                                                                                  Map k c)%type
+           := match arg_0__, arg_1__, arg_2__ with
+              | _, a, Tip => pair a Tip
+              | f, a, Bin sx kx x l r =>
+                  let 'pair a1 r' := mapAccumRWithKey f a r in
+                  let 'pair a2 x' := f a1 kx x in
+                  let 'pair a3 l' := mapAccumRWithKey f a2 l in
+                  pair a3 (Bin sx kx x' l' r')
+              end.
+
+Definition fromList {k} {a} `{GHC.Base.Ord k} : list (k * a)%type -> Map k a :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | nil => Tip
+    | cons (pair kx x) nil => Bin #1 kx x Tip Tip
+    | cons (pair kx0 x0) xs0 =>
+        let fromList' :=
+          fun t0 xs =>
+            let ins :=
+              fun arg_2__ arg_3__ =>
+                match arg_2__, arg_3__ with
+                | t, pair k x => insert k x t
+                end in
+            Data.Foldable.foldl' ins t0 xs in
+        let not_ordered :=
+          fun arg_7__ arg_8__ =>
+            match arg_7__, arg_8__ with
+            | _, nil => false
+            | kx, cons (pair ky _) _ => kx GHC.Base.>= ky
+            end in
+        let create :=
+          GHC.DeferredFix.deferredFix2 (fun create arg_11__ arg_12__ =>
+                                          match arg_11__, arg_12__ with
+                                          | _, nil => pair (pair Tip nil) nil
+                                          | s, (cons xp xss as xs) =>
+                                              if s GHC.Base.== #1 : bool
+                                              then let 'pair kx x := xp in
+                                                   if not_ordered kx xss : bool
+                                                   then pair (pair (Bin #1 kx x Tip Tip) nil) xss else
+                                                   pair (pair (Bin #1 kx x Tip Tip) xss) nil else
+                                              match create (Data.Bits.shiftR s #1) xs with
+                                              | (pair (pair _ nil) _ as res) => res
+                                              | pair (pair l (cons (pair ky y) nil)) zs =>
+                                                  pair (pair (insertMax ky y l) nil) zs
+                                              | pair (pair l (cons (pair ky y) yss as ys)) _ =>
+                                                  if not_ordered ky yss : bool then pair (pair l nil) ys else
+                                                  let 'pair (pair r zs) ws := create (Data.Bits.shiftR s #1) yss in
+                                                  pair (pair (link ky y l r) zs) ws
+                                              end
+                                          end) in
+        let go :=
+          GHC.DeferredFix.deferredFix3 (fun go arg_28__ arg_29__ arg_30__ =>
+                                          match arg_28__, arg_29__, arg_30__ with
+                                          | _, t, nil => t
+                                          | _, t, cons (pair kx x) nil => insertMax kx x t
+                                          | s, l, (cons (pair kx x) xss as xs) =>
+                                              if not_ordered kx xss : bool then fromList' l xs else
+                                              match create s xss with
+                                              | pair (pair r ys) nil => go (Data.Bits.shiftL s #1) (link kx x l r) ys
+                                              | pair (pair r _) ys => fromList' (link kx x l r) ys
+                                              end
+                                          end) in
+        if not_ordered kx0 xs0 : bool then fromList' (Bin #1 kx0 x0 Tip Tip) xs0 else
+        go (#1 : GHC.Num.Int) (Bin #1 kx0 x0 Tip Tip) xs0
+    end.
+
+Definition mapKeys {k2} {k1} {a} `{GHC.Base.Ord k2}
+   : (k1 -> k2) -> Map k1 a -> Map k2 a :=
+  fun f =>
+    fromList GHC.Base.∘ foldrWithKey (fun k x xs => cons (pair (f k) x) xs) nil.
+
+Definition fromListWithKey {k} {a} `{GHC.Base.Ord k}
+   : (k -> a -> a -> a) -> list (k * a)%type -> Map k a :=
+  fun f xs =>
+    let ins :=
+      fun arg_0__ arg_1__ =>
+        match arg_0__, arg_1__ with
+        | t, pair k x => insertWithKey f k x t
+        end in
+    Data.Foldable.foldl' ins empty xs.
+
+Definition fromListWith {k} {a} `{GHC.Base.Ord k}
+   : (a -> a -> a) -> list (k * a)%type -> Map k a :=
+  fun f xs =>
+    fromListWithKey (fun arg_0__ arg_1__ arg_2__ =>
+                       match arg_0__, arg_1__, arg_2__ with
+                       | _, x, y => f x y
+                       end) xs.
+
+Definition mapKeysWith {k2} {a} {k1} `{GHC.Base.Ord k2}
+   : (a -> a -> a) -> (k1 -> k2) -> Map k1 a -> Map k2 a :=
+  fun c f =>
+    fromListWith c GHC.Base.∘
+    foldrWithKey (fun k x xs => cons (pair (f k) x) xs) nil.
+
+Fixpoint mapKeysMonotonic {k1} {k2} {a} (arg_0__ : (k1 -> k2)) (arg_1__
+                            : Map k1 a) : Map k2 a
+           := match arg_0__, arg_1__ with
+              | _, Tip => Tip
+              | f, Bin sz k x l r =>
+                  Bin sz (f k) x (mapKeysMonotonic f l) (mapKeysMonotonic f r)
+              end.
+
+Definition foldrWithKey' {k} {a} {b}
+   : (k -> a -> b -> b) -> b -> Map k a -> b :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Tip => z'
+                 | z', Bin _ kx x l r => go (f kx x (go z' r)) l
+                 end in
+    go z.
+
+Definition foldlWithKey {a} {k} {b} : (a -> k -> b -> a) -> a -> Map k b -> a :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Tip => z'
+                 | z', Bin _ kx x l r => go (f (go z' l) kx x) r
+                 end in
+    go z.
+
+Definition foldlWithKey' {a} {k} {b}
+   : (a -> k -> b -> a) -> a -> Map k b -> a :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Tip => z'
+                 | z', Bin _ kx x l r => go (f (go z' l) kx x) r
+                 end in
+    go z.
+
+Definition foldMapWithKey {m} {k} {a} `{GHC.Base.Monoid m}
+   : (k -> a -> m) -> Map k a -> m :=
+  fun f =>
     let fix go arg_0__
               := match arg_0__ with
                  | Tip => GHC.Base.mempty
-                 | Bin num_1__ _ v _ _ =>
-                     if num_1__ GHC.Base.== #1 : bool then v else
+                 | Bin num_1__ k v _ _ =>
+                     if num_1__ GHC.Base.== #1 : bool then f k v else
                      match arg_0__ with
-                     | Bin _ _ v l r => GHC.Base.mappend (go l) (GHC.Base.mappend v (go r))
+                     | Bin _ k v l r => GHC.Base.mappend (go l) (GHC.Base.mappend (f k v) (go r))
                      | _ => GHC.Err.patternFailure
                      end
                  end in
     go.
 
-Local Definition Foldable__Map_foldMap {inst_k}
-   : forall {m} {a},
-     forall `{GHC.Base.Monoid m}, (a -> m) -> (Map inst_k) a -> m :=
-  fun {m} {a} `{GHC.Base.Monoid m} =>
-    fun f t =>
-      let fix go arg_0__
-                := match arg_0__ with
-                   | Tip => GHC.Base.mempty
-                   | Bin num_1__ _ v _ _ =>
-                       if num_1__ GHC.Base.== #1 : bool then f v else
-                       match arg_0__ with
-                       | Bin _ _ v l r => GHC.Base.mappend (go l) (GHC.Base.mappend (f v) (go r))
-                       | _ => GHC.Err.patternFailure
-                       end
-                   end in
-      go t.
+Definition keys {k} {a} : Map k a -> list k :=
+  foldrWithKey (fun arg_0__ arg_1__ arg_2__ =>
+                  match arg_0__, arg_1__, arg_2__ with
+                  | k, _, ks => cons k ks
+                  end) nil.
 
-Local Definition Foldable__Map_foldl {inst_k}
-   : forall {b} {a}, (b -> a -> b) -> b -> (Map inst_k) a -> b :=
-  fun {b} {a} => foldl.
+Definition assocs {k} {a} : Map k a -> list (k * a)%type :=
+  fun m => toAscList m.
 
-Local Definition Foldable__Map_foldl' {inst_k}
-   : forall {b} {a}, (b -> a -> b) -> b -> (Map inst_k) a -> b :=
-  fun {b} {a} => foldl'.
+Fixpoint keysSet {k} {a} (arg_0__ : Map k a) : Data.Set.Internal.Set_ k
+           := match arg_0__ with
+              | Tip => Data.Set.Internal.Tip
+              | Bin sz kx _ l r => Data.Set.Internal.Bin sz kx (keysSet l) (keysSet r)
+              end.
 
-Local Definition Foldable__Map_foldr {inst_k}
-   : forall {a} {b}, (a -> b -> b) -> b -> (Map inst_k) a -> b :=
-  fun {a} {b} => foldr.
+Fixpoint fromSet {k} {a} (arg_0__ : (k -> a)) (arg_1__
+                   : Data.Set.Internal.Set_ k) : Map k a
+           := match arg_0__, arg_1__ with
+              | _, Data.Set.Internal.Tip => Tip
+              | f, Data.Set.Internal.Bin sz x l r =>
+                  Bin sz x (f x) (fromSet f l) (fromSet f r)
+              end.
 
-Local Definition Foldable__Map_foldr' {inst_k}
-   : forall {a} {b}, (a -> b -> b) -> b -> (Map inst_k) a -> b :=
-  fun {a} {b} => foldr'.
+Definition toDescList {k} {a} : Map k a -> list (k * a)%type :=
+  foldlWithKey (fun xs k x => cons (pair k x) xs) nil.
 
-Local Definition Foldable__Map_length {inst_k}
-   : forall {a}, (Map inst_k) a -> GHC.Num.Int :=
-  fun {a} => size.
+Definition foldrFB {k} {a} {b} : (k -> a -> b -> b) -> b -> Map k a -> b :=
+  foldrWithKey.
 
-Local Definition Foldable__Map_null {inst_k}
-   : forall {a}, (Map inst_k) a -> bool :=
-  fun {a} => null.
+Definition foldlFB {a} {k} {b} : (a -> k -> b -> a) -> a -> Map k b -> a :=
+  foldlWithKey.
 
-Local Definition Foldable__Map_product {inst_k}
-   : forall {a}, forall `{GHC.Num.Num a}, (Map inst_k) a -> a :=
-  fun {a} `{GHC.Num.Num a} => foldl' _GHC.Num.*_ #1.
+Definition fromDistinctAscList {k} {a} : list (k * a)%type -> Map k a :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | nil => Tip
+    | cons (pair kx0 x0) xs0 =>
+        let create :=
+          GHC.DeferredFix.deferredFix2 (fun create arg_1__ arg_2__ =>
+                                          match arg_1__, arg_2__ with
+                                          | _, nil => (pair Tip nil)
+                                          | s, (cons x' xs' as xs) =>
+                                              if s GHC.Base.== #1 : bool
+                                              then let 'pair kx x := x' in
+                                                   (pair (Bin #1 kx x Tip Tip) xs') else
+                                              match create (Data.Bits.shiftR s #1) xs with
+                                              | (pair _ nil as res) => res
+                                              | pair l (cons (pair ky y) ys) =>
+                                                  let 'pair r zs := create (Data.Bits.shiftR s #1) ys in
+                                                  (pair (link ky y l r) zs)
+                                              end
+                                          end) in
+        let go :=
+          GHC.DeferredFix.deferredFix3 (fun go arg_15__ arg_16__ arg_17__ =>
+                                          match arg_15__, arg_16__, arg_17__ with
+                                          | _, t, nil => t
+                                          | s, l, cons (pair kx x) xs =>
+                                              let 'pair r ys := create s xs in
+                                              let t' := link kx x l r in go (Data.Bits.shiftL s #1) t' ys
+                                          end) in
+        go (#1 : GHC.Num.Int) (Bin #1 kx0 x0 Tip Tip) xs0
+    end.
 
-Local Definition Foldable__Map_sum {inst_k}
-   : forall {a}, forall `{GHC.Num.Num a}, (Map inst_k) a -> a :=
-  fun {a} `{GHC.Num.Num a} => foldl' _GHC.Num.+_ #0.
+Definition fromAscList {k} {a} `{GHC.Base.Eq_ k}
+   : list (k * a)%type -> Map k a :=
+  fun xs =>
+    let fix combineEq' arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z, nil => cons z nil
+                 | (pair kz _ as z), cons (pair kx xx as x) xs' =>
+                     if kx GHC.Base.== kz : bool then combineEq' (pair kx xx) xs' else
+                     cons z (combineEq' x xs')
+                 end in
+    let combineEq :=
+      fun xs' =>
+        match xs' with
+        | nil => nil
+        | cons x nil => cons x nil
+        | cons x xx => combineEq' x xx
+        end in
+    fromDistinctAscList (combineEq xs).
 
-Local Definition Foldable__Map_toList {inst_k}
-   : forall {a}, (Map inst_k) a -> list a :=
-  fun {a} => elems.
+Definition fromDistinctDescList {k} {a} : list (k * a)%type -> Map k a :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | nil => Tip
+    | cons (pair kx0 x0) xs0 =>
+        let create :=
+          GHC.DeferredFix.deferredFix2 (fun create arg_1__ arg_2__ =>
+                                          match arg_1__, arg_2__ with
+                                          | _, nil => (pair Tip nil)
+                                          | s, (cons x' xs' as xs) =>
+                                              if s GHC.Base.== #1 : bool
+                                              then let 'pair kx x := x' in
+                                                   (pair (Bin #1 kx x Tip Tip) xs') else
+                                              match create (Data.Bits.shiftR s #1) xs with
+                                              | (pair _ nil as res) => res
+                                              | pair r (cons (pair ky y) ys) =>
+                                                  let 'pair l zs := create (Data.Bits.shiftR s #1) ys in
+                                                  (pair (link ky y l r) zs)
+                                              end
+                                          end) in
+        let go :=
+          GHC.DeferredFix.deferredFix3 (fun go arg_15__ arg_16__ arg_17__ =>
+                                          match arg_15__, arg_16__, arg_17__ with
+                                          | _, t, nil => t
+                                          | s, r, cons (pair kx x) xs =>
+                                              let 'pair l ys := create s xs in
+                                              let t' := link kx x l r in go (Data.Bits.shiftL s #1) t' ys
+                                          end) in
+        go (#1 : GHC.Num.Int) (Bin #1 kx0 x0 Tip Tip) xs0
+    end.
 
-Program Instance Foldable__Map {k} : Data.Foldable.Foldable (Map k) :=
-  fun _ k__ =>
-    k__ {| Data.Foldable.fold__ := fun {m} `{GHC.Base.Monoid m} =>
-             Foldable__Map_fold ;
-           Data.Foldable.foldMap__ := fun {m} {a} `{GHC.Base.Monoid m} =>
-             Foldable__Map_foldMap ;
-           Data.Foldable.foldl__ := fun {b} {a} => Foldable__Map_foldl ;
-           Data.Foldable.foldl'__ := fun {b} {a} => Foldable__Map_foldl' ;
-           Data.Foldable.foldr__ := fun {a} {b} => Foldable__Map_foldr ;
-           Data.Foldable.foldr'__ := fun {a} {b} => Foldable__Map_foldr' ;
-           Data.Foldable.length__ := fun {a} => Foldable__Map_length ;
-           Data.Foldable.null__ := fun {a} => Foldable__Map_null ;
-           Data.Foldable.product__ := fun {a} `{GHC.Num.Num a} => Foldable__Map_product ;
-           Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Map_sum ;
-           Data.Foldable.toList__ := fun {a} => Foldable__Map_toList |}.
+Definition fromDescList {k} {a} `{GHC.Base.Eq_ k}
+   : list (k * a)%type -> Map k a :=
+  fun xs =>
+    let fix combineEq' arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z, nil => cons z nil
+                 | (pair kz _ as z), cons (pair kx xx as x) xs' =>
+                     if kx GHC.Base.== kz : bool then combineEq' (pair kx xx) xs' else
+                     cons z (combineEq' x xs')
+                 end in
+    let combineEq :=
+      fun xs' =>
+        match xs' with
+        | nil => nil
+        | cons x nil => cons x nil
+        | cons x xx => combineEq' x xx
+        end in
+    fromDistinctDescList (combineEq xs).
 
-Local Definition Traversable__Map_traverse {inst_k}
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f},
-     (a -> f b) -> (Map inst_k) a -> f ((Map inst_k) b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun f => traverseWithKey (fun arg_0__ => f).
+Definition fromAscListWithKey {k} {a} `{GHC.Base.Eq_ k}
+   : (k -> a -> a -> a) -> list (k * a)%type -> Map k a :=
+  fun f xs =>
+    let fix combineEq' arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z, nil => cons z nil
+                 | (pair kz zz as z), cons (pair kx xx as x) xs' =>
+                     if kx GHC.Base.== kz : bool
+                     then let yy := f kx xx zz in combineEq' (pair kx yy) xs' else
+                     cons z (combineEq' x xs')
+                 end in
+    let combineEq :=
+      fun arg_7__ arg_8__ =>
+        match arg_7__, arg_8__ with
+        | _, xs' =>
+            match xs' with
+            | nil => nil
+            | cons x nil => cons x nil
+            | cons x xx => combineEq' x xx
+            end
+        end in
+    fromDistinctAscList (combineEq f xs).
 
-Local Definition Traversable__Map_mapM {inst_k}
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m},
-     (a -> m b) -> (Map inst_k) a -> m ((Map inst_k) b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Map_traverse.
+Definition fromAscListWith {k} {a} `{GHC.Base.Eq_ k}
+   : (a -> a -> a) -> list (k * a)%type -> Map k a :=
+  fun f xs =>
+    fromAscListWithKey (fun arg_0__ arg_1__ arg_2__ =>
+                          match arg_0__, arg_1__, arg_2__ with
+                          | _, x, y => f x y
+                          end) xs.
 
-Local Definition Traversable__Map_sequenceA {inst_k}
-   : forall {f} {a},
-     forall `{GHC.Base.Applicative f}, (Map inst_k) (f a) -> f ((Map inst_k) a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} => Traversable__Map_traverse GHC.Base.id.
+Definition fromDescListWithKey {k} {a} `{GHC.Base.Eq_ k}
+   : (k -> a -> a -> a) -> list (k * a)%type -> Map k a :=
+  fun f xs =>
+    let fix combineEq' arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z, nil => cons z nil
+                 | (pair kz zz as z), cons (pair kx xx as x) xs' =>
+                     if kx GHC.Base.== kz : bool
+                     then let yy := f kx xx zz in combineEq' (pair kx yy) xs' else
+                     cons z (combineEq' x xs')
+                 end in
+    let combineEq :=
+      fun arg_7__ arg_8__ =>
+        match arg_7__, arg_8__ with
+        | _, xs' =>
+            match xs' with
+            | nil => nil
+            | cons x nil => cons x nil
+            | cons x xx => combineEq' x xx
+            end
+        end in
+    fromDistinctDescList (combineEq f xs).
 
-Local Definition Traversable__Map_sequence {inst_k}
-   : forall {m} {a},
-     forall `{GHC.Base.Monad m}, (Map inst_k) (m a) -> m ((Map inst_k) a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Map_sequenceA.
+Definition fromDescListWith {k} {a} `{GHC.Base.Eq_ k}
+   : (a -> a -> a) -> list (k * a)%type -> Map k a :=
+  fun f xs =>
+    fromDescListWithKey (fun arg_0__ arg_1__ arg_2__ =>
+                           match arg_0__, arg_1__, arg_2__ with
+                           | _, x, y => f x y
+                           end) xs.
 
-Program Instance Traversable__Map {k} : Data.Traversable.Traversable (Map k) :=
-  fun _ k__ =>
-    k__ {| Data.Traversable.mapM__ := fun {m} {a} {b} `{GHC.Base.Monad m} =>
-             Traversable__Map_mapM ;
-           Data.Traversable.sequence__ := fun {m} {a} `{GHC.Base.Monad m} =>
-             Traversable__Map_sequence ;
-           Data.Traversable.sequenceA__ := fun {f} {a} `{GHC.Base.Applicative f} =>
-             Traversable__Map_sequenceA ;
-           Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-             Traversable__Map_traverse |}.
+(* Skipping definition `Data.Map.Internal.deleteFindMin' *)
 
-(* Skipping all instances of class `Data.Functor.Classes.Read1', including
-   `Data.Map.Internal.Read1__Map' *)
+(* Skipping definition `Data.Map.Internal.deleteFindMax' *)
 
-(* Skipping all instances of class `Data.Functor.Classes.Show1', including
-   `Data.Map.Internal.Show1__Map' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Show2', including
-   `Data.Map.Internal.Show2__Map' *)
-
-(* Skipping instance `Data.Map.Internal.Ord1__Map' of class
-   `Data.Functor.Classes.Ord1' *)
-
-Local Definition Ord2__Map_liftCompare2
-   : forall {a} {b} {c} {d},
-     (a -> b -> comparison) ->
-     (c -> d -> comparison) -> Map a c -> Map b d -> comparison :=
-  fun {a} {b} {c} {d} =>
-    fun cmpk cmpv m n =>
-      Data.Functor.Classes.liftCompare (Data.Functor.Classes.liftCompare2 cmpk cmpv)
-      (toList m) (toList n).
-
-Local Definition Eq2__Map_liftEq2
-   : forall {a} {b} {c} {d},
-     (a -> b -> bool) -> (c -> d -> bool) -> Map a c -> Map b d -> bool :=
-  fun {a} {b} {c} {d} =>
-    fun eqk eqv m n =>
-      andb (size m GHC.Base.== size n) (Data.Functor.Classes.liftEq
-            (Data.Functor.Classes.liftEq2 eqk eqv) (toList m) (toList n)).
-
-Program Instance Eq2__Map : Data.Functor.Classes.Eq2 Map :=
-  fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftEq2__ := fun {a} {b} {c} {d} =>
-             Eq2__Map_liftEq2 |}.
-
-Program Instance Ord2__Map : Data.Functor.Classes.Ord2 Map :=
-  fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftCompare2__ := fun {a} {b} {c} {d} =>
-             Ord2__Map_liftCompare2 |}.
-
-(* Skipping instance `Data.Map.Internal.Eq1__Map' of class
-   `Data.Functor.Classes.Eq1' *)
-
-Local Definition Ord__Map_compare {inst_k} {inst_v} `{GHC.Base.Ord inst_k}
-  `{GHC.Base.Ord inst_v}
-   : (Map inst_k inst_v) -> (Map inst_k inst_v) -> comparison :=
-  fun m1 m2 => GHC.Base.compare (toAscList m1) (toAscList m2).
-
-Local Definition Ord__Map_op_zl__ {inst_k} {inst_v} `{GHC.Base.Ord inst_k}
-  `{GHC.Base.Ord inst_v}
-   : (Map inst_k inst_v) -> (Map inst_k inst_v) -> bool :=
-  fun x y => Ord__Map_compare x y GHC.Base.== Lt.
-
-Local Definition Ord__Map_op_zlze__ {inst_k} {inst_v} `{GHC.Base.Ord inst_k}
-  `{GHC.Base.Ord inst_v}
-   : (Map inst_k inst_v) -> (Map inst_k inst_v) -> bool :=
-  fun x y => Ord__Map_compare x y GHC.Base./= Gt.
-
-Local Definition Ord__Map_op_zg__ {inst_k} {inst_v} `{GHC.Base.Ord inst_k}
-  `{GHC.Base.Ord inst_v}
-   : (Map inst_k inst_v) -> (Map inst_k inst_v) -> bool :=
-  fun x y => Ord__Map_compare x y GHC.Base.== Gt.
-
-Local Definition Ord__Map_op_zgze__ {inst_k} {inst_v} `{GHC.Base.Ord inst_k}
-  `{GHC.Base.Ord inst_v}
-   : (Map inst_k inst_v) -> (Map inst_k inst_v) -> bool :=
-  fun x y => Ord__Map_compare x y GHC.Base./= Lt.
-
-Local Definition Ord__Map_max {inst_k} {inst_v} `{GHC.Base.Ord inst_k}
-  `{GHC.Base.Ord inst_v}
-   : (Map inst_k inst_v) -> (Map inst_k inst_v) -> (Map inst_k inst_v) :=
-  fun x y => if Ord__Map_op_zlze__ x y : bool then y else x.
-
-Local Definition Ord__Map_min {inst_k} {inst_v} `{GHC.Base.Ord inst_k}
-  `{GHC.Base.Ord inst_v}
-   : (Map inst_k inst_v) -> (Map inst_k inst_v) -> (Map inst_k inst_v) :=
-  fun x y => if Ord__Map_op_zlze__ x y : bool then x else y.
-
-Local Definition Eq___Map_op_zeze__ {inst_k} {inst_a} `{GHC.Base.Eq_ inst_k}
-  `{GHC.Base.Eq_ inst_a}
-   : (Map inst_k inst_a) -> (Map inst_k inst_a) -> bool :=
-  fun t1 t2 =>
-    andb (size t1 GHC.Base.== size t2) (toAscList t1 GHC.Base.== toAscList t2).
-
-Local Definition Eq___Map_op_zsze__ {inst_k} {inst_a} `{GHC.Base.Eq_ inst_k}
-  `{GHC.Base.Eq_ inst_a}
-   : (Map inst_k inst_a) -> (Map inst_k inst_a) -> bool :=
-  fun x y => negb (Eq___Map_op_zeze__ x y).
-
-Program Instance Eq___Map {k} {a} `{GHC.Base.Eq_ k} `{GHC.Base.Eq_ a}
-   : GHC.Base.Eq_ (Map k a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___Map_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___Map_op_zsze__ |}.
-
-Program Instance Ord__Map {k} {v} `{GHC.Base.Ord k} `{GHC.Base.Ord v}
-   : GHC.Base.Ord (Map k v) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zl____ := Ord__Map_op_zl__ ;
-           GHC.Base.op_zlze____ := Ord__Map_op_zlze__ ;
-           GHC.Base.op_zg____ := Ord__Map_op_zg__ ;
-           GHC.Base.op_zgze____ := Ord__Map_op_zgze__ ;
-           GHC.Base.compare__ := Ord__Map_compare ;
-           GHC.Base.max__ := Ord__Map_max ;
-           GHC.Base.min__ := Ord__Map_min |}.
-
-(* Skipping all instances of class `GHC.Exts.IsList', including
-   `Data.Map.Internal.IsList__Map' *)
-
-(* Skipping all instances of class `Data.Data.Data', including
-   `Data.Map.Internal.Data__Map' *)
-
-Local Definition Semigroup__Map_op_zlzlzgzg__ {inst_k} {inst_v} `{(GHC.Base.Ord
-   inst_k)}
-   : (Map inst_k inst_v) -> (Map inst_k inst_v) -> (Map inst_k inst_v) :=
-  union.
-
-Program Instance Semigroup__Map {k} {v} `{(GHC.Base.Ord k)}
-   : GHC.Base.Semigroup (Map k v) :=
-  fun _ k__ => k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__Map_op_zlzlzgzg__ |}.
-
-Local Definition Monoid__Map_mappend {inst_k} {inst_v} `{(GHC.Base.Ord inst_k)}
-   : (Map inst_k inst_v) -> (Map inst_k inst_v) -> (Map inst_k inst_v) :=
-  _GHC.Base.<<>>_.
-
-Local Definition Monoid__Map_mconcat {inst_k} {inst_v} `{(GHC.Base.Ord inst_k)}
-   : list (Map inst_k inst_v) -> (Map inst_k inst_v) :=
-  unions.
-
-Local Definition Monoid__Map_mempty {inst_k} {inst_v} `{(GHC.Base.Ord inst_k)}
-   : (Map inst_k inst_v) :=
-  empty.
-
-Program Instance Monoid__Map {k} {v} `{(GHC.Base.Ord k)}
-   : GHC.Base.Monoid (Map k v) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.mappend__ := Monoid__Map_mappend ;
-           GHC.Base.mconcat__ := Monoid__Map_mconcat ;
-           GHC.Base.mempty__ := Monoid__Map_mempty |}.
-
-(* Skipping instance `Data.Map.Internal.Monad__WhenMissing' of class
-   `GHC.Base.Monad' *)
-
-(* Skipping instance `Data.Map.Internal.Applicative__WhenMissing' of class
-   `GHC.Base.Applicative' *)
-
-(* Skipping instance `Data.Map.Internal.Category__WhenMissing' of class
-   `Control.Category.Category' *)
-
-Local Definition Functor__WhenMissing_fmap {inst_f} {inst_k} {inst_x}
-  `{GHC.Base.Applicative inst_f} `{GHC.Base.Monad inst_f}
-   : forall {a} {b},
-     (a -> b) ->
-     (WhenMissing inst_f inst_k inst_x) a -> (WhenMissing inst_f inst_k inst_x) b :=
-  fun {a} {b} => mapWhenMissing.
-
-Local Definition Functor__WhenMissing_op_zlzd__ {inst_f} {inst_k} {inst_x}
-  `{GHC.Base.Applicative inst_f} `{GHC.Base.Monad inst_f}
-   : forall {a} {b},
-     a ->
-     (WhenMissing inst_f inst_k inst_x) b -> (WhenMissing inst_f inst_k inst_x) a :=
-  fun {a} {b} => Functor__WhenMissing_fmap GHC.Base.∘ GHC.Base.const.
-
-Program Instance Functor__WhenMissing {f} {k} {x} `{GHC.Base.Applicative f}
-  `{GHC.Base.Monad f}
-   : GHC.Base.Functor (WhenMissing f k x) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__WhenMissing_fmap ;
-           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__WhenMissing_op_zlzd__ |}.
-
-(* Skipping instance `Data.Map.Internal.Monad__WhenMatched' of class
-   `GHC.Base.Monad' *)
-
-(* Skipping instance `Data.Map.Internal.Applicative__WhenMatched' of class
-   `GHC.Base.Applicative' *)
-
-(* Skipping instance `Data.Map.Internal.Category__WhenMatched' of class
-   `Control.Category.Category' *)
-
-Local Definition Functor__WhenMatched_fmap {inst_f} {inst_k} {inst_x} {inst_y}
-  `{GHC.Base.Functor inst_f}
-   : forall {a} {b},
-     (a -> b) ->
-     (WhenMatched inst_f inst_k inst_x inst_y) a ->
-     (WhenMatched inst_f inst_k inst_x inst_y) b :=
-  fun {a} {b} => mapWhenMatched.
-
-Local Definition Functor__WhenMatched_op_zlzd__ {inst_f} {inst_k} {inst_x}
-  {inst_y} `{GHC.Base.Functor inst_f}
-   : forall {a} {b},
-     a ->
-     (WhenMatched inst_f inst_k inst_x inst_y) b ->
-     (WhenMatched inst_f inst_k inst_x inst_y) a :=
-  fun {a} {b} => Functor__WhenMatched_fmap GHC.Base.∘ GHC.Base.const.
-
-Program Instance Functor__WhenMatched {f} {k} {x} {y} `{GHC.Base.Functor f}
-   : GHC.Base.Functor (WhenMatched f k x y) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__WhenMatched_fmap ;
-           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__WhenMatched_op_zlzd__ |}.
+Definition splitRoot {k} {b} : Map k b -> list (Map k b) :=
+  fun orig =>
+    match orig with
+    | Tip => nil
+    | Bin _ k v l r => cons l (cons (singleton k v) (cons r nil))
+    end.
 
 Module Notations.
 Notation "'_Data.Map.Internal.!?_'" := (op_znz3fU__).

--- a/examples/containers/lib/Data/Set/Internal.v
+++ b/examples/containers/lib/Data/Set/Internal.v
@@ -74,309 +74,14 @@ Instance MergeSetDefault {a} : Default (MergeSet a) :=
 
 (* Converted value declarations: *)
 
-(* Skipping definition `Data.Set.Internal.withEmpty' *)
-
-(* Skipping definition `Data.Set.Internal.withBar' *)
-
-Definition size {a} : Set_ a -> GHC.Num.Int :=
-  fun arg_0__ => match arg_0__ with | Tip => #0 | Bin sz _ _ _ => sz end.
-
-Definition validsize {a} : Set_ a -> bool :=
-  fun t =>
-    let fix realsize t'
-              := match t' with
-                 | Tip => Some #0
-                 | Bin sz _ l r =>
-                     match pair (realsize l) (realsize r) with
-                     | pair (Some n) (Some m) =>
-                         if ((n GHC.Num.+ m) GHC.Num.+ #1) GHC.Base.== sz : bool then Some sz else
-                         None
-                     | _ => None
-                     end
-                 end in
-    (realsize t GHC.Base.== Some (size t)).
-
-Definition singleton {a} : a -> Set_ a :=
-  fun x => Bin #1 x Tip Tip.
-
-Definition splitRoot {a} : Set_ a -> list (Set_ a) :=
-  fun orig =>
-    match orig with
-    | Tip => nil
-    | Bin _ v l r => cons l (cons (singleton v) (cons r nil))
-    end.
-
-(* Skipping definition `Data.Set.Internal.showsTreeHang' *)
-
-(* Skipping definition `Data.Set.Internal.showsTree' *)
-
-(* Skipping definition `Data.Set.Internal.showsBars' *)
-
-(* Skipping definition `Data.Set.Internal.showWide' *)
-
-(* Skipping definition `Data.Set.Internal.showTreeWith' *)
-
-(* Skipping definition `Data.Set.Internal.showTree' *)
-
-(* Skipping definition `Data.Set.Internal.setDataType' *)
+Definition delta : GHC.Num.Int :=
+  #3.
 
 Definition ratio : GHC.Num.Int :=
   #2.
 
-Definition ordered {a} `{GHC.Base.Ord a} : Set_ a -> bool :=
-  fun t =>
-    let fix bounded lo hi t'
-              := match t' with
-                 | Tip => true
-                 | Bin _ x l r =>
-                     andb (lo x) (andb (hi x) (andb (bounded lo (fun arg_0__ => arg_0__ GHC.Base.< x)
-                                                     l) (bounded (fun arg_1__ => arg_1__ GHC.Base.> x) hi r)))
-                 end in
-    bounded (GHC.Base.const true) (GHC.Base.const true) t.
-
-Definition null {a} : Set_ a -> bool :=
-  fun arg_0__ => match arg_0__ with | Tip => true | Bin _ _ _ _ => false end.
-
-(* Skipping definition `Data.Set.Internal.node' *)
-
-Definition member {a} `{GHC.Base.Ord a} : a -> Set_ a -> bool :=
-  let fix go arg_0__ arg_1__
-            := match arg_0__, arg_1__ with
-               | _, Tip => false
-               | x, Bin _ y l r =>
-                   match GHC.Base.compare x y with
-                   | Lt => go x l
-                   | Gt => go x r
-                   | Eq => true
-                   end
-               end in
-  go.
-
-Definition notMember {a} `{GHC.Base.Ord a} : a -> Set_ a -> bool :=
-  fun a t => negb (member a t).
-
-Fixpoint mapMonotonic {a} {b} (arg_0__ : (a -> b)) (arg_1__ : Set_ a) : Set_ b
-           := match arg_0__, arg_1__ with
-              | _, Tip => Tip
-              | f, Bin sz x l r => Bin sz (f x) (mapMonotonic f l) (mapMonotonic f r)
-              end.
-
-Fixpoint lookupMinSure {a} (arg_0__ : a) (arg_1__ : Set_ a) : a
-           := match arg_0__, arg_1__ with
-              | x, Tip => x
-              | _, Bin _ x l _ => lookupMinSure x l
-              end.
-
-Definition lookupMin {a} : Set_ a -> option a :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Tip => None
-    | Bin _ x l _ => Some (lookupMinSure x l)
-    end.
-
-Fixpoint lookupMaxSure {a} (arg_0__ : a) (arg_1__ : Set_ a) : a
-           := match arg_0__, arg_1__ with
-              | x, Tip => x
-              | _, Bin _ x _ r => lookupMaxSure x r
-              end.
-
-Definition lookupMax {a} : Set_ a -> option a :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Tip => None
-    | Bin _ x _ r => Some (lookupMaxSure x r)
-    end.
-
-Definition lookupLT {a} `{GHC.Base.Ord a} : a -> Set_ a -> option a :=
-  let fix goJust arg_0__ arg_1__ arg_2__
-            := match arg_0__, arg_1__, arg_2__ with
-               | _, best, Tip => Some best
-               | x, best, Bin _ y l r =>
-                   if x GHC.Base.<= y : bool then goJust x best l else
-                   goJust x y r
-               end in
-  let fix goNothing arg_7__ arg_8__
-            := match arg_7__, arg_8__ with
-               | _, Tip => None
-               | x, Bin _ y l r =>
-                   if x GHC.Base.<= y : bool then goNothing x l else
-                   goJust x y r
-               end in
-  goNothing.
-
-Definition lookupLE {a} `{GHC.Base.Ord a} : a -> Set_ a -> option a :=
-  let fix goJust arg_0__ arg_1__ arg_2__
-            := match arg_0__, arg_1__, arg_2__ with
-               | _, best, Tip => Some best
-               | x, best, Bin _ y l r =>
-                   match GHC.Base.compare x y with
-                   | Lt => goJust x best l
-                   | Eq => Some y
-                   | Gt => goJust x y r
-                   end
-               end in
-  let fix goNothing arg_11__ arg_12__
-            := match arg_11__, arg_12__ with
-               | _, Tip => None
-               | x, Bin _ y l r =>
-                   match GHC.Base.compare x y with
-                   | Lt => goNothing x l
-                   | Eq => Some y
-                   | Gt => goJust x y r
-                   end
-               end in
-  goNothing.
-
-Definition lookupIndex {a} `{GHC.Base.Ord a}
-   : a -> Set_ a -> option GHC.Num.Int :=
-  let go {a} `{GHC.Base.Ord a}
-   : GHC.Num.Int -> a -> Set_ a -> option GHC.Num.Int :=
-    fix go (arg_0__ : GHC.Num.Int) (arg_1__ : a) (arg_2__ : Set_ a) : option
-                                                                      GHC.Num.Int
-          := match arg_0__, arg_1__, arg_2__ with
-             | _, _, Tip => None
-             | idx, x, Bin _ kx l r =>
-                 match GHC.Base.compare x kx with
-                 | Lt => go idx x l
-                 | Gt => go ((idx GHC.Num.+ size l) GHC.Num.+ #1) x r
-                 | Eq => Some (idx GHC.Num.+ size l)
-                 end
-             end in
-  go #0.
-
-Definition lookupGT {a} `{GHC.Base.Ord a} : a -> Set_ a -> option a :=
-  let fix goJust arg_0__ arg_1__ arg_2__
-            := match arg_0__, arg_1__, arg_2__ with
-               | _, best, Tip => Some best
-               | x, best, Bin _ y l r =>
-                   if x GHC.Base.< y : bool then goJust x y l else
-                   goJust x best r
-               end in
-  let fix goNothing arg_7__ arg_8__
-            := match arg_7__, arg_8__ with
-               | _, Tip => None
-               | x, Bin _ y l r =>
-                   if x GHC.Base.< y : bool then goJust x y l else
-                   goNothing x r
-               end in
-  goNothing.
-
-Definition lookupGE {a} `{GHC.Base.Ord a} : a -> Set_ a -> option a :=
-  let fix goJust arg_0__ arg_1__ arg_2__
-            := match arg_0__, arg_1__, arg_2__ with
-               | _, best, Tip => Some best
-               | x, best, Bin _ y l r =>
-                   match GHC.Base.compare x y with
-                   | Lt => goJust x y l
-                   | Eq => Some y
-                   | Gt => goJust x best r
-                   end
-               end in
-  let fix goNothing arg_11__ arg_12__
-            := match arg_11__, arg_12__ with
-               | _, Tip => None
-               | x, Bin _ y l r =>
-                   match GHC.Base.compare x y with
-                   | Lt => goJust x y l
-                   | Eq => Some y
-                   | Gt => goNothing x r
-                   end
-               end in
-  goNothing.
-
-(* Skipping definition `Data.Set.Internal.fromListConstr' *)
-
-Definition foldr' {a} {b} : (a -> b -> b) -> b -> Set_ a -> b :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ x l r => go (f x (go z' r)) l
-                 end in
-    go z.
-
-Definition foldr {a} {b} : (a -> b -> b) -> b -> Set_ a -> b :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ x l r => go (f x (go z' r)) l
-                 end in
-    go z.
-
-Definition foldrFB {a} {b} : (a -> b -> b) -> b -> Set_ a -> b :=
-  foldr.
-
-Definition toAscList {a} : Set_ a -> list a :=
-  foldr cons nil.
-
-Definition toList {a} : Set_ a -> list a :=
-  toAscList.
-
-Definition foldl' {a} {b} : (a -> b -> a) -> a -> Set_ b -> a :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ x l r => go (f (go z' l) x) r
-                 end in
-    go z.
-
-Definition foldl {a} {b} : (a -> b -> a) -> a -> Set_ b -> a :=
-  fun f z =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | z', Tip => z'
-                 | z', Bin _ x l r => go (f (go z' l) x) r
-                 end in
-    go z.
-
-Definition foldlFB {a} {b} : (a -> b -> a) -> a -> Set_ b -> a :=
-  foldl.
-
-Definition toDescList {a} : Set_ a -> list a :=
-  foldl (GHC.Base.flip cons) nil.
-
-Definition fold {a} {b} : (a -> b -> b) -> b -> Set_ a -> b :=
-  foldr.
-
-(* Skipping definition `Data.Set.Internal.findMin' *)
-
-(* Skipping definition `Data.Set.Internal.findMax' *)
-
-(* Skipping definition `Data.Set.Internal.findIndex' *)
-
-Definition empty {a} : Set_ a :=
-  Tip.
-
-Definition elems {a} : Set_ a -> list a :=
-  toAscList.
-
-(* Skipping definition `Data.Set.Internal.elemAt' *)
-
-Definition delta : GHC.Num.Int :=
-  #3.
-
-(* Skipping definition `Data.Set.Internal.deleteFindMin' *)
-
-(* Skipping definition `Data.Set.Internal.deleteFindMax' *)
-
-(* Skipping definition `Data.Set.Internal.deleteAt' *)
-
-Definition combineEq {a} `{GHC.Base.Eq_ a} : list a -> list a :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | nil => nil
-    | cons x xs =>
-        let fix combineEq' arg_1__ arg_2__
-                  := match arg_1__, arg_2__ with
-                     | z, nil => cons z nil
-                     | z, cons y ys =>
-                         if z GHC.Base.== y : bool then combineEq' z ys else
-                         cons z (combineEq' y ys)
-                     end in
-        combineEq' x xs
-    end.
+Definition size {a} : Set_ a -> GHC.Num.Int :=
+  fun arg_0__ => match arg_0__ with | Tip => #0 | Bin sz _ _ _ => sz end.
 
 Definition balanceL {a} : a -> Set_ a -> Set_ a -> Set_ a :=
   fun x l r =>
@@ -459,6 +164,370 @@ Definition balanceR {a} : a -> Set_ a -> Set_ a -> Set_ a :=
         end
     end.
 
+Definition singleton {a} : a -> Set_ a :=
+  fun x => Bin #1 x Tip Tip.
+
+Definition insert {a} `{GHC.Base.Ord a} : a -> Set_ a -> Set_ a :=
+  fun x0 =>
+    let go {a} `{GHC.Base.Ord a} : a -> a -> Set_ a -> Set_ a :=
+      fix go (arg_0__ arg_1__ : a) (arg_2__ : Set_ a) : Set_ a
+            := match arg_0__, arg_1__, arg_2__ with
+               | orig, _, Tip => singleton (orig)
+               | orig, x, (Bin sz y l r as t) =>
+                   match GHC.Base.compare x y with
+                   | Lt =>
+                       let l' := go orig x l in
+                       if Utils.Containers.Internal.PtrEquality.ptrEq l' l : bool then t else
+                       balanceL y l' r
+                   | Gt =>
+                       let r' := go orig x r in
+                       if Utils.Containers.Internal.PtrEquality.ptrEq r' r : bool then t else
+                       balanceR y l r'
+                   | Eq =>
+                       if (Utils.Containers.Internal.PtrEquality.ptrEq orig y) : bool then t else
+                       Bin sz (orig) l r
+                   end
+               end in
+    go x0 x0.
+
+Definition insertR {a} `{GHC.Base.Ord a} : a -> Set_ a -> Set_ a :=
+  fun x0 =>
+    let go {a} `{GHC.Base.Ord a} : a -> a -> Set_ a -> Set_ a :=
+      fix go (arg_0__ arg_1__ : a) (arg_2__ : Set_ a) : Set_ a
+            := match arg_0__, arg_1__, arg_2__ with
+               | orig, _, Tip => singleton (orig)
+               | orig, x, (Bin _ y l r as t) =>
+                   match GHC.Base.compare x y with
+                   | Lt =>
+                       let l' := go orig x l in
+                       if Utils.Containers.Internal.PtrEquality.ptrEq l' l : bool then t else
+                       balanceL y l' r
+                   | Gt =>
+                       let r' := go orig x r in
+                       if Utils.Containers.Internal.PtrEquality.ptrEq r' r : bool then t else
+                       balanceR y l r'
+                   | Eq => t
+                   end
+               end in
+    go x0 x0.
+
+Definition bin {a} : a -> Set_ a -> Set_ a -> Set_ a :=
+  fun x l r => Bin ((size l GHC.Num.+ size r) GHC.Num.+ #1) x l r.
+
+Fixpoint insertMax {a} (x : a) (t : Set_ a) : Set_ a
+           := match t with
+              | Tip => singleton x
+              | Bin _ y l r => balanceR y l (insertMax x r)
+              end.
+
+Fixpoint insertMin {a} (x : a) (t : Set_ a) : Set_ a
+           := match t with
+              | Tip => singleton x
+              | Bin _ y l r => balanceL y (insertMin x l) r
+              end.
+
+Program Fixpoint link {a} (arg_0__ : a) (arg_1__ arg_2__ : Set_ a)
+                      {measure (Nat.add (set_size arg_1__) (set_size arg_2__))} : Set_ a
+                   := match arg_0__, arg_1__, arg_2__ with
+                      | x, Tip, r => insertMin x r
+                      | x, l, Tip => insertMax x l
+                      | x, (Bin sizeL y ly ry as l), (Bin sizeR z lz rz as r) =>
+                          if Bool.Sumbool.sumbool_of_bool ((delta GHC.Num.* sizeL) GHC.Base.< sizeR)
+                          then balanceL z (link x l lz) rz else
+                          if Bool.Sumbool.sumbool_of_bool ((delta GHC.Num.* sizeR) GHC.Base.< sizeL)
+                          then balanceR y ly (link x ry r) else
+                          bin x l r
+                      end.
+Solve Obligations with (termination_by_omega).
+
+Fixpoint splitS {a} `{GHC.Base.Ord a} (arg_0__ : a) (arg_1__ : Set_ a) : prod
+                                                                         (Set_ a) (Set_ a)
+           := match arg_0__, arg_1__ with
+              | _, Tip => (pair Tip Tip)
+              | x, Bin _ y l r =>
+                  match GHC.Base.compare x y with
+                  | Lt => let 'pair lt gt := splitS x l in (pair lt (link y gt r))
+                  | Gt => let 'pair lt gt := splitS x r in (pair (link y l lt) gt)
+                  | Eq => (pair l r)
+                  end
+              end.
+
+Fixpoint union {a} `{GHC.Base.Ord a} (arg_0__ arg_1__ : Set_ a) : Set_ a
+           := match arg_0__, arg_1__ with
+              | t1, Tip => t1
+              | t1, Bin num_2__ x _ _ =>
+                  if num_2__ GHC.Base.== #1 : bool then insertR x t1 else
+                  let j_11__ :=
+                    match arg_0__, arg_1__ with
+                    | Tip, t2 => t2
+                    | (Bin _ x l1 r1 as t1), t2 =>
+                        let 'pair l2 r2 := splitS x t2 in
+                        let r1r2 := union r1 r2 in
+                        let l1l2 := union l1 l2 in
+                        if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1l2 l1)
+                                (Utils.Containers.Internal.PtrEquality.ptrEq r1r2 r1) : bool
+                        then t1 else
+                        link x l1l2 r1r2
+                    end in
+                  match arg_0__, arg_1__ with
+                  | Bin num_3__ x _ _, t2 =>
+                      if num_3__ GHC.Base.== #1 : bool then insert x t2 else
+                      j_11__
+                  | _, _ => j_11__
+                  end
+              end.
+
+Local Definition Semigroup__Set__op_zlzlzgzg__ {inst_a} `{GHC.Base.Ord inst_a}
+   : (Set_ inst_a) -> (Set_ inst_a) -> (Set_ inst_a) :=
+  union.
+
+Program Instance Semigroup__Set_ {a} `{GHC.Base.Ord a}
+   : GHC.Base.Semigroup (Set_ a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__Set__op_zlzlzgzg__ |}.
+
+Local Definition Monoid__Set__mappend {inst_a} `{GHC.Base.Ord inst_a}
+   : (Set_ inst_a) -> (Set_ inst_a) -> (Set_ inst_a) :=
+  _GHC.Base.<<>>_.
+
+Definition empty {a} : Set_ a :=
+  Tip.
+
+Definition unions {f} {a} `{Data.Foldable.Foldable f} `{GHC.Base.Ord a}
+   : f (Set_ a) -> Set_ a :=
+  Data.Foldable.foldl' union empty.
+
+Local Definition Monoid__Set__mconcat {inst_a} `{GHC.Base.Ord inst_a}
+   : list (Set_ inst_a) -> (Set_ inst_a) :=
+  unions.
+
+Local Definition Monoid__Set__mempty {inst_a} `{GHC.Base.Ord inst_a}
+   : (Set_ inst_a) :=
+  empty.
+
+Program Instance Monoid__Set_ {a} `{GHC.Base.Ord a}
+   : GHC.Base.Monoid (Set_ a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.mappend__ := Monoid__Set__mappend ;
+           GHC.Base.mconcat__ := Monoid__Set__mconcat ;
+           GHC.Base.mempty__ := Monoid__Set__mempty |}.
+
+Local Definition Foldable__Set__fold
+   : forall {m}, forall `{GHC.Base.Monoid m}, Set_ m -> m :=
+  fun {m} `{GHC.Base.Monoid m} =>
+    let fix go arg_0__
+              := match arg_0__ with
+                 | Tip => GHC.Base.mempty
+                 | Bin num_1__ k _ _ =>
+                     if num_1__ GHC.Base.== #1 : bool then k else
+                     match arg_0__ with
+                     | Bin _ k l r => GHC.Base.mappend (go l) (GHC.Base.mappend k (go r))
+                     | _ => GHC.Err.patternFailure
+                     end
+                 end in
+    go.
+
+Local Definition Foldable__Set__foldMap
+   : forall {m} {a}, forall `{GHC.Base.Monoid m}, (a -> m) -> Set_ a -> m :=
+  fun {m} {a} `{GHC.Base.Monoid m} =>
+    fun f t =>
+      let fix go arg_0__
+                := match arg_0__ with
+                   | Tip => GHC.Base.mempty
+                   | Bin num_1__ k _ _ =>
+                       if num_1__ GHC.Base.== #1 : bool then f k else
+                       match arg_0__ with
+                       | Bin _ k l r => GHC.Base.mappend (go l) (GHC.Base.mappend (f k) (go r))
+                       | _ => GHC.Err.patternFailure
+                       end
+                   end in
+      go t.
+
+Definition foldl {a} {b} : (a -> b -> a) -> a -> Set_ b -> a :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Tip => z'
+                 | z', Bin _ x l r => go (f (go z' l) x) r
+                 end in
+    go z.
+
+Local Definition Foldable__Set__foldl
+   : forall {b} {a}, (b -> a -> b) -> b -> Set_ a -> b :=
+  fun {b} {a} => foldl.
+
+Definition foldl' {a} {b} : (a -> b -> a) -> a -> Set_ b -> a :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Tip => z'
+                 | z', Bin _ x l r => go (f (go z' l) x) r
+                 end in
+    go z.
+
+Local Definition Foldable__Set__foldl'
+   : forall {b} {a}, (b -> a -> b) -> b -> Set_ a -> b :=
+  fun {b} {a} => foldl'.
+
+Definition foldr {a} {b} : (a -> b -> b) -> b -> Set_ a -> b :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Tip => z'
+                 | z', Bin _ x l r => go (f x (go z' r)) l
+                 end in
+    go z.
+
+Local Definition Foldable__Set__foldr
+   : forall {a} {b}, (a -> b -> b) -> b -> Set_ a -> b :=
+  fun {a} {b} => foldr.
+
+Definition foldr' {a} {b} : (a -> b -> b) -> b -> Set_ a -> b :=
+  fun f z =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | z', Tip => z'
+                 | z', Bin _ x l r => go (f x (go z' r)) l
+                 end in
+    go z.
+
+Local Definition Foldable__Set__foldr'
+   : forall {a} {b}, (a -> b -> b) -> b -> Set_ a -> b :=
+  fun {a} {b} => foldr'.
+
+Local Definition Foldable__Set__length : forall {a}, Set_ a -> GHC.Num.Int :=
+  fun {a} => size.
+
+Definition null {a} : Set_ a -> bool :=
+  fun arg_0__ => match arg_0__ with | Tip => true | Bin _ _ _ _ => false end.
+
+Local Definition Foldable__Set__null : forall {a}, Set_ a -> bool :=
+  fun {a} => null.
+
+Local Definition Foldable__Set__product
+   : forall {a}, forall `{GHC.Num.Num a}, Set_ a -> a :=
+  fun {a} `{GHC.Num.Num a} => foldl' _GHC.Num.*_ #1.
+
+Local Definition Foldable__Set__sum
+   : forall {a}, forall `{GHC.Num.Num a}, Set_ a -> a :=
+  fun {a} `{GHC.Num.Num a} => foldl' _GHC.Num.+_ #0.
+
+Definition toAscList {a} : Set_ a -> list a :=
+  foldr cons nil.
+
+Definition toList {a} : Set_ a -> list a :=
+  toAscList.
+
+Local Definition Foldable__Set__toList : forall {a}, Set_ a -> list a :=
+  fun {a} => toList.
+
+Program Instance Foldable__Set_ : Data.Foldable.Foldable Set_ :=
+  fun _ k__ =>
+    k__ {| Data.Foldable.fold__ := fun {m} `{GHC.Base.Monoid m} =>
+             Foldable__Set__fold ;
+           Data.Foldable.foldMap__ := fun {m} {a} `{GHC.Base.Monoid m} =>
+             Foldable__Set__foldMap ;
+           Data.Foldable.foldl__ := fun {b} {a} => Foldable__Set__foldl ;
+           Data.Foldable.foldl'__ := fun {b} {a} => Foldable__Set__foldl' ;
+           Data.Foldable.foldr__ := fun {a} {b} => Foldable__Set__foldr ;
+           Data.Foldable.foldr'__ := fun {a} {b} => Foldable__Set__foldr' ;
+           Data.Foldable.length__ := fun {a} => Foldable__Set__length ;
+           Data.Foldable.null__ := fun {a} => Foldable__Set__null ;
+           Data.Foldable.product__ := fun {a} `{GHC.Num.Num a} => Foldable__Set__product ;
+           Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Set__sum ;
+           Data.Foldable.toList__ := fun {a} => Foldable__Set__toList |}.
+
+(* Skipping all instances of class `Data.Data.Data', including
+   `Data.Set.Internal.Data__Set_' *)
+
+(* Skipping all instances of class `GHC.Exts.IsList', including
+   `Data.Set.Internal.IsList__Set_' *)
+
+Local Definition Eq___Set__op_zeze__ {inst_a} `{GHC.Base.Eq_ inst_a}
+   : (Set_ inst_a) -> (Set_ inst_a) -> bool :=
+  fun t1 t2 =>
+    andb (size t1 GHC.Base.== size t2) (toAscList t1 GHC.Base.== toAscList t2).
+
+Local Definition Eq___Set__op_zsze__ {inst_a} `{GHC.Base.Eq_ inst_a}
+   : (Set_ inst_a) -> (Set_ inst_a) -> bool :=
+  fun x y => negb (Eq___Set__op_zeze__ x y).
+
+Program Instance Eq___Set_ {a} `{GHC.Base.Eq_ a} : GHC.Base.Eq_ (Set_ a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___Set__op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___Set__op_zsze__ |}.
+
+Local Definition Ord__Set__compare {inst_a} `{GHC.Base.Ord inst_a}
+   : (Set_ inst_a) -> (Set_ inst_a) -> comparison :=
+  fun s1 s2 => GHC.Base.compare (toAscList s1) (toAscList s2).
+
+Local Definition Ord__Set__op_zl__ {inst_a} `{GHC.Base.Ord inst_a}
+   : (Set_ inst_a) -> (Set_ inst_a) -> bool :=
+  fun x y => Ord__Set__compare x y GHC.Base.== Lt.
+
+Local Definition Ord__Set__op_zlze__ {inst_a} `{GHC.Base.Ord inst_a}
+   : (Set_ inst_a) -> (Set_ inst_a) -> bool :=
+  fun x y => Ord__Set__compare x y GHC.Base./= Gt.
+
+Local Definition Ord__Set__op_zg__ {inst_a} `{GHC.Base.Ord inst_a}
+   : (Set_ inst_a) -> (Set_ inst_a) -> bool :=
+  fun x y => Ord__Set__compare x y GHC.Base.== Gt.
+
+Local Definition Ord__Set__op_zgze__ {inst_a} `{GHC.Base.Ord inst_a}
+   : (Set_ inst_a) -> (Set_ inst_a) -> bool :=
+  fun x y => Ord__Set__compare x y GHC.Base./= Lt.
+
+Local Definition Ord__Set__max {inst_a} `{GHC.Base.Ord inst_a}
+   : (Set_ inst_a) -> (Set_ inst_a) -> (Set_ inst_a) :=
+  fun x y => if Ord__Set__op_zlze__ x y : bool then y else x.
+
+Local Definition Ord__Set__min {inst_a} `{GHC.Base.Ord inst_a}
+   : (Set_ inst_a) -> (Set_ inst_a) -> (Set_ inst_a) :=
+  fun x y => if Ord__Set__op_zlze__ x y : bool then x else y.
+
+Program Instance Ord__Set_ {a} `{GHC.Base.Ord a} : GHC.Base.Ord (Set_ a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zl____ := Ord__Set__op_zl__ ;
+           GHC.Base.op_zlze____ := Ord__Set__op_zlze__ ;
+           GHC.Base.op_zg____ := Ord__Set__op_zg__ ;
+           GHC.Base.op_zgze____ := Ord__Set__op_zgze__ ;
+           GHC.Base.compare__ := Ord__Set__compare ;
+           GHC.Base.max__ := Ord__Set__max ;
+           GHC.Base.min__ := Ord__Set__min |}.
+
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Data.Set.Internal.Show__Set_' *)
+
+Local Definition Eq1__Set__liftEq
+   : forall {a} {b}, (a -> b -> bool) -> Set_ a -> Set_ b -> bool :=
+  fun {a} {b} =>
+    fun eq m n =>
+      andb (size m GHC.Base.== size n) (Data.Functor.Classes.liftEq eq (toList m)
+            (toList n)).
+
+Program Instance Eq1__Set_ : Data.Functor.Classes.Eq1 Set_ :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__Set__liftEq |}.
+
+Local Definition Ord1__Set__liftCompare
+   : forall {a} {b}, (a -> b -> comparison) -> Set_ a -> Set_ b -> comparison :=
+  fun {a} {b} =>
+    fun cmp m n => Data.Functor.Classes.liftCompare cmp (toList m) (toList n).
+
+Program Instance Ord1__Set_ : Data.Functor.Classes.Ord1 Set_ :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
+             Ord1__Set__liftCompare |}.
+
+(* Skipping all instances of class `Data.Functor.Classes.Show1', including
+   `Data.Set.Internal.Show1__Set_' *)
+
+(* Skipping all instances of class `GHC.Read.Read', including
+   `Data.Set.Internal.Read__Set_' *)
+
+(* Skipping all instances of class `Control.DeepSeq.NFData', including
+   `Data.Set.Internal.NFData__Set_' *)
+
 Definition maxViewSure {a} : a -> Set_ a -> Set_ a -> prod a (Set_ a) :=
   let fix go arg_0__ arg_1__ arg_2__
             := match arg_0__, arg_1__, arg_2__ with
@@ -528,113 +597,224 @@ Local Definition Monoid__MergeSet_mconcat {inst_a}
    : list (MergeSet inst_a) -> (MergeSet inst_a) :=
   GHC.Base.foldr Monoid__MergeSet_mappend Monoid__MergeSet_mempty.
 
-Local Definition Foldable__Set__fold
-   : forall {m}, forall `{GHC.Base.Monoid m}, Set_ m -> m :=
-  fun {m} `{GHC.Base.Monoid m} =>
-    let fix go arg_0__
-              := match arg_0__ with
-                 | Tip => GHC.Base.mempty
-                 | Bin num_1__ k _ _ =>
-                     if num_1__ GHC.Base.== #1 : bool then k else
-                     match arg_0__ with
-                     | Bin _ k l r => GHC.Base.mappend (go l) (GHC.Base.mappend k (go r))
-                     | _ => GHC.Err.patternFailure
-                     end
-                 end in
-    go.
-
-Local Definition Foldable__Set__foldMap
-   : forall {m} {a}, forall `{GHC.Base.Monoid m}, (a -> m) -> Set_ a -> m :=
-  fun {m} {a} `{GHC.Base.Monoid m} =>
-    fun f t =>
-      let fix go arg_0__
-                := match arg_0__ with
-                   | Tip => GHC.Base.mempty
-                   | Bin num_1__ k _ _ =>
-                       if num_1__ GHC.Base.== #1 : bool then f k else
-                       match arg_0__ with
-                       | Bin _ k l r => GHC.Base.mappend (go l) (GHC.Base.mappend (f k) (go r))
-                       | _ => GHC.Err.patternFailure
-                       end
-                   end in
-      go t.
-
-Local Definition Foldable__Set__foldl
-   : forall {b} {a}, (b -> a -> b) -> b -> Set_ a -> b :=
-  fun {b} {a} => foldl.
-
-Local Definition Foldable__Set__foldl'
-   : forall {b} {a}, (b -> a -> b) -> b -> Set_ a -> b :=
-  fun {b} {a} => foldl'.
-
-Local Definition Foldable__Set__foldr
-   : forall {a} {b}, (a -> b -> b) -> b -> Set_ a -> b :=
-  fun {a} {b} => foldr.
-
-Local Definition Foldable__Set__foldr'
-   : forall {a} {b}, (a -> b -> b) -> b -> Set_ a -> b :=
-  fun {a} {b} => foldr'.
-
-Local Definition Foldable__Set__length : forall {a}, Set_ a -> GHC.Num.Int :=
-  fun {a} => size.
-
-Local Definition Foldable__Set__null : forall {a}, Set_ a -> bool :=
-  fun {a} => null.
-
-Local Definition Foldable__Set__product
-   : forall {a}, forall `{GHC.Num.Num a}, Set_ a -> a :=
-  fun {a} `{GHC.Num.Num a} => foldl' _GHC.Num.*_ #1.
-
-Local Definition Foldable__Set__sum
-   : forall {a}, forall `{GHC.Num.Num a}, Set_ a -> a :=
-  fun {a} `{GHC.Num.Num a} => foldl' _GHC.Num.+_ #0.
-
-Local Definition Foldable__Set__toList : forall {a}, Set_ a -> list a :=
-  fun {a} => toList.
-
-Program Instance Foldable__Set_ : Data.Foldable.Foldable Set_ :=
-  fun _ k__ =>
-    k__ {| Data.Foldable.fold__ := fun {m} `{GHC.Base.Monoid m} =>
-             Foldable__Set__fold ;
-           Data.Foldable.foldMap__ := fun {m} {a} `{GHC.Base.Monoid m} =>
-             Foldable__Set__foldMap ;
-           Data.Foldable.foldl__ := fun {b} {a} => Foldable__Set__foldl ;
-           Data.Foldable.foldl'__ := fun {b} {a} => Foldable__Set__foldl' ;
-           Data.Foldable.foldr__ := fun {a} {b} => Foldable__Set__foldr ;
-           Data.Foldable.foldr'__ := fun {a} {b} => Foldable__Set__foldr' ;
-           Data.Foldable.length__ := fun {a} => Foldable__Set__length ;
-           Data.Foldable.null__ := fun {a} => Foldable__Set__null ;
-           Data.Foldable.product__ := fun {a} `{GHC.Num.Num a} => Foldable__Set__product ;
-           Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Set__sum ;
-           Data.Foldable.toList__ := fun {a} => Foldable__Set__toList |}.
-
 Program Instance Monoid__MergeSet {a} : GHC.Base.Monoid (MergeSet a) :=
   fun _ k__ =>
     k__ {| GHC.Base.mappend__ := Monoid__MergeSet_mappend ;
            GHC.Base.mconcat__ := Monoid__MergeSet_mconcat ;
            GHC.Base.mempty__ := Monoid__MergeSet_mempty |}.
 
-Definition cartesianProduct {a} {b} : Set_ a -> Set_ b -> Set_ (a * b)%type :=
-  fun as_ bs =>
-    getMergeSet (Data.Foldable.foldMap (fun a =>
-                                          Mk_MergeSet (mapMonotonic (GHC.Tuple.pair2 a) bs)) as_).
+Definition split {a} `{GHC.Base.Ord a}
+   : a -> Set_ a -> (Set_ a * Set_ a)%type :=
+  fun x t => id (splitS x t).
 
-Definition bin {a} : a -> Set_ a -> Set_ a -> Set_ a :=
-  fun x l r => Bin ((size l GHC.Num.+ size r) GHC.Num.+ #1) x l r.
-
-Fixpoint balanced {a} (t : Set_ a) : bool
-           := match t with
-              | Tip => true
-              | Bin _ _ l r =>
-                  andb (orb ((size l GHC.Num.+ size r) GHC.Base.<= #1) (andb (size l GHC.Base.<=
-                                                                              (delta GHC.Num.* size r)) (size r
-                                                                              GHC.Base.<=
-                                                                              (delta GHC.Num.* size l)))) (andb
-                        (balanced l) (balanced r))
+Fixpoint difference {a} `{GHC.Base.Ord a} (arg_0__ arg_1__ : Set_ a) : Set_ a
+           := match arg_0__, arg_1__ with
+              | Tip, _ => Tip
+              | t1, Tip => t1
+              | t1, Bin _ x l2 r2 =>
+                  let 'pair l1 r1 := split x t1 in
+                  let r1r2 := difference r1 r2 in
+                  let l1l2 := difference l1 l2 in
+                  if (size l1l2 GHC.Num.+ size r1r2) GHC.Base.== size t1 : bool then t1 else
+                  merge l1l2 r1r2
               end.
 
-Definition valid {a} `{GHC.Base.Ord a} : Set_ a -> bool :=
-  fun t => andb (balanced t) (andb (ordered t) (validsize t)).
+Definition op_zrzr__ {a} `{GHC.Base.Ord a} : Set_ a -> Set_ a -> Set_ a :=
+  fun m1 m2 => difference m1 m2.
+
+Notation "'_\\_'" := (op_zrzr__).
+
+Infix "\\" := (_\\_) (at level 99).
+
+(* Skipping definition `Data.Set.Internal.fromListConstr' *)
+
+(* Skipping definition `Data.Set.Internal.setDataType' *)
+
+Definition member {a} `{GHC.Base.Ord a} : a -> Set_ a -> bool :=
+  let fix go arg_0__ arg_1__
+            := match arg_0__, arg_1__ with
+               | _, Tip => false
+               | x, Bin _ y l r =>
+                   match GHC.Base.compare x y with
+                   | Lt => go x l
+                   | Gt => go x r
+                   | Eq => true
+                   end
+               end in
+  go.
+
+Definition notMember {a} `{GHC.Base.Ord a} : a -> Set_ a -> bool :=
+  fun a t => negb (member a t).
+
+Definition lookupLT {a} `{GHC.Base.Ord a} : a -> Set_ a -> option a :=
+  let fix goJust arg_0__ arg_1__ arg_2__
+            := match arg_0__, arg_1__, arg_2__ with
+               | _, best, Tip => Some best
+               | x, best, Bin _ y l r =>
+                   if x GHC.Base.<= y : bool then goJust x best l else
+                   goJust x y r
+               end in
+  let fix goNothing arg_7__ arg_8__
+            := match arg_7__, arg_8__ with
+               | _, Tip => None
+               | x, Bin _ y l r =>
+                   if x GHC.Base.<= y : bool then goNothing x l else
+                   goJust x y r
+               end in
+  goNothing.
+
+Definition lookupGT {a} `{GHC.Base.Ord a} : a -> Set_ a -> option a :=
+  let fix goJust arg_0__ arg_1__ arg_2__
+            := match arg_0__, arg_1__, arg_2__ with
+               | _, best, Tip => Some best
+               | x, best, Bin _ y l r =>
+                   if x GHC.Base.< y : bool then goJust x y l else
+                   goJust x best r
+               end in
+  let fix goNothing arg_7__ arg_8__
+            := match arg_7__, arg_8__ with
+               | _, Tip => None
+               | x, Bin _ y l r =>
+                   if x GHC.Base.< y : bool then goJust x y l else
+                   goNothing x r
+               end in
+  goNothing.
+
+Definition lookupLE {a} `{GHC.Base.Ord a} : a -> Set_ a -> option a :=
+  let fix goJust arg_0__ arg_1__ arg_2__
+            := match arg_0__, arg_1__, arg_2__ with
+               | _, best, Tip => Some best
+               | x, best, Bin _ y l r =>
+                   match GHC.Base.compare x y with
+                   | Lt => goJust x best l
+                   | Eq => Some y
+                   | Gt => goJust x y r
+                   end
+               end in
+  let fix goNothing arg_11__ arg_12__
+            := match arg_11__, arg_12__ with
+               | _, Tip => None
+               | x, Bin _ y l r =>
+                   match GHC.Base.compare x y with
+                   | Lt => goNothing x l
+                   | Eq => Some y
+                   | Gt => goJust x y r
+                   end
+               end in
+  goNothing.
+
+Definition lookupGE {a} `{GHC.Base.Ord a} : a -> Set_ a -> option a :=
+  let fix goJust arg_0__ arg_1__ arg_2__
+            := match arg_0__, arg_1__, arg_2__ with
+               | _, best, Tip => Some best
+               | x, best, Bin _ y l r =>
+                   match GHC.Base.compare x y with
+                   | Lt => goJust x y l
+                   | Eq => Some y
+                   | Gt => goJust x best r
+                   end
+               end in
+  let fix goNothing arg_11__ arg_12__
+            := match arg_11__, arg_12__ with
+               | _, Tip => None
+               | x, Bin _ y l r =>
+                   match GHC.Base.compare x y with
+                   | Lt => goJust x y l
+                   | Eq => Some y
+                   | Gt => goNothing x r
+                   end
+               end in
+  goNothing.
+
+Definition delete {a} `{GHC.Base.Ord a} : a -> Set_ a -> Set_ a :=
+  let go {a} `{GHC.Base.Ord a} : a -> Set_ a -> Set_ a :=
+    fix go (arg_0__ : a) (arg_1__ : Set_ a) : Set_ a
+          := match arg_0__, arg_1__ with
+             | _, Tip => Tip
+             | x, (Bin _ y l r as t) =>
+                 match GHC.Base.compare x y with
+                 | Lt =>
+                     let l' := go x l in
+                     if Utils.Containers.Internal.PtrEquality.ptrEq l' l : bool then t else
+                     balanceR y l' r
+                 | Gt =>
+                     let r' := go x r in
+                     if Utils.Containers.Internal.PtrEquality.ptrEq r' r : bool then t else
+                     balanceL y l r'
+                 | Eq => glue l r
+                 end
+             end in
+  go.
+
+Fixpoint splitMember {a} `{GHC.Base.Ord a} (arg_0__ : a) (arg_1__ : Set_ a)
+           : (Set_ a * bool * Set_ a)%type
+           := match arg_0__, arg_1__ with
+              | _, Tip => pair (pair Tip false) Tip
+              | x, Bin _ y l r =>
+                  match GHC.Base.compare x y with
+                  | Lt =>
+                      let 'pair (pair lt found) gt := splitMember x l in
+                      let gt' := link y gt r in pair (pair lt found) gt'
+                  | Gt =>
+                      let 'pair (pair lt found) gt := splitMember x r in
+                      let lt' := link y l lt in pair (pair lt' found) gt
+                  | Eq => pair (pair l true) r
+                  end
+              end.
+
+Fixpoint isSubsetOfX {a} `{GHC.Base.Ord a} (arg_0__ arg_1__ : Set_ a) : bool
+           := match arg_0__, arg_1__ with
+              | Tip, _ => true
+              | _, Tip => false
+              | Bin _ x l r, t =>
+                  let 'pair (pair lt found) gt := splitMember x t in
+                  andb found (andb (isSubsetOfX l lt) (isSubsetOfX r gt))
+              end.
+
+Definition isSubsetOf {a} `{GHC.Base.Ord a} : Set_ a -> Set_ a -> bool :=
+  fun t1 t2 => andb (size t1 GHC.Base.<= size t2) (isSubsetOfX t1 t2).
+
+Definition isProperSubsetOf {a} `{GHC.Base.Ord a} : Set_ a -> Set_ a -> bool :=
+  fun s1 s2 => andb (size s1 GHC.Base.< size s2) (isSubsetOf s1 s2).
+
+Fixpoint disjoint {a} `{GHC.Base.Ord a} (arg_0__ arg_1__ : Set_ a) : bool
+           := match arg_0__, arg_1__ with
+              | Tip, _ => true
+              | _, Tip => true
+              | Bin _ x l r, t =>
+                  let 'pair (pair lt found) gt := splitMember x t in
+                  andb (negb found) (andb (disjoint l lt) (disjoint r gt))
+              end.
+
+Fixpoint lookupMinSure {a} (arg_0__ : a) (arg_1__ : Set_ a) : a
+           := match arg_0__, arg_1__ with
+              | x, Tip => x
+              | _, Bin _ x l _ => lookupMinSure x l
+              end.
+
+Definition lookupMin {a} : Set_ a -> option a :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Tip => None
+    | Bin _ x l _ => Some (lookupMinSure x l)
+    end.
+
+(* Skipping definition `Data.Set.Internal.findMin' *)
+
+Fixpoint lookupMaxSure {a} (arg_0__ : a) (arg_1__ : Set_ a) : a
+           := match arg_0__, arg_1__ with
+              | x, Tip => x
+              | _, Bin _ x _ r => lookupMaxSure x r
+              end.
+
+Definition lookupMax {a} : Set_ a -> option a :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Tip => None
+    | Bin _ x _ r => Some (lookupMaxSure x r)
+    end.
+
+(* Skipping definition `Data.Set.Internal.findMax' *)
 
 Fixpoint deleteMin {a} (arg_0__ : Set_ a) : Set_ a
            := match arg_0__ with
@@ -643,19 +823,6 @@ Fixpoint deleteMin {a} (arg_0__ : Set_ a) : Set_ a
               | Tip => Tip
               end.
 
-Fixpoint insertMax {a} (x : a) (t : Set_ a) : Set_ a
-           := match t with
-              | Tip => singleton x
-              | Bin _ y l r => balanceR y l (insertMax x r)
-              end.
-
-Definition minView {a} : Set_ a -> option (a * Set_ a)%type :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Tip => None
-    | Bin _ x l r => Some (id (minViewSure x l r))
-    end.
-
 Fixpoint deleteMax {a} (arg_0__ : Set_ a) : Set_ a
            := match arg_0__ with
               | Bin _ _ l Tip => l
@@ -663,104 +830,142 @@ Fixpoint deleteMax {a} (arg_0__ : Set_ a) : Set_ a
               | Tip => Tip
               end.
 
-Definition insert {a} `{GHC.Base.Ord a} : a -> Set_ a -> Set_ a :=
-  fun x0 =>
-    let go {a} `{GHC.Base.Ord a} : a -> a -> Set_ a -> Set_ a :=
-      fix go (arg_0__ arg_1__ : a) (arg_2__ : Set_ a) : Set_ a
-            := match arg_0__, arg_1__, arg_2__ with
-               | orig, _, Tip => singleton (orig)
-               | orig, x, (Bin sz y l r as t) =>
-                   match GHC.Base.compare x y with
-                   | Lt =>
-                       let l' := go orig x l in
-                       if Utils.Containers.Internal.PtrEquality.ptrEq l' l : bool then t else
-                       balanceL y l' r
-                   | Gt =>
-                       let r' := go orig x r in
-                       if Utils.Containers.Internal.PtrEquality.ptrEq r' r : bool then t else
-                       balanceR y l r'
-                   | Eq =>
-                       if (Utils.Containers.Internal.PtrEquality.ptrEq orig y) : bool then t else
-                       Bin sz (orig) l r
-                   end
-               end in
-    go x0 x0.
-
-Fixpoint insertMin {a} (x : a) (t : Set_ a) : Set_ a
-           := match t with
-              | Tip => singleton x
-              | Bin _ y l r => balanceL y (insertMin x l) r
+Fixpoint intersection {a} `{GHC.Base.Ord a} (arg_0__ arg_1__ : Set_ a) : Set_ a
+           := match arg_0__, arg_1__ with
+              | Tip, _ => Tip
+              | _, Tip => Tip
+              | (Bin _ x l1 r1 as t1), t2 =>
+                  let 'pair (pair l2 b) r2 := splitMember x t2 in
+                  let l1l2 := intersection l1 l2 in
+                  let r1r2 := intersection r1 r2 in
+                  if b : bool
+                  then if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1l2 l1)
+                               (Utils.Containers.Internal.PtrEquality.ptrEq r1r2 r1) : bool
+                       then t1
+                       else link x l1l2 r1r2 else
+                  merge l1l2 r1r2
               end.
 
-Definition insertR {a} `{GHC.Base.Ord a} : a -> Set_ a -> Set_ a :=
-  fun x0 =>
-    let go {a} `{GHC.Base.Ord a} : a -> a -> Set_ a -> Set_ a :=
-      fix go (arg_0__ arg_1__ : a) (arg_2__ : Set_ a) : Set_ a
-            := match arg_0__, arg_1__, arg_2__ with
-               | orig, _, Tip => singleton (orig)
-               | orig, x, (Bin _ y l r as t) =>
-                   match GHC.Base.compare x y with
-                   | Lt =>
-                       let l' := go orig x l in
-                       if Utils.Containers.Internal.PtrEquality.ptrEq l' l : bool then t else
-                       balanceL y l' r
-                   | Gt =>
-                       let r' := go orig x r in
-                       if Utils.Containers.Internal.PtrEquality.ptrEq r' r : bool then t else
-                       balanceR y l r'
-                   | Eq => t
-                   end
-               end in
-    go x0 x0.
-
-Program Fixpoint link {a} (arg_0__ : a) (arg_1__ arg_2__ : Set_ a)
-                      {measure (Nat.add (set_size arg_1__) (set_size arg_2__))} : Set_ a
-                   := match arg_0__, arg_1__, arg_2__ with
-                      | x, Tip, r => insertMin x r
-                      | x, l, Tip => insertMax x l
-                      | x, (Bin sizeL y ly ry as l), (Bin sizeR z lz rz as r) =>
-                          if Bool.Sumbool.sumbool_of_bool ((delta GHC.Num.* sizeL) GHC.Base.< sizeR)
-                          then balanceL z (link x l lz) rz else
-                          if Bool.Sumbool.sumbool_of_bool ((delta GHC.Num.* sizeR) GHC.Base.< sizeL)
-                          then balanceR y ly (link x ry r) else
-                          bin x l r
-                      end.
-Solve Obligations with (termination_by_omega).
-
-Definition drop {a} : GHC.Num.Int -> Set_ a -> Set_ a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | i, m =>
-        if i GHC.Base.>= size m : bool then Tip else
-        match arg_0__, arg_1__ with
-        | i0, m0 =>
-            let fix go arg_2__ arg_3__
-                      := match arg_2__, arg_3__ with
-                         | i, m =>
-                             if i GHC.Base.<= #0 : bool then m else
-                             match arg_2__, arg_3__ with
-                             | _, Tip => Tip
-                             | i, Bin _ x l r =>
-                                 let sizeL := size l in
-                                 match GHC.Base.compare i sizeL with
-                                 | Lt => link x (go i l) r
-                                 | Gt => go ((i GHC.Num.- sizeL) GHC.Num.- #1) r
-                                 | Eq => insertMin x r
-                                 end
-                             end
-                         end in
-            go i0 m0
-        end
-    end.
-
-Fixpoint dropWhileAntitone {a} (arg_0__ : (a -> bool)) (arg_1__ : Set_ a) : Set_
-                                                                            a
+Fixpoint filter {a} (arg_0__ : (a -> bool)) (arg_1__ : Set_ a) : Set_ a
            := match arg_0__, arg_1__ with
               | _, Tip => Tip
-              | p, Bin _ x l r =>
-                  if p x : bool then dropWhileAntitone p r else
-                  link x (dropWhileAntitone p l) r
+              | p, (Bin _ x l r as t) =>
+                  let r' := filter p r in
+                  let l' := filter p l in
+                  if p x : bool
+                  then if andb (Utils.Containers.Internal.PtrEquality.ptrEq l l')
+                               (Utils.Containers.Internal.PtrEquality.ptrEq r r') : bool
+                       then t
+                       else link x l' r' else
+                  merge l' r'
               end.
+
+Definition partition {a} : (a -> bool) -> Set_ a -> (Set_ a * Set_ a)%type :=
+  fun p0 t0 =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | _, Tip => (pair Tip Tip)
+                 | p, (Bin _ x l r as t) =>
+                     let 'pair (pair l1 l2) (pair r1 r2) := pair (go p l) (go p r) in
+                     if p x : bool
+                     then pair (if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1 l)
+                                        (Utils.Containers.Internal.PtrEquality.ptrEq r1 r) : bool
+                                then t
+                                else link x l1 r1) (merge l2 r2) else
+                     pair (merge l1 r1) (if andb (Utils.Containers.Internal.PtrEquality.ptrEq l2 l)
+                                                 (Utils.Containers.Internal.PtrEquality.ptrEq r2 r) : bool
+                           then t
+                           else link x l2 r2)
+                 end in
+    id (go p0 t0).
+
+Definition fromList {a} `{GHC.Base.Ord a} : list a -> Set_ a :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | nil => Tip
+    | cons x nil => Bin #1 x Tip Tip
+    | cons x0 xs0 =>
+        let fromList' :=
+          fun t0 xs =>
+            let ins := fun t x => insert x t in Data.Foldable.foldl' ins t0 xs in
+        let not_ordered :=
+          fun arg_4__ arg_5__ =>
+            match arg_4__, arg_5__ with
+            | _, nil => false
+            | x, cons y _ => x GHC.Base.>= y
+            end in
+        let create :=
+          GHC.DeferredFix.deferredFix2 (fun create arg_8__ arg_9__ =>
+                                          match arg_8__, arg_9__ with
+                                          | _, nil => pair (pair Tip nil) nil
+                                          | s, (cons x xss as xs) =>
+                                              if s GHC.Base.== #1 : bool
+                                              then if not_ordered x xss : bool
+                                                   then pair (pair (Bin #1 x Tip Tip) nil) xss
+                                                   else pair (pair (Bin #1 x Tip Tip) xss) nil else
+                                              match create (Data.Bits.shiftR s #1) xs with
+                                              | (pair (pair _ nil) _ as res) => res
+                                              | pair (pair l (cons y nil)) zs => pair (pair (insertMax y l) nil) zs
+                                              | pair (pair l (cons y yss as ys)) _ =>
+                                                  if not_ordered y yss : bool then pair (pair l nil) ys else
+                                                  let 'pair (pair r zs) ws := create (Data.Bits.shiftR s #1) yss in
+                                                  pair (pair (link y l r) zs) ws
+                                              end
+                                          end) in
+        let go :=
+          GHC.DeferredFix.deferredFix3 (fun go arg_22__ arg_23__ arg_24__ =>
+                                          match arg_22__, arg_23__, arg_24__ with
+                                          | _, t, nil => t
+                                          | _, t, cons x nil => insertMax x t
+                                          | s, l, (cons x xss as xs) =>
+                                              if not_ordered x xss : bool then fromList' l xs else
+                                              match create s xss with
+                                              | pair (pair r ys) nil => go (Data.Bits.shiftL s #1) (link x l r) ys
+                                              | pair (pair r _) ys => fromList' (link x l r) ys
+                                              end
+                                          end) in
+        if not_ordered x0 xs0 : bool then fromList' (Bin #1 x0 Tip Tip) xs0 else
+        go (#1 : GHC.Num.Int) (Bin #1 x0 Tip Tip) xs0
+    end.
+
+Definition map {b} {a} `{GHC.Base.Ord b} : (a -> b) -> Set_ a -> Set_ b :=
+  fun f => fromList GHC.Base.∘ (GHC.Base.map f GHC.Base.∘ toList).
+
+Fixpoint mapMonotonic {a} {b} (arg_0__ : (a -> b)) (arg_1__ : Set_ a) : Set_ b
+           := match arg_0__, arg_1__ with
+              | _, Tip => Tip
+              | f, Bin sz x l r => Bin sz (f x) (mapMonotonic f l) (mapMonotonic f r)
+              end.
+
+Definition fold {a} {b} : (a -> b -> b) -> b -> Set_ a -> b :=
+  foldr.
+
+Definition elems {a} : Set_ a -> list a :=
+  toAscList.
+
+Definition toDescList {a} : Set_ a -> list a :=
+  foldl (GHC.Base.flip cons) nil.
+
+Definition foldrFB {a} {b} : (a -> b -> b) -> b -> Set_ a -> b :=
+  foldr.
+
+Definition foldlFB {a} {b} : (a -> b -> a) -> a -> Set_ b -> a :=
+  foldl.
+
+Definition combineEq {a} `{GHC.Base.Eq_ a} : list a -> list a :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | nil => nil
+    | cons x xs =>
+        let fix combineEq' arg_1__ arg_2__
+                  := match arg_1__, arg_2__ with
+                     | z, nil => cons z nil
+                     | z, cons y ys =>
+                         if z GHC.Base.== y : bool then combineEq' z ys else
+                         cons z (combineEq' y ys)
+                     end in
+        combineEq' x xs
+    end.
 
 Definition fromDistinctAscList {a} : list a -> Set_ a :=
   fun arg_0__ =>
@@ -826,147 +1031,28 @@ Definition fromDistinctDescList {a} : list a -> Set_ a :=
 Definition fromDescList {a} `{GHC.Base.Eq_ a} : list a -> Set_ a :=
   fun xs => fromDistinctDescList (combineEq xs).
 
-Definition fromList {a} `{GHC.Base.Ord a} : list a -> Set_ a :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | nil => Tip
-    | cons x nil => Bin #1 x Tip Tip
-    | cons x0 xs0 =>
-        let fromList' :=
-          fun t0 xs =>
-            let ins := fun t x => insert x t in Data.Foldable.foldl' ins t0 xs in
-        let not_ordered :=
-          fun arg_4__ arg_5__ =>
-            match arg_4__, arg_5__ with
-            | _, nil => false
-            | x, cons y _ => x GHC.Base.>= y
-            end in
-        let create :=
-          GHC.DeferredFix.deferredFix2 (fun create arg_8__ arg_9__ =>
-                                          match arg_8__, arg_9__ with
-                                          | _, nil => pair (pair Tip nil) nil
-                                          | s, (cons x xss as xs) =>
-                                              if s GHC.Base.== #1 : bool
-                                              then if not_ordered x xss : bool
-                                                   then pair (pair (Bin #1 x Tip Tip) nil) xss
-                                                   else pair (pair (Bin #1 x Tip Tip) xss) nil else
-                                              match create (Data.Bits.shiftR s #1) xs with
-                                              | (pair (pair _ nil) _ as res) => res
-                                              | pair (pair l (cons y nil)) zs => pair (pair (insertMax y l) nil) zs
-                                              | pair (pair l (cons y yss as ys)) _ =>
-                                                  if not_ordered y yss : bool then pair (pair l nil) ys else
-                                                  let 'pair (pair r zs) ws := create (Data.Bits.shiftR s #1) yss in
-                                                  pair (pair (link y l r) zs) ws
-                                              end
-                                          end) in
-        let go :=
-          GHC.DeferredFix.deferredFix3 (fun go arg_22__ arg_23__ arg_24__ =>
-                                          match arg_22__, arg_23__, arg_24__ with
-                                          | _, t, nil => t
-                                          | _, t, cons x nil => insertMax x t
-                                          | s, l, (cons x xss as xs) =>
-                                              if not_ordered x xss : bool then fromList' l xs else
-                                              match create s xss with
-                                              | pair (pair r ys) nil => go (Data.Bits.shiftL s #1) (link x l r) ys
-                                              | pair (pair r _) ys => fromList' (link x l r) ys
-                                              end
-                                          end) in
-        if not_ordered x0 xs0 : bool then fromList' (Bin #1 x0 Tip Tip) xs0 else
-        go (#1 : GHC.Num.Int) (Bin #1 x0 Tip Tip) xs0
-    end.
+(* Skipping definition `Data.Set.Internal.findIndex' *)
 
-Definition map {b} {a} `{GHC.Base.Ord b} : (a -> b) -> Set_ a -> Set_ b :=
-  fun f => fromList GHC.Base.∘ (GHC.Base.map f GHC.Base.∘ toList).
+Definition lookupIndex {a} `{GHC.Base.Ord a}
+   : a -> Set_ a -> option GHC.Num.Int :=
+  let go {a} `{GHC.Base.Ord a}
+   : GHC.Num.Int -> a -> Set_ a -> option GHC.Num.Int :=
+    fix go (arg_0__ : GHC.Num.Int) (arg_1__ : a) (arg_2__ : Set_ a) : option
+                                                                      GHC.Num.Int
+          := match arg_0__, arg_1__, arg_2__ with
+             | _, _, Tip => None
+             | idx, x, Bin _ kx l r =>
+                 match GHC.Base.compare x kx with
+                 | Lt => go idx x l
+                 | Gt => go ((idx GHC.Num.+ size l) GHC.Num.+ #1) x r
+                 | Eq => Some (idx GHC.Num.+ size l)
+                 end
+             end in
+  go #0.
 
-Definition spanAntitone {a} : (a -> bool) -> Set_ a -> (Set_ a * Set_ a)%type :=
-  fun p0 m =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | _, Tip => pair Tip Tip
-                 | p, Bin _ x l r =>
-                     if p x : bool then let 'pair u v := go p r in pair (link x l u) v else
-                     let 'pair u v := go p l in
-                     pair u (link x v r)
-                 end in
-    id (go p0 m).
+(* Skipping definition `Data.Set.Internal.elemAt' *)
 
-Definition splitAt {a} : GHC.Num.Int -> Set_ a -> (Set_ a * Set_ a)%type :=
-  fun i0 m0 =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | i, m =>
-                     if i GHC.Base.<= #0 : bool then pair Tip m else
-                     match arg_0__, arg_1__ with
-                     | _, Tip => pair Tip Tip
-                     | i, Bin _ x l r =>
-                         let sizeL := size l in
-                         match GHC.Base.compare i sizeL with
-                         | Lt => let 'pair ll lr := go i l in pair ll (link x lr r)
-                         | Gt =>
-                             let 'pair rl rr := go ((i GHC.Num.- sizeL) GHC.Num.- #1) r in
-                             pair (link x l rl) rr
-                         | Eq => pair l (insertMin x r)
-                         end
-                     end
-                 end in
-    if i0 GHC.Base.>= size m0 : bool then pair m0 Tip else
-    id (go i0 m0).
-
-Fixpoint splitMember {a} `{GHC.Base.Ord a} (arg_0__ : a) (arg_1__ : Set_ a)
-           : (Set_ a * bool * Set_ a)%type
-           := match arg_0__, arg_1__ with
-              | _, Tip => pair (pair Tip false) Tip
-              | x, Bin _ y l r =>
-                  match GHC.Base.compare x y with
-                  | Lt =>
-                      let 'pair (pair lt found) gt := splitMember x l in
-                      let gt' := link y gt r in pair (pair lt found) gt'
-                  | Gt =>
-                      let 'pair (pair lt found) gt := splitMember x r in
-                      let lt' := link y l lt in pair (pair lt' found) gt
-                  | Eq => pair (pair l true) r
-                  end
-              end.
-
-Fixpoint disjoint {a} `{GHC.Base.Ord a} (arg_0__ arg_1__ : Set_ a) : bool
-           := match arg_0__, arg_1__ with
-              | Tip, _ => true
-              | _, Tip => true
-              | Bin _ x l r, t =>
-                  let 'pair (pair lt found) gt := splitMember x t in
-                  andb (negb found) (andb (disjoint l lt) (disjoint r gt))
-              end.
-
-Fixpoint isSubsetOfX {a} `{GHC.Base.Ord a} (arg_0__ arg_1__ : Set_ a) : bool
-           := match arg_0__, arg_1__ with
-              | Tip, _ => true
-              | _, Tip => false
-              | Bin _ x l r, t =>
-                  let 'pair (pair lt found) gt := splitMember x t in
-                  andb found (andb (isSubsetOfX l lt) (isSubsetOfX r gt))
-              end.
-
-Definition isSubsetOf {a} `{GHC.Base.Ord a} : Set_ a -> Set_ a -> bool :=
-  fun t1 t2 => andb (size t1 GHC.Base.<= size t2) (isSubsetOfX t1 t2).
-
-Definition isProperSubsetOf {a} `{GHC.Base.Ord a} : Set_ a -> Set_ a -> bool :=
-  fun s1 s2 => andb (size s1 GHC.Base.< size s2) (isSubsetOf s1 s2).
-
-Fixpoint splitS {a} `{GHC.Base.Ord a} (arg_0__ : a) (arg_1__ : Set_ a) : prod
-                                                                         (Set_ a) (Set_ a)
-           := match arg_0__, arg_1__ with
-              | _, Tip => (pair Tip Tip)
-              | x, Bin _ y l r =>
-                  match GHC.Base.compare x y with
-                  | Lt => let 'pair lt gt := splitS x l in (pair lt (link y gt r))
-                  | Gt => let 'pair lt gt := splitS x r in (pair (link y l lt) gt)
-                  | Eq => (pair l r)
-                  end
-              end.
-
-Definition split {a} `{GHC.Base.Ord a}
-   : a -> Set_ a -> (Set_ a * Set_ a)%type :=
-  fun x t => id (splitS x t).
+(* Skipping definition `Data.Set.Internal.deleteAt' *)
 
 Definition take {a} : GHC.Num.Int -> Set_ a -> Set_ a :=
   fun arg_0__ arg_1__ =>
@@ -994,6 +1080,54 @@ Definition take {a} : GHC.Num.Int -> Set_ a -> Set_ a :=
         end
     end.
 
+Definition drop {a} : GHC.Num.Int -> Set_ a -> Set_ a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | i, m =>
+        if i GHC.Base.>= size m : bool then Tip else
+        match arg_0__, arg_1__ with
+        | i0, m0 =>
+            let fix go arg_2__ arg_3__
+                      := match arg_2__, arg_3__ with
+                         | i, m =>
+                             if i GHC.Base.<= #0 : bool then m else
+                             match arg_2__, arg_3__ with
+                             | _, Tip => Tip
+                             | i, Bin _ x l r =>
+                                 let sizeL := size l in
+                                 match GHC.Base.compare i sizeL with
+                                 | Lt => link x (go i l) r
+                                 | Gt => go ((i GHC.Num.- sizeL) GHC.Num.- #1) r
+                                 | Eq => insertMin x r
+                                 end
+                             end
+                         end in
+            go i0 m0
+        end
+    end.
+
+Definition splitAt {a} : GHC.Num.Int -> Set_ a -> (Set_ a * Set_ a)%type :=
+  fun i0 m0 =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | i, m =>
+                     if i GHC.Base.<= #0 : bool then pair Tip m else
+                     match arg_0__, arg_1__ with
+                     | _, Tip => pair Tip Tip
+                     | i, Bin _ x l r =>
+                         let sizeL := size l in
+                         match GHC.Base.compare i sizeL with
+                         | Lt => let 'pair ll lr := go i l in pair ll (link x lr r)
+                         | Gt =>
+                             let 'pair rl rr := go ((i GHC.Num.- sizeL) GHC.Num.- #1) r in
+                             pair (link x l rl) rr
+                         | Eq => pair l (insertMin x r)
+                         end
+                     end
+                 end in
+    if i0 GHC.Base.>= size m0 : bool then pair m0 Tip else
+    id (go i0 m0).
+
 Fixpoint takeWhileAntitone {a} (arg_0__ : (a -> bool)) (arg_1__ : Set_ a) : Set_
                                                                             a
            := match arg_0__, arg_1__ with
@@ -1003,61 +1137,37 @@ Fixpoint takeWhileAntitone {a} (arg_0__ : (a -> bool)) (arg_1__ : Set_ a) : Set_
                   takeWhileAntitone p l
               end.
 
-Fixpoint union {a} `{GHC.Base.Ord a} (arg_0__ arg_1__ : Set_ a) : Set_ a
+Fixpoint dropWhileAntitone {a} (arg_0__ : (a -> bool)) (arg_1__ : Set_ a) : Set_
+                                                                            a
            := match arg_0__, arg_1__ with
-              | t1, Tip => t1
-              | t1, Bin num_2__ x _ _ =>
-                  if num_2__ GHC.Base.== #1 : bool then insertR x t1 else
-                  let j_11__ :=
-                    match arg_0__, arg_1__ with
-                    | Tip, t2 => t2
-                    | (Bin _ x l1 r1 as t1), t2 =>
-                        let 'pair l2 r2 := splitS x t2 in
-                        let r1r2 := union r1 r2 in
-                        let l1l2 := union l1 l2 in
-                        if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1l2 l1)
-                                (Utils.Containers.Internal.PtrEquality.ptrEq r1r2 r1) : bool
-                        then t1 else
-                        link x l1l2 r1r2
-                    end in
-                  match arg_0__, arg_1__ with
-                  | Bin num_3__ x _ _, t2 =>
-                      if num_3__ GHC.Base.== #1 : bool then insert x t2 else
-                      j_11__
-                  | _, _ => j_11__
-                  end
+              | _, Tip => Tip
+              | p, Bin _ x l r =>
+                  if p x : bool then dropWhileAntitone p r else
+                  link x (dropWhileAntitone p l) r
               end.
 
-Definition unions {f} {a} `{Data.Foldable.Foldable f} `{GHC.Base.Ord a}
-   : f (Set_ a) -> Set_ a :=
-  Data.Foldable.foldl' union empty.
+Definition spanAntitone {a} : (a -> bool) -> Set_ a -> (Set_ a * Set_ a)%type :=
+  fun p0 m =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | _, Tip => pair Tip Tip
+                 | p, Bin _ x l r =>
+                     if p x : bool then let 'pair u v := go p r in pair (link x l u) v else
+                     let 'pair u v := go p l in
+                     pair u (link x v r)
+                 end in
+    id (go p0 m).
 
-Definition delete {a} `{GHC.Base.Ord a} : a -> Set_ a -> Set_ a :=
-  let go {a} `{GHC.Base.Ord a} : a -> Set_ a -> Set_ a :=
-    fix go (arg_0__ : a) (arg_1__ : Set_ a) : Set_ a
-          := match arg_0__, arg_1__ with
-             | _, Tip => Tip
-             | x, (Bin _ y l r as t) =>
-                 match GHC.Base.compare x y with
-                 | Lt =>
-                     let l' := go x l in
-                     if Utils.Containers.Internal.PtrEquality.ptrEq l' l : bool then t else
-                     balanceR y l' r
-                 | Gt =>
-                     let r' := go x r in
-                     if Utils.Containers.Internal.PtrEquality.ptrEq r' r : bool then t else
-                     balanceL y l r'
-                 | Eq => glue l r
-                 end
-             end in
-  go.
+(* Skipping definition `Data.Set.Internal.deleteFindMin' *)
 
-Definition powerSet {a} : Set_ a -> Set_ (Set_ a) :=
-  fun xs0 =>
-    let step :=
-      fun x pxs =>
-        glue (insertMin (singleton x) (mapMonotonic (insertMin x) pxs)) pxs in
-    insertMin empty (foldr' step Tip xs0).
+(* Skipping definition `Data.Set.Internal.deleteFindMax' *)
+
+Definition minView {a} : Set_ a -> option (a * Set_ a)%type :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Tip => None
+    | Bin _ x l r => Some (id (minViewSure x l r))
+    end.
 
 Definition maxView {a} : Set_ a -> option (a * Set_ a)%type :=
   fun arg_0__ =>
@@ -1066,197 +1176,87 @@ Definition maxView {a} : Set_ a -> option (a * Set_ a)%type :=
     | Bin _ x l r => Some (id (maxViewSure x l r))
     end.
 
-Fixpoint difference {a} `{GHC.Base.Ord a} (arg_0__ arg_1__ : Set_ a) : Set_ a
-           := match arg_0__, arg_1__ with
-              | Tip, _ => Tip
-              | t1, Tip => t1
-              | t1, Bin _ x l2 r2 =>
-                  let 'pair l1 r1 := split x t1 in
-                  let r1r2 := difference r1 r2 in
-                  let l1l2 := difference l1 l2 in
-                  if (size l1l2 GHC.Num.+ size r1r2) GHC.Base.== size t1 : bool then t1 else
-                  merge l1l2 r1r2
-              end.
+Definition splitRoot {a} : Set_ a -> list (Set_ a) :=
+  fun orig =>
+    match orig with
+    | Tip => nil
+    | Bin _ v l r => cons l (cons (singleton v) (cons r nil))
+    end.
 
-Definition op_zrzr__ {a} `{GHC.Base.Ord a} : Set_ a -> Set_ a -> Set_ a :=
-  fun m1 m2 => difference m1 m2.
+Definition powerSet {a} : Set_ a -> Set_ (Set_ a) :=
+  fun xs0 =>
+    let step :=
+      fun x pxs =>
+        glue (insertMin (singleton x) (mapMonotonic (insertMin x) pxs)) pxs in
+    insertMin empty (foldr' step Tip xs0).
 
-Notation "'_\\_'" := (op_zrzr__).
-
-Infix "\\" := (_\\_) (at level 99).
+Definition cartesianProduct {a} {b} : Set_ a -> Set_ b -> Set_ (a * b)%type :=
+  fun as_ bs =>
+    getMergeSet (Data.Foldable.foldMap (fun a =>
+                                          Mk_MergeSet (mapMonotonic (GHC.Tuple.pair2 a) bs)) as_).
 
 Definition disjointUnion {a} {b}
    : Set_ a -> Set_ b -> Set_ (Data.Either.Either a b) :=
   fun as_ bs =>
     merge (mapMonotonic Data.Either.Left as_) (mapMonotonic Data.Either.Right bs).
 
-Fixpoint filter {a} (arg_0__ : (a -> bool)) (arg_1__ : Set_ a) : Set_ a
-           := match arg_0__, arg_1__ with
-              | _, Tip => Tip
-              | p, (Bin _ x l r as t) =>
-                  let r' := filter p r in
-                  let l' := filter p l in
-                  if p x : bool
-                  then if andb (Utils.Containers.Internal.PtrEquality.ptrEq l l')
-                               (Utils.Containers.Internal.PtrEquality.ptrEq r r') : bool
-                       then t
-                       else link x l' r' else
-                  merge l' r'
+(* Skipping definition `Data.Set.Internal.showTree' *)
+
+(* Skipping definition `Data.Set.Internal.showTreeWith' *)
+
+(* Skipping definition `Data.Set.Internal.showsTree' *)
+
+(* Skipping definition `Data.Set.Internal.showsTreeHang' *)
+
+(* Skipping definition `Data.Set.Internal.showWide' *)
+
+(* Skipping definition `Data.Set.Internal.showsBars' *)
+
+(* Skipping definition `Data.Set.Internal.node' *)
+
+(* Skipping definition `Data.Set.Internal.withBar' *)
+
+(* Skipping definition `Data.Set.Internal.withEmpty' *)
+
+Fixpoint balanced {a} (t : Set_ a) : bool
+           := match t with
+              | Tip => true
+              | Bin _ _ l r =>
+                  andb (orb ((size l GHC.Num.+ size r) GHC.Base.<= #1) (andb (size l GHC.Base.<=
+                                                                              (delta GHC.Num.* size r)) (size r
+                                                                              GHC.Base.<=
+                                                                              (delta GHC.Num.* size l)))) (andb
+                        (balanced l) (balanced r))
               end.
 
-Fixpoint intersection {a} `{GHC.Base.Ord a} (arg_0__ arg_1__ : Set_ a) : Set_ a
-           := match arg_0__, arg_1__ with
-              | Tip, _ => Tip
-              | _, Tip => Tip
-              | (Bin _ x l1 r1 as t1), t2 =>
-                  let 'pair (pair l2 b) r2 := splitMember x t2 in
-                  let l1l2 := intersection l1 l2 in
-                  let r1r2 := intersection r1 r2 in
-                  if b : bool
-                  then if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1l2 l1)
-                               (Utils.Containers.Internal.PtrEquality.ptrEq r1r2 r1) : bool
-                       then t1
-                       else link x l1l2 r1r2 else
-                  merge l1l2 r1r2
-              end.
-
-Definition partition {a} : (a -> bool) -> Set_ a -> (Set_ a * Set_ a)%type :=
-  fun p0 t0 =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | _, Tip => (pair Tip Tip)
-                 | p, (Bin _ x l r as t) =>
-                     let 'pair (pair l1 l2) (pair r1 r2) := pair (go p l) (go p r) in
-                     if p x : bool
-                     then pair (if andb (Utils.Containers.Internal.PtrEquality.ptrEq l1 l)
-                                        (Utils.Containers.Internal.PtrEquality.ptrEq r1 r) : bool
-                                then t
-                                else link x l1 r1) (merge l2 r2) else
-                     pair (merge l1 r1) (if andb (Utils.Containers.Internal.PtrEquality.ptrEq l2 l)
-                                                 (Utils.Containers.Internal.PtrEquality.ptrEq r2 r) : bool
-                           then t
-                           else link x l2 r2)
+Definition ordered {a} `{GHC.Base.Ord a} : Set_ a -> bool :=
+  fun t =>
+    let fix bounded lo hi t'
+              := match t' with
+                 | Tip => true
+                 | Bin _ x l r =>
+                     andb (lo x) (andb (hi x) (andb (bounded lo (fun arg_0__ => arg_0__ GHC.Base.< x)
+                                                     l) (bounded (fun arg_1__ => arg_1__ GHC.Base.> x) hi r)))
                  end in
-    id (go p0 t0).
+    bounded (GHC.Base.const true) (GHC.Base.const true) t.
 
-(* Skipping all instances of class `Control.DeepSeq.NFData', including
-   `Data.Set.Internal.NFData__Set_' *)
+Definition validsize {a} : Set_ a -> bool :=
+  fun t =>
+    let fix realsize t'
+              := match t' with
+                 | Tip => Some #0
+                 | Bin sz _ l r =>
+                     match pair (realsize l) (realsize r) with
+                     | pair (Some n) (Some m) =>
+                         if ((n GHC.Num.+ m) GHC.Num.+ #1) GHC.Base.== sz : bool then Some sz else
+                         None
+                     | _ => None
+                     end
+                 end in
+    (realsize t GHC.Base.== Some (size t)).
 
-(* Skipping all instances of class `GHC.Read.Read', including
-   `Data.Set.Internal.Read__Set_' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Show1', including
-   `Data.Set.Internal.Show1__Set_' *)
-
-Local Definition Ord1__Set__liftCompare
-   : forall {a} {b}, (a -> b -> comparison) -> Set_ a -> Set_ b -> comparison :=
-  fun {a} {b} =>
-    fun cmp m n => Data.Functor.Classes.liftCompare cmp (toList m) (toList n).
-
-Local Definition Eq1__Set__liftEq
-   : forall {a} {b}, (a -> b -> bool) -> Set_ a -> Set_ b -> bool :=
-  fun {a} {b} =>
-    fun eq m n =>
-      andb (size m GHC.Base.== size n) (Data.Functor.Classes.liftEq eq (toList m)
-            (toList n)).
-
-Program Instance Eq1__Set_ : Data.Functor.Classes.Eq1 Set_ :=
-  fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__Set__liftEq |}.
-
-Program Instance Ord1__Set_ : Data.Functor.Classes.Ord1 Set_ :=
-  fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
-             Ord1__Set__liftCompare |}.
-
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Data.Set.Internal.Show__Set_' *)
-
-Local Definition Ord__Set__compare {inst_a} `{GHC.Base.Ord inst_a}
-   : (Set_ inst_a) -> (Set_ inst_a) -> comparison :=
-  fun s1 s2 => GHC.Base.compare (toAscList s1) (toAscList s2).
-
-Local Definition Ord__Set__op_zl__ {inst_a} `{GHC.Base.Ord inst_a}
-   : (Set_ inst_a) -> (Set_ inst_a) -> bool :=
-  fun x y => Ord__Set__compare x y GHC.Base.== Lt.
-
-Local Definition Ord__Set__op_zlze__ {inst_a} `{GHC.Base.Ord inst_a}
-   : (Set_ inst_a) -> (Set_ inst_a) -> bool :=
-  fun x y => Ord__Set__compare x y GHC.Base./= Gt.
-
-Local Definition Ord__Set__op_zg__ {inst_a} `{GHC.Base.Ord inst_a}
-   : (Set_ inst_a) -> (Set_ inst_a) -> bool :=
-  fun x y => Ord__Set__compare x y GHC.Base.== Gt.
-
-Local Definition Ord__Set__op_zgze__ {inst_a} `{GHC.Base.Ord inst_a}
-   : (Set_ inst_a) -> (Set_ inst_a) -> bool :=
-  fun x y => Ord__Set__compare x y GHC.Base./= Lt.
-
-Local Definition Ord__Set__max {inst_a} `{GHC.Base.Ord inst_a}
-   : (Set_ inst_a) -> (Set_ inst_a) -> (Set_ inst_a) :=
-  fun x y => if Ord__Set__op_zlze__ x y : bool then y else x.
-
-Local Definition Ord__Set__min {inst_a} `{GHC.Base.Ord inst_a}
-   : (Set_ inst_a) -> (Set_ inst_a) -> (Set_ inst_a) :=
-  fun x y => if Ord__Set__op_zlze__ x y : bool then x else y.
-
-Local Definition Eq___Set__op_zeze__ {inst_a} `{GHC.Base.Eq_ inst_a}
-   : (Set_ inst_a) -> (Set_ inst_a) -> bool :=
-  fun t1 t2 =>
-    andb (size t1 GHC.Base.== size t2) (toAscList t1 GHC.Base.== toAscList t2).
-
-Local Definition Eq___Set__op_zsze__ {inst_a} `{GHC.Base.Eq_ inst_a}
-   : (Set_ inst_a) -> (Set_ inst_a) -> bool :=
-  fun x y => negb (Eq___Set__op_zeze__ x y).
-
-Program Instance Eq___Set_ {a} `{GHC.Base.Eq_ a} : GHC.Base.Eq_ (Set_ a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___Set__op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___Set__op_zsze__ |}.
-
-Program Instance Ord__Set_ {a} `{GHC.Base.Ord a} : GHC.Base.Ord (Set_ a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zl____ := Ord__Set__op_zl__ ;
-           GHC.Base.op_zlze____ := Ord__Set__op_zlze__ ;
-           GHC.Base.op_zg____ := Ord__Set__op_zg__ ;
-           GHC.Base.op_zgze____ := Ord__Set__op_zgze__ ;
-           GHC.Base.compare__ := Ord__Set__compare ;
-           GHC.Base.max__ := Ord__Set__max ;
-           GHC.Base.min__ := Ord__Set__min |}.
-
-(* Skipping all instances of class `GHC.Exts.IsList', including
-   `Data.Set.Internal.IsList__Set_' *)
-
-(* Skipping all instances of class `Data.Data.Data', including
-   `Data.Set.Internal.Data__Set_' *)
-
-Local Definition Semigroup__Set__op_zlzlzgzg__ {inst_a} `{GHC.Base.Ord inst_a}
-   : (Set_ inst_a) -> (Set_ inst_a) -> (Set_ inst_a) :=
-  union.
-
-Program Instance Semigroup__Set_ {a} `{GHC.Base.Ord a}
-   : GHC.Base.Semigroup (Set_ a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__Set__op_zlzlzgzg__ |}.
-
-Local Definition Monoid__Set__mappend {inst_a} `{GHC.Base.Ord inst_a}
-   : (Set_ inst_a) -> (Set_ inst_a) -> (Set_ inst_a) :=
-  _GHC.Base.<<>>_.
-
-Local Definition Monoid__Set__mconcat {inst_a} `{GHC.Base.Ord inst_a}
-   : list (Set_ inst_a) -> (Set_ inst_a) :=
-  unions.
-
-Local Definition Monoid__Set__mempty {inst_a} `{GHC.Base.Ord inst_a}
-   : (Set_ inst_a) :=
-  empty.
-
-Program Instance Monoid__Set_ {a} `{GHC.Base.Ord a}
-   : GHC.Base.Monoid (Set_ a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.mappend__ := Monoid__Set__mappend ;
-           GHC.Base.mconcat__ := Monoid__Set__mconcat ;
-           GHC.Base.mempty__ := Monoid__Set__mempty |}.
+Definition valid {a} `{GHC.Base.Ord a} : Set_ a -> bool :=
+  fun t => andb (balanced t) (andb (ordered t) (validsize t)).
 
 Module Notations.
 Notation "'_Data.Set.Internal.\\_'" := (op_zrzr__).

--- a/examples/containers/lib/Utils/Containers/Internal/BitUtil.v
+++ b/examples/containers/lib/Utils/Containers/Internal/BitUtil.v
@@ -34,12 +34,12 @@ Definition bitcount : Coq.Numbers.BinNums.N -> Coq.Numbers.BinNums.N -> Coq.Numb
 
 (* No value declarations to convert. *)
 
-(* Skipping definition `Utils.Containers.Internal.BitUtil.wordSize' *)
+(* Skipping definition `Utils.Containers.Internal.BitUtil.bitcount' *)
+
+(* Skipping definition `Utils.Containers.Internal.BitUtil.highestBitMask' *)
 
 (* Skipping definition `Utils.Containers.Internal.BitUtil.shiftRL' *)
 
 (* Skipping definition `Utils.Containers.Internal.BitUtil.shiftLL' *)
 
-(* Skipping definition `Utils.Containers.Internal.BitUtil.highestBitMask' *)
-
-(* Skipping definition `Utils.Containers.Internal.BitUtil.bitcount' *)
+(* Skipping definition `Utils.Containers.Internal.BitUtil.wordSize' *)

--- a/examples/containers/module-edits/Data/Map/Internal/edits
+++ b/examples/containers/module-edits/Data/Map/Internal/edits
@@ -24,6 +24,7 @@ order Data.Map.Internal.Functor__WhenMatched  Data.Map.Internal.Applicative__Whe
 
 order Data.Map.Internal.Functor__Map Data.Map.Internal.mapWhenMissing
 order Data.Map.Internal.Functor__Map Data.Map.Internal.lmapWhenMissing
+order Data.Map.Internal.Functor__Map Data.Map.Internal.Foldable__Map Data.Map.Internal.Traversable__Map
 
 # TODOs
 skip Data.Map.Internal.Eq1__Map

--- a/examples/ghc/lib/Bag.v
+++ b/examples/ghc/lib/Bag.v
@@ -54,54 +54,11 @@ Instance Default_Bag {a} : GHC.Err.Default (Bag a):=
 
 (* Converted value declarations: *)
 
-Definition unitBag {a} : a -> Bag a :=
-  UnitBag.
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Bag.Outputable__Bag' *)
 
-Definition unionBags {a} : Bag a -> Bag a -> Bag a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | EmptyBag, b => b
-    | b, EmptyBag => b
-    | b1, b2 => TwoBags b1 b2
-    end.
-
-Definition unionManyBags {a} : list (Bag a) -> Bag a :=
-  fun xs => Data.Foldable.foldr unionBags EmptyBag xs.
-
-Definition snocBag {a} : Bag a -> a -> Bag a :=
-  fun bag elt => unionBags bag (unitBag elt).
-
-Fixpoint mapMaybeBag {a} {b} (arg_0__ : (a -> option b)) (arg_1__ : Bag a) : Bag
-                                                                             b
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => EmptyBag
-              | f, UnitBag x => match f x with | None => EmptyBag | Some y => UnitBag y end
-              | f, TwoBags b1 b2 => unionBags (mapMaybeBag f b1) (mapMaybeBag f b2)
-              | f, ListBag xs => ListBag (Data.Maybe.mapMaybe f xs)
-              end.
-
-Fixpoint mapBagM_ {m} {a} {b} `{GHC.Base.Monad m} (arg_0__ : (a -> m b))
-                  (arg_1__ : Bag a) : m unit
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => GHC.Base.return_ tt
-              | f, UnitBag x => f x GHC.Base.>> GHC.Base.return_ tt
-              | f, TwoBags b1 b2 => mapBagM_ f b1 GHC.Base.>> mapBagM_ f b2
-              | f, ListBag xs => Data.Foldable.mapM_ f xs
-              end.
-
-Fixpoint mapBagM {m} {a} {b} `{GHC.Base.Monad m} (arg_0__ : (a -> m b)) (arg_1__
-                   : Bag a) : m (Bag b)
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => GHC.Base.return_ EmptyBag
-              | f, UnitBag x => f x GHC.Base.>>= (fun r => GHC.Base.return_ (UnitBag r))
-              | f, TwoBags b1 b2 =>
-                  mapBagM f b1 GHC.Base.>>=
-                  (fun r1 =>
-                     mapBagM f b2 GHC.Base.>>= (fun r2 => GHC.Base.return_ (TwoBags r1 r2)))
-              | f, ListBag xs =>
-                  Data.Traversable.mapM f xs GHC.Base.>>=
-                  (fun rs => GHC.Base.return_ (ListBag rs))
-              end.
+(* Skipping all instances of class `Data.Data.Data', including
+   `Bag.Data__Bag' *)
 
 Fixpoint mapBag {a} {b} (arg_0__ : (a -> b)) (arg_1__ : Bag a) : Bag b
            := match arg_0__, arg_1__ with
@@ -111,136 +68,17 @@ Fixpoint mapBag {a} {b} (arg_0__ : (a -> b)) (arg_1__ : Bag a) : Bag b
               | f, ListBag xs => ListBag (GHC.Base.map f xs)
               end.
 
-Fixpoint mapAndUnzipBagM {m} {a} {b} {c} `{GHC.Base.Monad m} (arg_0__
-                           : (a -> m (b * c)%type)) (arg_1__ : Bag a) : m (Bag b * Bag c)%type
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => GHC.Base.return_ (pair EmptyBag EmptyBag)
-              | f, UnitBag x =>
-                  let cont_3__ arg_4__ :=
-                    let 'pair r s := arg_4__ in
-                    GHC.Base.return_ (pair (UnitBag r) (UnitBag s)) in
-                  f x GHC.Base.>>= cont_3__
-              | f, TwoBags b1 b2 =>
-                  let cont_6__ arg_7__ :=
-                    let 'pair r1 s1 := arg_7__ in
-                    let cont_8__ arg_9__ :=
-                      let 'pair r2 s2 := arg_9__ in
-                      GHC.Base.return_ (pair (TwoBags r1 r2) (TwoBags s1 s2)) in
-                    mapAndUnzipBagM f b2 GHC.Base.>>= cont_8__ in
-                  mapAndUnzipBagM f b1 GHC.Base.>>= cont_6__
-              | f, ListBag xs =>
-                  Data.Traversable.mapM f xs GHC.Base.>>=
-                  (fun ts =>
-                     let 'pair rs ss := GHC.List.unzip ts in
-                     GHC.Base.return_ (pair (ListBag rs) (ListBag ss)))
-              end.
+Local Definition Functor__Bag_fmap
+   : forall {a} {b}, (a -> b) -> Bag a -> Bag b :=
+  fun {a} {b} => mapBag.
 
-Fixpoint mapAccumBagLM {m} {acc} {x} {y} `{GHC.Base.Monad m} (arg_0__
-                         : (acc -> x -> m (acc * y)%type)) (arg_1__ : acc) (arg_2__ : Bag x) : m (acc *
-                                                                                                  Bag y)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, s, EmptyBag => GHC.Base.return_ (pair s EmptyBag)
-              | f, s, UnitBag x =>
-                  let cont_4__ arg_5__ :=
-                    let 'pair s1 x1 := arg_5__ in
-                    GHC.Base.return_ (pair s1 (UnitBag x1)) in
-                  f s x GHC.Base.>>= cont_4__
-              | f, s, TwoBags b1 b2 =>
-                  let cont_7__ arg_8__ :=
-                    let 'pair s1 b1' := arg_8__ in
-                    let cont_9__ arg_10__ :=
-                      let 'pair s2 b2' := arg_10__ in
-                      GHC.Base.return_ (pair s2 (TwoBags b1' b2')) in
-                    mapAccumBagLM f s1 b2 GHC.Base.>>= cont_9__ in
-                  mapAccumBagLM f s b1 GHC.Base.>>= cont_7__
-              | f, s, ListBag xs =>
-                  let cont_12__ arg_13__ :=
-                    let 'pair s' xs' := arg_13__ in
-                    GHC.Base.return_ (pair s' (ListBag xs')) in
-                  MonadUtils.mapAccumLM f s xs GHC.Base.>>= cont_12__
-              end.
+Local Definition Functor__Bag_op_zlzd__ : forall {a} {b}, a -> Bag b -> Bag a :=
+  fun {a} {b} => Functor__Bag_fmap GHC.Base.∘ GHC.Base.const.
 
-Fixpoint mapAccumBagL {acc} {x} {y} (arg_0__ : (acc -> x -> (acc * y)%type))
-                      (arg_1__ : acc) (arg_2__ : Bag x) : (acc * Bag y)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, s, EmptyBag => pair s EmptyBag
-              | f, s, UnitBag x => let 'pair s1 x1 := f s x in pair s1 (UnitBag x1)
-              | f, s, TwoBags b1 b2 =>
-                  let 'pair s1 b1' := mapAccumBagL f s b1 in
-                  let 'pair s2 b2' := mapAccumBagL f s1 b2 in
-                  pair s2 (TwoBags b1' b2')
-              | f, s, ListBag xs =>
-                  let 'pair s' xs' := Data.Traversable.mapAccumL f s xs in
-                  pair s' (ListBag xs')
-              end.
-
-Definition listToBag {a} : list a -> Bag a :=
-  fun arg_0__ => match arg_0__ with | nil => EmptyBag | vs => ListBag vs end.
-
-Fixpoint partitionBag {a} (arg_0__ : (a -> bool)) (arg_1__ : Bag a) : (Bag a *
-                                                                       Bag a)%type
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => pair EmptyBag EmptyBag
-              | pred, (UnitBag val as b) =>
-                  if pred val : bool
-                  then pair b EmptyBag
-                  else pair EmptyBag b
-              | pred, TwoBags b1 b2 =>
-                  let 'pair sat2 fail2 := partitionBag pred b2 in
-                  let 'pair sat1 fail1 := partitionBag pred b1 in
-                  pair (unionBags sat1 sat2) (unionBags fail1 fail2)
-              | pred, ListBag vs =>
-                  let 'pair sats fails := Data.OldList.partition pred vs in
-                  pair (listToBag sats) (listToBag fails)
-              end.
-
-Fixpoint partitionBagWith {a} {b} {c} (arg_0__ : (a -> Data.Either.Either b c))
-                          (arg_1__ : Bag a) : (Bag b * Bag c)%type
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => pair EmptyBag EmptyBag
-              | pred, UnitBag val =>
-                  match pred val with
-                  | Data.Either.Left a => pair (UnitBag a) EmptyBag
-                  | Data.Either.Right b => pair EmptyBag (UnitBag b)
-                  end
-              | pred, TwoBags b1 b2 =>
-                  let 'pair sat2 fail2 := partitionBagWith pred b2 in
-                  let 'pair sat1 fail1 := partitionBagWith pred b1 in
-                  pair (unionBags sat1 sat2) (unionBags fail1 fail2)
-              | pred, ListBag vs =>
-                  let 'pair sats fails := Util.partitionWith pred vs in
-                  pair (listToBag sats) (listToBag fails)
-              end.
-
-Fixpoint lengthBag {a} (arg_0__ : Bag a) : nat
-           := match arg_0__ with
-              | EmptyBag => #0
-              | UnitBag _ => #1
-              | TwoBags b1 b2 => lengthBag b1 GHC.Num.+ lengthBag b2
-              | ListBag xs => BinInt.Z.to_nat (Data.Foldable.length xs)
-              end.
-
-Definition isSingletonBag {a} : Bag a -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | EmptyBag => false
-    | UnitBag _ => true
-    | TwoBags _ _ => false
-    | ListBag xs => Util.isSingleton xs
-    end.
-
-Definition isEmptyBag {a} : Bag a -> bool :=
-  fun arg_0__ => match arg_0__ with | EmptyBag => true | _ => false end.
-
-Fixpoint foldrBagM {m} {a} {b} `{(GHC.Base.Monad m)} (arg_0__ : (a -> b -> m b))
-                   (arg_1__ : b) (arg_2__ : Bag a) : m b
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, z, EmptyBag => GHC.Base.return_ z
-              | k, z, UnitBag x => k x z
-              | k, z, TwoBags b1 b2 =>
-                  foldrBagM k z b2 GHC.Base.>>= (fun z' => foldrBagM k z' b1)
-              | k, z, ListBag xs => MonadUtils.foldrM k z xs
-              end.
+Program Instance Functor__Bag : GHC.Base.Functor Bag :=
+  fun _ k__ =>
+    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Bag_fmap ;
+           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Bag_op_zlzd__ |}.
 
 Fixpoint foldrBag {a} {r} (arg_0__ : (a -> r -> r)) (arg_1__ : r) (arg_2__
                     : Bag a) : r
@@ -249,170 +87,6 @@ Fixpoint foldrBag {a} {r} (arg_0__ : (a -> r -> r)) (arg_1__ : r) (arg_2__
               | k, z, UnitBag x => k x z
               | k, z, TwoBags b1 b2 => foldrBag k (foldrBag k z b2) b1
               | k, z, ListBag xs => Data.Foldable.foldr k z xs
-              end.
-
-Fixpoint foldlBagM {m} {b} {a} `{(GHC.Base.Monad m)} (arg_0__ : (b -> a -> m b))
-                   (arg_1__ : b) (arg_2__ : Bag a) : m b
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, z, EmptyBag => GHC.Base.return_ z
-              | k, z, UnitBag x => k z x
-              | k, z, TwoBags b1 b2 =>
-                  foldlBagM k z b1 GHC.Base.>>= (fun z' => foldlBagM k z' b2)
-              | k, z, ListBag xs => MonadUtils.foldlM k z xs
-              end.
-
-Fixpoint foldlBag {r} {a} (arg_0__ : (r -> a -> r)) (arg_1__ : r) (arg_2__
-                    : Bag a) : r
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, z, EmptyBag => z
-              | k, z, UnitBag x => k z x
-              | k, z, TwoBags b1 b2 => foldlBag k (foldlBag k z b1) b2
-              | k, z, ListBag xs => Data.Foldable.foldl k z xs
-              end.
-
-Fixpoint foldBag {r} {a} (arg_0__ : (r -> r -> r)) (arg_1__ : (a -> r)) (arg_2__
-                   : r) (arg_3__ : Bag a) : r
-           := match arg_0__, arg_1__, arg_2__, arg_3__ with
-              | _, _, e, EmptyBag => e
-              | t, u, e, UnitBag x => t (u x) e
-              | t, u, e, TwoBags b1 b2 => foldBag t u (foldBag t u e b2) b1
-              | t, u, e, ListBag xs => Data.Foldable.foldr (t GHC.Base.∘ u) e xs
-              end.
-
-Fixpoint flatMapBagPairM {m} {a} {b} {c} `{GHC.Base.Monad m} (arg_0__
-                           : (a -> m (Bag b * Bag c)%type)) (arg_1__ : Bag a) : m (Bag b * Bag c)%type
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => GHC.Base.return_ (pair EmptyBag EmptyBag)
-              | f, UnitBag x => f x
-              | f, TwoBags b1 b2 =>
-                  let cont_4__ arg_5__ :=
-                    let 'pair r1 s1 := arg_5__ in
-                    let cont_6__ arg_7__ :=
-                      let 'pair r2 s2 := arg_7__ in
-                      GHC.Base.return_ (pair (unionBags r1 r2) (unionBags s1 s2)) in
-                    flatMapBagPairM f b2 GHC.Base.>>= cont_6__ in
-                  flatMapBagPairM f b1 GHC.Base.>>= cont_4__
-              | f, ListBag xs =>
-                  let k :=
-                    fun arg_9__ arg_10__ =>
-                      match arg_9__, arg_10__ with
-                      | x, pair r2 s2 =>
-                          let cont_11__ arg_12__ :=
-                            let 'pair r1 s1 := arg_12__ in
-                            GHC.Base.return_ (pair (unionBags r1 r2) (unionBags s1 s2)) in
-                          f x GHC.Base.>>= cont_11__
-                      end in
-                  MonadUtils.foldrM k (pair EmptyBag EmptyBag) xs
-              end.
-
-Fixpoint flatMapBagM {m} {a} {b} `{GHC.Base.Monad m} (arg_0__
-                       : (a -> m (Bag b))) (arg_1__ : Bag a) : m (Bag b)
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => GHC.Base.return_ EmptyBag
-              | f, UnitBag x => f x
-              | f, TwoBags b1 b2 =>
-                  flatMapBagM f b1 GHC.Base.>>=
-                  (fun r1 =>
-                     flatMapBagM f b2 GHC.Base.>>= (fun r2 => GHC.Base.return_ (unionBags r1 r2)))
-              | f, ListBag xs =>
-                  let k :=
-                    fun x b2 => f x GHC.Base.>>= (fun b1 => GHC.Base.return_ (unionBags b1 b2)) in
-                  MonadUtils.foldrM k EmptyBag xs
-              end.
-
-Fixpoint filterBagM {m} {a} `{GHC.Base.Monad m} (arg_0__ : (a -> m bool))
-                    (arg_1__ : Bag a) : m (Bag a)
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => GHC.Base.return_ EmptyBag
-              | pred, (UnitBag val as b) =>
-                  pred val GHC.Base.>>=
-                  (fun flag =>
-                     if flag : bool
-                     then GHC.Base.return_ b
-                     else GHC.Base.return_ EmptyBag)
-              | pred, TwoBags b1 b2 =>
-                  filterBagM pred b1 GHC.Base.>>=
-                  (fun sat1 =>
-                     filterBagM pred b2 GHC.Base.>>=
-                     (fun sat2 => GHC.Base.return_ (unionBags sat1 sat2)))
-              | pred, ListBag vs =>
-                  Control.Monad.filterM pred vs GHC.Base.>>=
-                  (fun sat => GHC.Base.return_ (listToBag sat))
-              end.
-
-Fixpoint filterBag {a} (arg_0__ : (a -> bool)) (arg_1__ : Bag a) : Bag a
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => EmptyBag
-              | pred, (UnitBag val as b) => if pred val : bool then b else EmptyBag
-              | pred, TwoBags b1 b2 =>
-                  let sat2 := filterBag pred b2 in
-                  let sat1 := filterBag pred b1 in unionBags sat1 sat2
-              | pred, ListBag vs => listToBag (GHC.List.filter pred vs)
-              end.
-
-Definition emptyBag {a} : Bag a :=
-  EmptyBag.
-
-Fixpoint elemBag {a} `{GHC.Base.Eq_ a} (arg_0__ : a) (arg_1__ : Bag a) : bool
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => false
-              | x, UnitBag y => x GHC.Base.== y
-              | x, TwoBags b1 b2 => orb (elemBag x b1) (elemBag x b2)
-              | x, ListBag ys => Data.Foldable.any (fun arg_4__ => x GHC.Base.== arg_4__) ys
-              end.
-
-Definition consBag {a} : a -> Bag a -> Bag a :=
-  fun elt bag => unionBags (unitBag elt) bag.
-
-Fixpoint concatMapBag {a} {b} (arg_0__ : (a -> Bag b)) (arg_1__ : Bag a) : Bag b
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => EmptyBag
-              | f, UnitBag x => f x
-              | f, TwoBags b1 b2 => unionBags (concatMapBag f b1) (concatMapBag f b2)
-              | f, ListBag xs => Data.Foldable.foldr (unionBags GHC.Base.∘ f) emptyBag xs
-              end.
-
-Definition concatBag {a} : Bag (Bag a) -> Bag a :=
-  fun bss => let add := fun bs rs => unionBags bs rs in foldrBag add emptyBag bss.
-
-Definition catBagMaybes {a} : Bag (option a) -> Bag a :=
-  fun bs =>
-    let add :=
-      fun arg_0__ arg_1__ =>
-        match arg_0__, arg_1__ with
-        | None, rs => rs
-        | Some x, rs => consBag x rs
-        end in
-    foldrBag add emptyBag bs.
-
-Definition bagToList {a} : Bag a -> list a :=
-  fun b => foldrBag cons nil b.
-
-Fixpoint anyBagM {m} {a} `{GHC.Base.Monad m} (arg_0__ : (a -> m bool)) (arg_1__
-                   : Bag a) : m bool
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => GHC.Base.return_ false
-              | p, UnitBag v => p v
-              | p, TwoBags b1 b2 =>
-                  anyBagM p b1 GHC.Base.>>=
-                  (fun flag => if flag : bool then GHC.Base.return_ true else anyBagM p b2)
-              | p, ListBag xs => MonadUtils.anyM p xs
-              end.
-
-Fixpoint anyBag {a} (arg_0__ : (a -> bool)) (arg_1__ : Bag a) : bool
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => false
-              | p, UnitBag v => p v
-              | p, TwoBags b1 b2 => orb (anyBag p b1) (anyBag p b2)
-              | p, ListBag xs => Data.Foldable.any p xs
-              end.
-
-Fixpoint allBag {a} (arg_0__ : (a -> bool)) (arg_1__ : Bag a) : bool
-           := match arg_0__, arg_1__ with
-              | _, EmptyBag => true
-              | p, UnitBag v => p v
-              | p, TwoBags b1 b2 => andb (allBag p b1) (allBag p b2)
-              | p, ListBag xs => Data.Foldable.all p xs
               end.
 
 Local Definition Foldable__Bag_foldr
@@ -491,23 +165,349 @@ Program Instance Foldable__Bag : Data.Foldable.Foldable Bag :=
            Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Bag_sum ;
            Data.Foldable.toList__ := fun {a} => Foldable__Bag_toList |}.
 
-Local Definition Functor__Bag_fmap
-   : forall {a} {b}, (a -> b) -> Bag a -> Bag b :=
-  fun {a} {b} => mapBag.
+Definition emptyBag {a} : Bag a :=
+  EmptyBag.
 
-Local Definition Functor__Bag_op_zlzd__ : forall {a} {b}, a -> Bag b -> Bag a :=
-  fun {a} {b} => Functor__Bag_fmap GHC.Base.∘ GHC.Base.const.
+Definition unitBag {a} : a -> Bag a :=
+  UnitBag.
 
-Program Instance Functor__Bag : GHC.Base.Functor Bag :=
-  fun _ k__ =>
-    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Bag_fmap ;
-           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Bag_op_zlzd__ |}.
+Fixpoint lengthBag {a} (arg_0__ : Bag a) : nat
+           := match arg_0__ with
+              | EmptyBag => #0
+              | UnitBag _ => #1
+              | TwoBags b1 b2 => lengthBag b1 GHC.Num.+ lengthBag b2
+              | ListBag xs => BinInt.Z.to_nat (Data.Foldable.length xs)
+              end.
 
-(* Skipping all instances of class `Data.Data.Data', including
-   `Bag.Data__Bag' *)
+Fixpoint elemBag {a} `{GHC.Base.Eq_ a} (arg_0__ : a) (arg_1__ : Bag a) : bool
+           := match arg_0__, arg_1__ with
+              | _, EmptyBag => false
+              | x, UnitBag y => x GHC.Base.== y
+              | x, TwoBags b1 b2 => orb (elemBag x b1) (elemBag x b2)
+              | x, ListBag ys => Data.Foldable.any (fun arg_4__ => x GHC.Base.== arg_4__) ys
+              end.
 
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Bag.Outputable__Bag' *)
+Definition unionBags {a} : Bag a -> Bag a -> Bag a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | EmptyBag, b => b
+    | b, EmptyBag => b
+    | b1, b2 => TwoBags b1 b2
+    end.
+
+Definition unionManyBags {a} : list (Bag a) -> Bag a :=
+  fun xs => Data.Foldable.foldr unionBags EmptyBag xs.
+
+Definition consBag {a} : a -> Bag a -> Bag a :=
+  fun elt bag => unionBags (unitBag elt) bag.
+
+Definition snocBag {a} : Bag a -> a -> Bag a :=
+  fun bag elt => unionBags bag (unitBag elt).
+
+Definition isEmptyBag {a} : Bag a -> bool :=
+  fun arg_0__ => match arg_0__ with | EmptyBag => true | _ => false end.
+
+Definition isSingletonBag {a} : Bag a -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | EmptyBag => false
+    | UnitBag _ => true
+    | TwoBags _ _ => false
+    | ListBag xs => Util.isSingleton xs
+    end.
+
+Definition listToBag {a} : list a -> Bag a :=
+  fun arg_0__ => match arg_0__ with | nil => EmptyBag | vs => ListBag vs end.
+
+Fixpoint filterBag {a} (arg_0__ : (a -> bool)) (arg_1__ : Bag a) : Bag a
+           := match arg_0__, arg_1__ with
+              | _, EmptyBag => EmptyBag
+              | pred, (UnitBag val as b) => if pred val : bool then b else EmptyBag
+              | pred, TwoBags b1 b2 =>
+                  let sat2 := filterBag pred b2 in
+                  let sat1 := filterBag pred b1 in unionBags sat1 sat2
+              | pred, ListBag vs => listToBag (GHC.List.filter pred vs)
+              end.
+
+Fixpoint filterBagM {m} {a} `{GHC.Base.Monad m} (arg_0__ : (a -> m bool))
+                    (arg_1__ : Bag a) : m (Bag a)
+           := match arg_0__, arg_1__ with
+              | _, EmptyBag => GHC.Base.return_ EmptyBag
+              | pred, (UnitBag val as b) =>
+                  pred val GHC.Base.>>=
+                  (fun flag =>
+                     if flag : bool
+                     then GHC.Base.return_ b
+                     else GHC.Base.return_ EmptyBag)
+              | pred, TwoBags b1 b2 =>
+                  filterBagM pred b1 GHC.Base.>>=
+                  (fun sat1 =>
+                     filterBagM pred b2 GHC.Base.>>=
+                     (fun sat2 => GHC.Base.return_ (unionBags sat1 sat2)))
+              | pred, ListBag vs =>
+                  Control.Monad.filterM pred vs GHC.Base.>>=
+                  (fun sat => GHC.Base.return_ (listToBag sat))
+              end.
+
+Fixpoint allBag {a} (arg_0__ : (a -> bool)) (arg_1__ : Bag a) : bool
+           := match arg_0__, arg_1__ with
+              | _, EmptyBag => true
+              | p, UnitBag v => p v
+              | p, TwoBags b1 b2 => andb (allBag p b1) (allBag p b2)
+              | p, ListBag xs => Data.Foldable.all p xs
+              end.
+
+Fixpoint anyBag {a} (arg_0__ : (a -> bool)) (arg_1__ : Bag a) : bool
+           := match arg_0__, arg_1__ with
+              | _, EmptyBag => false
+              | p, UnitBag v => p v
+              | p, TwoBags b1 b2 => orb (anyBag p b1) (anyBag p b2)
+              | p, ListBag xs => Data.Foldable.any p xs
+              end.
+
+Fixpoint anyBagM {m} {a} `{GHC.Base.Monad m} (arg_0__ : (a -> m bool)) (arg_1__
+                   : Bag a) : m bool
+           := match arg_0__, arg_1__ with
+              | _, EmptyBag => GHC.Base.return_ false
+              | p, UnitBag v => p v
+              | p, TwoBags b1 b2 =>
+                  anyBagM p b1 GHC.Base.>>=
+                  (fun flag => if flag : bool then GHC.Base.return_ true else anyBagM p b2)
+              | p, ListBag xs => MonadUtils.anyM p xs
+              end.
+
+Definition concatBag {a} : Bag (Bag a) -> Bag a :=
+  fun bss => let add := fun bs rs => unionBags bs rs in foldrBag add emptyBag bss.
+
+Definition catBagMaybes {a} : Bag (option a) -> Bag a :=
+  fun bs =>
+    let add :=
+      fun arg_0__ arg_1__ =>
+        match arg_0__, arg_1__ with
+        | None, rs => rs
+        | Some x, rs => consBag x rs
+        end in
+    foldrBag add emptyBag bs.
+
+Fixpoint partitionBag {a} (arg_0__ : (a -> bool)) (arg_1__ : Bag a) : (Bag a *
+                                                                       Bag a)%type
+           := match arg_0__, arg_1__ with
+              | _, EmptyBag => pair EmptyBag EmptyBag
+              | pred, (UnitBag val as b) =>
+                  if pred val : bool
+                  then pair b EmptyBag
+                  else pair EmptyBag b
+              | pred, TwoBags b1 b2 =>
+                  let 'pair sat2 fail2 := partitionBag pred b2 in
+                  let 'pair sat1 fail1 := partitionBag pred b1 in
+                  pair (unionBags sat1 sat2) (unionBags fail1 fail2)
+              | pred, ListBag vs =>
+                  let 'pair sats fails := Data.OldList.partition pred vs in
+                  pair (listToBag sats) (listToBag fails)
+              end.
+
+Fixpoint partitionBagWith {a} {b} {c} (arg_0__ : (a -> Data.Either.Either b c))
+                          (arg_1__ : Bag a) : (Bag b * Bag c)%type
+           := match arg_0__, arg_1__ with
+              | _, EmptyBag => pair EmptyBag EmptyBag
+              | pred, UnitBag val =>
+                  match pred val with
+                  | Data.Either.Left a => pair (UnitBag a) EmptyBag
+                  | Data.Either.Right b => pair EmptyBag (UnitBag b)
+                  end
+              | pred, TwoBags b1 b2 =>
+                  let 'pair sat2 fail2 := partitionBagWith pred b2 in
+                  let 'pair sat1 fail1 := partitionBagWith pred b1 in
+                  pair (unionBags sat1 sat2) (unionBags fail1 fail2)
+              | pred, ListBag vs =>
+                  let 'pair sats fails := Util.partitionWith pred vs in
+                  pair (listToBag sats) (listToBag fails)
+              end.
+
+Fixpoint foldBag {r} {a} (arg_0__ : (r -> r -> r)) (arg_1__ : (a -> r)) (arg_2__
+                   : r) (arg_3__ : Bag a) : r
+           := match arg_0__, arg_1__, arg_2__, arg_3__ with
+              | _, _, e, EmptyBag => e
+              | t, u, e, UnitBag x => t (u x) e
+              | t, u, e, TwoBags b1 b2 => foldBag t u (foldBag t u e b2) b1
+              | t, u, e, ListBag xs => Data.Foldable.foldr (t GHC.Base.∘ u) e xs
+              end.
+
+Fixpoint foldlBag {r} {a} (arg_0__ : (r -> a -> r)) (arg_1__ : r) (arg_2__
+                    : Bag a) : r
+           := match arg_0__, arg_1__, arg_2__ with
+              | _, z, EmptyBag => z
+              | k, z, UnitBag x => k z x
+              | k, z, TwoBags b1 b2 => foldlBag k (foldlBag k z b1) b2
+              | k, z, ListBag xs => Data.Foldable.foldl k z xs
+              end.
+
+Fixpoint foldrBagM {m} {a} {b} `{(GHC.Base.Monad m)} (arg_0__ : (a -> b -> m b))
+                   (arg_1__ : b) (arg_2__ : Bag a) : m b
+           := match arg_0__, arg_1__, arg_2__ with
+              | _, z, EmptyBag => GHC.Base.return_ z
+              | k, z, UnitBag x => k x z
+              | k, z, TwoBags b1 b2 =>
+                  foldrBagM k z b2 GHC.Base.>>= (fun z' => foldrBagM k z' b1)
+              | k, z, ListBag xs => MonadUtils.foldrM k z xs
+              end.
+
+Fixpoint foldlBagM {m} {b} {a} `{(GHC.Base.Monad m)} (arg_0__ : (b -> a -> m b))
+                   (arg_1__ : b) (arg_2__ : Bag a) : m b
+           := match arg_0__, arg_1__, arg_2__ with
+              | _, z, EmptyBag => GHC.Base.return_ z
+              | k, z, UnitBag x => k z x
+              | k, z, TwoBags b1 b2 =>
+                  foldlBagM k z b1 GHC.Base.>>= (fun z' => foldlBagM k z' b2)
+              | k, z, ListBag xs => MonadUtils.foldlM k z xs
+              end.
+
+Fixpoint concatMapBag {a} {b} (arg_0__ : (a -> Bag b)) (arg_1__ : Bag a) : Bag b
+           := match arg_0__, arg_1__ with
+              | _, EmptyBag => EmptyBag
+              | f, UnitBag x => f x
+              | f, TwoBags b1 b2 => unionBags (concatMapBag f b1) (concatMapBag f b2)
+              | f, ListBag xs => Data.Foldable.foldr (unionBags GHC.Base.∘ f) emptyBag xs
+              end.
+
+Fixpoint mapMaybeBag {a} {b} (arg_0__ : (a -> option b)) (arg_1__ : Bag a) : Bag
+                                                                             b
+           := match arg_0__, arg_1__ with
+              | _, EmptyBag => EmptyBag
+              | f, UnitBag x => match f x with | None => EmptyBag | Some y => UnitBag y end
+              | f, TwoBags b1 b2 => unionBags (mapMaybeBag f b1) (mapMaybeBag f b2)
+              | f, ListBag xs => ListBag (Data.Maybe.mapMaybe f xs)
+              end.
+
+Fixpoint mapBagM {m} {a} {b} `{GHC.Base.Monad m} (arg_0__ : (a -> m b)) (arg_1__
+                   : Bag a) : m (Bag b)
+           := match arg_0__, arg_1__ with
+              | _, EmptyBag => GHC.Base.return_ EmptyBag
+              | f, UnitBag x => f x GHC.Base.>>= (fun r => GHC.Base.return_ (UnitBag r))
+              | f, TwoBags b1 b2 =>
+                  mapBagM f b1 GHC.Base.>>=
+                  (fun r1 =>
+                     mapBagM f b2 GHC.Base.>>= (fun r2 => GHC.Base.return_ (TwoBags r1 r2)))
+              | f, ListBag xs =>
+                  Data.Traversable.mapM f xs GHC.Base.>>=
+                  (fun rs => GHC.Base.return_ (ListBag rs))
+              end.
+
+Fixpoint mapBagM_ {m} {a} {b} `{GHC.Base.Monad m} (arg_0__ : (a -> m b))
+                  (arg_1__ : Bag a) : m unit
+           := match arg_0__, arg_1__ with
+              | _, EmptyBag => GHC.Base.return_ tt
+              | f, UnitBag x => f x GHC.Base.>> GHC.Base.return_ tt
+              | f, TwoBags b1 b2 => mapBagM_ f b1 GHC.Base.>> mapBagM_ f b2
+              | f, ListBag xs => Data.Foldable.mapM_ f xs
+              end.
+
+Fixpoint flatMapBagM {m} {a} {b} `{GHC.Base.Monad m} (arg_0__
+                       : (a -> m (Bag b))) (arg_1__ : Bag a) : m (Bag b)
+           := match arg_0__, arg_1__ with
+              | _, EmptyBag => GHC.Base.return_ EmptyBag
+              | f, UnitBag x => f x
+              | f, TwoBags b1 b2 =>
+                  flatMapBagM f b1 GHC.Base.>>=
+                  (fun r1 =>
+                     flatMapBagM f b2 GHC.Base.>>= (fun r2 => GHC.Base.return_ (unionBags r1 r2)))
+              | f, ListBag xs =>
+                  let k :=
+                    fun x b2 => f x GHC.Base.>>= (fun b1 => GHC.Base.return_ (unionBags b1 b2)) in
+                  MonadUtils.foldrM k EmptyBag xs
+              end.
+
+Fixpoint flatMapBagPairM {m} {a} {b} {c} `{GHC.Base.Monad m} (arg_0__
+                           : (a -> m (Bag b * Bag c)%type)) (arg_1__ : Bag a) : m (Bag b * Bag c)%type
+           := match arg_0__, arg_1__ with
+              | _, EmptyBag => GHC.Base.return_ (pair EmptyBag EmptyBag)
+              | f, UnitBag x => f x
+              | f, TwoBags b1 b2 =>
+                  let cont_4__ arg_5__ :=
+                    let 'pair r1 s1 := arg_5__ in
+                    let cont_6__ arg_7__ :=
+                      let 'pair r2 s2 := arg_7__ in
+                      GHC.Base.return_ (pair (unionBags r1 r2) (unionBags s1 s2)) in
+                    flatMapBagPairM f b2 GHC.Base.>>= cont_6__ in
+                  flatMapBagPairM f b1 GHC.Base.>>= cont_4__
+              | f, ListBag xs =>
+                  let k :=
+                    fun arg_9__ arg_10__ =>
+                      match arg_9__, arg_10__ with
+                      | x, pair r2 s2 =>
+                          let cont_11__ arg_12__ :=
+                            let 'pair r1 s1 := arg_12__ in
+                            GHC.Base.return_ (pair (unionBags r1 r2) (unionBags s1 s2)) in
+                          f x GHC.Base.>>= cont_11__
+                      end in
+                  MonadUtils.foldrM k (pair EmptyBag EmptyBag) xs
+              end.
+
+Fixpoint mapAndUnzipBagM {m} {a} {b} {c} `{GHC.Base.Monad m} (arg_0__
+                           : (a -> m (b * c)%type)) (arg_1__ : Bag a) : m (Bag b * Bag c)%type
+           := match arg_0__, arg_1__ with
+              | _, EmptyBag => GHC.Base.return_ (pair EmptyBag EmptyBag)
+              | f, UnitBag x =>
+                  let cont_3__ arg_4__ :=
+                    let 'pair r s := arg_4__ in
+                    GHC.Base.return_ (pair (UnitBag r) (UnitBag s)) in
+                  f x GHC.Base.>>= cont_3__
+              | f, TwoBags b1 b2 =>
+                  let cont_6__ arg_7__ :=
+                    let 'pair r1 s1 := arg_7__ in
+                    let cont_8__ arg_9__ :=
+                      let 'pair r2 s2 := arg_9__ in
+                      GHC.Base.return_ (pair (TwoBags r1 r2) (TwoBags s1 s2)) in
+                    mapAndUnzipBagM f b2 GHC.Base.>>= cont_8__ in
+                  mapAndUnzipBagM f b1 GHC.Base.>>= cont_6__
+              | f, ListBag xs =>
+                  Data.Traversable.mapM f xs GHC.Base.>>=
+                  (fun ts =>
+                     let 'pair rs ss := GHC.List.unzip ts in
+                     GHC.Base.return_ (pair (ListBag rs) (ListBag ss)))
+              end.
+
+Fixpoint mapAccumBagL {acc} {x} {y} (arg_0__ : (acc -> x -> (acc * y)%type))
+                      (arg_1__ : acc) (arg_2__ : Bag x) : (acc * Bag y)%type
+           := match arg_0__, arg_1__, arg_2__ with
+              | _, s, EmptyBag => pair s EmptyBag
+              | f, s, UnitBag x => let 'pair s1 x1 := f s x in pair s1 (UnitBag x1)
+              | f, s, TwoBags b1 b2 =>
+                  let 'pair s1 b1' := mapAccumBagL f s b1 in
+                  let 'pair s2 b2' := mapAccumBagL f s1 b2 in
+                  pair s2 (TwoBags b1' b2')
+              | f, s, ListBag xs =>
+                  let 'pair s' xs' := Data.Traversable.mapAccumL f s xs in
+                  pair s' (ListBag xs')
+              end.
+
+Fixpoint mapAccumBagLM {m} {acc} {x} {y} `{GHC.Base.Monad m} (arg_0__
+                         : (acc -> x -> m (acc * y)%type)) (arg_1__ : acc) (arg_2__ : Bag x) : m (acc *
+                                                                                                  Bag y)%type
+           := match arg_0__, arg_1__, arg_2__ with
+              | _, s, EmptyBag => GHC.Base.return_ (pair s EmptyBag)
+              | f, s, UnitBag x =>
+                  let cont_4__ arg_5__ :=
+                    let 'pair s1 x1 := arg_5__ in
+                    GHC.Base.return_ (pair s1 (UnitBag x1)) in
+                  f s x GHC.Base.>>= cont_4__
+              | f, s, TwoBags b1 b2 =>
+                  let cont_7__ arg_8__ :=
+                    let 'pair s1 b1' := arg_8__ in
+                    let cont_9__ arg_10__ :=
+                      let 'pair s2 b2' := arg_10__ in
+                      GHC.Base.return_ (pair s2 (TwoBags b1' b2')) in
+                    mapAccumBagLM f s1 b2 GHC.Base.>>= cont_9__ in
+                  mapAccumBagLM f s b1 GHC.Base.>>= cont_7__
+              | f, s, ListBag xs =>
+                  let cont_12__ arg_13__ :=
+                    let 'pair s' xs' := arg_13__ in
+                    GHC.Base.return_ (pair s' (ListBag xs')) in
+                  MonadUtils.mapAccumLM f s xs GHC.Base.>>= cont_12__
+              end.
+
+Definition bagToList {a} : Bag a -> list a :=
+  fun b => foldrBag cons nil b.
 
 (* External variables:
      None Some andb bool cons false list nat nil op_zt__ option orb pair true tt unit

--- a/examples/ghc/lib/BasicTypes.v
+++ b/examples/ghc/lib/BasicTypes.v
@@ -440,512 +440,6 @@ Instance Default__InlinePragma : GHC.Err.Default InlinePragma :=
 
 (* Converted value declarations: *)
 
-Definition zapOccTailCallInfo : OccInfo -> OccInfo :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | IAmDead => IAmDead
-    | occ =>
-        match occ with
-        | ManyOccs occ_tail_1__ => ManyOccs NoTailCallInfo
-        | IAmDead => GHC.Err.error (GHC.Base.hs_string__ "Partial record update")
-        | OneOcc occ_in_lam_2__ occ_one_br_3__ occ_int_cxt_4__ occ_tail_5__ =>
-            OneOcc occ_in_lam_2__ occ_one_br_3__ occ_int_cxt_4__ NoTailCallInfo
-        | IAmALoopBreaker occ_rules_only_6__ occ_tail_7__ =>
-            IAmALoopBreaker occ_rules_only_6__ NoTailCallInfo
-        end
-    end.
-
-Definition worstOneShot : OneShotInfo -> OneShotInfo -> OneShotInfo :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | NoOneShotInfo, _ => NoOneShotInfo
-    | OneShotLam, os => os
-    end.
-
-Definition weakLoopBreaker : OccInfo :=
-  IAmALoopBreaker true NoTailCallInfo.
-
-Definition unSwap {a} {b} : SwapFlag -> (a -> a -> b) -> a -> a -> b :=
-  fun arg_0__ arg_1__ arg_2__ arg_3__ =>
-    match arg_0__, arg_1__, arg_2__, arg_3__ with
-    | NotSwapped, f, a, b => f a b
-    | IsSwapped, f, a, b => f b a
-    end.
-
-Definition tupleSortBoxity : TupleSort -> Boxity :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | BoxedTuple => Boxed
-    | UnboxedTuple => Unboxed
-    | ConstraintTuple => Boxed
-    end.
-
-(* Skipping definition `BasicTypes.tupleParens' *)
-
-Definition treatZeroAsInf : GHC.Num.Int -> IntWithInf :=
-  fun arg_0__ =>
-    let 'num_1__ := arg_0__ in
-    if num_1__ GHC.Base.== #0 : bool then Infinity else
-    let 'n := arg_0__ in
-    Int n.
-
-Definition tailCallInfo : OccInfo -> TailCallInfo :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | IAmDead => NoTailCallInfo
-    | other => occ_tail other
-    end.
-
-Definition sumParens : GHC.Base.String -> GHC.Base.String :=
-  fun p => GHC.Base.mappend (GHC.Base.mappend Panic.someSDoc p) Panic.someSDoc.
-
-Definition successIf : bool -> SuccessFlag :=
-  fun arg_0__ => match arg_0__ with | true => Succeeded | false => Failed end.
-
-Definition succeeded : SuccessFlag -> bool :=
-  fun arg_0__ => match arg_0__ with | Succeeded => true | Failed => false end.
-
-Definition strongLoopBreaker : OccInfo :=
-  IAmALoopBreaker false NoTailCallInfo.
-
-Definition setOverlapModeMaybe
-   : OverlapFlag -> option OverlapMode -> OverlapFlag :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, None => f
-    | f, Some m =>
-        let 'Mk_OverlapFlag overlapMode_2__ isSafeOverlap_3__ := f in
-        Mk_OverlapFlag m isSafeOverlap_3__
-    end.
-
-Definition setInlinePragmaRuleMatchInfo
-   : InlinePragma -> RuleMatchInfo -> InlinePragma :=
-  fun prag info =>
-    let 'Mk_InlinePragma inl_src_0__ inl_inline_1__ inl_sat_2__ inl_act_3__
-       inl_rule_4__ := prag in
-    Mk_InlinePragma inl_src_0__ inl_inline_1__ inl_sat_2__ inl_act_3__ info.
-
-Definition setInlinePragmaActivation
-   : InlinePragma -> Activation -> InlinePragma :=
-  fun prag activation =>
-    let 'Mk_InlinePragma inl_src_0__ inl_inline_1__ inl_sat_2__ inl_act_3__
-       inl_rule_4__ := prag in
-    Mk_InlinePragma inl_src_0__ inl_inline_1__ inl_sat_2__ activation inl_rule_4__.
-
-Definition seqOccInfo : OccInfo -> unit :=
-  fun occ => GHC.Prim.seq occ tt.
-
-Definition pprWithSourceText
-   : SourceText -> GHC.Base.String -> GHC.Base.String :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | NoSourceText, d => d
-    | Mk_SourceText src, _ => Datatypes.id src
-    end.
-
-Definition pprWarningTxtForMsg : WarningTxt -> GHC.Base.String :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Mk_WarningTxt _ ws => Panic.someSDoc
-    | DeprecatedTxt _ ds =>
-        GHC.Base.mappend (Datatypes.id (GHC.Base.hs_string__ "Deprecated:"))
-                         Panic.someSDoc
-    end.
-
-Definition pprShortTailCallInfo : TailCallInfo -> GHC.Base.String :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | AlwaysTailCalled ar => GHC.Base.mappend Panic.someSDoc Panic.someSDoc
-    | NoTailCallInfo => Panic.someSDoc
-    end.
-
-(* Skipping definition `BasicTypes.pprSafeOverlap' *)
-
-(* Skipping definition `BasicTypes.pprRuleName' *)
-
-(* Skipping definition `BasicTypes.pprOneShotInfo' *)
-
-(* Skipping definition `BasicTypes.pprAlternative' *)
-
-Definition pp_ws : list (SrcLoc.Located StringLiteral) -> GHC.Base.String :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | cons l nil => Panic.someSDoc
-    | ws =>
-        GHC.Base.mappend (GHC.Base.mappend (Datatypes.id (GHC.Base.hs_string__ "["))
-                                           Panic.someSDoc) (Datatypes.id (GHC.Base.hs_string__ "]"))
-    end.
-
-Definition plusWithInf : IntWithInf -> IntWithInf -> IntWithInf :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Infinity, _ => Infinity
-    | _, Infinity => Infinity
-    | Int a, Int b => Int (a GHC.Num.+ b)
-    end.
-
-Definition pickLR {a} : LeftOrRight -> (a * a)%type -> a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | CLeft, pair l _ => l
-    | CRight, pair _ r => r
-    end.
-
-Definition oneBranch : OneBranch :=
-  true.
-
-Definition notOneBranch : OneBranch :=
-  false.
-
-Definition notInsideLam : InsideLam :=
-  false.
-
-Definition noUserInlineSpec : InlineSpec -> bool :=
-  fun arg_0__ => match arg_0__ with | NoUserInline => true | _ => false end.
-
-Definition noOneShotInfo : OneShotInfo :=
-  NoOneShotInfo.
-
-Definition noOccInfo : OccInfo :=
-  ManyOccs NoTailCallInfo.
-
-Definition zapFragileOcc : OccInfo -> OccInfo :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | OneOcc _ _ _ _ => noOccInfo
-    | occ => zapOccTailCallInfo occ
-    end.
-
-(* Skipping definition `BasicTypes.negateIntegralLit' *)
-
-(* Skipping definition `BasicTypes.negateFractionalLit' *)
-
-Definition negateFixity : Fixity :=
-  Mk_Fixity NoSourceText #6 InfixL.
-
-Definition mulWithInf : IntWithInf -> IntWithInf -> IntWithInf :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Infinity, _ => Infinity
-    | _, Infinity => Infinity
-    | Int a, Int b => Int (a GHC.Num.* b)
-    end.
-
-(* Skipping definition `BasicTypes.mkIntegralLit' *)
-
-Definition mkIntWithInf : GHC.Num.Int -> IntWithInf :=
-  Int.
-
-(* Skipping definition `BasicTypes.mkFractionalLit' *)
-
-Definition minPrecedence : GHC.Num.Int :=
-  #0.
-
-(* Skipping definition `BasicTypes.maybeParen' *)
-
-Definition maxPrecedence : GHC.Num.Int :=
-  #9.
-
-Definition isWeakLoopBreaker : OccInfo -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | IAmALoopBreaker _ _ => true
-    | _ => false
-    end.
-
-Definition isTopLevel : TopLevelFlag -> bool :=
-  fun arg_0__ => match arg_0__ with | TopLevel => true | NotTopLevel => false end.
-
-Definition isSwapped : SwapFlag -> bool :=
-  fun arg_0__ => match arg_0__ with | IsSwapped => true | NotSwapped => false end.
-
-Definition isStrongLoopBreaker : OccInfo -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | IAmALoopBreaker false _ => true
-    | _ => false
-    end.
-
-Definition isRec : RecFlag -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Recursive => true
-    | NonRecursive => false
-    end.
-
-Definition isOneShotInfo : OneShotInfo -> bool :=
-  fun arg_0__ => match arg_0__ with | OneShotLam => true | _ => false end.
-
-Definition isOneOcc : OccInfo -> bool :=
-  fun arg_0__ => match arg_0__ with | OneOcc _ _ _ _ => true | _ => false end.
-
-Definition isNotTopLevel : TopLevelFlag -> bool :=
-  fun arg_0__ => match arg_0__ with | NotTopLevel => true | TopLevel => false end.
-
-Definition isNonRec : RecFlag -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Recursive => false
-    | NonRecursive => true
-    end.
-
-Definition isNeverActive : Activation -> bool :=
-  fun arg_0__ => match arg_0__ with | NeverActive => true | _ => false end.
-
-Definition isManyOccs : OccInfo -> bool :=
-  fun arg_0__ => match arg_0__ with | ManyOccs _ => true | _ => false end.
-
-Definition isInlinePragma : InlinePragma -> bool :=
-  fun prag => match inl_inline prag with | Inline => true | _ => false end.
-
-Definition isInlinablePragma : InlinePragma -> bool :=
-  fun prag => match inl_inline prag with | Inlinable => true | _ => false end.
-
-Definition isGenerated : Origin -> bool :=
-  fun arg_0__ => match arg_0__ with | Generated => true | FromSource => false end.
-
-Definition isFunLike : RuleMatchInfo -> bool :=
-  fun arg_0__ => match arg_0__ with | FunLike => true | _ => false end.
-
-Definition pprInline' : bool -> InlinePragma -> GHC.Base.String :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | emptyInline, Mk_InlinePragma _ inline mb_arity activation info =>
-        let pp_info :=
-          if isFunLike info : bool then Panic.someSDoc else
-          Panic.someSDoc in
-        let pp_sat :=
-          match mb_arity with
-          | Some ar =>
-              GHC.Base.mappend (Datatypes.id (GHC.Base.hs_string__ "sat-args="))
-                               Panic.someSDoc
-          | _ => Panic.someSDoc
-          end in
-        let pp_act :=
-          fun arg_4__ arg_5__ =>
-            match arg_4__, arg_5__ with
-            | Inline, AlwaysActive => Panic.someSDoc
-            | NoInline, NeverActive => Panic.someSDoc
-            | _, act => Panic.someSDoc
-            end in
-        let pp_inl :=
-          fun x => if emptyInline : bool then Panic.someSDoc else Panic.someSDoc in
-        GHC.Base.mappend (GHC.Base.mappend (GHC.Base.mappend (pp_inl inline) (pp_act
-                                                              inline activation)) pp_sat) pp_info
-    end.
-
-Definition pprInline : InlinePragma -> GHC.Base.String :=
-  pprInline' true.
-
-Definition pprInlineDebug : InlinePragma -> GHC.Base.String :=
-  pprInline' false.
-
-Definition isEarlyActive : Activation -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | AlwaysActive => true
-    | ActiveBefore _ _ => true
-    | _ => false
-    end.
-
-Definition isDeadOcc : OccInfo -> bool :=
-  fun arg_0__ => match arg_0__ with | IAmDead => true | _ => false end.
-
-Definition isConLike : RuleMatchInfo -> bool :=
-  fun arg_0__ => match arg_0__ with | ConLike => true | _ => false end.
-
-Definition isBoxed : Boxity -> bool :=
-  fun arg_0__ => match arg_0__ with | Boxed => true | Unboxed => false end.
-
-Definition isAnyInlinePragma : InlinePragma -> bool :=
-  fun prag =>
-    match inl_inline prag with
-    | Inline => true
-    | Inlinable => true
-    | _ => false
-    end.
-
-Definition isAlwaysTailCalled : OccInfo -> bool :=
-  fun occ =>
-    match tailCallInfo occ with
-    | AlwaysTailCalled _ => true
-    | NoTailCallInfo => false
-    end.
-
-Definition isAlwaysActive : Activation -> bool :=
-  fun arg_0__ => match arg_0__ with | AlwaysActive => true | _ => false end.
-
-Definition isDefaultInlinePragma : InlinePragma -> bool :=
-  fun '(Mk_InlinePragma _ inline _ activation match_info) =>
-    andb (noUserInlineSpec inline) (andb (isAlwaysActive activation) (isFunLike
-                                          match_info)).
-
-Definition isActiveIn : PhaseNum -> Activation -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | _, NeverActive => false
-    | _, AlwaysActive => true
-    | p, ActiveAfter _ n => p GHC.Base.<= n
-    | p, ActiveBefore _ n => p GHC.Base.> n
-    end.
-
-Definition isActive : CompilerPhase -> Activation -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | InitialPhase, AlwaysActive => true
-    | InitialPhase, ActiveBefore _ _ => true
-    | InitialPhase, _ => false
-    | Phase p, act => isActiveIn p act
-    end.
-
-(* Skipping definition `BasicTypes.integralFractionalLit' *)
-
-Definition intGtLimit : GHC.Num.Int -> IntWithInf -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | _, Infinity => false
-    | n, Int m => n GHC.Base.> m
-    end.
-
-Definition insideLam : InsideLam :=
-  true.
-
-Definition inlinePragmaSpec : InlinePragma -> InlineSpec :=
-  inl_inline.
-
-Definition inlinePragmaSat : InlinePragma -> option Arity :=
-  inl_sat.
-
-Definition inlinePragmaRuleMatchInfo : InlinePragma -> RuleMatchInfo :=
-  fun '(Mk_InlinePragma _ _ _ _ info) => info.
-
-Definition inlinePragmaActivation : InlinePragma -> Activation :=
-  fun '(Mk_InlinePragma _ _ _ activation _) => activation.
-
-Definition initialVersion : Version :=
-  #1.
-
-Definition infinity : IntWithInf :=
-  Infinity.
-
-Definition hasOverlappingFlag : OverlapMode -> bool :=
-  fun mode =>
-    match mode with
-    | Overlapping _ => true
-    | Overlaps _ => true
-    | Incoherent _ => true
-    | _ => false
-    end.
-
-Definition hasOverlappableFlag : OverlapMode -> bool :=
-  fun mode =>
-    match mode with
-    | Overlappable _ => true
-    | Overlaps _ => true
-    | Incoherent _ => true
-    | _ => false
-    end.
-
-Definition hasNoOneShotInfo : OneShotInfo -> bool :=
-  fun arg_0__ => match arg_0__ with | NoOneShotInfo => true | _ => false end.
-
-Definition hasIncoherentFlag : OverlapMode -> bool :=
-  fun mode => match mode with | Incoherent _ => true | _ => false end.
-
-Definition funTyFixity : Fixity :=
-  Mk_Fixity NoSourceText #0 InfixR.
-
-Definition flipSwap : SwapFlag -> SwapFlag :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | IsSwapped => NotSwapped
-    | NotSwapped => IsSwapped
-    end.
-
-Definition failed : SuccessFlag -> bool :=
-  fun arg_0__ => match arg_0__ with | Succeeded => false | Failed => true end.
-
-Definition fIRST_TAG : ConTag :=
-  #1.
-
-Definition defaultInlinePragma : InlinePragma :=
-  Mk_InlinePragma (Mk_SourceText (GHC.Base.hs_string__ "{-# INLINE")) NoUserInline
-                  None AlwaysActive FunLike.
-
-Definition dfunInlinePragma : InlinePragma :=
-  let 'Mk_InlinePragma inl_src_0__ inl_inline_1__ inl_sat_2__ inl_act_3__
-     inl_rule_4__ := defaultInlinePragma in
-  Mk_InlinePragma inl_src_0__ inl_inline_1__ inl_sat_2__ AlwaysActive ConLike.
-
-Definition neverInlinePragma : InlinePragma :=
-  let 'Mk_InlinePragma inl_src_0__ inl_inline_1__ inl_sat_2__ inl_act_3__
-     inl_rule_4__ := defaultInlinePragma in
-  Mk_InlinePragma inl_src_0__ inl_inline_1__ inl_sat_2__ NeverActive inl_rule_4__.
-
-(* Skipping definition `BasicTypes.defaultFixity' *)
-
-Definition competesWith : Activation -> Activation -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | NeverActive, _ => false
-    | _, NeverActive => false
-    | AlwaysActive, _ => true
-    | ActiveBefore _ _, AlwaysActive => true
-    | ActiveBefore _ _, ActiveBefore _ _ => true
-    | ActiveBefore _ a, ActiveAfter _ b => a GHC.Base.< b
-    | ActiveAfter _ _, AlwaysActive => false
-    | ActiveAfter _ _, ActiveBefore _ _ => false
-    | ActiveAfter _ a, ActiveAfter _ b => a GHC.Base.>= b
-    end.
-
-Definition compareFixity : Fixity -> Fixity -> (bool * bool)%type :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_Fixity _ prec1 dir1, Mk_Fixity _ prec2 dir2 =>
-        let error_please := pair true false in
-        let left_ := pair false false in
-        let right_ := pair false true in
-        match GHC.Base.compare prec1 prec2 with
-        | Gt => left_
-        | Lt => right_
-        | Eq =>
-            match pair dir1 dir2 with
-            | pair InfixR InfixR => right_
-            | pair InfixL InfixL => left_
-            | _ => error_please
-            end
-        end
-    end.
-
-Definition bumpVersion : Version -> Version :=
-  fun v => v GHC.Num.+ #1.
-
-Definition boxityTupleSort : Boxity -> TupleSort :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Boxed => BoxedTuple
-    | Unboxed => UnboxedTuple
-    end.
-
-Definition boolToRecFlag : bool -> RecFlag :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | true => Recursive
-    | false => NonRecursive
-    end.
-
-Definition bestOneShot : OneShotInfo -> OneShotInfo -> OneShotInfo :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | NoOneShotInfo, os => os
-    | OneShotLam, _ => OneShotLam
-    end.
-
-Definition alwaysInlinePragma : InlinePragma :=
-  let 'Mk_InlinePragma inl_src_0__ inl_inline_1__ inl_sat_2__ inl_act_3__
-     inl_rule_4__ := defaultInlinePragma in
-  Mk_InlinePragma inl_src_0__ Inline inl_sat_2__ inl_act_3__ inl_rule_4__.
-
 Local Definition Eq___LeftOrRight_op_zeze__
    : LeftOrRight -> LeftOrRight -> bool :=
   fun arg_0__ arg_1__ =>
@@ -1479,6 +973,30 @@ Program Instance Eq___IntWithInf : GHC.Base.Eq_ IntWithInf :=
    `BasicTypes.Outputable__FunctionOrData' *)
 
 (* Skipping all instances of class `Outputable.Outputable', including
+   `BasicTypes.Outputable__StringLiteral' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `BasicTypes.Outputable__WarningTxt' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `BasicTypes.Outputable__Fixity' *)
+
+Local Definition Eq___Fixity_op_zeze__ : Fixity -> Fixity -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_Fixity _ p1 dir1, Mk_Fixity _ p2 dir2 =>
+        andb (p1 GHC.Base.== p2) (dir1 GHC.Base.== dir2)
+    end.
+
+Local Definition Eq___Fixity_op_zsze__ : Fixity -> Fixity -> bool :=
+  fun x y => negb (Eq___Fixity_op_zeze__ x y).
+
+Program Instance Eq___Fixity : GHC.Base.Eq_ Fixity :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___Fixity_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___Fixity_op_zsze__ |}.
+
+(* Skipping all instances of class `Outputable.Outputable', including
    `BasicTypes.Outputable__FixityDirection' *)
 
 (* Skipping all instances of class `Outputable.Outputable', including
@@ -1499,9 +1017,15 @@ Program Instance Eq___IntWithInf : GHC.Base.Eq_ IntWithInf :=
 (* Skipping all instances of class `Outputable.Outputable', including
    `BasicTypes.Outputable__DerivStrategy' *)
 
-(* Skipping instance `BasicTypes.Ord__TyPrec' of class `GHC.Base.Ord' *)
+(* Skipping all instances of class `Outputable.Outputable', including
+   `BasicTypes.Outputable__OverlapFlag' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `BasicTypes.Outputable__OverlapMode' *)
 
 (* Skipping instance `BasicTypes.Eq___TyPrec' of class `GHC.Base.Eq_' *)
+
+(* Skipping instance `BasicTypes.Ord__TyPrec' of class `GHC.Base.Ord' *)
 
 (* Skipping all instances of class `Outputable.Outputable', including
    `BasicTypes.Outputable__TailCallInfo' *)
@@ -1519,36 +1043,6 @@ Program Instance Eq___IntWithInf : GHC.Base.Eq_ IntWithInf :=
    `BasicTypes.Outputable__SourceText' *)
 
 (* Skipping all instances of class `Outputable.Outputable', including
-   `BasicTypes.Outputable__OverlapMode' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `BasicTypes.Outputable__OverlapFlag' *)
-
-Local Definition Eq___Fixity_op_zeze__ : Fixity -> Fixity -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_Fixity _ p1 dir1, Mk_Fixity _ p2 dir2 =>
-        andb (p1 GHC.Base.== p2) (dir1 GHC.Base.== dir2)
-    end.
-
-Local Definition Eq___Fixity_op_zsze__ : Fixity -> Fixity -> bool :=
-  fun x y => negb (Eq___Fixity_op_zeze__ x y).
-
-Program Instance Eq___Fixity : GHC.Base.Eq_ Fixity :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___Fixity_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___Fixity_op_zsze__ |}.
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `BasicTypes.Outputable__Fixity' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `BasicTypes.Outputable__StringLiteral' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `BasicTypes.Outputable__WarningTxt' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
    `BasicTypes.Outputable__CompilerPhase' *)
 
 (* Skipping all instances of class `Outputable.Outputable', including
@@ -1563,8 +1057,18 @@ Program Instance Eq___Fixity : GHC.Base.Eq_ Fixity :=
 (* Skipping all instances of class `Outputable.Outputable', including
    `BasicTypes.Outputable__InlinePragma' *)
 
-(* Skipping all instances of class `Outputable.Outputable', including
-   `BasicTypes.Outputable__IntegralLit' *)
+Local Definition Eq___IntegralLit_op_zeze__
+   : IntegralLit -> IntegralLit -> bool :=
+  Data.Function.on _GHC.Base.==_ il_value.
+
+Local Definition Eq___IntegralLit_op_zsze__
+   : IntegralLit -> IntegralLit -> bool :=
+  fun x y => negb (Eq___IntegralLit_op_zeze__ x y).
+
+Program Instance Eq___IntegralLit : GHC.Base.Eq_ IntegralLit :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___IntegralLit_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___IntegralLit_op_zsze__ |}.
 
 Local Definition Ord__IntegralLit_compare
    : IntegralLit -> IntegralLit -> comparison :=
@@ -1594,19 +1098,6 @@ Local Definition Ord__IntegralLit_min
    : IntegralLit -> IntegralLit -> IntegralLit :=
   fun x y => if Ord__IntegralLit_op_zlze__ x y : bool then x else y.
 
-Local Definition Eq___IntegralLit_op_zeze__
-   : IntegralLit -> IntegralLit -> bool :=
-  Data.Function.on _GHC.Base.==_ il_value.
-
-Local Definition Eq___IntegralLit_op_zsze__
-   : IntegralLit -> IntegralLit -> bool :=
-  fun x y => negb (Eq___IntegralLit_op_zeze__ x y).
-
-Program Instance Eq___IntegralLit : GHC.Base.Eq_ IntegralLit :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___IntegralLit_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___IntegralLit_op_zsze__ |}.
-
 Program Instance Ord__IntegralLit : GHC.Base.Ord IntegralLit :=
   fun _ k__ =>
     k__ {| GHC.Base.op_zl____ := Ord__IntegralLit_op_zl__ ;
@@ -1618,7 +1109,7 @@ Program Instance Ord__IntegralLit : GHC.Base.Ord IntegralLit :=
            GHC.Base.min__ := Ord__IntegralLit_min |}.
 
 (* Skipping all instances of class `Outputable.Outputable', including
-   `BasicTypes.Outputable__FractionalLit' *)
+   `BasicTypes.Outputable__IntegralLit' *)
 
 Local Definition Eq___FractionalLit_op_zeze__
    : FractionalLit -> FractionalLit -> bool :=
@@ -1671,11 +1162,8 @@ Program Instance Ord__FractionalLit : GHC.Base.Ord FractionalLit :=
            GHC.Base.max__ := Ord__FractionalLit_max ;
            GHC.Base.min__ := Ord__FractionalLit_min |}.
 
-(* Skipping all instances of class `GHC.Num.Num', including
-   `BasicTypes.Num__IntWithInf' *)
-
 (* Skipping all instances of class `Outputable.Outputable', including
-   `BasicTypes.Outputable__IntWithInf' *)
+   `BasicTypes.Outputable__FractionalLit' *)
 
 Local Definition Ord__IntWithInf_compare
    : IntWithInf -> IntWithInf -> comparison :=
@@ -1714,6 +1202,518 @@ Program Instance Ord__IntWithInf : GHC.Base.Ord IntWithInf :=
            GHC.Base.compare__ := Ord__IntWithInf_compare ;
            GHC.Base.max__ := Ord__IntWithInf_max ;
            GHC.Base.min__ := Ord__IntWithInf_min |}.
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `BasicTypes.Outputable__IntWithInf' *)
+
+(* Skipping all instances of class `GHC.Num.Num', including
+   `BasicTypes.Num__IntWithInf' *)
+
+Definition pickLR {a} : LeftOrRight -> (a * a)%type -> a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | CLeft, pair l _ => l
+    | CRight, pair _ r => r
+    end.
+
+Definition fIRST_TAG : ConTag :=
+  #1.
+
+Definition noOneShotInfo : OneShotInfo :=
+  NoOneShotInfo.
+
+Definition isOneShotInfo : OneShotInfo -> bool :=
+  fun arg_0__ => match arg_0__ with | OneShotLam => true | _ => false end.
+
+Definition hasNoOneShotInfo : OneShotInfo -> bool :=
+  fun arg_0__ => match arg_0__ with | NoOneShotInfo => true | _ => false end.
+
+Definition worstOneShot : OneShotInfo -> OneShotInfo -> OneShotInfo :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | NoOneShotInfo, _ => NoOneShotInfo
+    | OneShotLam, os => os
+    end.
+
+Definition bestOneShot : OneShotInfo -> OneShotInfo -> OneShotInfo :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | NoOneShotInfo, os => os
+    | OneShotLam, _ => OneShotLam
+    end.
+
+(* Skipping definition `BasicTypes.pprOneShotInfo' *)
+
+Definition flipSwap : SwapFlag -> SwapFlag :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | IsSwapped => NotSwapped
+    | NotSwapped => IsSwapped
+    end.
+
+Definition isSwapped : SwapFlag -> bool :=
+  fun arg_0__ => match arg_0__ with | IsSwapped => true | NotSwapped => false end.
+
+Definition unSwap {a} {b} : SwapFlag -> (a -> a -> b) -> a -> a -> b :=
+  fun arg_0__ arg_1__ arg_2__ arg_3__ =>
+    match arg_0__, arg_1__, arg_2__, arg_3__ with
+    | NotSwapped, f, a, b => f a b
+    | IsSwapped, f, a, b => f b a
+    end.
+
+Definition bumpVersion : Version -> Version :=
+  fun v => v GHC.Num.+ #1.
+
+Definition initialVersion : Version :=
+  #1.
+
+Definition pp_ws : list (SrcLoc.Located StringLiteral) -> GHC.Base.String :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | cons l nil => Panic.someSDoc
+    | ws =>
+        GHC.Base.mappend (GHC.Base.mappend (Datatypes.id (GHC.Base.hs_string__ "["))
+                                           Panic.someSDoc) (Datatypes.id (GHC.Base.hs_string__ "]"))
+    end.
+
+Definition pprWarningTxtForMsg : WarningTxt -> GHC.Base.String :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Mk_WarningTxt _ ws => Panic.someSDoc
+    | DeprecatedTxt _ ds =>
+        GHC.Base.mappend (Datatypes.id (GHC.Base.hs_string__ "Deprecated:"))
+                         Panic.someSDoc
+    end.
+
+(* Skipping definition `BasicTypes.pprRuleName' *)
+
+Definition maxPrecedence : GHC.Num.Int :=
+  #9.
+
+Definition minPrecedence : GHC.Num.Int :=
+  #0.
+
+(* Skipping definition `BasicTypes.defaultFixity' *)
+
+Definition negateFixity : Fixity :=
+  Mk_Fixity NoSourceText #6 InfixL.
+
+Definition funTyFixity : Fixity :=
+  Mk_Fixity NoSourceText #0 InfixR.
+
+Definition compareFixity : Fixity -> Fixity -> (bool * bool)%type :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_Fixity _ prec1 dir1, Mk_Fixity _ prec2 dir2 =>
+        let error_please := pair true false in
+        let left_ := pair false false in
+        let right_ := pair false true in
+        match GHC.Base.compare prec1 prec2 with
+        | Gt => left_
+        | Lt => right_
+        | Eq =>
+            match pair dir1 dir2 with
+            | pair InfixR InfixR => right_
+            | pair InfixL InfixL => left_
+            | _ => error_please
+            end
+        end
+    end.
+
+Definition isNotTopLevel : TopLevelFlag -> bool :=
+  fun arg_0__ => match arg_0__ with | NotTopLevel => true | TopLevel => false end.
+
+Definition isTopLevel : TopLevelFlag -> bool :=
+  fun arg_0__ => match arg_0__ with | TopLevel => true | NotTopLevel => false end.
+
+Definition isBoxed : Boxity -> bool :=
+  fun arg_0__ => match arg_0__ with | Boxed => true | Unboxed => false end.
+
+Definition isRec : RecFlag -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Recursive => true
+    | NonRecursive => false
+    end.
+
+Definition isNonRec : RecFlag -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Recursive => false
+    | NonRecursive => true
+    end.
+
+Definition boolToRecFlag : bool -> RecFlag :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | true => Recursive
+    | false => NonRecursive
+    end.
+
+Definition isGenerated : Origin -> bool :=
+  fun arg_0__ => match arg_0__ with | Generated => true | FromSource => false end.
+
+Definition setOverlapModeMaybe
+   : OverlapFlag -> option OverlapMode -> OverlapFlag :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, None => f
+    | f, Some m =>
+        let 'Mk_OverlapFlag overlapMode_2__ isSafeOverlap_3__ := f in
+        Mk_OverlapFlag m isSafeOverlap_3__
+    end.
+
+Definition hasIncoherentFlag : OverlapMode -> bool :=
+  fun mode => match mode with | Incoherent _ => true | _ => false end.
+
+Definition hasOverlappableFlag : OverlapMode -> bool :=
+  fun mode =>
+    match mode with
+    | Overlappable _ => true
+    | Overlaps _ => true
+    | Incoherent _ => true
+    | _ => false
+    end.
+
+Definition hasOverlappingFlag : OverlapMode -> bool :=
+  fun mode =>
+    match mode with
+    | Overlapping _ => true
+    | Overlaps _ => true
+    | Incoherent _ => true
+    | _ => false
+    end.
+
+(* Skipping definition `BasicTypes.pprSafeOverlap' *)
+
+(* Skipping definition `BasicTypes.maybeParen' *)
+
+Definition tupleSortBoxity : TupleSort -> Boxity :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | BoxedTuple => Boxed
+    | UnboxedTuple => Unboxed
+    | ConstraintTuple => Boxed
+    end.
+
+Definition boxityTupleSort : Boxity -> TupleSort :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Boxed => BoxedTuple
+    | Unboxed => UnboxedTuple
+    end.
+
+(* Skipping definition `BasicTypes.tupleParens' *)
+
+Definition sumParens : GHC.Base.String -> GHC.Base.String :=
+  fun p => GHC.Base.mappend (GHC.Base.mappend Panic.someSDoc p) Panic.someSDoc.
+
+(* Skipping definition `BasicTypes.pprAlternative' *)
+
+Definition noOccInfo : OccInfo :=
+  ManyOccs NoTailCallInfo.
+
+Definition isManyOccs : OccInfo -> bool :=
+  fun arg_0__ => match arg_0__ with | ManyOccs _ => true | _ => false end.
+
+Definition seqOccInfo : OccInfo -> unit :=
+  fun occ => GHC.Prim.seq occ tt.
+
+Definition insideLam : InsideLam :=
+  true.
+
+Definition notInsideLam : InsideLam :=
+  false.
+
+Definition oneBranch : OneBranch :=
+  true.
+
+Definition notOneBranch : OneBranch :=
+  false.
+
+Definition tailCallInfo : OccInfo -> TailCallInfo :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | IAmDead => NoTailCallInfo
+    | other => occ_tail other
+    end.
+
+Definition zapOccTailCallInfo : OccInfo -> OccInfo :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | IAmDead => IAmDead
+    | occ =>
+        match occ with
+        | ManyOccs occ_tail_1__ => ManyOccs NoTailCallInfo
+        | IAmDead => GHC.Err.error (GHC.Base.hs_string__ "Partial record update")
+        | OneOcc occ_in_lam_2__ occ_one_br_3__ occ_int_cxt_4__ occ_tail_5__ =>
+            OneOcc occ_in_lam_2__ occ_one_br_3__ occ_int_cxt_4__ NoTailCallInfo
+        | IAmALoopBreaker occ_rules_only_6__ occ_tail_7__ =>
+            IAmALoopBreaker occ_rules_only_6__ NoTailCallInfo
+        end
+    end.
+
+Definition isAlwaysTailCalled : OccInfo -> bool :=
+  fun occ =>
+    match tailCallInfo occ with
+    | AlwaysTailCalled _ => true
+    | NoTailCallInfo => false
+    end.
+
+Definition strongLoopBreaker : OccInfo :=
+  IAmALoopBreaker false NoTailCallInfo.
+
+Definition weakLoopBreaker : OccInfo :=
+  IAmALoopBreaker true NoTailCallInfo.
+
+Definition isWeakLoopBreaker : OccInfo -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | IAmALoopBreaker _ _ => true
+    | _ => false
+    end.
+
+Definition isStrongLoopBreaker : OccInfo -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | IAmALoopBreaker false _ => true
+    | _ => false
+    end.
+
+Definition isDeadOcc : OccInfo -> bool :=
+  fun arg_0__ => match arg_0__ with | IAmDead => true | _ => false end.
+
+Definition isOneOcc : OccInfo -> bool :=
+  fun arg_0__ => match arg_0__ with | OneOcc _ _ _ _ => true | _ => false end.
+
+Definition zapFragileOcc : OccInfo -> OccInfo :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | OneOcc _ _ _ _ => noOccInfo
+    | occ => zapOccTailCallInfo occ
+    end.
+
+Definition pprShortTailCallInfo : TailCallInfo -> GHC.Base.String :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | AlwaysTailCalled ar => GHC.Base.mappend Panic.someSDoc Panic.someSDoc
+    | NoTailCallInfo => Panic.someSDoc
+    end.
+
+Definition successIf : bool -> SuccessFlag :=
+  fun arg_0__ => match arg_0__ with | true => Succeeded | false => Failed end.
+
+Definition succeeded : SuccessFlag -> bool :=
+  fun arg_0__ => match arg_0__ with | Succeeded => true | Failed => false end.
+
+Definition failed : SuccessFlag -> bool :=
+  fun arg_0__ => match arg_0__ with | Succeeded => false | Failed => true end.
+
+Definition pprWithSourceText
+   : SourceText -> GHC.Base.String -> GHC.Base.String :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | NoSourceText, d => d
+    | Mk_SourceText src, _ => Datatypes.id src
+    end.
+
+Definition isConLike : RuleMatchInfo -> bool :=
+  fun arg_0__ => match arg_0__ with | ConLike => true | _ => false end.
+
+Definition isFunLike : RuleMatchInfo -> bool :=
+  fun arg_0__ => match arg_0__ with | FunLike => true | _ => false end.
+
+Definition noUserInlineSpec : InlineSpec -> bool :=
+  fun arg_0__ => match arg_0__ with | NoUserInline => true | _ => false end.
+
+Definition defaultInlinePragma : InlinePragma :=
+  Mk_InlinePragma (Mk_SourceText (GHC.Base.hs_string__ "{-# INLINE")) NoUserInline
+                  None AlwaysActive FunLike.
+
+Definition alwaysInlinePragma : InlinePragma :=
+  let 'Mk_InlinePragma inl_src_0__ inl_inline_1__ inl_sat_2__ inl_act_3__
+     inl_rule_4__ := defaultInlinePragma in
+  Mk_InlinePragma inl_src_0__ Inline inl_sat_2__ inl_act_3__ inl_rule_4__.
+
+Definition neverInlinePragma : InlinePragma :=
+  let 'Mk_InlinePragma inl_src_0__ inl_inline_1__ inl_sat_2__ inl_act_3__
+     inl_rule_4__ := defaultInlinePragma in
+  Mk_InlinePragma inl_src_0__ inl_inline_1__ inl_sat_2__ NeverActive inl_rule_4__.
+
+Definition inlinePragmaSpec : InlinePragma -> InlineSpec :=
+  inl_inline.
+
+Definition dfunInlinePragma : InlinePragma :=
+  let 'Mk_InlinePragma inl_src_0__ inl_inline_1__ inl_sat_2__ inl_act_3__
+     inl_rule_4__ := defaultInlinePragma in
+  Mk_InlinePragma inl_src_0__ inl_inline_1__ inl_sat_2__ AlwaysActive ConLike.
+
+Definition isAlwaysActive : Activation -> bool :=
+  fun arg_0__ => match arg_0__ with | AlwaysActive => true | _ => false end.
+
+Definition isDefaultInlinePragma : InlinePragma -> bool :=
+  fun '(Mk_InlinePragma _ inline _ activation match_info) =>
+    andb (noUserInlineSpec inline) (andb (isAlwaysActive activation) (isFunLike
+                                          match_info)).
+
+Definition isInlinePragma : InlinePragma -> bool :=
+  fun prag => match inl_inline prag with | Inline => true | _ => false end.
+
+Definition isInlinablePragma : InlinePragma -> bool :=
+  fun prag => match inl_inline prag with | Inlinable => true | _ => false end.
+
+Definition isAnyInlinePragma : InlinePragma -> bool :=
+  fun prag =>
+    match inl_inline prag with
+    | Inline => true
+    | Inlinable => true
+    | _ => false
+    end.
+
+Definition inlinePragmaSat : InlinePragma -> option Arity :=
+  inl_sat.
+
+Definition inlinePragmaActivation : InlinePragma -> Activation :=
+  fun '(Mk_InlinePragma _ _ _ activation _) => activation.
+
+Definition inlinePragmaRuleMatchInfo : InlinePragma -> RuleMatchInfo :=
+  fun '(Mk_InlinePragma _ _ _ _ info) => info.
+
+Definition setInlinePragmaActivation
+   : InlinePragma -> Activation -> InlinePragma :=
+  fun prag activation =>
+    let 'Mk_InlinePragma inl_src_0__ inl_inline_1__ inl_sat_2__ inl_act_3__
+       inl_rule_4__ := prag in
+    Mk_InlinePragma inl_src_0__ inl_inline_1__ inl_sat_2__ activation inl_rule_4__.
+
+Definition setInlinePragmaRuleMatchInfo
+   : InlinePragma -> RuleMatchInfo -> InlinePragma :=
+  fun prag info =>
+    let 'Mk_InlinePragma inl_src_0__ inl_inline_1__ inl_sat_2__ inl_act_3__
+       inl_rule_4__ := prag in
+    Mk_InlinePragma inl_src_0__ inl_inline_1__ inl_sat_2__ inl_act_3__ info.
+
+Definition pprInline' : bool -> InlinePragma -> GHC.Base.String :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | emptyInline, Mk_InlinePragma _ inline mb_arity activation info =>
+        let pp_info :=
+          if isFunLike info : bool then Panic.someSDoc else
+          Panic.someSDoc in
+        let pp_sat :=
+          match mb_arity with
+          | Some ar =>
+              GHC.Base.mappend (Datatypes.id (GHC.Base.hs_string__ "sat-args="))
+                               Panic.someSDoc
+          | _ => Panic.someSDoc
+          end in
+        let pp_act :=
+          fun arg_4__ arg_5__ =>
+            match arg_4__, arg_5__ with
+            | Inline, AlwaysActive => Panic.someSDoc
+            | NoInline, NeverActive => Panic.someSDoc
+            | _, act => Panic.someSDoc
+            end in
+        let pp_inl :=
+          fun x => if emptyInline : bool then Panic.someSDoc else Panic.someSDoc in
+        GHC.Base.mappend (GHC.Base.mappend (GHC.Base.mappend (pp_inl inline) (pp_act
+                                                              inline activation)) pp_sat) pp_info
+    end.
+
+Definition pprInline : InlinePragma -> GHC.Base.String :=
+  pprInline' true.
+
+Definition pprInlineDebug : InlinePragma -> GHC.Base.String :=
+  pprInline' false.
+
+Definition isActiveIn : PhaseNum -> Activation -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | _, NeverActive => false
+    | _, AlwaysActive => true
+    | p, ActiveAfter _ n => p GHC.Base.<= n
+    | p, ActiveBefore _ n => p GHC.Base.> n
+    end.
+
+Definition isActive : CompilerPhase -> Activation -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | InitialPhase, AlwaysActive => true
+    | InitialPhase, ActiveBefore _ _ => true
+    | InitialPhase, _ => false
+    | Phase p, act => isActiveIn p act
+    end.
+
+Definition competesWith : Activation -> Activation -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | NeverActive, _ => false
+    | _, NeverActive => false
+    | AlwaysActive, _ => true
+    | ActiveBefore _ _, AlwaysActive => true
+    | ActiveBefore _ _, ActiveBefore _ _ => true
+    | ActiveBefore _ a, ActiveAfter _ b => a GHC.Base.< b
+    | ActiveAfter _ _, AlwaysActive => false
+    | ActiveAfter _ _, ActiveBefore _ _ => false
+    | ActiveAfter _ a, ActiveAfter _ b => a GHC.Base.>= b
+    end.
+
+Definition isNeverActive : Activation -> bool :=
+  fun arg_0__ => match arg_0__ with | NeverActive => true | _ => false end.
+
+Definition isEarlyActive : Activation -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | AlwaysActive => true
+    | ActiveBefore _ _ => true
+    | _ => false
+    end.
+
+(* Skipping definition `BasicTypes.mkIntegralLit' *)
+
+(* Skipping definition `BasicTypes.negateIntegralLit' *)
+
+(* Skipping definition `BasicTypes.mkFractionalLit' *)
+
+(* Skipping definition `BasicTypes.negateFractionalLit' *)
+
+(* Skipping definition `BasicTypes.integralFractionalLit' *)
+
+Definition infinity : IntWithInf :=
+  Infinity.
+
+Definition intGtLimit : GHC.Num.Int -> IntWithInf -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | _, Infinity => false
+    | n, Int m => n GHC.Base.> m
+    end.
+
+Definition plusWithInf : IntWithInf -> IntWithInf -> IntWithInf :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Infinity, _ => Infinity
+    | _, Infinity => Infinity
+    | Int a, Int b => Int (a GHC.Num.+ b)
+    end.
+
+Definition mulWithInf : IntWithInf -> IntWithInf -> IntWithInf :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Infinity, _ => Infinity
+    | _, Infinity => Infinity
+    | Int a, Int b => Int (a GHC.Num.* b)
+    end.
+
+Definition treatZeroAsInf : GHC.Num.Int -> IntWithInf :=
+  fun arg_0__ =>
+    let 'num_1__ := arg_0__ in
+    if num_1__ GHC.Base.== #0 : bool then Infinity else
+    let 'n := arg_0__ in
+    Int n.
+
+Definition mkIntWithInf : GHC.Num.Int -> IntWithInf :=
+  Int.
 
 (* External variables:
      Eq Gt Lt None Some andb bool comparison cons false list nat negb op_zt__ option

--- a/examples/ghc/lib/CoAxiom.v
+++ b/examples/ghc/lib/CoAxiom.v
@@ -39,89 +39,6 @@ Instance Default__BranchFlag : GHC.Err.Default BranchFlag :=
 
 (* Converted value declarations: *)
 
-Axiom unbranched : AxiomatizedTypes.CoAxBranch ->
-                   Branches AxiomatizedTypes.Unbranched.
-
-Axiom trivialBuiltInFamily : AxiomatizedTypes.BuiltInSynFamily.
-
-Axiom toUnbranchedAxiom : forall {br},
-                          AxiomatizedTypes.CoAxiom br ->
-                          AxiomatizedTypes.CoAxiom AxiomatizedTypes.Unbranched.
-
-Axiom toUnbranched : forall {br},
-                     Branches br -> Branches AxiomatizedTypes.Unbranched.
-
-Axiom toBranchedAxiom : forall {br},
-                        AxiomatizedTypes.CoAxiom br ->
-                        AxiomatizedTypes.CoAxiom AxiomatizedTypes.Branched.
-
-Axiom toBranched : forall {br},
-                   Branches br -> Branches AxiomatizedTypes.Branched.
-
-Axiom placeHolderIncomps : list AxiomatizedTypes.CoAxBranch.
-
-Axiom numBranches : forall {br}, Branches br -> nat.
-
-Axiom mapAccumBranches : forall {br},
-                         (list AxiomatizedTypes.CoAxBranch ->
-                          AxiomatizedTypes.CoAxBranch -> AxiomatizedTypes.CoAxBranch) ->
-                         Branches br -> Branches br.
-
-Axiom manyBranches : list AxiomatizedTypes.CoAxBranch ->
-                     Branches AxiomatizedTypes.Branched.
-
-Axiom isImplicitCoAxiom : forall {br}, AxiomatizedTypes.CoAxiom br -> bool.
-
-Axiom fsFromRole : AxiomatizedTypes.Role -> FastString.FastString.
-
-Axiom fromBranches : forall {br},
-                     Branches br -> list AxiomatizedTypes.CoAxBranch.
-
-Axiom coAxiomTyCon : forall {br}, AxiomatizedTypes.CoAxiom br -> Core.TyCon.
-
-Axiom coAxiomSingleBranch_maybe : forall {br},
-                                  AxiomatizedTypes.CoAxiom br -> option AxiomatizedTypes.CoAxBranch.
-
-Axiom coAxiomSingleBranch : AxiomatizedTypes.CoAxiom
-                            AxiomatizedTypes.Unbranched ->
-                            AxiomatizedTypes.CoAxBranch.
-
-Axiom coAxiomRole : forall {br},
-                    AxiomatizedTypes.CoAxiom br -> AxiomatizedTypes.Role.
-
-Axiom coAxiomNumPats : forall {br}, AxiomatizedTypes.CoAxiom br -> nat.
-
-Axiom coAxiomNthBranch : forall {br},
-                         AxiomatizedTypes.CoAxiom br ->
-                         AxiomatizedTypes.BranchIndex -> AxiomatizedTypes.CoAxBranch.
-
-Axiom coAxiomName : forall {br}, AxiomatizedTypes.CoAxiom br -> Name.Name.
-
-Axiom coAxiomBranches : forall {br}, AxiomatizedTypes.CoAxiom br -> Branches br.
-
-Axiom coAxiomArity : forall {br},
-                     AxiomatizedTypes.CoAxiom br -> AxiomatizedTypes.BranchIndex -> BasicTypes.Arity.
-
-Axiom coAxBranchTyVars : AxiomatizedTypes.CoAxBranch -> list Core.TyVar.
-
-Axiom coAxBranchSpan : AxiomatizedTypes.CoAxBranch -> SrcLoc.SrcSpan.
-
-Axiom coAxBranchRoles : AxiomatizedTypes.CoAxBranch ->
-                        list AxiomatizedTypes.Role.
-
-Axiom coAxBranchRHS : AxiomatizedTypes.CoAxBranch -> AxiomatizedTypes.Type_.
-
-Axiom coAxBranchLHS : AxiomatizedTypes.CoAxBranch ->
-                      list AxiomatizedTypes.Type_.
-
-Axiom coAxBranchIncomps : AxiomatizedTypes.CoAxBranch ->
-                          list AxiomatizedTypes.CoAxBranch.
-
-Axiom coAxBranchCoVars : AxiomatizedTypes.CoAxBranch -> list Core.CoVar.
-
-Axiom branchesNth : forall {br},
-                    Branches br -> AxiomatizedTypes.BranchIndex -> AxiomatizedTypes.CoAxBranch.
-
 Instance Eq___Role : GHC.Base.Eq_ AxiomatizedTypes.Role.
 Proof.
 Admitted.
@@ -136,39 +53,39 @@ Admitted.
 (* Skipping all instances of class `Data.Data.Data', including
    `CoAxiom.Data__CoAxBranch' *)
 
-(* Skipping all instances of class `Binary.Binary', including
-   `CoAxiom.Binary__Role' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `CoAxiom.Outputable__Role' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `CoAxiom.Outputable__CoAxBranch' *)
-
-(* Skipping all instances of class `Data.Data.Data', including
-   `CoAxiom.Data__CoAxiom' *)
-
-Instance NamedThing__CoAxiom
-   : forall {br}, Name.NamedThing (AxiomatizedTypes.CoAxiom br).
+Instance Eq___CoAxiom : forall {br}, GHC.Base.Eq_ (AxiomatizedTypes.CoAxiom br).
 Proof.
 Admitted.
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `CoAxiom.Outputable__CoAxiom' *)
 
 Instance Uniquable__CoAxiom
    : forall {br}, Unique.Uniquable (AxiomatizedTypes.CoAxiom br).
 Proof.
 Admitted.
 
-Instance Eq___CoAxiom : forall {br}, GHC.Base.Eq_ (AxiomatizedTypes.CoAxiom br).
+(* Skipping all instances of class `Outputable.Outputable', including
+   `CoAxiom.Outputable__CoAxiom' *)
+
+Instance NamedThing__CoAxiom
+   : forall {br}, Name.NamedThing (AxiomatizedTypes.CoAxiom br).
 Proof.
 Admitted.
 
-(* Skipping all instances of class `Outputable.Outputable', including
-   `CoAxiom.Outputable__CoAxiomRule' *)
+(* Skipping all instances of class `Data.Data.Data', including
+   `CoAxiom.Data__CoAxiom' *)
 
-Instance Ord__CoAxiomRule : GHC.Base.Ord AxiomatizedTypes.CoAxiomRule.
+(* Skipping all instances of class `Outputable.Outputable', including
+   `CoAxiom.Outputable__CoAxBranch' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `CoAxiom.Outputable__Role' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `CoAxiom.Binary__Role' *)
+
+(* Skipping all instances of class `Data.Data.Data', including
+   `CoAxiom.Data__CoAxiomRule' *)
+
+Instance Uniquable__CoAxiomRule : Unique.Uniquable AxiomatizedTypes.CoAxiomRule.
 Proof.
 Admitted.
 
@@ -176,12 +93,95 @@ Instance Eq___CoAxiomRule : GHC.Base.Eq_ AxiomatizedTypes.CoAxiomRule.
 Proof.
 Admitted.
 
-Instance Uniquable__CoAxiomRule : Unique.Uniquable AxiomatizedTypes.CoAxiomRule.
+Instance Ord__CoAxiomRule : GHC.Base.Ord AxiomatizedTypes.CoAxiomRule.
 Proof.
 Admitted.
 
-(* Skipping all instances of class `Data.Data.Data', including
-   `CoAxiom.Data__CoAxiomRule' *)
+(* Skipping all instances of class `Outputable.Outputable', including
+   `CoAxiom.Outputable__CoAxiomRule' *)
+
+Axiom manyBranches : list AxiomatizedTypes.CoAxBranch ->
+                     Branches AxiomatizedTypes.Branched.
+
+Axiom unbranched : AxiomatizedTypes.CoAxBranch ->
+                   Branches AxiomatizedTypes.Unbranched.
+
+Axiom toBranched : forall {br},
+                   Branches br -> Branches AxiomatizedTypes.Branched.
+
+Axiom toUnbranched : forall {br},
+                     Branches br -> Branches AxiomatizedTypes.Unbranched.
+
+Axiom fromBranches : forall {br},
+                     Branches br -> list AxiomatizedTypes.CoAxBranch.
+
+Axiom branchesNth : forall {br},
+                    Branches br -> AxiomatizedTypes.BranchIndex -> AxiomatizedTypes.CoAxBranch.
+
+Axiom numBranches : forall {br}, Branches br -> nat.
+
+Axiom mapAccumBranches : forall {br},
+                         (list AxiomatizedTypes.CoAxBranch ->
+                          AxiomatizedTypes.CoAxBranch -> AxiomatizedTypes.CoAxBranch) ->
+                         Branches br -> Branches br.
+
+Axiom toBranchedAxiom : forall {br},
+                        AxiomatizedTypes.CoAxiom br ->
+                        AxiomatizedTypes.CoAxiom AxiomatizedTypes.Branched.
+
+Axiom toUnbranchedAxiom : forall {br},
+                          AxiomatizedTypes.CoAxiom br ->
+                          AxiomatizedTypes.CoAxiom AxiomatizedTypes.Unbranched.
+
+Axiom coAxiomNumPats : forall {br}, AxiomatizedTypes.CoAxiom br -> nat.
+
+Axiom coAxiomNthBranch : forall {br},
+                         AxiomatizedTypes.CoAxiom br ->
+                         AxiomatizedTypes.BranchIndex -> AxiomatizedTypes.CoAxBranch.
+
+Axiom coAxiomArity : forall {br},
+                     AxiomatizedTypes.CoAxiom br -> AxiomatizedTypes.BranchIndex -> BasicTypes.Arity.
+
+Axiom coAxiomName : forall {br}, AxiomatizedTypes.CoAxiom br -> Name.Name.
+
+Axiom coAxiomRole : forall {br},
+                    AxiomatizedTypes.CoAxiom br -> AxiomatizedTypes.Role.
+
+Axiom coAxiomBranches : forall {br}, AxiomatizedTypes.CoAxiom br -> Branches br.
+
+Axiom coAxiomSingleBranch_maybe : forall {br},
+                                  AxiomatizedTypes.CoAxiom br -> option AxiomatizedTypes.CoAxBranch.
+
+Axiom coAxiomSingleBranch : AxiomatizedTypes.CoAxiom
+                            AxiomatizedTypes.Unbranched ->
+                            AxiomatizedTypes.CoAxBranch.
+
+Axiom coAxiomTyCon : forall {br}, AxiomatizedTypes.CoAxiom br -> Core.TyCon.
+
+Axiom coAxBranchTyVars : AxiomatizedTypes.CoAxBranch -> list Core.TyVar.
+
+Axiom coAxBranchCoVars : AxiomatizedTypes.CoAxBranch -> list Core.CoVar.
+
+Axiom coAxBranchLHS : AxiomatizedTypes.CoAxBranch ->
+                      list AxiomatizedTypes.Type_.
+
+Axiom coAxBranchRHS : AxiomatizedTypes.CoAxBranch -> AxiomatizedTypes.Type_.
+
+Axiom coAxBranchRoles : AxiomatizedTypes.CoAxBranch ->
+                        list AxiomatizedTypes.Role.
+
+Axiom coAxBranchSpan : AxiomatizedTypes.CoAxBranch -> SrcLoc.SrcSpan.
+
+Axiom isImplicitCoAxiom : forall {br}, AxiomatizedTypes.CoAxiom br -> bool.
+
+Axiom coAxBranchIncomps : AxiomatizedTypes.CoAxBranch ->
+                          list AxiomatizedTypes.CoAxBranch.
+
+Axiom placeHolderIncomps : list AxiomatizedTypes.CoAxBranch.
+
+Axiom fsFromRole : AxiomatizedTypes.Role -> FastString.FastString.
+
+Axiom trivialBuiltInFamily : AxiomatizedTypes.BuiltInSynFamily.
 
 (* External variables:
      Type bool list nat option AxiomatizedTypes.BranchIndex AxiomatizedTypes.Branched

--- a/examples/ghc/lib/ConLike.v
+++ b/examples/ghc/lib/ConLike.v
@@ -28,30 +28,48 @@ Inductive ConLike : Type
 
 (* Converted value declarations: *)
 
+Instance Eq___ConLike : GHC.Base.Eq_ ConLike.
+Proof.
+Admitted.
+
 Instance Uniquable__ConLike : Unique.Uniquable ConLike.
 Proof.
 Admitted.
 
+Instance NamedThing__ConLike : Name.NamedThing ConLike.
+Proof.
+Admitted.
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `ConLike.Outputable__ConLike' *)
+
+(* Skipping all instances of class `Outputable.OutputableBndr', including
+   `ConLike.OutputableBndr__ConLike' *)
+
+(* Skipping all instances of class `Data.Data.Data', including
+   `ConLike.Data__ConLike' *)
+
 Axiom eqConLike : ConLike -> ConLike -> bool.
 
-Axiom conLikesWithFields : list ConLike ->
-                           list FieldLabel.FieldLabelString -> list ConLike.
+Axiom conLikeArity : ConLike -> BasicTypes.Arity.
 
-Axiom conLikeWrapId_maybe : ConLike -> option Core.Id.
-
-Axiom conLikeStupidTheta : ConLike -> AxiomatizedTypes.ThetaType.
-
-Axiom conLikeResTy : ConLike ->
-                     list AxiomatizedTypes.Type_ -> AxiomatizedTypes.Type_.
-
-Axiom conLikeName : ConLike -> Name.Name.
-
-Axiom conLikeIsInfix : ConLike -> bool.
+Axiom conLikeFieldLabels : ConLike -> list FieldLabel.FieldLabel.
 
 Axiom conLikeInstOrigArgTys : ConLike ->
                               list AxiomatizedTypes.Type_ -> list AxiomatizedTypes.Type_.
 
+Axiom conLikeExTyVars : ConLike -> list Core.TyVar.
+
+Axiom conLikeName : ConLike -> Name.Name.
+
+Axiom conLikeStupidTheta : ConLike -> AxiomatizedTypes.ThetaType.
+
+Axiom conLikeWrapId_maybe : ConLike -> option Core.Id.
+
 Axiom conLikeImplBangs : ConLike -> list Core.HsImplBang.
+
+Axiom conLikeResTy : ConLike ->
+                     list AxiomatizedTypes.Type_ -> AxiomatizedTypes.Type_.
 
 Axiom conLikeFullSig : ConLike ->
                        (list Core.TyVar * list Core.TyVar * list Core.EqSpec *
@@ -63,28 +81,10 @@ Axiom conLikeFullSig : ConLike ->
 Axiom conLikeFieldType : ConLike ->
                          FieldLabel.FieldLabelString -> AxiomatizedTypes.Type_.
 
-Axiom conLikeFieldLabels : ConLike -> list FieldLabel.FieldLabel.
+Axiom conLikesWithFields : list ConLike ->
+                           list FieldLabel.FieldLabelString -> list ConLike.
 
-Axiom conLikeExTyVars : ConLike -> list Core.TyVar.
-
-Axiom conLikeArity : ConLike -> BasicTypes.Arity.
-
-(* Skipping all instances of class `Data.Data.Data', including
-   `ConLike.Data__ConLike' *)
-
-(* Skipping all instances of class `Outputable.OutputableBndr', including
-   `ConLike.OutputableBndr__ConLike' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `ConLike.Outputable__ConLike' *)
-
-Instance NamedThing__ConLike : Name.NamedThing ConLike.
-Proof.
-Admitted.
-
-Instance Eq___ConLike : GHC.Base.Eq_ ConLike.
-Proof.
-Admitted.
+Axiom conLikeIsInfix : ConLike -> bool.
 
 (* External variables:
      bool list op_zt__ option AxiomatizedTypes.ThetaType AxiomatizedTypes.Type_

--- a/examples/ghc/lib/Constants.v
+++ b/examples/ghc/lib/Constants.v
@@ -20,23 +20,23 @@ Require GHC.Nat.
 
 (* Converted value declarations: *)
 
-Axiom wORD64_SIZE : nat.
-
-Axiom tARGET_MAX_CHAR : nat.
+(* Skipping definition `Constants.hiVersion' *)
 
 Axiom mAX_TUPLE_SIZE : nat.
 
-Axiom mAX_SUM_SIZE : nat.
+Axiom mAX_CTUPLE_SIZE : nat.
 
-Axiom mAX_SOLVER_ITERATIONS : nat.
+Axiom mAX_SUM_SIZE : nat.
 
 Axiom mAX_REDUCTION_DEPTH : nat.
 
-Axiom mAX_CTUPLE_SIZE : nat.
+Axiom mAX_SOLVER_ITERATIONS : nat.
 
-(* Skipping definition `Constants.hiVersion' *)
+Axiom wORD64_SIZE : nat.
 
 Axiom fLOAT_SIZE : nat.
+
+Axiom tARGET_MAX_CHAR : nat.
 
 (* External variables:
      nat

--- a/examples/ghc/lib/Core.v
+++ b/examples/ghc/lib/Core.v
@@ -2530,3692 +2530,6 @@ Definition ArgStrDmd_size := Str_size StrDmd_size.
 
 (* Converted value declarations: *)
 
-Axiom zipTyEnv : list TyVar -> list Type_ -> TvSubstEnv.
-
-Axiom zipTvSubst : list TyVar -> list Type_ -> TCvSubst.
-
-Axiom zipCvSubst : list CoVar -> list Coercion -> TCvSubst.
-
-Axiom zipCoEnv : list CoVar -> list Coercion -> CvSubstEnv.
-
-Axiom zap_usg : KillFlags -> UseDmd -> UseDmd.
-
-Axiom zap_musg : KillFlags -> ArgUse -> ArgUse.
-
-Axiom zapUsedOnceSig : StrictSig -> StrictSig.
-
-Axiom zapUsedOnceDemand : Demand -> Demand.
-
-Axiom zapUsageEnvSig : StrictSig -> StrictSig.
-
-Axiom zapUsageDemand : Demand -> Demand.
-
-Axiom zapTCvSubst : TCvSubst -> TCvSubst.
-
-Axiom zapLiftingContext : LiftingContext -> LiftingContext.
-
-Axiom visibleDataCons : AlgTyConRhs -> list DataCon.
-
-Axiom vanillaCprProdRes : BasicTypes.Arity -> DmdResult.
-
-Axiom userTypeError_maybe : Type_ -> option Type_.
-
-Axiom useTop : ArgUse.
-
-Axiom useCount : forall {u}, Use u -> Count.
-
-Axiom useBot : ArgUse.
-
-Axiom unwrapNewTypeStepper : NormaliseStepper Coercion.
-
-Axiom unwrapNewTyCon_maybe : TyCon ->
-                             option (list TyVar * Type_ * CoAxiom Unbranched)%type.
-
-Axiom unwrapNewTyConEtad_maybe : TyCon ->
-                                 option (list TyVar * Type_ * CoAxiom Unbranched)%type.
-
-Axiom unionTCvSubst : TCvSubst -> TCvSubst -> TCvSubst.
-
-Axiom typeSize : Type_ -> nat.
-
-Axiom typeLiteralKind : TyLit -> Kind.
-
-Axiom typeKind : forall `{Util.HasDebugCallStack}, Type_ -> Kind.
-
-Axiom ty_co_subst : LiftingContext -> Role -> Type_ -> Coercion.
-
-Axiom tyThingCategory : TyThing -> GHC.Base.String.
-
-Axiom tyConsOfType : Type_ -> UniqSet.UniqSet TyCon.
-
-Axiom tyConVisibleTyVars : TyCon -> list TyVar.
-
-Axiom tyConTyVarBinders : list TyConBinder -> list TyVarBinder.
-
-Axiom tyConTuple_maybe : TyCon -> option BasicTypes.TupleSort.
-
-Axiom tyConStupidTheta : TyCon -> list PredType.
-
-Axiom tyConSkolem : TyCon -> bool.
-
-Axiom tyConSingleDataCon_maybe : TyCon -> option DataCon.
-
-Axiom tyConSingleDataCon : TyCon -> DataCon.
-
-Axiom tyConSingleAlgDataCon_maybe : TyCon -> option DataCon.
-
-Axiom tyConRuntimeRepInfo : TyCon -> RuntimeRepInfo.
-
-Axiom tyConRolesX : Role -> TyCon -> list Role.
-
-Axiom tyConRolesRepresentational : TyCon -> list Role.
-
-Axiom tyConRoles : TyCon -> list Role.
-
-Axiom tyConRepName_maybe : TyCon -> option TyConRepName.
-
-Axiom tyConRepModOcc : Module.Module ->
-                       OccName.OccName -> (Module.Module * OccName.OccName)%type.
-
-Axiom tyConInjectivityInfo : TyCon -> Injectivity.
-
-Axiom tyConFlavour : TyCon -> TyConFlavour.
-
-Axiom tyConFieldLabels : TyCon -> list FieldLabel.FieldLabel.
-
-Axiom tyConFieldLabelEnv : TyCon -> FieldLabel.FieldLabelEnv.
-
-Axiom tyConFamilySizeAtMost : TyCon -> nat -> bool.
-
-Axiom tyConFamilySize : TyCon -> nat.
-
-Axiom tyConFamilyResVar_maybe : TyCon -> option Name.Name.
-
-Axiom tyConFamilyCoercion_maybe : TyCon -> option (CoAxiom Unbranched).
-
-Axiom tyConFamInst_maybe : TyCon -> option (TyCon * list Type_)%type.
-
-Axiom tyConFamInstSig_maybe : TyCon ->
-                              option (TyCon * list Type_ * CoAxiom Unbranched)%type.
-
-Axiom tyConDataCons_maybe : TyCon -> option (list DataCon).
-
-Axiom tyConDataCons : TyCon -> list DataCon.
-
-Axiom tyConClass_maybe : TyCon -> option Class.
-
-Axiom tyConCType_maybe : TyCon -> option CType.
-
-Axiom tyConBindersTyBinders : list TyConBinder -> list TyBinder.
-
-Axiom tyConBinderArgFlag : TyConBinder -> ArgFlag.
-
-Axiom tyConAssoc_maybe : TyCon -> option Class.
-
-Axiom tyConAppTyCon_maybe : Type_ -> option TyCon.
-
-Axiom tyConAppTyConPicky_maybe : Type_ -> option TyCon.
-
-Axiom tyConAppTyCon : Type_ -> TyCon.
-
-Axiom tyConAppArgs_maybe : Type_ -> option (list Type_).
-
-Axiom tyConAppArgs : Type_ -> list Type_.
-
-Axiom tyConAppArgN : nat -> Type_ -> Type_.
-
-Axiom tyConATs : TyCon -> list TyCon.
-
-Axiom tyCoVarsOfTypesWellScoped : list Type_ -> list TyVar.
-
-Axiom tyCoVarsOfTypesSet : TyVarEnv Type_ -> TyCoVarSet.
-
-Axiom tyCoVarsOfTypesList : list Type_ -> list TyCoVar.
-
-Axiom tyCoVarsOfTypesDSet : list Type_ -> DTyCoVarSet.
-
-Axiom tyCoVarsOfTypes : list Type_ -> TyCoVarSet.
-
-Axiom tyCoVarsOfTypeWellScoped : Type_ -> list TyVar.
-
-Axiom tyCoVarsOfTypeList : Type_ -> list TyCoVar.
-
-Axiom tyCoVarsOfTypeDSet : Type_ -> DTyCoVarSet.
-
-Axiom tyCoVarsOfType : Type_ -> TyCoVarSet.
-
-Axiom tyCoVarsOfProv : UnivCoProvenance -> TyCoVarSet.
-
-Axiom tyCoVarsOfCosSet : CoVarEnv Coercion -> TyCoVarSet.
-
-Axiom tyCoVarsOfCos : list Coercion -> TyCoVarSet.
-
-Axiom tyCoVarsOfCoList : Coercion -> list TyCoVar.
-
-Axiom tyCoVarsOfCoDSet : Coercion -> DTyCoVarSet.
-
-Axiom tyCoVarsOfCo : Coercion -> TyCoVarSet.
-
-(* Skipping definition `Core.tyCoFVsOfTypes' *)
-
-(* Skipping definition `Core.tyCoFVsOfType' *)
-
-(* Skipping definition `Core.tyCoFVsOfProv' *)
-
-(* Skipping definition `Core.tyCoFVsOfCos' *)
-
-(* Skipping definition `Core.tyCoFVsOfCoVar' *)
-
-(* Skipping definition `Core.tyCoFVsOfCo' *)
-
-(* Skipping definition `Core.tyCoFVsBndr' *)
-
-Axiom tyBinderType : TyBinder -> Type_.
-
-(* Skipping definition `Core.trimToType' *)
-
-Axiom trimCPRInfo : bool -> bool -> DmdResult -> DmdResult.
-
-Axiom toposortTyVars : list TyCoVar -> list TyCoVar.
-
-Axiom resTypeArgDmd : forall {r}, Termination r -> Demand.
-
-Axiom topRes : DmdResult.
-
-Axiom topNormaliseTypeX : forall {ev},
-                          NormaliseStepper ev -> (ev -> ev -> ev) -> Type_ -> option (ev * Type_)%type.
-
-Axiom topNormaliseNewType_maybe : Type_ -> option (Coercion * Type_)%type.
-
-Axiom topDmd : Demand.
-
-Axiom toPhantomCo : Coercion -> Coercion.
-
-(* Skipping definition `Core.toCleanDmd' *)
-
-Axiom toBothDmdArg : DmdType -> BothDmdArg.
-
-Axiom tidyTypes : TidyEnv -> list Type_ -> list Type_.
-
-Axiom tidyType : TidyEnv -> Type_ -> Type_.
-
-Axiom tidyTyVarOcc : TidyEnv -> TyVar -> TyVar.
-
-Axiom tidyTyVarBinders : forall {vis},
-                         TidyEnv ->
-                         list (TyVarBndr TyVar vis) -> (TidyEnv * list (TyVarBndr TyVar vis))%type.
-
-Axiom tidyTyVarBinder : forall {vis},
-                        TidyEnv -> TyVarBndr TyVar vis -> (TidyEnv * TyVarBndr TyVar vis)%type.
-
-Axiom tidyTyCoVarBndrs : TidyEnv ->
-                         list TyCoVar -> (TidyEnv * list TyCoVar)%type.
-
-Axiom tidyTyCoVarBndr : TidyEnv -> TyCoVar -> (TidyEnv * TyCoVar)%type.
-
-Axiom tidyTopType : Type_ -> Type_.
-
-(* Skipping definition `Core.tidyToIfaceTypeSty' *)
-
-(* Skipping definition `Core.tidyToIfaceType' *)
-
-(* Skipping definition `Core.tidyToIfaceCoSty' *)
-
-(* Skipping definition `Core.tidyToIfaceCo' *)
-
-Axiom tidyPatSynIds : (Id -> Id) -> PatSyn -> PatSyn.
-
-Axiom tidyOpenTypes : TidyEnv -> list Type_ -> (TidyEnv * list Type_)%type.
-
-Axiom tidyOpenType : TidyEnv -> Type_ -> (TidyEnv * Type_)%type.
-
-Axiom tidyOpenTyCoVars : TidyEnv ->
-                         list TyCoVar -> (TidyEnv * list TyCoVar)%type.
-
-Axiom tidyOpenTyCoVar : TidyEnv -> TyCoVar -> (TidyEnv * TyCoVar)%type.
-
-Axiom tidyOpenKind : TidyEnv -> Kind -> (TidyEnv * Kind)%type.
-
-Axiom tidyKind : TidyEnv -> Kind -> Kind.
-
-Axiom tidyFreeTyCoVars : TidyEnv -> list TyCoVar -> TidyEnv.
-
-Axiom tidyCos : TidyEnv -> list Coercion -> list Coercion.
-
-Axiom tidyCo : TidyEnv -> Coercion -> Coercion.
-
-Axiom tcView : Type_ -> option Type_.
-
-Axiom tcSplitTyConApp_maybe : forall `{Util.HasDebugCallStack},
-                              Type_ -> option (TyCon * list Type_)%type.
-
-Axiom tcRepSplitTyConApp_maybe : forall `{Util.HasDebugCallStack},
-                                 Type_ -> option (TyCon * list Type_)%type.
-
-Axiom tcRepSplitAppTy_maybe : Type_ -> option (Type_ * Type_)%type.
-
-Axiom tcFlavourIsOpen : TyConFlavour -> bool.
-
-Axiom tcFlavourCanBeUnsaturated : TyConFlavour -> bool.
-
-Axiom synTyConRhs_maybe : TyCon -> option Type_.
-
-Axiom synTyConResKind : TyCon -> Kind.
-
-Axiom synTyConDefn_maybe : TyCon -> option (list TyVar * Type_)%type.
-
-Axiom swapLiftCoEnv : LiftCoEnv -> LiftCoEnv.
-
-Axiom subst_ty : TCvSubst -> Type_ -> Type_.
-
-Axiom subst_co : TCvSubst -> Coercion -> Coercion.
-
-Axiom substTysWithCoVars : list CoVar ->
-                           list Coercion -> list Type_ -> list Type_.
-
-Axiom substTysWith : list TyVar -> list Type_ -> list Type_ -> list Type_.
-
-Axiom substTysUnchecked : TCvSubst -> list Type_ -> list Type_.
-
-Axiom substTys : forall `{Util.HasDebugCallStack},
-                 TCvSubst -> list Type_ -> list Type_.
-
-Axiom substTyWithUnchecked : list TyVar -> list Type_ -> Type_ -> Type_.
-
-Axiom substTyWithInScope : InScopeSet ->
-                           list TyVar -> list Type_ -> Type_ -> Type_.
-
-Axiom substTyWithCoVars : list CoVar -> list Coercion -> Type_ -> Type_.
-
-Axiom substTyWith : forall `{Util.HasDebugCallStack},
-                    list TyVar -> list Type_ -> Type_ -> Type_.
-
-Axiom substTyVars : TCvSubst -> list TyVar -> list Type_.
-
-Axiom substTyVarBndrUnchecked : TCvSubst -> TyVar -> (TCvSubst * TyVar)%type.
-
-Axiom substTyVarBndrCallback : (TCvSubst -> Type_ -> Type_) ->
-                               TCvSubst -> TyVar -> (TCvSubst * TyVar)%type.
-
-Axiom substTyVarBndr : forall `{Util.HasDebugCallStack},
-                       TCvSubst -> TyVar -> (TCvSubst * TyVar)%type.
-
-Axiom substTyVar : TCvSubst -> TyVar -> Type_.
-
-Axiom substTyUnchecked : TCvSubst -> Type_ -> Type_.
-
-Axiom substTyAddInScope : TCvSubst -> Type_ -> Type_.
-
-Axiom substTy : forall `{Util.HasDebugCallStack}, TCvSubst -> Type_ -> Type_.
-
-Axiom substThetaUnchecked : TCvSubst -> ThetaType -> ThetaType.
-
-Axiom substTheta : forall `{Util.HasDebugCallStack},
-                   TCvSubst -> ThetaType -> ThetaType.
-
-Axiom substRightCo : LiftingContext -> Coercion -> Coercion.
-
-Axiom substLeftCo : LiftingContext -> Coercion -> Coercion.
-
-Axiom substForAllCoBndrUnchecked : TCvSubst ->
-                                   TyVar -> Coercion -> (TCvSubst * TyVar * Coercion)%type.
-
-Axiom substForAllCoBndrCallbackLC : bool ->
-                                    (Coercion -> Coercion) ->
-                                    LiftingContext -> TyVar -> Coercion -> (LiftingContext * TyVar * Coercion)%type.
-
-Axiom substForAllCoBndrCallback : bool ->
-                                  (Coercion -> Coercion) ->
-                                  TCvSubst -> TyVar -> Coercion -> (TCvSubst * TyVar * Coercion)%type.
-
-Axiom substForAllCoBndr : TCvSubst ->
-                          TyVar -> Coercion -> (TCvSubst * TyVar * Coercion)%type.
-
-Axiom substEqSpec : TCvSubst -> EqSpec -> EqSpec.
-
-Axiom substCos : forall `{Util.HasDebugCallStack},
-                 TCvSubst -> list Coercion -> list Coercion.
-
-Axiom substCoWithUnchecked : list TyVar -> list Type_ -> Coercion -> Coercion.
-
-Axiom substCoWith : forall `{Util.HasDebugCallStack},
-                    list TyVar -> list Type_ -> Coercion -> Coercion.
-
-Axiom substCoVars : TCvSubst -> list CoVar -> list Coercion.
-
-Axiom substCoVarBndr : TCvSubst -> CoVar -> (TCvSubst * CoVar)%type.
-
-Axiom substCoVar : TCvSubst -> CoVar -> Coercion.
-
-Axiom substCoUnchecked : TCvSubst -> Coercion -> Coercion.
-
-Axiom substCo : forall `{Util.HasDebugCallStack},
-                TCvSubst -> Coercion -> Coercion.
-
-Axiom stripCoercionTy : Type_ -> Coercion.
-
-(* Skipping definition `Core.strictifyDictDmd' *)
-
-Axiom strictenDmd : Demand -> CleanDemand.
-
-Axiom strictSigDmdEnv : StrictSig -> DmdEnv.
-
-Axiom strictApply1Dmd : Demand.
-
-Axiom strTop : ArgStr.
-
-Axiom strBot : ArgStr.
-
-Axiom splitVisVarsOfTypes : list Type_ -> Pair.Pair TyCoVarSet.
-
-Axiom splitVisVarsOfType : Type_ -> Pair.Pair TyCoVarSet.
-
-Axiom splitUseProdDmd : nat -> UseDmd -> option (list ArgUse).
-
-Axiom splitTyConApp_maybe : forall `{Util.HasDebugCallStack},
-                            Type_ -> option (TyCon * list Type_)%type.
-
-Axiom splitTyConAppCo_maybe : Coercion -> option (TyCon * list Coercion)%type.
-
-Axiom splitTyConApp : Type_ -> (TyCon * list Type_)%type.
-
-Axiom splitStrictSig : StrictSig -> (list Demand * DmdResult)%type.
-
-Axiom splitStrProdDmd : nat -> StrDmd -> option (list ArgStr).
-
-Axiom splitProdDmd_maybe : Demand -> option (list Demand).
-
-Axiom splitPiTysInvisible : Type_ -> (list TyBinder * Type_)%type.
-
-Axiom splitPiTys : Type_ -> (list TyBinder * Type_)%type.
-
-Axiom splitPiTy_maybe : Type_ -> option (TyBinder * Type_)%type.
-
-Axiom splitPiTy : Type_ -> (TyBinder * Type_)%type.
-
-Axiom splitListTyConApp_maybe : Type_ -> option Type_.
-
-Axiom splitFunTys : Type_ -> (list Type_ * Type_)%type.
-
-Axiom splitFunTy_maybe : Type_ -> option (Type_ * Type_)%type.
-
-Axiom splitFunTy : Type_ -> (Type_ * Type_)%type.
-
-Axiom splitFunCo_maybe : Coercion -> option (Coercion * Coercion)%type.
-
-Axiom splitForAllTys' : Type_ -> (list TyVar * list ArgFlag * Type_)%type.
-
-Axiom splitForAllTys : Type_ -> (list TyVar * Type_)%type.
-
-Axiom splitForAllTy_maybe : Type_ -> option (TyVar * Type_)%type.
-
-Axiom splitForAllTyVarBndrs : Type_ -> (list TyVarBinder * Type_)%type.
-
-Axiom splitForAllTy : Type_ -> (TyVar * Type_)%type.
-
-Axiom splitForAllCo_maybe : Coercion ->
-                            option (TyVar * Coercion * Coercion)%type.
-
-Axiom splitFVs : bool -> DmdEnv -> (DmdEnv * DmdEnv)%type.
-
-Axiom splitDmdTy : DmdType -> (Demand * DmdType)%type.
-
-Axiom splitDataProductType_maybe : Type_ ->
-                                   option (TyCon * list Type_ * DataCon * list Type_)%type.
-
-Axiom splitCoercionType_maybe : Type_ -> option (Type_ * Type_)%type.
-
-Axiom splitCastTy_maybe : Type_ -> option (Type_ * Coercion)%type.
-
-Axiom splitArgStrProdDmd : nat -> ArgStr -> option (list ArgStr).
-
-Axiom splitAppTys : Type_ -> (Type_ * list Type_)%type.
-
-Axiom splitAppTy_maybe : Type_ -> option (Type_ * Type_)%type.
-
-Axiom splitAppTy : Type_ -> (Type_ * Type_)%type.
-
-Axiom splitAppCo_maybe : Coercion -> option (Coercion * Coercion)%type.
-
-Axiom specialPromotedDc : DataCon -> bool.
-
-Axiom setTvSubstEnv : TCvSubst -> TvSubstEnv -> TCvSubst.
-
-Axiom setNominalRole_maybe : Coercion -> option Coercion.
-
-Axiom setJoinResTy : nat -> Type_ -> Type_ -> Type_.
-
-Axiom setCvSubstEnv : TCvSubst -> CvSubstEnv -> TCvSubst.
-
-Axiom setCoVarUnique : CoVar -> Unique.Unique -> CoVar.
-
-Axiom setCoVarName : CoVar -> Name.Name -> CoVar.
-
-Definition seqUseDmd : UseDmd -> unit :=
-  fun x => tt.
-
-Axiom seqTypes : list Type_ -> unit.
-
-Axiom seqType : Type_ -> unit.
-
-Definition seqStrictSig : StrictSig -> unit :=
-  fun x => tt.
-
-Definition seqStrDmdList : list ArgStr -> unit :=
-  fun x => tt.
-
-Definition seqStrDmd : StrDmd -> unit :=
-  fun x => tt.
-
-Axiom seqProv : UnivCoProvenance -> unit.
-
-Definition seqDmdType : DmdType -> unit :=
-  fun x => tt.
-
-Definition seqDmdResult : DmdResult -> unit :=
-  fun x => tt.
-
-Definition seqDmdEnv : DmdEnv -> unit :=
-  fun x => tt.
-
-Axiom seqDmd : Demand.
-
-Definition seqDemandList : list Demand -> unit :=
-  fun x => tt.
-
-Definition seqDemand : Demand -> unit :=
-  fun x => tt.
-
-Axiom seqCos : list Coercion -> unit.
-
-Axiom seqCo : Coercion -> unit.
-
-Definition seqCPRResult : CPRResult -> unit :=
-  fun x => tt.
-
-Definition seqArgUseList : list ArgUse -> unit :=
-  fun x => tt.
-
-Definition seqArgUse : ArgUse -> unit :=
-  fun x => tt.
-
-Definition seqArgStr : ArgStr -> unit :=
-  fun x => tt.
-
-Axiom saturatedByOneShots : nat -> Demand -> bool.
-
-Axiom reuseEnv : DmdEnv -> DmdEnv.
-
-Axiom returnsCPR_maybe : DmdResult -> option BasicTypes.ConTag.
-
-Axiom retCPR_maybe : CPRResult -> option BasicTypes.ConTag.
-
-Axiom resultIsLevPoly : Type_ -> bool.
-
-Axiom repSplitTyConApp_maybe : forall `{Util.HasDebugCallStack},
-                               Type_ -> option (TyCon * list Type_)%type.
-
-Axiom repSplitAppTys : forall `{Util.HasDebugCallStack},
-                       Type_ -> (Type_ * list Type_)%type.
-
-Axiom repSplitAppTy_maybe : forall `{Util.HasDebugCallStack},
-                            Type_ -> option (Type_ * Type_)%type.
-
-Axiom repGetTyVar_maybe : Type_ -> option TyVar.
-
-Axiom removeDmdTyArgs : DmdType -> DmdType.
-
-Axiom provSize : UnivCoProvenance -> nat.
-
-Axiom promoteDataCon : DataCon -> TyCon.
-
-Axiom promoteCoercion : Coercion -> Coercion.
-
-(* Skipping definition `Core.primRepSizeB' *)
-
-Axiom primRepIsFloat : PrimRep -> option bool.
-
-Axiom primElemRepSizeB : PrimElemRep -> nat.
-
-Axiom predTypeEqRel : PredType -> EqRel.
-
-Axiom ppr_co_ax_branch : forall {br},
-                         (TyCon -> Type_ -> GHC.Base.String) ->
-                         CoAxiom br -> CoAxBranch -> GHC.Base.String.
-
-Axiom pprUserTypeErrorTy : Type_ -> GHC.Base.String.
-
-Axiom pprUserForAll : list TyVarBinder -> GHC.Base.String.
-
-Axiom pprTypeApp : TyCon -> list Type_ -> GHC.Base.String.
-
-Axiom pprType : Type_ -> GHC.Base.String.
-
-Axiom pprTyVars : list TyVar -> GHC.Base.String.
-
-Axiom pprTyVar : TyVar -> GHC.Base.String.
-
-Axiom pprTyThingCategory : TyThing -> GHC.Base.String.
-
-Axiom pprTyLit : TyLit -> GHC.Base.String.
-
-Axiom pprTvBndrs : list TyVarBinder -> GHC.Base.String.
-
-Axiom pprTvBndr : TyVarBinder -> GHC.Base.String.
-
-Axiom pprThetaArrowTy : ThetaType -> GHC.Base.String.
-
-Axiom pprTheta : ThetaType -> GHC.Base.String.
-
-Axiom pprSourceTyCon : TyCon -> GHC.Base.String.
-
-Axiom pprSigmaType : Type_ -> GHC.Base.String.
-
-Axiom pprShortTyThing : TyThing -> GHC.Base.String.
-
-Axiom pprPromotionQuote : TyCon -> GHC.Base.String.
-
-Axiom pprPrecType : BasicTypes.TyPrec -> Type_ -> GHC.Base.String.
-
-(* Skipping definition `Core.pprPatSynType' *)
-
-Axiom pprParendType : Type_ -> GHC.Base.String.
-
-Axiom pprParendTheta : ThetaType -> GHC.Base.String.
-
-Axiom pprParendKind : Kind -> GHC.Base.String.
-
-Axiom pprParendCo : Coercion -> GHC.Base.String.
-
-Axiom pprKind : Kind -> GHC.Base.String.
-
-(* Skipping definition `Core.pprIfaceStrictSig' *)
-
-(* Skipping definition `Core.pprFundeps' *)
-
-(* Skipping definition `Core.pprFunDep' *)
-
-Axiom pprForAll : list TyVarBinder -> GHC.Base.String.
-
-(* Skipping definition `Core.pprDefMethInfo' *)
-
-Axiom pprDataCons : TyCon -> GHC.Base.String.
-
-Axiom pprDataConWithArgs : DataCon -> GHC.Base.String.
-
-Axiom pprCoAxiom : forall {br}, CoAxiom br -> GHC.Base.String.
-
-Axiom pprCoAxBranchHdr : forall {br},
-                         CoAxiom br -> BranchIndex -> GHC.Base.String.
-
-Axiom pprCoAxBranch : forall {br}, CoAxiom br -> CoAxBranch -> GHC.Base.String.
-
-Axiom pprCo : Coercion -> GHC.Base.String.
-
-Axiom pprClassPred : Class -> list Type_ -> GHC.Base.String.
-
-Axiom ppSuggestExplicitKinds : GHC.Base.String.
-
-Axiom postProcessUnsat : DmdShell -> DmdType -> DmdType.
-
-Axiom postProcessDmdType : DmdShell -> DmdType -> BothDmdArg.
-
-Axiom postProcessDmdResult : Str unit -> DmdResult -> DmdResult.
-
-Axiom postProcessDmdEnv : DmdShell -> DmdEnv -> DmdEnv.
-
-Axiom postProcessDmd : DmdShell -> Demand -> Demand.
-
-Axiom piResultTys : forall `{Util.HasDebugCallStack},
-                    Type_ -> list Type_ -> Type_.
-
-Axiom piResultTy_maybe : Type_ -> Type_ -> option Type_.
-
-Axiom piResultTy : forall `{Util.HasDebugCallStack}, Type_ -> Type_ -> Type_.
-
-Axiom peelUseCall : UseDmd -> option (Count * UseDmd)%type.
-
-Axiom peelManyCalls : nat -> CleanDemand -> DmdShell.
-
-Axiom peelFV : DmdType -> Var -> (DmdType * Demand)%type.
-
-Axiom peelCallDmd : CleanDemand -> (CleanDemand * DmdShell)%type.
-
-Axiom patSynUnivTyVarBinders : PatSyn -> list TyVarBinder.
-
-Axiom patSynSig : PatSyn ->
-                  (list TyVar * ThetaType * list TyVar * ThetaType * list Type_ * Type_)%type.
-
-Axiom patSynName : PatSyn -> Name.Name.
-
-Axiom patSynMatcher : PatSyn -> (Id * bool)%type.
-
-Axiom patSynIsInfix : PatSyn -> bool.
-
-Axiom patSynInstResTy : PatSyn -> list Type_ -> Type_.
-
-Axiom patSynInstArgTys : PatSyn -> list Type_ -> list Type_.
-
-Axiom patSynFieldType : PatSyn -> FieldLabel.FieldLabelString -> Type_.
-
-Axiom patSynFieldLabels : PatSyn -> list FieldLabel.FieldLabel.
-
-Axiom patSynExTyVars : PatSyn -> list TyVar.
-
-Axiom patSynExTyVarBinders : PatSyn -> list TyVarBinder.
-
-Axiom patSynBuilder : PatSyn -> option (Id * bool)%type.
-
-Axiom patSynArity : PatSyn -> BasicTypes.Arity.
-
-Axiom patSynArgs : PatSyn -> list Type_.
-
-Axiom partitionInvisibles : forall {a},
-                            TyCon -> (a -> Type_) -> list a -> (list a * list a)%type.
-
-Axiom oneifyDmd : Demand -> Demand.
-
-Axiom okParent : Name.Name -> AlgTyConFlav -> bool.
-
-Axiom nthRole : Role -> TyCon -> nat -> Role.
-
-Axiom notElemTCvSubst : Var -> TCvSubst -> bool.
-
-Axiom nopSig : StrictSig.
-
-Axiom nopDmdType : DmdType.
-
-Axiom nonDetCmpTypesX : RnEnv2 -> list Type_ -> list Type_ -> comparison.
-
-Axiom nonDetCmpTypes : list Type_ -> list Type_ -> comparison.
-
-Axiom nonDetCmpTypeX : RnEnv2 -> Type_ -> Type_ -> comparison.
-
-Axiom nonDetCmpType : Type_ -> Type_ -> comparison.
-
-Axiom nonDetCmpTc : TyCon -> TyCon -> comparison.
-
-Axiom noFreeVarsOfType : Type_ -> bool.
-
-Axiom noFreeVarsOfProv : UnivCoProvenance -> bool.
-
-Axiom noFreeVarsOfCo : Coercion -> bool.
-
-Axiom nextRole : Type_ -> Role.
-
-Axiom newTyConRhs : TyCon -> (list TyVar * Type_)%type.
-
-Axiom newTyConInstRhs : TyCon -> list Type_ -> Type_.
-
-Axiom newTyConEtadRhs : TyCon -> (list TyVar * Type_)%type.
-
-Axiom newTyConEtadArity : TyCon -> nat.
-
-Axiom newTyConDataCon_maybe : TyCon -> option DataCon.
-
-Axiom newTyConCo_maybe : TyCon -> option (CoAxiom Unbranched).
-
-Axiom newTyConCo : TyCon -> CoAxiom Unbranched.
-
-Axiom modifyJoinResTy : nat -> (Type_ -> Type_) -> Type_ -> Type_.
-
-Axiom mkWorkerDemand : nat -> Demand.
-
-Axiom mkVisForAllTys : list TyVar -> Type_ -> Type_.
-
-Axiom mkUnsafeCo : Role -> Type_ -> Type_ -> Coercion.
-
-Axiom mkUnivCo : UnivCoProvenance -> Role -> Type_ -> Type_ -> Coercion.
-
-Axiom mkUnbranchedAxInstRHS : CoAxiom Unbranched ->
-                              list Type_ -> list Coercion -> Type_.
-
-Axiom mkUnbranchedAxInstLHS : CoAxiom Unbranched ->
-                              list Type_ -> list Coercion -> Type_.
-
-Axiom mkUnbranchedAxInstCo : Role ->
-                             CoAxiom Unbranched -> list Type_ -> list Coercion -> Coercion.
-
-Local Definition Eq___Count_op_zeze__ : Count -> Count -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | One, One => true
-    | Many, Many => true
-    | _, _ => false
-    end.
-
-Local Definition Eq___Count_op_zsze__ : Count -> Count -> bool :=
-  fun x y => negb (Eq___Count_op_zeze__ x y).
-
-Program Instance Eq___Count : GHC.Base.Eq_ Count :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___Count_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___Count_op_zsze__ |}.
-
-Local Definition Eq___Use_op_zeze__ {inst_u} `{GHC.Base.Eq_ inst_u}
-   : Use inst_u -> Use inst_u -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Abs, Abs => true
-    | Mk_Use a1 a2, Mk_Use b1 b2 =>
-        (andb ((a1 GHC.Base.== b1)) ((a2 GHC.Base.== b2)))
-    | _, _ => false
-    end.
-
-Local Definition Eq___Use_op_zsze__ {inst_u} `{GHC.Base.Eq_ inst_u}
-   : Use inst_u -> Use inst_u -> bool :=
-  fun x y => negb (Eq___Use_op_zeze__ x y).
-
-Program Instance Eq___Use {u} `{GHC.Base.Eq_ u} : GHC.Base.Eq_ (Use u) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___Use_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___Use_op_zsze__ |}.
-
-Local Definition Eq___UseDmd_op_zeze__ : UseDmd -> UseDmd -> bool :=
-  fix UseDmd_eq x y
-        := let eq' : GHC.Base.Eq_ UseDmd := GHC.Base.eq_default UseDmd_eq in
-           match x, y with
-           | UCall a1 a2, UCall b1 b2 => andb (a1 GHC.Base.== b1) (a2 GHC.Base.== b2)
-           | UProd a1, UProd b1 => a1 GHC.Base.== b1
-           | UHead, UHead => true
-           | Used, Used => true
-           | _, _ => false
-           end.
-
-Local Definition Eq___UseDmd_op_zsze__ : UseDmd -> UseDmd -> bool :=
-  fun x y => negb (Eq___UseDmd_op_zeze__ x y).
-
-Program Instance Eq___UseDmd : GHC.Base.Eq_ UseDmd :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___UseDmd_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___UseDmd_op_zsze__ |}.
-
-Axiom mkUProd : list ArgUse -> UseDmd.
-
-Axiom mkUCall : Count -> UseDmd -> UseDmd.
-
-(* Skipping definition `Core.mkTyVarTys' *)
-
-(* Skipping definition `Core.mkTyVarTy' *)
-
-Axiom mkTyConTy : TyCon -> Type_.
-
-Axiom mkTyConKind : list TyConBinder -> Kind -> Kind.
-
-Axiom mkTyConBindersPreferAnon : list TyVar -> Type_ -> list TyConBinder.
-
-Axiom mkTyConAppCo : forall `{Util.HasDebugCallStack},
-                     Role -> TyCon -> list Coercion -> Coercion.
-
-Axiom mkTyConApp : TyCon -> list Type_ -> Type_.
-
-Axiom mkTyCoInScopeSet : list Type_ -> list Coercion -> InScopeSet.
-
-Axiom mkTvSubstPrs : list (TyVar * Type_)%type -> TCvSubst.
-
-Axiom mkTvSubst : InScopeSet -> TvSubstEnv -> TCvSubst.
-
-Axiom mkTupleTyCon : Name.Name ->
-                     list TyConBinder ->
-                     Kind ->
-                     BasicTypes.Arity -> DataCon -> BasicTypes.TupleSort -> AlgTyConFlav -> TyCon.
-
-Axiom mkTransCo : Coercion -> Coercion -> Coercion.
-
-Axiom mkTransAppCo : Role ->
-                     Coercion ->
-                     Type_ -> Type_ -> Role -> Coercion -> Type_ -> Type_ -> Role -> Coercion.
-
-Axiom mkTcTyCon : Name.Name ->
-                  list TyConBinder ->
-                  Kind -> list (Name.Name * TyVar)%type -> TyConFlavour -> TyCon.
-
-Axiom mkTCvSubst : InScopeSet -> (TvSubstEnv * CvSubstEnv)%type -> TCvSubst.
-
-Axiom mkSynonymTyCon : Name.Name ->
-                       list TyConBinder -> Kind -> list Role -> Type_ -> bool -> bool -> TyCon.
-
-Axiom mkSymCo : Coercion -> Coercion.
-
-Axiom mkSumTyCon : Name.Name ->
-                   list TyConBinder ->
-                   Kind -> BasicTypes.Arity -> list TyVar -> list DataCon -> AlgTyConFlav -> TyCon.
-
-Axiom mkSubstLiftingContext : TCvSubst -> LiftingContext.
-
-Axiom mkSubCo : Coercion -> Coercion.
-
-Axiom mkStrictSig : DmdType -> StrictSig.
-
-Axiom mkStrLitTy : FastString.FastString -> Type_.
-
-Axiom mkSpecForAllTys : list TyVar -> Type_ -> Type_.
-
-Axiom mkSProd : list ArgStr -> StrDmd.
-
-Axiom mkSCall : StrDmd -> StrDmd.
-
-Axiom mkRuntimeRepCo : forall `{Util.HasDebugCallStack}, Coercion -> Coercion.
-
-Axiom mkReprPrimEqPred : Type_ -> Type_ -> Type_.
-
-Axiom mkRepReflCo : Type_ -> Coercion.
-
-Axiom mkReflCo : Role -> Type_ -> Coercion.
-
-Axiom mkProofIrrelCo : Role -> Coercion -> Coercion -> Coercion -> Coercion.
-
-Axiom mkPromotedDataCon : DataCon ->
-                          Name.Name ->
-                          TyConRepName ->
-                          list TyConBinder -> Kind -> list Role -> RuntimeRepInfo -> TyCon.
-
-Axiom mkProdDmd : list Demand -> CleanDemand.
-
-Axiom mkPrimTyCon' : Name.Name ->
-                     list TyConBinder -> Kind -> list Role -> bool -> option TyConRepName -> TyCon.
-
-Axiom mkPrimTyCon : Name.Name -> list TyConBinder -> Kind -> list Role -> TyCon.
-
-Axiom mkPrimEqPredRole : Role -> Type_ -> Type_ -> PredType.
-
-Axiom mkPrimEqPred : Type_ -> Type_ -> Type_.
-
-Axiom mkPrelTyConRepName : Name.Name -> TyConRepName.
-
-Axiom mkPiTys : list TyBinder -> Type_ -> Type_.
-
-Axiom mkPiTy : TyBinder -> Type_ -> Type_.
-
-Axiom mkPiCos : Role -> list Var -> Coercion -> Coercion.
-
-Axiom mkPiCo : Role -> Var -> Coercion -> Coercion.
-
-Axiom mkPhantomCo : Coercion -> Type_ -> Type_ -> Coercion.
-
-Axiom mkPatSyn : Name.Name ->
-                 bool ->
-                 (list TyVarBinder * ThetaType)%type ->
-                 (list TyVarBinder * ThetaType)%type ->
-                 list Type_ ->
-                 Type_ ->
-                 (Id * bool)%type ->
-                 option (Id * bool)%type -> list FieldLabel.FieldLabel -> PatSyn.
-
-Axiom mkOnceUsedDmd : CleanDemand -> Demand.
-
-Axiom mkNumLitTy : GHC.Num.Integer -> Type_.
-
-Axiom mkNthCoRole : Role -> nat -> Coercion -> Coercion.
-
-Axiom mkNthCo : nat -> Coercion -> Coercion.
-
-Axiom mkNomReflCo : Type_ -> Coercion.
-
-Axiom mkNamedTyConBinders : ArgFlag -> list TyVar -> list TyConBinder.
-
-Axiom mkNamedTyConBinder : ArgFlag -> TyVar -> TyConBinder.
-
-Axiom mkManyUsedDmd : CleanDemand -> Demand.
-
-Axiom mkLiftingContext : list (TyCoVar * Coercion)%type -> LiftingContext.
-
-Axiom mkLiftedPrimTyCon : Name.Name ->
-                          list TyConBinder -> Kind -> list Role -> TyCon.
-
-Axiom mkLamTypes : list Var -> Type_ -> Type_.
-
-Axiom mkLamType : Var -> Type_ -> Type_.
-
-Axiom mkLRCo : BasicTypes.LeftOrRight -> Coercion -> Coercion.
-
-Axiom mkKindTyCon : Name.Name ->
-                    list TyConBinder -> Kind -> list Role -> Name.Name -> TyCon.
-
-Axiom mkKindCo : Coercion -> Coercion.
-
-Axiom mkJointDmds : forall {s} {u}, list s -> list u -> list (JointDmd s u).
-
-Axiom mkJointDmd : forall {s} {u}, s -> u -> JointDmd s u.
-
-Axiom mkInvForAllTys : list TyVar -> Type_ -> Type_.
-
-Axiom mkInvForAllTy : TyVar -> Type_ -> Type_.
-
-Axiom mkInstCo : Coercion -> Coercion -> Coercion.
-
-Axiom mkHomoPhantomCo : Type_ -> Type_ -> Coercion.
-
-Axiom mkHomoForAllCos_NoRefl : list TyVar -> Coercion -> Coercion.
-
-Axiom mkHomoForAllCos : list TyVar -> Coercion -> Coercion.
-
-Axiom mkHoleCo : CoercionHole -> Coercion.
-
-Axiom mkHeteroReprPrimEqPred : Kind -> Kind -> Type_ -> Type_ -> Type_.
-
-Axiom mkHeteroPrimEqPred : Kind -> Kind -> Type_ -> Type_ -> Type_.
-
-Axiom mkHeteroCoercionType : Role -> Kind -> Kind -> Type_ -> Type_ -> Type_.
-
-Axiom mkHeadStrict : CleanDemand -> CleanDemand.
-
-Axiom mkFunTys : list Type_ -> Type_ -> Type_.
-
-Axiom mkFunTyCon : Name.Name -> list TyConBinder -> Name.Name -> TyCon.
-
-Axiom mkFunTy : Type_ -> Type_ -> Type_.
-
-Axiom mkFunCos : Role -> list Coercion -> Coercion -> Coercion.
-
-Axiom mkFunCo : Role -> Coercion -> Coercion -> Coercion.
-
-Axiom mkForAllTys' : list (TyVar * ArgFlag)%type -> Type_ -> Type_.
-
-Axiom mkForAllTys : list TyVarBinder -> Type_ -> Type_.
-
-Axiom mkForAllTy : TyVar -> ArgFlag -> Type_ -> Type_.
-
-Axiom mkForAllCos : list (TyVar * Coercion)%type -> Coercion -> Coercion.
-
-Axiom mkForAllCo : TyVar -> Coercion -> Coercion -> Coercion.
-
-Axiom mkFamilyTyConApp : TyCon -> list Type_ -> Type_.
-
-Axiom mkFamilyTyCon : Name.Name ->
-                      list TyConBinder ->
-                      Kind ->
-                      option Name.Name -> FamTyConFlav -> option Class -> Injectivity -> TyCon.
-
-Axiom mkEqSpec : TyVar -> Type_ -> EqSpec.
-
-Axiom mkEmptyTCvSubst : InScopeSet -> TCvSubst.
-
-Axiom mkDmdType : DmdEnv -> list Demand -> DmdResult -> DmdType.
-
-Axiom mkDataCon : Name.Name ->
-                  bool ->
-                  TyConRepName ->
-                  list HsSrcBang ->
-                  list FieldLabel.FieldLabel ->
-                  list TyVar ->
-                  list TyVar ->
-                  list TyVarBinder ->
-                  list EqSpec ->
-                  ThetaType ->
-                  list Type_ ->
-                  Type_ -> RuntimeRepInfo -> TyCon -> ThetaType -> Id -> DataConRep -> DataCon.
-
-Axiom mkCoherenceRightCo : Coercion -> Coercion -> Coercion.
-
-Axiom mkCoherenceLeftCo : Coercion -> Coercion -> Coercion.
-
-Axiom mkCoherenceCo : Coercion -> Coercion -> Coercion.
-
-Axiom mkCoercionType : Role -> Type_ -> Type_ -> Type_.
-
-Axiom mkCoercionTy : Coercion -> Type_.
-
-(* Skipping definition `Core.mkCoVarCos' *)
-
-(* Skipping definition `Core.mkCoVarCo' *)
-
-Axiom mkCoCast : Coercion -> Coercion -> Coercion.
-
-Axiom mkClosedStrictSig : list Demand -> DmdResult -> StrictSig.
-
-(* Skipping definition `Core.mkCleanAnonTyConBinders' *)
-
-Axiom mkClassTyCon : Name.Name ->
-                     list TyConBinder -> list Role -> AlgTyConRhs -> Class -> Name.Name -> TyCon.
-
-Axiom mkClassPred : Class -> list Type_ -> PredType.
-
-Axiom mkClass : Name.Name ->
-                list TyVar ->
-                list (FunDep TyVar) ->
-                list PredType ->
-                list Id ->
-                list ClassATItem -> list ClassOpItem -> ClassMinimalDef -> TyCon -> Class.
-
-Axiom mkCastTy : Type_ -> Coercion -> Type_.
-
-Axiom mkCallDmd : CleanDemand -> CleanDemand.
-
-Axiom mkBothDmdArg : DmdEnv -> BothDmdArg.
-
-Axiom mkAxiomRuleCo : CoAxiomRule -> list Coercion -> Coercion.
-
-Axiom mkAxiomInstCo : CoAxiom Branched ->
-                      BranchIndex -> list Coercion -> Coercion.
-
-Axiom mkAxInstRHS : forall {br},
-                    CoAxiom br -> BranchIndex -> list Type_ -> list Coercion -> Type_.
-
-Axiom mkAxInstLHS : forall {br},
-                    CoAxiom br -> BranchIndex -> list Type_ -> list Coercion -> Type_.
-
-Axiom mkAxInstCo : forall {br},
-                   Role -> CoAxiom br -> BranchIndex -> list Type_ -> list Coercion -> Coercion.
-
-Axiom mkAppTys : Type_ -> list Type_ -> Type_.
-
-Axiom mkAppTy : Type_ -> Type_ -> Type_.
-
-Axiom mkAppCos : Coercion -> list Coercion -> Coercion.
-
-Axiom mkAppCo : Coercion -> Coercion -> Coercion.
-
-Axiom mkAnonTyConBinders : list TyVar -> list TyConBinder.
-
-Axiom mkAnonTyConBinder : TyVar -> TyConBinder.
-
-Axiom mkAnonBinder : Type_ -> TyBinder.
-
-Axiom mkAlgTyCon : Name.Name ->
-                   list TyConBinder ->
-                   Kind ->
-                   list Role ->
-                   option CType -> list PredType -> AlgTyConRhs -> AlgTyConFlav -> bool -> TyCon.
-
-Axiom mkAbstractClass : Name.Name ->
-                        list TyVar -> list (FunDep TyVar) -> TyCon -> Class.
-
-Axiom mightBeUnsaturatedTyCon : TyCon -> bool.
-
-(* Skipping definition `Core.maybeSubCo' *)
-
-Axiom markReusedDmd : ArgUse -> ArgUse.
-
-Axiom markReused : UseDmd -> UseDmd.
-
-Axiom markExnStr : ArgStr -> ArgStr.
-
-Axiom mapType : forall {m} {env},
-                forall `{GHC.Base.Monad m}, TyCoMapper env m -> env -> Type_ -> m Type_.
-
-Axiom mapStepResult : forall {ev1} {ev2},
-                      (ev1 -> ev2) -> NormaliseStepResult ev1 -> NormaliseStepResult ev2.
-
-Axiom mapCoercion : forall {m} {env},
-                    forall `{GHC.Base.Monad m}, TyCoMapper env m -> env -> Coercion -> m Coercion.
-
-Axiom makeRecoveryTyCon : TyCon -> TyCon.
-
-Axiom lubUse : UseDmd -> UseDmd -> UseDmd.
-
-Axiom lubStr : StrDmd -> StrDmd -> StrDmd.
-
-Axiom lubExnStr : ExnStr -> ExnStr -> ExnStr.
-
-Axiom lubDmdType : DmdType -> DmdType -> DmdType.
-
-Axiom lubDmdResult : DmdResult -> DmdResult -> DmdResult.
-
-Axiom lubDmd : Demand -> Demand -> Demand.
-
-Axiom lubCount : Count -> Count -> Count.
-
-Axiom lubCPR : CPRResult -> CPRResult -> CPRResult.
-
-Axiom lubArgUse : ArgUse -> ArgUse -> ArgUse.
-
-Axiom lubArgStr : ArgStr -> ArgStr -> ArgStr.
-
-Axiom ltRole : Role -> Role -> bool.
-
-Axiom lookupTyVar : TCvSubst -> TyVar -> option Type_.
-
-Axiom lookupTyConFieldLabel : FieldLabel.FieldLabelString ->
-                              TyCon -> option FieldLabel.FieldLabel.
-
-Axiom lookupCoVar : TCvSubst -> Var -> option Coercion.
-
-Axiom liftEnvSubstRight : TCvSubst -> LiftCoEnv -> TCvSubst.
-
-Axiom liftEnvSubstLeft : TCvSubst -> LiftCoEnv -> TCvSubst.
-
-Axiom liftEnvSubst : (forall {a}, Pair.Pair a -> a) ->
-                     TCvSubst -> LiftCoEnv -> TCvSubst.
-
-Axiom liftCoSubstWithEx : Role ->
-                          list TyVar ->
-                          list Coercion ->
-                          list TyVar -> list Type_ -> ((Type_ -> Coercion) * list Type_)%type.
-
-Axiom liftCoSubstWith : Role ->
-                        list TyCoVar -> list Coercion -> Type_ -> Coercion.
-
-Axiom liftCoSubstVarBndrCallback : forall {a},
-                                   (LiftingContext -> Type_ -> (Coercion * a)%type) ->
-                                   LiftingContext -> TyVar -> (LiftingContext * TyVar * Coercion * a)%type.
-
-Axiom liftCoSubstVarBndr : LiftingContext ->
-                           TyVar -> (LiftingContext * TyVar * Coercion)%type.
-
-Axiom liftCoSubstTyVar : LiftingContext -> Role -> TyVar -> option Coercion.
-
-Axiom liftCoSubst : forall `{Util.HasDebugCallStack},
-                    Role -> LiftingContext -> Type_ -> Coercion.
-
-Axiom lcTCvSubst : LiftingContext -> TCvSubst.
-
-Axiom lcSubstRight : LiftingContext -> TCvSubst.
-
-Axiom lcSubstLeft : LiftingContext -> TCvSubst.
-
-Axiom lcInScopeSet : LiftingContext -> InScopeSet.
-
-Axiom lazyApply2Dmd : Demand.
-
-Axiom lazyApply1Dmd : Demand.
-
-Axiom kindTyConKeys : UniqSet.UniqSet Unique.Unique.
-
-Axiom kill_usage : KillFlags -> Demand -> Demand.
-
-Axiom killUsageSig : DynFlags.DynFlags -> StrictSig -> StrictSig.
-
-Axiom killUsageDemand : DynFlags.DynFlags -> Demand -> Demand.
-
-Axiom killFlags : DynFlags.DynFlags -> option KillFlags.
-
-Axiom is_TYPE : (Type_ -> bool) -> Kind -> bool.
-
-Axiom isWeakDmd : Demand -> bool.
-
-Axiom isVoidRep : PrimRep -> bool.
-
-Axiom isVisibleTyConBinder : forall {tv}, TyVarBndr tv TyConBndrVis -> bool.
-
-Axiom isVisibleTcbVis : TyConBndrVis -> bool.
-
-Axiom isVisibleBinder : TyBinder -> bool.
-
-Axiom isVanillaDataCon : DataCon -> bool.
-
-Axiom isVanillaAlgTyCon : TyCon -> bool.
-
-Axiom isValidTCvSubst : TCvSubst -> bool.
-
-Axiom isValidJoinPointType : BasicTypes.JoinArity -> Type_ -> bool.
-
-Axiom isUsedU : UseDmd -> bool.
-
-Axiom isUsedOnce : Demand -> bool.
-
-Axiom isUsedMU : ArgUse -> bool.
-
-Axiom isUnliftedTypeKind : Kind -> bool.
-
-Axiom isUnliftedType : forall `{Util.HasDebugCallStack}, Type_ -> bool.
-
-Axiom isUnliftedTyCon : TyCon -> bool.
-
-Axiom isUnboxedTupleType : Type_ -> bool.
-
-Axiom isUnboxedTupleTyCon : TyCon -> bool.
-
-Axiom isUnboxedTupleCon : DataCon -> bool.
-
-Axiom isUnboxedSumType : Type_ -> bool.
-
-Axiom isUnboxedSumTyCon : TyCon -> bool.
-
-Axiom isUnboxedSumCon : DataCon -> bool.
-
-Axiom isTypeSynonymTyCon : TyCon -> bool.
-
-Axiom isTypeLevPoly : Type_ -> bool.
-
-Axiom isTypeFamilyTyCon : TyCon -> bool.
-
-Axiom isTyVarTy : Type_ -> bool.
-
-Axiom isTyConWithSrcDataCons : TyCon -> bool.
-
-Axiom isTyConAssoc : TyCon -> bool.
-
-Axiom isTupleTyCon : TyCon -> bool.
-
-Axiom isTupleDataCon : DataCon -> bool.
-
-Axiom isTopSig : StrictSig -> bool.
-
-Axiom isTopRes : DmdResult -> bool.
-
-Axiom isTopDmdType : DmdType -> bool.
-
-Axiom isTopDmd : Demand -> bool.
-
-Axiom isTcTyCon : TyCon -> bool.
-
-Axiom isTcLevPoly : TyCon -> bool.
-
-Axiom isTauTyCon : TyCon -> bool.
-
-Axiom isTauTy : Type_ -> bool.
-
-Axiom isStrictType : forall `{Util.HasDebugCallStack}, Type_ -> bool.
-
-Axiom isStrictDmd : Demand -> bool.
-
-Axiom isStrLitTy : Type_ -> option FastString.FastString.
-
-Axiom isSrcUnpacked : SrcUnpackedness -> bool.
-
-Axiom isSrcStrict : SrcStrictness -> bool.
-
-Axiom isSeqDmd : Demand -> bool.
-
-Axiom isRuntimeRepVar : TyVar -> bool.
-
-Axiom isRuntimeRepTy : Type_ -> bool.
-
-Axiom isRuntimeRepKindedTy : Type_ -> bool.
-
-Axiom isReflexiveCo_maybe : Coercion -> option (Type_ * Role)%type.
-
-Axiom isReflexiveCo : Coercion -> bool.
-
-Axiom isReflCo_maybe : Coercion -> option (Type_ * Role)%type.
-
-Axiom isReflCoVar_maybe : CoVar -> option Coercion.
-
-Axiom isReflCo : Coercion -> bool.
-
-Axiom isPromotedTupleTyCon : TyCon -> bool.
-
-Axiom isPromotedDataCon_maybe : TyCon -> option DataCon.
-
-Axiom isPromotedDataCon : TyCon -> bool.
-
-Axiom isProductTyCon : TyCon -> bool.
-
-Axiom isPrimitiveType : Type_ -> bool.
-
-Axiom isPrimTyCon : TyCon -> bool.
-
-Axiom isPredTy : Type_ -> bool.
-
-Axiom isPiTy : Type_ -> bool.
-
-Axiom isOpenTypeFamilyTyCon : TyCon -> bool.
-
-Axiom isOpenFamilyTyCon : TyCon -> bool.
-
-Axiom isNumLitTy : Type_ -> option GHC.Num.Integer.
-
-Axiom isNullarySrcDataCon : DataCon -> bool.
-
-Axiom isNullaryRepDataCon : DataCon -> bool.
-
-Axiom isNomEqPred : PredType -> bool.
-
-Axiom isNoParent : AlgTyConFlav -> bool.
-
-Axiom isNewTyCon : TyCon -> bool.
-
-Axiom isNamedTyConBinder : TyConBinder -> bool.
-
-Axiom isNamedTyBinder : TyBinder -> bool.
-
-Axiom isMarkedStrict : StrictnessMark -> bool.
-
-Axiom isMappedByLC : TyCoVar -> LiftingContext -> bool.
-
-Axiom isLiftedType_maybe : forall `{Util.HasDebugCallStack},
-                           Type_ -> option bool.
-
-Axiom isLiftedTypeKindTyConName : Name.Name -> bool.
-
-Axiom isLiftedTypeKind : Kind -> bool.
-
-Axiom isLegacyPromotableTyCon : TyCon -> bool.
-
-Axiom isLegacyPromotableDataCon : DataCon -> bool.
-
-Axiom isLazy : ArgStr -> bool.
-
-Axiom isKindTyCon : TyCon -> bool.
-
-Axiom isInvisibleTyConBinder : forall {tv}, TyVarBndr tv TyConBndrVis -> bool.
-
-Axiom isInvisibleBinder : TyBinder -> bool.
-
-Axiom isInjectiveTyCon : TyCon -> Role -> bool.
-
-Axiom isInScope : Var -> TCvSubst -> bool.
-
-Axiom isImplicitTyCon : TyCon -> bool.
-
-Axiom isIPTyCon : TyCon -> bool.
-
-Axiom isIPPred_maybe : Type_ -> option (FastString.FastString * Type_)%type.
-
-Axiom isIPPred : PredType -> bool.
-
-Axiom isIPClass : Class -> bool.
-
-Axiom isHyperStr : ArgStr -> bool.
-
-Axiom isGenerativeTyCon : TyCon -> Role -> bool.
-
-Axiom isGenInjAlgRhs : AlgTyConRhs -> bool.
-
-Axiom isGcPtrRep : PrimRep -> bool.
-
-Axiom isGadtSyntaxTyCon : TyCon -> bool.
-
-Axiom isFunTyCon : TyCon -> bool.
-
-Axiom isFunTy : Type_ -> bool.
-
-Axiom isForAllTy : Type_ -> bool.
-
-Axiom isFamilyTyCon : TyCon -> bool.
-
-Axiom isFamInstTyCon : TyCon -> bool.
-
-Axiom isFamFreeTyCon : TyCon -> bool.
-
-Axiom isFamFreeTy : Type_ -> bool.
-
-Axiom isEqPred : PredType -> bool.
-
-Axiom isEnumerationTyCon : TyCon -> bool.
-
-Axiom isEmptyTCvSubst : TCvSubst -> bool.
-
-Axiom isDictTy : Type_ -> bool.
-
-Axiom isDictLikeTy : Type_ -> bool.
-
-Axiom isDataTyCon : TyCon -> bool.
-
-Axiom isDataSumTyCon_maybe : TyCon -> option (list DataCon).
-
-Axiom isDataProductTyCon_maybe : TyCon -> option DataCon.
-
-Axiom isDataFamilyTyCon : TyCon -> bool.
-
-Axiom isDataFamilyAppType : Type_ -> bool.
-
-Axiom isDataFamFlav : FamTyConFlav -> bool.
-
-Axiom isCoercionType : Type_ -> bool.
-
-Axiom isCoercionTy_maybe : Type_ -> option Coercion.
-
-Axiom isCoercionTy : Type_ -> bool.
-
-Axiom isCoVar_maybe : Coercion -> option CoVar.
-
-Axiom isClosedSynFamilyTyConWithAxiom_maybe : TyCon ->
-                                              option (CoAxiom Branched).
-
-Axiom isClassTyCon : TyCon -> bool.
-
-Axiom isClassPred : PredType -> bool.
-
-Axiom isCTupleClass : Class -> bool.
-
-Axiom isBuiltInSynFamTyCon_maybe : TyCon -> option BuiltInSynFamily.
-
-Axiom isBoxedTupleTyCon : TyCon -> bool.
-
-Axiom isBottomingSig : StrictSig -> bool.
-
-Axiom isBotRes : DmdResult -> bool.
-
-Axiom isBanged : HsImplBang -> bool.
-
-Axiom isAnonTyBinder : TyBinder -> bool.
-
-Axiom isAlgType : Type_ -> bool.
-
-Axiom isAlgTyCon : TyCon -> bool.
-
-Axiom isAbstractTyCon : TyCon -> bool.
-
-Axiom isAbstractClass : Class -> bool.
-
-Axiom isAbsDmd : Demand -> bool.
-
-Axiom instNewTyCon_maybe : TyCon ->
-                           list Type_ -> option (Type_ * Coercion)%type.
-
-Axiom instCoercions : Coercion -> list Coercion -> option Coercion.
-
-Axiom instCoercion : Pair.Pair Type_ -> Coercion -> Coercion -> option Coercion.
-
-(* Skipping definition `Core.injectiveVarsOfType' *)
-
-(* Skipping definition `Core.injectiveVarsOfBinder' *)
-
-Axiom initRecTc : RecTcChecker.
-
-Axiom increaseStrictSigArity : nat -> StrictSig -> StrictSig.
-
-Axiom hasDemandEnvSig : StrictSig -> bool.
-
-Axiom getUseDmd : forall {s} {u}, JointDmd s u -> u.
-
-Axiom getTyVar_maybe : Type_ -> option TyVar.
-
-Axiom getTyVar : GHC.Base.String -> Type_ -> TyVar.
-
-Axiom getTvSubstEnv : TCvSubst -> TvSubstEnv.
-
-Axiom getTCvSubstRangeFVs : TCvSubst -> VarSet.
-
-Axiom getTCvInScope : TCvSubst -> InScopeSet.
-
-Axiom getStrDmd : forall {s} {u}, JointDmd s u -> s.
-
-Axiom getRuntimeRep_maybe : forall `{Util.HasDebugCallStack},
-                            Type_ -> option Type_.
-
-Axiom getRuntimeRepFromKind_maybe : forall `{Util.HasDebugCallStack},
-                                    Type_ -> option Type_.
-
-Axiom getRuntimeRepFromKind : forall `{Util.HasDebugCallStack}, Type_ -> Type_.
-
-Axiom getRuntimeRep : forall `{Util.HasDebugCallStack}, Type_ -> Type_.
-
-Axiom getHelpfulOccName : TyCoVar -> OccName.OccName.
-
-Axiom getEqPredTys_maybe : PredType -> option (Role * Type_ * Type_)%type.
-
-Axiom getEqPredTys : PredType -> (Type_ * Type_)%type.
-
-Axiom getEqPredRole : PredType -> Role.
-
-Axiom getCvSubstEnv : TCvSubst -> CvSubstEnv.
-
-Axiom getCoVar_maybe : Coercion -> option CoVar.
-
-Axiom getClassPredTys_maybe : PredType -> option (Class * list Type_)%type.
-
-Axiom getClassPredTys : PredType -> (Class * list Type_)%type.
-
-Axiom getCastedTyVar_maybe : Type_ -> option (TyVar * CoercionN)%type.
-
-Axiom funResultTy : Type_ -> Type_.
-
-Axiom funArgTy : Type_ -> Type_.
-
-(* Skipping definition `Core.freshNames' *)
-
-Axiom findIdDemand : DmdType -> Var -> Demand.
-
-Axiom filterOutInvisibleTypes : TyCon -> list Type_ -> list Type_.
-
-Local Definition Eq___Var_op_zeze__ : Var -> Var -> bool :=
-  fun a b => realUnique a GHC.Base.== realUnique b.
-
-Local Definition Eq___Var_op_zsze__ : Var -> Var -> bool :=
-  fun x y => negb (Eq___Var_op_zeze__ x y).
-
-Program Instance Eq___Var : GHC.Base.Eq_ Var :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___Var_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___Var_op_zsze__ |}.
-
-Axiom filterEqSpec : list EqSpec -> list TyVar -> list TyVar.
-
-Axiom fieldsOfAlgTcRhs : AlgTyConRhs -> FieldLabel.FieldLabelEnv.
-
-Axiom famTyConFlav_maybe : TyCon -> option FamTyConFlav.
-
-Axiom extendTvSubstWithClone : TCvSubst -> TyVar -> TyVar -> TCvSubst.
-
-Axiom extendTvSubstList : TCvSubst -> list Var -> list Type_ -> TCvSubst.
-
-Axiom extendTvSubstBinderAndInScope : TCvSubst -> TyBinder -> Type_ -> TCvSubst.
-
-Axiom extendTvSubstAndInScope : TCvSubst -> TyVar -> Type_ -> TCvSubst.
-
-Axiom extendTvSubst : TCvSubst -> TyVar -> Type_ -> TCvSubst.
-
-Axiom extendTCvSubst : TCvSubst -> TyCoVar -> Type_ -> TCvSubst.
-
-Axiom extendTCvInScopeSet : TCvSubst -> VarSet -> TCvSubst.
-
-Axiom extendTCvInScopeList : TCvSubst -> list Var -> TCvSubst.
-
-Axiom extendTCvInScope : TCvSubst -> Var -> TCvSubst.
-
-Axiom extendLiftingContextEx : LiftingContext ->
-                               list (TyVar * Type_)%type -> LiftingContext.
-
-Axiom extendLiftingContext : LiftingContext ->
-                             TyVar -> Coercion -> LiftingContext.
-
-Axiom extendCvSubstWithClone : TCvSubst -> CoVar -> CoVar -> TCvSubst.
-
-Axiom extendCvSubst : TCvSubst -> CoVar -> Coercion -> TCvSubst.
-
-Axiom expandTypeSynonyms : Type_ -> Type_.
-
-Axiom expandSynTyCon_maybe : forall {tyco},
-                             TyCon ->
-                             list tyco -> option (list (TyVar * tyco)%type * Type_ * list tyco)%type.
-
-Axiom exnSig : StrictSig.
-
-Axiom exnRes : DmdResult.
-
-Axiom exnDmdType : DmdType.
-
-Axiom evalDmd : Demand.
-
-Axiom equalityTyCon : Role -> TyCon.
-
-Axiom eqVarBndrs : RnEnv2 -> list Var -> list Var -> option RnEnv2.
-
-Axiom eqTypes : list Type_ -> list Type_ -> bool.
-
-Axiom eqTypeX : RnEnv2 -> Type_ -> Type_ -> bool.
-
-Axiom eqType : Type_ -> Type_ -> bool.
-
-Axiom eqSpecType : EqSpec -> Type_.
-
-Axiom eqSpecTyVar : EqSpec -> TyVar.
-
-Axiom eqSpecPreds : list EqSpec -> ThetaType.
-
-Axiom eqSpecPair : EqSpec -> (TyVar * Type_)%type.
-
-Axiom eqRelRole : EqRel -> Role.
-
-Axiom eqHsBang : HsImplBang -> HsImplBang -> bool.
-
-Axiom eqCoercionX : RnEnv2 -> Coercion -> Coercion -> bool.
-
-Axiom eqCoercion : Coercion -> Coercion -> bool.
-
-Axiom dmdTypeDepth : DmdType -> BasicTypes.Arity.
-
-Axiom ensureArgs : BasicTypes.Arity -> DmdType -> DmdType.
-
-Axiom emptyTvSubstEnv : TvSubstEnv.
-
-Axiom emptyTCvSubst : TCvSubst.
-
-Axiom emptyLiftingContext : InScopeSet -> LiftingContext.
-
-Axiom emptyDmdEnv : VarEnv Demand.
-
-Axiom emptyCvSubstEnv : CvSubstEnv.
-
-Axiom dropRuntimeRepArgs : list Type_ -> list Type_.
-
-Axiom dropForAlls : Type_ -> Type_.
-
-Axiom downgradeRole_maybe : Role -> Role -> Coercion -> option Coercion.
-
-Axiom downgradeRole : Role -> Role -> Coercion -> Coercion.
-
-Axiom dmdTransformSig : StrictSig -> CleanDemand -> DmdType.
-
-Axiom dmdTransformDictSelSig : StrictSig -> CleanDemand -> DmdType.
-
-Axiom dmdTransformDataConSig : BasicTypes.Arity ->
-                               StrictSig -> CleanDemand -> DmdType.
-
-Axiom delBinderVar : VarSet -> TyVarBinder -> VarSet.
-
-Axiom deferAfterIO : DmdType -> DmdType.
-
-Axiom defaultDmd : forall {r}, Termination r -> Demand.
-
-Axiom decomposeFunCo : Coercion -> (Coercion * Coercion)%type.
-
-Axiom decomposeCo : BasicTypes.Arity -> Coercion -> list Coercion.
-
-Axiom debug_ppr_ty : BasicTypes.TyPrec -> Type_ -> GHC.Base.String.
-
-Axiom debugPprType : Type_ -> GHC.Base.String.
-
-Axiom dataConWrapId_maybe : DataCon -> option Id.
-
-Axiom dataConWrapId : DataCon -> Id.
-
-Axiom dataConWorkId : DataCon -> Id.
-
-Axiom dataConUserType : DataCon -> Type_.
-
-Axiom dataConUserTyVarsArePermuted : DataCon -> bool.
-
-Axiom dataConUserTyVars : DataCon -> list TyVar.
-
-Axiom dataConUserTyVarBinders : DataCon -> list TyVarBinder.
-
-Axiom dataConUnivTyVars : DataCon -> list TyVar.
-
-Axiom dataConUnivAndExTyVars : DataCon -> list TyVar.
-
-Axiom dataConTyCon : DataCon -> TyCon.
-
-Axiom dataConTheta : DataCon -> ThetaType.
-
-Axiom dataConTagZ : DataCon -> BasicTypes.ConTagZ.
-
-Axiom dataConTag : DataCon -> BasicTypes.ConTag.
-
-Axiom dataConStupidTheta : DataCon -> ThetaType.
-
-Axiom dataConSrcBangs : DataCon -> list HsSrcBang.
-
-Axiom dataConSourceArity : DataCon -> BasicTypes.Arity.
-
-Axiom dataConSig : DataCon ->
-                   (list TyVar * ThetaType * list Type_ * Type_)%type.
-
-Axiom dataConRepType : DataCon -> Type_.
-
-Axiom dataConRepStrictness : DataCon -> list StrictnessMark.
-
-Axiom dataConRepArity : DataCon -> BasicTypes.Arity.
-
-Axiom dataConRepArgTys : DataCon -> list Type_.
-
-Axiom dataConOrigTyCon : DataCon -> TyCon.
-
-Axiom dataConOrigResTy : DataCon -> Type_.
-
-Axiom dataConOrigArgTys : DataCon -> list Type_.
-
-Axiom dataConName : DataCon -> Name.Name.
-
-Axiom dataConIsInfix : DataCon -> bool.
-
-Axiom dataConInstSig : DataCon ->
-                       list Type_ -> (list TyVar * ThetaType * list Type_)%type.
-
-Axiom dataConInstOrigArgTys : DataCon -> list Type_ -> list Type_.
-
-Axiom dataConInstArgTys : DataCon -> list Type_ -> list Type_.
-
-Axiom dataConImplicitTyThings : DataCon -> list TyThing.
-
-Axiom dataConImplBangs : DataCon -> list HsImplBang.
-
-(* Skipping definition `Core.dataConIdentity' *)
-
-Axiom dataConFullSig : DataCon ->
-                       (list TyVar * list TyVar * list EqSpec * ThetaType * list Type_ * Type_)%type.
-
-Axiom dataConFieldType_maybe : DataCon ->
-                               FieldLabel.FieldLabelString -> option (FieldLabel.FieldLabel * Type_)%type.
-
-Axiom dataConFieldType : DataCon -> FieldLabel.FieldLabelString -> Type_.
-
-Axiom dataConFieldLabels : DataCon -> list FieldLabel.FieldLabel.
-
-Axiom dataConExTyVars : DataCon -> list TyVar.
-
-Axiom dataConEqSpec : DataCon -> list EqSpec.
-
-Axiom dataConCannotMatch : list Type_ -> DataCon -> bool.
-
-Axiom dataConBoxer : DataCon -> option DataConBoxer.
-
-Axiom dVarSetElemsWellScoped : DVarSet -> list Var.
-
-Axiom cprSumRes : BasicTypes.ConTag -> DmdResult.
-
-Axiom cprProdSig : BasicTypes.Arity -> StrictSig.
-
-Axiom cprProdRes : list DmdType -> DmdResult.
-
-Axiom cprProdDmdType : BasicTypes.Arity -> DmdType.
-
-Axiom coreView : Type_ -> option Type_.
-
-Axiom composeTCvSubstEnv : InScopeSet ->
-                           (TvSubstEnv * CvSubstEnv)%type ->
-                           (TvSubstEnv * CvSubstEnv)%type -> (TvSubstEnv * CvSubstEnv)%type.
-
-Axiom composeTCvSubst : TCvSubst -> TCvSubst -> TCvSubst.
-
-Axiom composeSteppers : forall {ev},
-                        NormaliseStepper ev -> NormaliseStepper ev -> NormaliseStepper ev.
-
-Axiom coercionType : Coercion -> Type_.
-
-Axiom coercionSize : Coercion -> nat.
-
-Axiom coercionRole : Coercion -> Role.
-
-Axiom coercionKinds : list Coercion -> Pair.Pair (list Type_).
-
-Axiom coercionKindRole : Coercion -> (Pair.Pair Type_ * Role)%type.
-
-Axiom coercionKind : Coercion -> Pair.Pair Type_.
-
-Axiom coVarsOfTypes : list Type_ -> TyCoVarSet.
-
-Axiom coVarsOfType : Type_ -> CoVarSet.
-
-Axiom coVarsOfProv : UnivCoProvenance -> CoVarSet.
-
-Axiom coVarsOfCos : list Coercion -> CoVarSet.
-
-Axiom coVarsOfCoVar : CoVar -> CoVarSet.
-
-Axiom coVarsOfCo : Coercion -> CoVarSet.
-
-Axiom coVarTypes : CoVar -> Pair.Pair Type_.
-
-Axiom coVarRole : CoVar -> Role.
-
-Axiom coVarName : CoVar -> Name.Name.
-
-Axiom coVarKindsTypesRole : CoVar -> (Kind * Kind * Type_ * Type_ * Role)%type.
-
-Axiom coVarKind : CoVar -> Type_.
-
-Axiom coHoleCoVar : CoercionHole -> CoVar.
-
-Axiom coAxNthLHS : forall {br}, CoAxiom br -> nat -> Type_.
-
-Axiom closeOverKindsList : list TyVar -> list TyVar.
-
-(* Skipping definition `Core.closeOverKindsFV' *)
-
-Axiom closeOverKindsDSet : DTyVarSet -> DTyVarSet.
-
-Axiom closeOverKinds : TyVarSet -> TyVarSet.
-
-Axiom cloneTyVarBndrs : TCvSubst ->
-                        list TyVar -> UniqSupply.UniqSupply -> (TCvSubst * list TyVar)%type.
-
-Axiom cloneTyVarBndr : TCvSubst ->
-                       TyVar -> Unique.Unique -> (TCvSubst * TyVar)%type.
-
-Axiom cleanUseDmd_maybe : Demand -> option UseDmd.
-
-Axiom cleanEvalProdDmd : BasicTypes.Arity -> CleanDemand.
-
-Axiom cleanEvalDmd : CleanDemand.
-
-Axiom classifyPredType : PredType -> PredTree.
-
-Axiom classTvsFds : Class -> (list TyVar * list (FunDep TyVar))%type.
-
-Axiom classSCTheta : Class -> list PredType.
-
-(* Skipping definition `Core.classSCSelId' *)
-
-Axiom classOpItems : Class -> list ClassOpItem.
-
-Axiom classMinimalDef : Class -> ClassMinimalDef.
-
-Axiom classMethods : Class -> list Id.
-
-Axiom classHasFds : Class -> bool.
-
-Axiom classExtraBigSig : Class ->
-                         (list TyVar * list (FunDep TyVar) * list PredType * list Id * list ClassATItem *
-                          list ClassOpItem)%type.
-
-Axiom classDataCon : Class -> DataCon.
-
-Axiom classBigSig : Class ->
-                    (list TyVar * list PredType * list Id * list ClassOpItem)%type.
-
-Axiom classArity : Class -> BasicTypes.Arity.
-
-Axiom classAllSelIds : Class -> list Id.
-
-Axiom classATs : Class -> list TyCon.
-
-Axiom classATItems : Class -> list ClassATItem.
-
-Axiom checkValidSubst : forall {a},
-                        forall `{Util.HasDebugCallStack},
-                        TCvSubst -> list Type_ -> list Coercion -> a -> a.
-
-Axiom checkRecTc : RecTcChecker -> TyCon -> option RecTcChecker.
-
-Axiom catchArgDmd : Demand.
-
-Axiom castCoercionKind : Coercion -> Coercion -> Coercion -> Coercion.
-
-Axiom caseBinder : forall {a},
-                   TyBinder -> (TyVarBinder -> a) -> (Type_ -> a) -> a.
-
-Axiom buildSynTyCon : Name.Name ->
-                      list TyConBinder -> Kind -> list Role -> Type_ -> TyCon.
-
-Axiom buildAlgTyCon : Name.Name ->
-                      list TyVar ->
-                      list Role ->
-                      option CType -> ThetaType -> AlgTyConRhs -> bool -> AlgTyConFlav -> TyCon.
-
-Axiom bothUse : UseDmd -> UseDmd -> UseDmd.
-
-Axiom bothStr : StrDmd -> StrDmd -> StrDmd.
-
-Axiom bothExnStr : ExnStr -> ExnStr -> ExnStr.
-
-Axiom bothDmdType : DmdType -> BothDmdArg -> DmdType.
-
-Axiom bothDmdResult : DmdResult -> Termination unit -> DmdResult.
-
-Axiom bothDmd : Demand -> Demand -> Demand.
-
-Axiom bothCleanDmd : CleanDemand -> CleanDemand -> CleanDemand.
-
-Axiom bothArgUse : ArgUse -> ArgUse -> ArgUse.
-
-Axiom bothArgStr : ArgStr -> ArgStr -> ArgStr.
-
-Axiom botSig : StrictSig.
-
-Axiom botRes : DmdResult.
-
-Axiom botDmdType : DmdType.
-
-Axiom botDmd : Demand.
-
-Axiom binderRelevantType_maybe : TyBinder -> option Type_.
-
-Axiom argsOneShots : StrictSig ->
-                     BasicTypes.Arity -> list (list BasicTypes.OneShotInfo).
-
-Axiom argOneShots : Demand -> list BasicTypes.OneShotInfo.
-
-Axiom applyTysX : list TyVar -> Type_ -> list Type_ -> Type_.
-
-Axiom applyRoles : TyCon -> list Coercion -> list Coercion.
-
-Axiom appIsBottom : StrictSig -> nat -> bool.
-
-Axiom algTyConRhs : TyCon -> AlgTyConRhs.
-
-Axiom addDemand : Demand -> DmdType -> DmdType.
-
-(* Skipping definition `Core.addCaseBndrDmd' *)
-
-Axiom absDmd : Demand.
-
-Definition zapUsedOnceInfo : IdInfo -> option IdInfo :=
-  fun info =>
-    Some (let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
-             oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
-             callArityInfo_9__ levityInfo_10__ := info in
-          Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
-                    oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ (zapUsedOnceSig (strictnessInfo
-                                                                                    info)) (zapUsedOnceDemand
-                     (demandInfo info)) callArityInfo_9__ levityInfo_10__).
-
-Definition zapUsageInfo : IdInfo -> option IdInfo :=
-  fun info =>
-    Some (let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
-             oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
-             callArityInfo_9__ levityInfo_10__ := info in
-          Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
-                    oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__
-                    (zapUsageDemand (demandInfo info)) callArityInfo_9__ levityInfo_10__).
-
-Definition zapUsageEnvInfo : IdInfo -> option IdInfo :=
-  fun info =>
-    if hasDemandEnvSig (strictnessInfo info) : bool
-    then Some (let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__
-                  cafInfo_3__ oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__
-                  demandInfo_8__ callArityInfo_9__ levityInfo_10__ := info in
-               Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
-                         oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ (zapUsageEnvSig (strictnessInfo
-                                                                                         info)) demandInfo_8__
-                         callArityInfo_9__ levityInfo_10__) else
-    None.
-
-Definition zapLamInfo : IdInfo -> option IdInfo :=
-  fun '((Mk_IdInfo _ _ _ _ _ _ occ _ demand _ _ as info)) =>
-    let is_safe_dmd := fun dmd => negb (isStrictDmd dmd) in
-    let safe_occ :=
-      match occ with
-      | BasicTypes.OneOcc _ _ _ _ =>
-          match occ with
-          | BasicTypes.ManyOccs _ =>
-              GHC.Err.error (GHC.Base.hs_string__ "Partial record update")
-          | BasicTypes.IAmDead =>
-              GHC.Err.error (GHC.Base.hs_string__ "Partial record update")
-          | BasicTypes.OneOcc occ_in_lam_2__ occ_one_br_3__ occ_int_cxt_4__
-          occ_tail_5__ =>
-              BasicTypes.OneOcc true occ_one_br_3__ occ_int_cxt_4__ BasicTypes.NoTailCallInfo
-          | BasicTypes.IAmALoopBreaker _ _ =>
-              GHC.Err.error (GHC.Base.hs_string__ "Partial record update")
-          end
-      | BasicTypes.IAmALoopBreaker _ _ =>
-          match occ with
-          | BasicTypes.ManyOccs occ_tail_12__ =>
-              BasicTypes.ManyOccs BasicTypes.NoTailCallInfo
-          | BasicTypes.IAmDead =>
-              GHC.Err.error (GHC.Base.hs_string__ "Partial record update")
-          | BasicTypes.OneOcc occ_in_lam_13__ occ_one_br_14__ occ_int_cxt_15__
-          occ_tail_16__ =>
-              BasicTypes.OneOcc occ_in_lam_13__ occ_one_br_14__ occ_int_cxt_15__
-                                BasicTypes.NoTailCallInfo
-          | BasicTypes.IAmALoopBreaker occ_rules_only_17__ occ_tail_18__ =>
-              BasicTypes.IAmALoopBreaker occ_rules_only_17__ BasicTypes.NoTailCallInfo
-          end
-      | _other => occ
-      end in
-    let is_safe_occ :=
-      fun arg_27__ =>
-        let 'occ := arg_27__ in
-        if BasicTypes.isAlwaysTailCalled occ : bool then false else
-        match arg_27__ with
-        | BasicTypes.OneOcc in_lam _ _ _ => in_lam
-        | _other => true
-        end in
-    if andb (is_safe_occ occ) (is_safe_dmd demand) : bool then None else
-    Some (let 'Mk_IdInfo arityInfo_31__ ruleInfo_32__ unfoldingInfo_33__
-             cafInfo_34__ oneShotInfo_35__ inlinePragInfo_36__ occInfo_37__
-             strictnessInfo_38__ demandInfo_39__ callArityInfo_40__ levityInfo_41__ :=
-            info in
-          Mk_IdInfo arityInfo_31__ ruleInfo_32__ unfoldingInfo_33__ cafInfo_34__
-                    oneShotInfo_35__ inlinePragInfo_36__ safe_occ strictnessInfo_38__ topDmd
-                    callArityInfo_40__ levityInfo_41__).
-
-Definition zapDemandInfo : IdInfo -> option IdInfo :=
-  fun info =>
-    Some (let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
-             oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
-             callArityInfo_9__ levityInfo_10__ := info in
-          Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
-                    oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ topDmd
-                    callArityInfo_9__ levityInfo_10__).
-
-Definition varUnique : Var -> Unique.Unique :=
-  fun var => Unique.mkUniqueGrimily (realUnique var).
-
-Definition varToCoreExpr {b} : CoreBndr -> Expr b :=
-  fun v =>
-    if andb Util.debugIsOn (negb (true)) : bool
-    then (Panic.assertPanic (GHC.Base.hs_string__ "ghc/compiler/coreSyn/CoreSyn.hs")
-          #1920)
-    else Mk_Var v.
-
-Definition varsToCoreExprs {b} : list CoreBndr -> list (Expr b) :=
-  fun vs => GHC.Base.map varToCoreExpr vs.
-
-Definition vanillaCafInfo : CafInfo :=
-  MayHaveCafRefs.
-
-Definition updateVarTypeM {m} `{GHC.Base.Monad m}
-   : (Type_ -> m Type_) -> Id -> m Id :=
-  fun f id =>
-    f (varType id) GHC.Base.>>=
-    (fun ty' =>
-       GHC.Base.return_ (let 'Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__
-                            id_details_4__ id_info_5__ := id in
-                         Mk_Id varName_0__ realUnique_1__ ty' idScope_3__ id_details_4__ id_info_5__)).
-
-Definition updateVarType : (Type_ -> Type_) -> Id -> Id :=
-  fun f id =>
-    let 'Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__ id_details_4__
-       id_info_5__ := id in
-    Mk_Id varName_0__ realUnique_1__ (f (varType id)) idScope_3__ id_details_4__
-          id_info_5__.
-
-Definition unknownArity : BasicTypes.Arity :=
-  #0.
-
-Local Definition Uniquable__Var_getUnique : Var -> Unique.Unique :=
-  varUnique.
-
-Program Instance Uniquable__Var : Unique.Uniquable Var :=
-  fun _ k__ => k__ {| Unique.getUnique__ := Uniquable__Var_getUnique |}.
-
-Definition unitDVarEnv {a} : Var -> a -> DVarEnv a :=
-  UniqFM.unitUFM.
-
-Definition unitVarEnv {a} : Var -> a -> VarEnv a :=
-  UniqFM.unitUFM.
-
-Definition unitDVarSet : Var -> DVarSet :=
-  UniqSet.unitUniqSet.
-
-Definition unitVarSet : Var -> VarSet :=
-  UniqSet.unitUniqSet.
-
-Axiom uniqAway : InScopeSet -> Var -> Var.
-
-Definition unionVarSets : list VarSet -> VarSet :=
-  UniqSet.unionManyUniqSets.
-
-Definition unionVarSet : VarSet -> VarSet -> VarSet :=
-  UniqSet.unionUniqSets.
-
-Definition unionInScope : InScopeSet -> InScopeSet -> InScopeSet :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | InScope s1 _, InScope s2 n2 => InScope (unionVarSet s1 s2) n2
-    end.
-
-Definition unionDVarSets : list DVarSet -> DVarSet :=
-  UniqSet.unionManyUniqSets.
-
-Definition unionDVarSet : DVarSet -> DVarSet -> DVarSet :=
-  UniqSet.unionUniqSets.
-
-Axiom unfoldingTemplate : Unfolding -> CoreExpr.
-
-Definition unSaturatedOk : bool :=
-  true.
-
-Definition tyVarName : TyVar -> Name.Name :=
-  varName.
-
-Definition tyVarKind : TyVar -> Kind :=
-  varType.
-
-Definition updateTyVarKind : (Kind -> Kind) -> TyVar -> TyVar :=
-  fun update tv =>
-    let 'Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__ id_details_4__
-       id_info_5__ := tv in
-    Mk_Id varName_0__ realUnique_1__ (update (tyVarKind tv)) idScope_3__
-          id_details_4__ id_info_5__.
-
-Definition updateTyVarKindM {m} `{(GHC.Base.Monad m)}
-   : (Kind -> m Kind) -> TyVar -> m TyVar :=
-  fun update tv =>
-    update (tyVarKind tv) GHC.Base.>>=
-    (fun k' =>
-       GHC.Base.return_ (let 'Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__
-                            id_details_4__ id_info_5__ := tv in
-                         Mk_Id varName_0__ realUnique_1__ k' idScope_3__ id_details_4__ id_info_5__)).
-
-Definition tickishScoped {id} : Tickish id -> TickishScoping :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | (ProfNote _ _ _ as n) =>
-        if profNoteScope n : bool then CostCentreScope else
-        NoScope
-    | HpcTick _ _ => NoScope
-    | Breakpoint _ _ => CostCentreScope
-    | SourceNote _ _ => SoftScope
-    end.
-
-Definition tickishScopesLike {id} : Tickish id -> TickishScoping -> bool :=
-  fun t scope =>
-    let like :=
-      fun arg_0__ arg_1__ =>
-        match arg_0__, arg_1__ with
-        | NoScope, _ => true
-        | _, NoScope => false
-        | SoftScope, _ => true
-        | _, SoftScope => false
-        | CostCentreScope, _ => true
-        end in
-    like (tickishScoped t) scope.
-
-Definition tickishPlace {id} : Tickish id -> TickishPlacement :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | (ProfNote _ _ _ as n) =>
-        if profNoteCount n : bool then PlaceRuntime else
-        PlaceCostCentre
-    | HpcTick _ _ => PlaceRuntime
-    | Breakpoint _ _ => PlaceRuntime
-    | SourceNote _ _ => PlaceNonLam
-    end.
-
-Axiom tickishIsCode : forall {id}, Tickish id -> bool.
-
-Axiom tickishCounts : forall {id}, Tickish id -> bool.
-
-Definition tickishFloatable {id} : Tickish id -> bool :=
-  fun t => andb (tickishScopesLike t SoftScope) (negb (tickishCounts t)).
-
-(* Skipping definition `Core.tickishContains' *)
-
-(* Skipping definition `Core.tickishCanSplit' *)
-
-(* Skipping definition `Core.tcTyVarDetails' *)
-
-Definition sizeVarSet : VarSet -> nat :=
-  UniqSet.sizeUniqSet.
-
-Definition sizeDVarSet : DVarSet -> nat :=
-  UniqSet.sizeUniqSet.
-
-Definition setVarUnique : Var -> Unique.Unique -> Var :=
-  fun var uniq =>
-    let 'Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__ id_details_4__
-       id_info_5__ := var in
-    Mk_Id (Name.setNameUnique (varName var) uniq) (Unique.getKey uniq) varType_2__
-          idScope_3__ id_details_4__ id_info_5__.
-
-Definition setVarType : Id -> Type_ -> Id :=
-  fun id ty =>
-    let 'Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__ id_details_4__
-       id_info_5__ := id in
-    Mk_Id varName_0__ realUnique_1__ ty idScope_3__ id_details_4__ id_info_5__.
-
-Definition setVarName : Var -> Name.Name -> Var :=
-  fun var new_name =>
-    let 'Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__ id_details_4__
-       id_info_5__ := var in
-    Mk_Id new_name (Unique.getKey (Unique.getUnique new_name)) varType_2__
-          idScope_3__ id_details_4__ id_info_5__.
-
-Definition setUnfoldingInfo : IdInfo -> Unfolding -> IdInfo :=
-  fun info uf =>
-    let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
-       oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
-       callArityInfo_9__ levityInfo_10__ := info in
-    Mk_IdInfo arityInfo_0__ ruleInfo_1__ uf cafInfo_3__ oneShotInfo_4__
-              inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
-              callArityInfo_9__ levityInfo_10__.
-
-Definition setTyVarUnique : TyVar -> Unique.Unique -> TyVar :=
-  setVarUnique.
-
-Definition setTyVarName : TyVar -> Name.Name -> TyVar :=
-  setVarName.
-
-Definition setTyVarKind : TyVar -> Kind -> TyVar :=
-  fun tv k =>
-    let 'Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__ id_details_4__
-       id_info_5__ := tv in
-    Mk_Id varName_0__ realUnique_1__ k idScope_3__ id_details_4__ id_info_5__.
-
-(* Skipping definition `Core.setTcTyVarDetails' *)
-
-Definition setStrictnessInfo : IdInfo -> StrictSig -> IdInfo :=
-  fun info dd =>
-    GHC.Prim.seq dd (let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__
-                        cafInfo_3__ oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__
-                        demandInfo_8__ callArityInfo_9__ levityInfo_10__ := info in
-                  Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
-                            oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ dd demandInfo_8__
-                            callArityInfo_9__ levityInfo_10__).
-
-Definition setRuleInfoHead : Name.Name -> RuleInfo -> RuleInfo :=
-  fun x y => EmptyRuleInfo.
-
-Definition setRuleInfo : IdInfo -> RuleInfo -> IdInfo :=
-  fun info sp =>
-    GHC.Prim.seq sp (let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__
-                        cafInfo_3__ oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__
-                        demandInfo_8__ callArityInfo_9__ levityInfo_10__ := info in
-                  Mk_IdInfo arityInfo_0__ sp unfoldingInfo_2__ cafInfo_3__ oneShotInfo_4__
-                            inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
-                            callArityInfo_9__ levityInfo_10__).
-
-Definition setRuleIdName : Name.Name -> CoreRule -> CoreRule :=
-  fun nm ru =>
-    match ru with
-    | Rule ru_name_0__ ru_act_1__ ru_fn_2__ ru_rough_3__ ru_bndrs_4__ ru_args_5__
-    ru_rhs_6__ ru_auto_7__ ru_origin_8__ ru_orphan_9__ ru_local_10__ =>
-        Rule ru_name_0__ ru_act_1__ nm ru_rough_3__ ru_bndrs_4__ ru_args_5__ ru_rhs_6__
-             ru_auto_7__ ru_origin_8__ ru_orphan_9__ ru_local_10__
-    | BuiltinRule ru_name_11__ ru_fn_12__ ru_nargs_13__ ru_try_14__ =>
-        BuiltinRule ru_name_11__ nm ru_nargs_13__ ru_try_14__
-    end.
-
-Definition setOneShotInfo : IdInfo -> BasicTypes.OneShotInfo -> IdInfo :=
-  fun info lb =>
-    let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
-       oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
-       callArityInfo_9__ levityInfo_10__ := info in
-    Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__ lb
-              inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
-              callArityInfo_9__ levityInfo_10__.
-
-Definition setOccInfo : IdInfo -> BasicTypes.OccInfo -> IdInfo :=
-  fun info oc =>
-    GHC.Prim.seq oc (let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__
-                        cafInfo_3__ oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__
-                        demandInfo_8__ callArityInfo_9__ levityInfo_10__ := info in
-                  Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
-                            oneShotInfo_4__ inlinePragInfo_5__ oc strictnessInfo_7__ demandInfo_8__
-                            callArityInfo_9__ levityInfo_10__).
-
-Definition zapTailCallInfo : IdInfo -> option IdInfo :=
-  fun info =>
-    let 'occ := occInfo info in
-    let safe_occ :=
-      match occ with
-      | BasicTypes.ManyOccs occ_tail_1__ =>
-          BasicTypes.ManyOccs BasicTypes.NoTailCallInfo
-      | BasicTypes.IAmDead =>
-          GHC.Err.error (GHC.Base.hs_string__ "Partial record update")
-      | BasicTypes.OneOcc occ_in_lam_2__ occ_one_br_3__ occ_int_cxt_4__
-      occ_tail_5__ =>
-          BasicTypes.OneOcc occ_in_lam_2__ occ_one_br_3__ occ_int_cxt_4__
-                            BasicTypes.NoTailCallInfo
-      | BasicTypes.IAmALoopBreaker occ_rules_only_6__ occ_tail_7__ =>
-          BasicTypes.IAmALoopBreaker occ_rules_only_6__ BasicTypes.NoTailCallInfo
-      end in
-    if BasicTypes.isAlwaysTailCalled occ : bool
-    then Some (setOccInfo info safe_occ) else
-    None.
-
-Definition setNeverLevPoly `{Util.HasDebugCallStack}
-   : IdInfo -> Type_ -> IdInfo :=
-  fun info ty =>
-    if andb Util.debugIsOn (negb (negb (resultIsLevPoly ty))) : bool
-    then (GHC.Err.error Panic.someSDoc)
-    else let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
-            oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
-            callArityInfo_9__ levityInfo_10__ := info in
-         Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
-                   oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
-                   callArityInfo_9__ NeverLevityPolymorphic.
-
-(* Skipping definition `Core.setLevityInfoWithType' *)
-
-Definition setInlinePragInfo : IdInfo -> BasicTypes.InlinePragma -> IdInfo :=
-  fun info pr =>
-    GHC.Prim.seq pr (let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__
-                        cafInfo_3__ oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__
-                        demandInfo_8__ callArityInfo_9__ levityInfo_10__ := info in
-                  Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
-                            oneShotInfo_4__ pr occInfo_6__ strictnessInfo_7__ demandInfo_8__
-                            callArityInfo_9__ levityInfo_10__).
-
-(* Skipping definition `Core.setIdNotExported' *)
-
-(* Skipping definition `Core.setIdExported' *)
-
-Definition setIdDetails : Id -> IdDetails -> Id :=
-  fun id details =>
-    let 'Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__ id_details_4__
-       id_info_5__ := id in
-    Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__ details id_info_5__.
-
-Definition setDemandInfo : IdInfo -> Demand -> IdInfo :=
-  fun info dd =>
-    GHC.Prim.seq dd (let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__
-                        cafInfo_3__ oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__
-                        demandInfo_8__ callArityInfo_9__ levityInfo_10__ := info in
-                  Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
-                            oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ dd
-                            callArityInfo_9__ levityInfo_10__).
-
-Definition setCallArityInfo : IdInfo -> ArityInfo -> IdInfo :=
-  fun info ar =>
-    let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
-       oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
-       callArityInfo_9__ levityInfo_10__ := info in
-    Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
-              oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
-              ar levityInfo_10__.
-
-Definition zapCallArityInfo : IdInfo -> IdInfo :=
-  fun info => setCallArityInfo info #0.
-
-Definition setCafInfo : IdInfo -> CafInfo -> IdInfo :=
-  fun info caf =>
-    let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
-       oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
-       callArityInfo_9__ levityInfo_10__ := info in
-    Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ caf oneShotInfo_4__
-              inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
-              callArityInfo_9__ levityInfo_10__.
-
-Definition setArityInfo : IdInfo -> ArityInfo -> IdInfo :=
-  fun info ar =>
-    let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
-       oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
-       callArityInfo_9__ levityInfo_10__ := info in
-    Mk_IdInfo ar ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__ oneShotInfo_4__
-              inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
-              callArityInfo_9__ levityInfo_10__.
-
-Definition seqVarSet : VarSet -> unit :=
-  fun s => GHC.Prim.seq (sizeVarSet s) tt.
-
-Definition seqDVarSet : DVarSet -> unit :=
-  fun s => GHC.Prim.seq (sizeDVarSet s) tt.
-
-Definition sameVis : ArgFlag -> ArgFlag -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Required, Required => true
-    | Required, _ => false
-    | _, Required => false
-    | _, _ => true
-    end.
-
-Definition ruleName : CoreRule -> BasicTypes.RuleName :=
-  ru_name.
-
-Definition ruleModule : CoreRule -> option Module.Module :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Rule _ _ _ _ _ _ _ _ ru_origin _ _ => Some ru_origin
-    | BuiltinRule _ _ _ _ => None
-    end.
-
-Definition ruleInfoRules : RuleInfo -> list CoreRule :=
-  fun x => nil.
-
-Definition ruleIdName : CoreRule -> Name.Name :=
-  ru_fn.
-
-Definition ruleArity : CoreRule -> nat :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | BuiltinRule _ _ n _ => n
-    | Rule _ _ _ _ _ args _ _ _ _ _ => Coq.Lists.List.length args
-    end.
-
-Definition ruleActivation : CoreRule -> BasicTypes.Activation :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | BuiltinRule _ _ _ _ => BasicTypes.AlwaysActive
-    | Rule _ act _ _ _ _ _ _ _ _ _ => act
-    end.
-
-Definition rnSwap : RnEnv2 -> RnEnv2 :=
-  fun '(RV2 envL envR in_scope) => RV2 envR envL in_scope.
-
-Definition rnInScopeSet : RnEnv2 -> InScopeSet :=
-  in_scope.
-
-Definition rnEnvR : RnEnv2 -> VarEnv Var :=
-  envR.
-
-Definition rnEnvL : RnEnv2 -> VarEnv Var :=
-  envL.
-
-Definition rhssOfBind {b} : Bind b -> list (Expr b) :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | NonRec _ rhs => cons rhs nil
-    | Rec pairs =>
-        let cont_2__ arg_3__ := let 'pair _ rhs := arg_3__ in cons rhs nil in
-        Coq.Lists.List.flat_map cont_2__ pairs
-    end.
-
-Definition rhssOfAlts {b} : list (Alt b) -> list (Expr b) :=
-  fun alts =>
-    let cont_0__ arg_1__ := let 'pair (pair _ _) e := arg_1__ in cons e nil in
-    Coq.Lists.List.flat_map cont_0__ alts.
-
-(* Skipping definition `Core.ppr_id_scope' *)
-
-(* Skipping definition `Core.ppr_debug' *)
-
-(* Skipping definition `Core.pprVarSet' *)
-
-(* Skipping definition `Core.pprStrictness' *)
-
-(* Skipping definition `Core.pprIdDetails' *)
-
-(* Skipping definition `Core.ppCafInfo' *)
-
-(* Skipping definition `Core.ppArityInfo' *)
-
-Definition plusVarEnv_CD {a}
-   : (a -> a -> a) -> VarEnv a -> a -> VarEnv a -> a -> VarEnv a :=
-  UniqFM.plusUFM_CD.
-
-Definition plusVarEnv_C {a}
-   : (a -> a -> a) -> VarEnv a -> VarEnv a -> VarEnv a :=
-  UniqFM.plusUFM_C.
-
-Definition plusVarEnvList {a} : list (VarEnv a) -> VarEnv a :=
-  UniqFM.plusUFMList.
-
-Definition plusVarEnv {a} : VarEnv a -> VarEnv a -> VarEnv a :=
-  UniqFM.plusUFM.
-
-Definition plusMaybeVarEnv_C {a}
-   : (a -> a -> option a) -> VarEnv a -> VarEnv a -> VarEnv a :=
-  UniqFM.plusMaybeUFM_C.
-
-Definition plusDVarEnv_C {a}
-   : (a -> a -> a) -> DVarEnv a -> DVarEnv a -> DVarEnv a :=
-  UniqFM.plusUFM_C.
-
-Definition plusDVarEnv {a} : DVarEnv a -> DVarEnv a -> DVarEnv a :=
-  UniqFM.plusUFM.
-
-(* Skipping definition `Core.pluralVarSet' *)
-
-(* Skipping definition `Core.partitionVarSet' *)
-
-Definition partitionVarEnv {a}
-   : (a -> bool) -> VarEnv a -> (VarEnv a * VarEnv a)%type :=
-  UniqFM.partitionUFM.
-
-Definition partitionDVarSet
-   : (Var -> bool) -> DVarSet -> (DVarSet * DVarSet)%type :=
-  UniqSet.partitionUniqSet.
-
-Definition partitionDVarEnv {a}
-   : (a -> bool) -> DVarEnv a -> (DVarEnv a * DVarEnv a)%type :=
-  UniqFM.partitionUFM.
-
-Definition otherCons : Unfolding -> list AltCon :=
-  fun arg_0__ => nil.
-
-Definition notOrphan : IsOrphan -> bool :=
-  fun arg_0__ => match arg_0__ with | NotOrphan _ => true | _ => false end.
-
-Definition nonDetCmpVar : Var -> Var -> comparison :=
-  fun a b => Unique.nonDetCmpUnique (varUnique a) (varUnique b).
-
-Definition noUnfolding : Unfolding :=
-  NoUnfolding.
-
-Definition neverUnfoldGuidance : UnfoldingGuidance -> bool :=
-  fun arg_0__ => match arg_0__ with | UnfNever => true | _ => false end.
-
-Definition needSaturated : bool :=
-  false.
-
-Definition modifyVarEnv_Directly {a}
-   : (a -> a) -> UniqFM.UniqFM a -> Unique.Unique -> UniqFM.UniqFM a :=
-  fun mangle_fn env key =>
-    match (UniqFM.lookupUFM_Directly env key) with
-    | None => env
-    | Some xx => UniqFM.addToUFM_Directly env key (mangle_fn xx)
-    end.
-
-Definition mk_id : Name.Name -> Type_ -> IdScope -> IdDetails -> IdInfo -> Id :=
-  fun name ty scope details info =>
-    Mk_Id name (Unique.getKey (Name.nameUnique name)) ty scope details info.
-
-(* Skipping definition `Core.mkWordLitWord' *)
-
-(* Skipping definition `Core.mkWordLit' *)
-
-(* Skipping definition `Core.mkWord64LitWord64' *)
-
-Definition mkDVarEnv {a} : list (Var * a)%type -> DVarEnv a :=
-  UniqFM.listToUFM.
-
-Definition mkVarEnv {a} : list (Var * a)%type -> VarEnv a :=
-  UniqFM.listToUFM.
-
-Definition mkDVarSet : list Var -> DVarSet :=
-  UniqSet.mkUniqSet.
-
-Definition mkVarSet : list Var -> VarSet :=
-  UniqSet.mkUniqSet.
-
-Definition mkVarEnv_Directly {a} : list (Unique.Unique * a)%type -> VarEnv a :=
-  UniqFM.listToUFM_Directly.
-
-Definition zipVarEnv {a} : list Var -> list a -> VarEnv a :=
-  fun tyvars tys =>
-    mkVarEnv (Util.zipEqual (GHC.Base.hs_string__ "zipVarEnv") tyvars tys).
-
-Definition mkVarApps {b} : Expr b -> list Var -> Expr b :=
-  fun f vars => Data.Foldable.foldl (fun e a => App e (varToCoreExpr a)) f vars.
-
-Definition mkTyVarBinder : ArgFlag -> Var -> TyVarBinder :=
-  fun vis var => TvBndr var vis.
-
-Definition mkTyVarBinders : ArgFlag -> list TyVar -> list TyVarBinder :=
-  fun vis => GHC.Base.map (mkTyVarBinder vis).
-
-(* Skipping definition `Core.mkTyVar' *)
-
-Definition mkTyBind : TyVar -> Type_ -> CoreBind :=
-  fun tv ty => NonRec tv (Mk_Type ty).
-
-Definition mkTyArg {b} : Type_ -> Expr b :=
-  fun ty =>
-    match isCoercionTy_maybe ty with
-    | Some co => Mk_Coercion co
-    | _ => Mk_Type ty
-    end.
-
-Definition mkTyApps {b} : Expr b -> list Type_ -> Expr b :=
-  fun f args => Data.Foldable.foldl (fun e a => App e (mkTyArg a)) f args.
-
-(* Skipping definition `Core.mkTcTyVar' *)
-
-Definition mkStringLit {b} : GHC.Base.String -> Expr b :=
-  fun s => Lit (mkMachString s).
-
-Definition mkRuleEnv : RuleBase -> list Module.Module -> RuleEnv :=
-  fun rules vis_orphs => Mk_RuleEnv rules (Module.mkModuleSet vis_orphs).
-
-(* Skipping definition `Core.mkOtherCon' *)
-
-(* Skipping definition `Core.mkNoScope' *)
-
-(* Skipping definition `Core.mkNoCount' *)
-
-Definition mkLocalVar : IdDetails -> Name.Name -> Type_ -> IdInfo -> Id :=
-  fun details name ty info => mk_id name ty (LocalId NotExported) details info.
-
-Definition mkLetRec {b} : list (b * Expr b)%type -> Expr b -> Expr b :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | nil, body => body
-    | bs, body => Let (Rec bs) body
-    end.
-
-Definition mkLetNonRec {b} : b -> Expr b -> Expr b -> Expr b :=
-  fun b rhs body => Let (NonRec b rhs) body.
-
-Definition mkLet {b} : Bind b -> Expr b -> Expr b :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Rec nil, body => body
-    | bind, body => Let bind body
-    end.
-
-Definition mkLets {b} : list (Bind b) -> Expr b -> Expr b :=
-  fun binds body => Data.Foldable.foldr mkLet body binds.
-
-Definition mkLams {b} : list b -> Expr b -> Expr b :=
-  fun binders body => Data.Foldable.foldr Lam body binders.
-
-(* Skipping definition `Core.mkIntLitInt' *)
-
-(* Skipping definition `Core.mkIntLit' *)
-
-(* Skipping definition `Core.mkInt64LitInt64' *)
-
-Definition mkInScopeSet : VarSet -> InScopeSet :=
-  fun in_scope => InScope in_scope #1.
-
-Definition mkGlobalVar : IdDetails -> Name.Name -> Type_ -> IdInfo -> Id :=
-  fun details name ty info => mk_id name ty GlobalId details info.
-
-(* Skipping definition `Core.mkFloatLitFloat' *)
-
-Definition mkFloatLit {b} : GHC.Real.Rational -> Expr b :=
-  fun f => Lit (mkMachFloat f).
-
-Definition mkExportedLocalVar
-   : IdDetails -> Name.Name -> Type_ -> IdInfo -> Id :=
-  fun details name ty info => mk_id name ty (LocalId Exported) details info.
-
-(* Skipping definition `Core.mkDoubleLitDouble' *)
-
-Definition mkDoubleLit {b} : GHC.Real.Rational -> Expr b :=
-  fun d => Lit (mkMachDouble d).
-
-(* Skipping definition `Core.mkCoVar' *)
-
-Definition mkCoBind : CoVar -> Coercion -> CoreBind :=
-  fun cv co => NonRec cv (Mk_Coercion co).
-
-Definition mkCoApps {b} : Expr b -> list Coercion -> Expr b :=
-  fun f args => Data.Foldable.foldl (fun e a => App e (Mk_Coercion a)) f args.
-
-Definition mkCharLit {b} : GHC.Char.Char -> Expr b :=
-  fun c => Lit (mkMachChar c).
-
-Definition mkApps {b} : Expr b -> list (Arg b) -> Expr b :=
-  fun f args => Data.Foldable.foldl App f args.
-
-Definition mkConApp {b} : DataCon -> list (Arg b) -> Expr b :=
-  fun con args => mkApps (Mk_Var (dataConWorkId con)) args.
-
-Definition mkConApp2 {b} : DataCon -> list Type_ -> list Var -> Expr b :=
-  fun con tys arg_ids =>
-    mkApps (mkApps (Mk_Var (dataConWorkId con)) (GHC.Base.map Mk_Type tys))
-           (GHC.Base.map varToCoreExpr arg_ids).
-
-Definition minusVarSet : VarSet -> VarSet -> VarSet :=
-  UniqSet.minusUniqSet.
-
-Definition minusVarEnv {a} {b} : VarEnv a -> VarEnv b -> VarEnv a :=
-  UniqFM.minusUFM.
-
-Definition minusDVarSet : DVarSet -> DVarSet -> DVarSet :=
-  UniqSet.minusUniqSet.
-
-Definition minusDVarEnv {a} {a'} : DVarEnv a -> DVarEnv a' -> DVarEnv a :=
-  UniqFM.minusUFM.
-
-Definition maybeUnfoldingTemplate : Unfolding -> option CoreExpr :=
-  fun arg_0__ => None.
-
-Definition mayHaveCafRefs : CafInfo -> bool :=
-  fun arg_0__ => match arg_0__ with | MayHaveCafRefs => true | _ => false end.
-
-(* Skipping definition `Core.mapVarSet' *)
-
-Definition mapVarEnv {a} {b} : (a -> b) -> VarEnv a -> VarEnv b :=
-  UniqFM.mapUFM.
-
-Definition mapDVarEnv {a} {b} : (a -> b) -> DVarEnv a -> DVarEnv b :=
-  UniqFM.mapUFM.
-
-Definition lookupDVarEnv {a} : DVarEnv a -> Var -> option a :=
-  UniqFM.lookupUFM.
-
-Definition lookupVarEnv {a} : VarEnv a -> Var -> option a :=
-  UniqFM.lookupUFM.
-
-Definition lookupVarEnv_Directly {a} : VarEnv a -> Unique.Unique -> option a :=
-  UniqFM.lookupUFM_Directly.
-
-Definition lookupVarEnv_NF {a} `{_ : GHC.Err.Default a} (env : VarEnv a) id
-   : a :=
-  match lookupVarEnv env id with
-  | Some xx => xx
-  | None => GHC.Err.default
-  end.
-
-Definition lookupVarSet : VarSet -> Var -> option Var :=
-  UniqSet.lookupUniqSet.
-
-Definition lookupVarSetByName : VarSet -> Name.Name -> option Var :=
-  UniqSet.lookupUniqSet.
-
-Definition lookupVarSet_Directly : VarSet -> Unique.Unique -> option Var :=
-  UniqSet.lookupUniqSet_Directly.
-
-Definition lookupWithDefaultVarEnv {a} : VarEnv a -> a -> Var -> a :=
-  UniqFM.lookupWithDefaultUFM.
-
-Definition rnOccL : RnEnv2 -> Var -> Var :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | RV2 env _ _, v => Maybes.orElse (lookupVarEnv env v) v
-    end.
-
-Definition rnOccL_maybe : RnEnv2 -> Var -> option Var :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | RV2 env _ _, v => lookupVarEnv env v
-    end.
-
-Definition rnOccR : RnEnv2 -> Var -> Var :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | RV2 _ env _, v => Maybes.orElse (lookupVarEnv env v) v
-    end.
-
-Definition rnOccR_maybe : RnEnv2 -> Var -> option Var :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | RV2 _ env _, v => lookupVarEnv env v
-    end.
-
-Definition lookupInScope_Directly : InScopeSet -> Unique.Unique -> option Var :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | InScope in_scope _, uniq => lookupVarSet_Directly in_scope uniq
-    end.
-
-Definition lookupInScope : InScopeSet -> Var -> option Var :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | InScope in_scope _, v => lookupVarSet in_scope v
-    end.
-
-Definition lookupRnInScope : RnEnv2 -> Var -> Var :=
-  fun env v => Maybes.orElse (lookupInScope (in_scope env) v) v.
-
-Definition lazySetIdInfo : Id -> IdInfo -> Var :=
-  fun id info =>
-    let 'Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__ id_details_4__
-       id_info_5__ := id in
-    Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__ id_details_4__ info.
-
-Definition isVisibleArgFlag : ArgFlag -> bool :=
-  fun arg_0__ => match arg_0__ with | Required => true | _ => false end.
-
-Definition isValueUnfolding : Unfolding -> bool :=
-  fun arg_0__ => false.
-
-Definition isTypeArg {b} : Expr b -> bool :=
-  fun arg_0__ => match arg_0__ with | Mk_Type _ => true | _ => false end.
-
-Definition isValArg {b} : Expr b -> bool :=
-  fun e => negb (isTypeArg e).
-
-Definition valArgCount {b} : list (Arg b) -> nat :=
-  Util.count isValArg.
-
-Definition isTyVar : Var -> bool :=
-  fun arg_0__ => false.
-
-Definition isTyCoArg {b} : Expr b -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Mk_Type _ => true
-    | Mk_Coercion _ => true
-    | _ => false
-    end.
-
-Definition isTcTyVar : Var -> bool :=
-  fun arg_0__ => false.
-
-Definition isStableUnfolding : Unfolding -> bool :=
-  fun arg_0__ => false.
-
-Definition isStableSource : UnfoldingSource -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | InlineCompulsory => true
-    | InlineStable => true
-    | InlineRhs => false
-    end.
-
-Definition isRuntimeArg : CoreExpr -> bool :=
-  isValArg.
-
-Definition isOrphan : IsOrphan -> bool :=
-  fun arg_0__ => match arg_0__ with | Mk_IsOrphan => true | _ => false end.
-
-Definition isNeverLevPolyIdInfo : IdInfo -> bool :=
-  fun info =>
-    match levityInfo info with
-    | NeverLevityPolymorphic => true
-    | _ => false
-    end.
-
-Definition isLocalRule : CoreRule -> bool :=
-  ru_local.
-
-Definition isLocalId : Var -> bool :=
-  fun v => Unique.isLocalUnique (varUnique v).
-
-Definition isJoinIdDetails_maybe : IdDetails -> option BasicTypes.JoinArity :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Mk_JoinId join_arity => Some join_arity
-    | _ => None
-    end.
-
-Definition isInvisibleArgFlag : ArgFlag -> bool :=
-  negb GHC.Base.∘ isVisibleArgFlag.
-
-Definition isId : Var -> bool :=
-  fun '(Mk_Id _ _ _ _ _ _) => true.
-
-Definition isRuntimeVar : Var -> bool :=
-  isId.
-
-Definition valBndrCount : list CoreBndr -> nat :=
-  Util.count isId.
-
-Definition isGlobalId : Var -> bool :=
-  fun v => negb (Unique.isLocalUnique (varUnique v)).
-
-Definition isLocalVar : Var -> bool :=
-  fun v => negb (isGlobalId v).
-
-Definition mustHaveLocalBinding : Var -> bool :=
-  fun var => isLocalVar var.
-
-Definition isFragileUnfolding : Unfolding -> bool :=
-  fun arg_0__ => false.
-
-Definition zapFragileUnfolding : Unfolding -> Unfolding :=
-  fun unf => if isFragileUnfolding unf : bool then noUnfolding else unf.
-
-Axiom isExportedId : Var -> bool.
-
-Definition isExpandableUnfolding : Unfolding -> bool :=
-  fun arg_0__ => false.
-
-Definition isEvaldUnfolding : Unfolding -> bool :=
-  fun arg_0__ => false.
-
-Definition isEmptyVarSet : VarSet -> bool :=
-  UniqSet.isEmptyUniqSet.
-
-Definition subVarSet : VarSet -> VarSet -> bool :=
-  fun s1 s2 => isEmptyVarSet (minusVarSet s1 s2).
-
-Definition varSetInScope : VarSet -> InScopeSet -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | vars, InScope s1 _ => subVarSet vars s1
-    end.
-
-Definition transCloVarSet : (VarSet -> VarSet) -> VarSet -> VarSet :=
-  fun fn seeds =>
-    let go : VarSet -> VarSet -> VarSet :=
-      GHC.DeferredFix.deferredFix1 (fun go (acc candidates : VarSet) =>
-                                      let new_vs := minusVarSet (fn candidates) acc in
-                                      if isEmptyVarSet new_vs : bool then acc else
-                                      go (unionVarSet acc new_vs) new_vs) in
-    go seeds seeds.
-
-Definition isEmptyVarEnv {a} : VarEnv a -> bool :=
-  UniqFM.isNullUFM.
-
-Definition isEmptyRuleInfo : RuleInfo -> bool :=
-  fun x => true.
-
-Definition isEmptyDVarSet : DVarSet -> bool :=
-  UniqSet.isEmptyUniqSet.
-
-Definition subDVarSet : DVarSet -> DVarSet -> bool :=
-  fun s1 s2 => isEmptyDVarSet (minusDVarSet s1 s2).
-
-Definition transCloDVarSet : (DVarSet -> DVarSet) -> DVarSet -> DVarSet :=
-  fun fn seeds =>
-    let go : DVarSet -> DVarSet -> DVarSet :=
-      GHC.DeferredFix.deferredFix1 (fun go (acc candidates : DVarSet) =>
-                                      let new_vs := minusDVarSet (fn candidates) acc in
-                                      if isEmptyDVarSet new_vs : bool then acc else
-                                      go (unionDVarSet acc new_vs) new_vs) in
-    go seeds seeds.
-
-Definition isEmptyDVarEnv {a} : DVarEnv a -> bool :=
-  UniqFM.isNullUFM.
-
-Definition isConLikeUnfolding : Unfolding -> bool :=
-  fun arg_0__ => false.
-
-Definition isCompulsoryUnfolding : Unfolding -> bool :=
-  fun arg_0__ => false.
-
-Definition isCoVarDetails : IdDetails -> bool :=
-  fun arg_0__ => false.
-
-Definition isNonCoVarId : Var -> bool :=
-  fun '(Mk_Id _ _ _ _ details _) => negb (isCoVarDetails details).
-
-Definition isCoVar : Var -> bool :=
-  fun '(Mk_Id _ _ _ _ details _) => isCoVarDetails details.
-
-Definition isTyCoVar : Var -> bool :=
-  fun v => orb (isTyVar v) (isCoVar v).
-
-Definition isCheapUnfolding : Unfolding -> bool :=
-  fun arg_0__ => false.
-
-Definition isBuiltinRule : CoreRule -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | BuiltinRule _ _ _ _ => true
-    | _ => false
-    end.
-
-Definition isBootUnfolding : Unfolding -> bool :=
-  fun arg_0__ => false.
-
-Definition isAutoRule : CoreRule -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | BuiltinRule _ _ _ _ => false
-    | Rule _ _ _ _ _ _ _ is_auto _ _ _ => is_auto
-    end.
-
-Definition intersectsVarEnv {a} : VarEnv a -> VarEnv a -> bool :=
-  fun e1 e2 => negb (isEmptyVarEnv (UniqFM.intersectUFM e1 e2)).
-
-Definition intersectVarSet : VarSet -> VarSet -> VarSet :=
-  UniqSet.intersectUniqSets.
-
-Definition intersectDVarSet : DVarSet -> DVarSet -> DVarSet :=
-  UniqSet.intersectUniqSets.
-
-Definition idInfo `{Util.HasDebugCallStack} : Id -> IdInfo :=
-  fun '(Mk_Id _ _ _ _ _ info) => info.
-
-Definition idDetails : Id -> IdDetails :=
-  fun '(Mk_Id _ _ _ _ details _) => details.
-
-Definition hasSomeUnfolding : Unfolding -> bool :=
-  fun '(NoUnfolding) => false.
-
-(* Skipping definition `Core.globaliseId' *)
-
-Definition getInScopeVars : InScopeSet -> VarSet :=
-  fun '(InScope vs _) => vs.
-
-Definition foldDVarSet {a} : (Var -> a -> a) -> a -> DVarSet -> a :=
-  UniqSet.nonDetFoldUniqSet.
-
-Definition foldDVarEnv {a} {b} : (a -> b -> b) -> b -> DVarEnv a -> b :=
-  UniqFM.nonDetFoldUFM.
-
-Fixpoint flattenBinds {b} (arg_0__ : list (Bind b)) : list (b * Expr b)%type
-           := match arg_0__ with
-              | cons (NonRec b r) binds => cons (pair b r) (flattenBinds binds)
-              | cons (Rec prs1) binds => Coq.Init.Datatypes.app prs1 (flattenBinds binds)
-              | nil => nil
-              end.
-
-Definition fixVarSet : (VarSet -> VarSet) -> VarSet -> VarSet :=
-  GHC.DeferredFix.deferredFix2 (fun fixVarSet
-                                (fn : (VarSet -> VarSet))
-                                (vars : VarSet) =>
-                                  let new_vars := fn vars in
-                                  if subVarSet new_vars vars : bool then vars else
-                                  fixVarSet fn new_vars).
-
-Definition filterVarSet : (Var -> bool) -> VarSet -> VarSet :=
-  UniqSet.filterUniqSet.
-
-Definition filterVarEnv_Directly {a}
-   : (Unique.Unique -> a -> bool) -> VarEnv a -> VarEnv a :=
-  UniqFM.filterUFM_Directly.
-
-Definition filterVarEnv {a} : (a -> bool) -> VarEnv a -> VarEnv a :=
-  UniqFM.filterUFM.
-
-Definition filterDVarSet : (Var -> bool) -> DVarSet -> DVarSet :=
-  UniqSet.filterUniqSet.
-
-Definition filterDVarEnv {a} : (a -> bool) -> DVarEnv a -> DVarEnv a :=
-  UniqFM.filterUFM.
-
-Definition extendDVarEnv {a} : DVarEnv a -> Var -> a -> DVarEnv a :=
-  UniqFM.addToUFM.
-
-Definition extendVarEnv {a} : VarEnv a -> Var -> a -> VarEnv a :=
-  UniqFM.addToUFM.
-
-Definition extendDVarEnvList {a}
-   : DVarEnv a -> list (Var * a)%type -> DVarEnv a :=
-  UniqFM.addListToUFM.
-
-Definition extendVarEnvList {a} : VarEnv a -> list (Var * a)%type -> VarEnv a :=
-  UniqFM.addListToUFM.
-
-Definition extendDVarEnv_C {a}
-   : (a -> a -> a) -> DVarEnv a -> Var -> a -> DVarEnv a :=
-  UniqFM.addToUFM_C.
-
-Definition extendVarEnv_Acc {a} {b}
-   : (a -> b -> b) -> (a -> b) -> VarEnv b -> Var -> a -> VarEnv b :=
-  UniqFM.addToUFM_Acc.
-
-Definition extendVarEnv_C {a}
-   : (a -> a -> a) -> VarEnv a -> Var -> a -> VarEnv a :=
-  UniqFM.addToUFM_C.
-
-Definition extendVarEnv_Directly {a}
-   : VarEnv a -> Unique.Unique -> a -> VarEnv a :=
-  UniqFM.addToUFM_Directly.
-
-Definition extendVarSet : VarSet -> Var -> VarSet :=
-  UniqSet.addOneToUniqSet.
-
-Definition extendDVarSet : DVarSet -> Var -> DVarSet :=
-  UniqSet.addOneToUniqSet.
-
-Definition extendDVarSetList : DVarSet -> list Var -> DVarSet :=
-  UniqSet.addListToUniqSet.
-
-Definition extendVarSetList : VarSet -> list Var -> VarSet :=
-  UniqSet.addListToUniqSet.
-
-Definition modifyVarEnv {a} : (a -> a) -> VarEnv a -> Var -> VarEnv a :=
-  fun mangle_fn env key =>
-    match (lookupVarEnv env key) with
-    | None => env
-    | Some xx => extendVarEnv env key (mangle_fn xx)
-    end.
-
-Definition extendInScopeSetSet : InScopeSet -> VarSet -> InScopeSet :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | InScope in_scope n, vs =>
-        InScope (unionVarSet in_scope vs) (n GHC.Num.+ UniqSet.sizeUniqSet vs)
-    end.
-
-Definition extendInScopeSetList : InScopeSet -> list Var -> InScopeSet :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | InScope in_scope n, vs =>
-        InScope (Data.Foldable.foldl (fun s v => extendVarSet s v) in_scope vs) (n
-                                                                                 GHC.Num.+
-                                                                                 Coq.Lists.List.length vs)
-    end.
-
-Definition extendInScopeSet : InScopeSet -> Var -> InScopeSet :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | InScope in_scope n, v => InScope (extendVarSet in_scope v) (n GHC.Num.+ #1)
-    end.
-
-Definition rnBndrL : RnEnv2 -> Var -> (RnEnv2 * Var)%type :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | RV2 envL envR in_scope, bL =>
-        let new_b := uniqAway in_scope bL in
-        pair (RV2 (extendVarEnv envL bL new_b) envR (extendInScopeSet in_scope new_b))
-             new_b
-    end.
-
-Definition rnBndrR : RnEnv2 -> Var -> (RnEnv2 * Var)%type :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | RV2 envL envR in_scope, bR =>
-        let new_b := uniqAway in_scope bR in
-        pair (RV2 envL (extendVarEnv envR bR new_b) (extendInScopeSet in_scope new_b))
-             new_b
-    end.
-
-Definition rnEtaL : RnEnv2 -> Var -> (RnEnv2 * Var)%type :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | RV2 envL envR in_scope, bL =>
-        let new_b := uniqAway in_scope bL in
-        pair (RV2 (extendVarEnv envL bL new_b) (extendVarEnv envR new_b new_b)
-                  (extendInScopeSet in_scope new_b)) new_b
-    end.
-
-Definition rnEtaR : RnEnv2 -> Var -> (RnEnv2 * Var)%type :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | RV2 envL envR in_scope, bR =>
-        let new_b := uniqAway in_scope bR in
-        pair (RV2 (extendVarEnv envL new_b new_b) (extendVarEnv envR bR new_b)
-                  (extendInScopeSet in_scope new_b)) new_b
-    end.
-
-Definition modifyDVarEnv {a} : (a -> a) -> DVarEnv a -> Var -> DVarEnv a :=
-  fun mangle_fn env key =>
-    match (lookupDVarEnv env key) with
-    | None => env
-    | Some xx => extendDVarEnv env key (mangle_fn xx)
-    end.
-
-(* Skipping definition `Core.exprToType' *)
-
-Definition exprToCoercion_maybe : CoreExpr -> option Coercion :=
-  fun arg_0__ => match arg_0__ with | Mk_Coercion co => Some co | _ => None end.
-
-Definition expandUnfolding_maybe : Unfolding -> option CoreExpr :=
-  fun arg_0__ => None.
-
-(* Skipping definition `Core.evaldUnfolding' *)
-
-Definition emptyVarSet : VarSet :=
-  UniqSet.emptyUniqSet.
-
-Definition mapUnionVarSet {a} : (a -> VarSet) -> list a -> VarSet :=
-  fun get_set xs =>
-    Data.Foldable.foldr (unionVarSet GHC.Base.∘ get_set) emptyVarSet xs.
-
-Definition emptyVarEnv {a} : VarEnv a :=
-  UniqFM.emptyUFM.
-
-Definition mkRnEnv2 : InScopeSet -> RnEnv2 :=
-  fun vars => RV2 emptyVarEnv emptyVarEnv vars.
-
-Definition nukeRnEnvL : RnEnv2 -> RnEnv2 :=
-  fun '(RV2 envL_0__ envR_1__ in_scope_2__) =>
-    RV2 emptyVarEnv envR_1__ in_scope_2__.
-
-Definition nukeRnEnvR : RnEnv2 -> RnEnv2 :=
-  fun '(RV2 envL_0__ envR_1__ in_scope_2__) =>
-    RV2 envL_0__ emptyVarEnv in_scope_2__.
-
-Definition emptyTidyEnv : TidyEnv :=
-  pair OccName.emptyTidyOccEnv emptyVarEnv.
-
-Definition emptyRuleInfo :=
-  EmptyRuleInfo.
-
-Definition vanillaIdInfo : IdInfo :=
-  Mk_IdInfo unknownArity emptyRuleInfo noUnfolding vanillaCafInfo
-            BasicTypes.NoOneShotInfo BasicTypes.defaultInlinePragma BasicTypes.noOccInfo
-            nopSig topDmd unknownArity NoLevityInfo.
-
-Definition noCafIdInfo : IdInfo :=
-  setCafInfo vanillaIdInfo NoCafRefs.
-
-Definition zapFragileInfo : IdInfo -> option IdInfo :=
-  fun '((Mk_IdInfo _ _ unf _ _ _ occ _ _ _ _ as info)) =>
-    let new_unf := zapFragileUnfolding unf in
-    GHC.Prim.seq new_unf (Some (setOccInfo (setUnfoldingInfo (setRuleInfo info
-                                                                          emptyRuleInfo) new_unf)
-                                           (BasicTypes.zapFragileOcc occ))).
-
-Definition emptyRuleEnv : RuleEnv :=
-  Mk_RuleEnv NameEnv.emptyNameEnv Module.emptyModuleSet.
-
-Definition emptyInScopeSet : InScopeSet :=
-  InScope emptyVarSet #1.
-
-Definition emptyDVarSet : DVarSet :=
-  UniqSet.emptyUniqSet.
-
-Definition mapUnionDVarSet {a} : (a -> DVarSet) -> list a -> DVarSet :=
-  fun get_set xs =>
-    Data.Foldable.foldr (unionDVarSet GHC.Base.∘ get_set) emptyDVarSet xs.
-
-Definition ruleInfoFreeVars : RuleInfo -> DVarSet :=
-  fun x => emptyDVarSet.
-
-Definition emptyDVarEnv {a} : DVarEnv a :=
-  UniqFM.emptyUFM.
-
-Definition elemVarSetByKey : Unique.Unique -> VarSet -> bool :=
-  UniqSet.elemUniqSet_Directly.
-
-Definition restrictVarEnv {a} : VarEnv a -> VarSet -> VarEnv a :=
-  fun env vs =>
-    let keep :=
-      fun arg_0__ arg_1__ =>
-        match arg_0__, arg_1__ with
-        | u, _ => elemVarSetByKey u vs
-        end in
-    filterVarEnv_Directly keep env.
-
-Definition uniqAway' : InScopeSet -> Var -> Var :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | InScope set n, var =>
-        let orig_unique := Unique.getUnique var in
-        let try :=
-          GHC.DeferredFix.deferredFix1 (fun try k =>
-                                          let uniq := Unique.deriveUnique orig_unique (BinNat.N.of_nat n GHC.Num.* k) in
-                                          let msg :=
-                                            GHC.Base.mappend (GHC.Base.mappend (GHC.Base.mappend Panic.someSDoc
-                                                                                                 (Datatypes.id
-                                                                                                  (GHC.Base.hs_string__
-                                                                                                   "tries")))
-                                                                               Panic.someSDoc) Panic.someSDoc in
-                                          if andb Util.debugIsOn (k GHC.Base.> #1000) : bool
-                                          then Panic.panicStr (GHC.Base.hs_string__ "uniqAway loop:") msg else
-                                          if elemVarSetByKey uniq set : bool then try (k GHC.Num.+ #1) else
-                                          if k GHC.Base.> #3 : bool then setVarUnique var uniq else
-                                          setVarUnique var uniq) in
-        try #1
-    end.
-
-Definition alterDVarEnv {a}
-   : (option a -> option a) -> DVarEnv a -> Var -> DVarEnv a :=
-  UniqFM.alterUFM.
-
-Definition alterVarEnv {a}
-   : (option a -> option a) -> VarEnv a -> Var -> VarEnv a :=
-  UniqFM.alterUFM.
-
-Definition delDVarEnv {a} : DVarEnv a -> Var -> DVarEnv a :=
-  UniqFM.delFromUFM.
-
-Definition delVarEnv {a} : VarEnv a -> Var -> VarEnv a :=
-  UniqFM.delFromUFM.
-
-Definition delDVarEnvList {a} : DVarEnv a -> list Var -> DVarEnv a :=
-  UniqFM.delListFromUFM.
-
-Definition delVarEnvList {a} : VarEnv a -> list Var -> VarEnv a :=
-  UniqFM.delListFromUFM.
-
-Definition delDVarSet : DVarSet -> Var -> DVarSet :=
-  UniqSet.delOneFromUniqSet.
-
-Definition delVarSet : VarSet -> Var -> VarSet :=
-  UniqSet.delOneFromUniqSet.
-
-Definition delDVarSetList : DVarSet -> list Var -> DVarSet :=
-  UniqSet.delListFromUniqSet.
-
-Definition delVarSetList : VarSet -> list Var -> VarSet :=
-  UniqSet.delListFromUniqSet.
-
-Definition delVarEnv_Directly {a} : VarEnv a -> Unique.Unique -> VarEnv a :=
-  UniqFM.delFromUFM_Directly.
-
-Definition delVarSetByKey : VarSet -> Unique.Unique -> VarSet :=
-  UniqSet.delOneFromUniqSet_Directly.
-
-Definition elemDVarEnv {a} : Var -> DVarEnv a -> bool :=
-  UniqFM.elemUFM.
-
-Definition elemVarEnv {a} : Var -> VarEnv a -> bool :=
-  UniqFM.elemUFM.
-
-Definition elemDVarSet : Var -> DVarSet -> bool :=
-  UniqSet.elementOfUniqSet.
-
-Definition elemVarSet : Var -> VarSet -> bool :=
-  UniqSet.elementOfUniqSet.
-
-Definition elemVarEnvByKey {a} : Unique.Unique -> VarEnv a -> bool :=
-  UniqFM.elemUFM_Directly.
-
-Definition inRnEnvL : RnEnv2 -> Var -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | RV2 env _ _, v => elemVarEnv v env
-    end.
-
-Definition inRnEnvR : RnEnv2 -> Var -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | RV2 _ env _, v => elemVarEnv v env
-    end.
-
-Definition elemInScopeSet : Var -> InScopeSet -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | v, InScope in_scope _ => elemVarSet v in_scope
-    end.
-
-Definition rnBndr2_var : RnEnv2 -> Var -> Var -> (RnEnv2 * Var)%type :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | RV2 envL envR in_scope, bL, bR =>
-        let new_b :=
-          if negb (elemInScopeSet bL in_scope) : bool then bL else
-          if negb (elemInScopeSet bR in_scope) : bool then bR else
-          uniqAway' in_scope bL in
-        pair (RV2 (extendVarEnv envL bL new_b) (extendVarEnv envR bR new_b)
-                  (extendInScopeSet in_scope new_b)) new_b
-    end.
-
-Definition rnBndr2 : RnEnv2 -> Var -> Var -> RnEnv2 :=
-  fun env bL bR => Data.Tuple.fst (rnBndr2_var env bL bR).
-
-Definition rnBndrs2 : RnEnv2 -> list Var -> list Var -> RnEnv2 :=
-  fun env bsL bsR => Util.foldl2 rnBndr2 env bsL bsR.
-
-Definition rnInScope : Var -> RnEnv2 -> bool :=
-  fun x env => elemInScopeSet x (in_scope env).
-
-Definition disjointVarSet : VarSet -> VarSet -> bool :=
-  fun s1 s2 => UniqFM.disjointUFM (UniqSet.getUniqSet s1) (UniqSet.getUniqSet s2).
-
-Definition intersectsVarSet : VarSet -> VarSet -> bool :=
-  fun s1 s2 => negb (disjointVarSet s1 s2).
-
-Definition disjointVarEnv {a} : VarEnv a -> VarEnv a -> bool :=
-  UniqFM.disjointUFM.
-
-Definition disjointDVarSet :=
-  disjointVarSet.
-
-Definition intersectsDVarSet : DVarSet -> DVarSet -> bool :=
-  fun s1 s2 => negb (disjointDVarSet s1 s2).
-
-Definition delInScopeSet : InScopeSet -> Var -> InScopeSet :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | InScope in_scope n, v => InScope (delVarSet in_scope v) n
-    end.
-
-Definition delBndrsR : RnEnv2 -> list Var -> RnEnv2 :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | (RV2 _ env in_scope as rn), v =>
-        let 'RV2 envL_2__ envR_3__ in_scope_4__ := rn in
-        RV2 envL_2__ (delVarEnvList env v) (extendInScopeSetList in_scope v)
-    end.
-
-Definition delBndrsL : RnEnv2 -> list Var -> RnEnv2 :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | (RV2 env _ in_scope as rn), v =>
-        let 'RV2 envL_2__ envR_3__ in_scope_4__ := rn in
-        RV2 (delVarEnvList env v) envR_3__ (extendInScopeSetList in_scope v)
-    end.
-
-Definition delBndrR : RnEnv2 -> Var -> RnEnv2 :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | (RV2 _ env in_scope as rn), v =>
-        let 'RV2 envL_2__ envR_3__ in_scope_4__ := rn in
-        RV2 envL_2__ (delVarEnv env v) (extendInScopeSet in_scope v)
-    end.
-
-Definition delBndrL : RnEnv2 -> Var -> RnEnv2 :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | (RV2 env _ in_scope as rn), v =>
-        let 'RV2 envL_2__ envR_3__ in_scope_4__ := rn in
-        RV2 (delVarEnv env v) envR_3__ (extendInScopeSet in_scope v)
-    end.
-
-Fixpoint deTagExpr {t} (arg_0__ : TaggedExpr t) : CoreExpr
-           := let deTagBind (arg_0__ : TaggedBind t) : CoreBind :=
-                match arg_0__ with
-                | NonRec (TB b _) rhs => NonRec b (deTagExpr rhs)
-                | Rec prs =>
-                    Rec (let cont_2__ arg_3__ :=
-                           let 'pair (TB b _) rhs := arg_3__ in
-                           cons (pair b (deTagExpr rhs)) nil in
-                         Coq.Lists.List.flat_map cont_2__ prs)
-                end in
-              let deTagAlt (arg_0__ : TaggedAlt t) : CoreAlt :=
-                let 'pair (pair con bndrs) rhs := arg_0__ in
-                pair (pair con (let cont_1__ arg_2__ := let 'TB b _ := arg_2__ in cons b nil in
-                            Coq.Lists.List.flat_map cont_1__ bndrs)) (deTagExpr rhs) in
-              match arg_0__ with
-              | Mk_Var v => Mk_Var v
-              | Lit l => Lit l
-              | Mk_Type ty => Mk_Type ty
-              | Mk_Coercion co => Mk_Coercion co
-              | App e1 e2 => App (deTagExpr e1) (deTagExpr e2)
-              | Lam (TB b _) e => Lam b (deTagExpr e)
-              | Let bind body => Let (deTagBind bind) (deTagExpr body)
-              | Case e (TB b _) ty alts =>
-                  Case (deTagExpr e) b ty (GHC.Base.map deTagAlt alts)
-              | Cast e co => Cast (deTagExpr e) co
-              end.
-
-Definition deTagBind {t} : TaggedBind t -> CoreBind :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | NonRec (TB b _) rhs => NonRec b (deTagExpr rhs)
-    | Rec prs =>
-        Rec (let cont_2__ arg_3__ :=
-               let 'pair (TB b _) rhs := arg_3__ in
-               cons (pair b (deTagExpr rhs)) nil in
-             Coq.Lists.List.flat_map cont_2__ prs)
-    end.
-
-Definition deTagAlt {t} : TaggedAlt t -> CoreAlt :=
-  fun '(pair (pair con bndrs) rhs) =>
-    pair (pair con (let cont_1__ arg_2__ := let 'TB b _ := arg_2__ in cons b nil in
-                Coq.Lists.List.flat_map cont_1__ bndrs)) (deTagExpr rhs).
-
-Definition deAnnotate'
-   : forall {bndr} {annot}, AnnExpr' bndr annot -> Expr bndr :=
-  fix deAnnotate' {bndr} {annot} (arg_0__ : AnnExpr' bndr annot) : Expr bndr
-        := let deAnnotate {bndr} {annot} (arg_0__ : AnnExpr bndr annot) : Expr bndr :=
-             let 'pair _ e := arg_0__ in
-             deAnnotate' e in
-           let deAnnAlt {bndr} {annot} (arg_0__ : AnnAlt bndr annot) : Alt bndr :=
-             let 'pair (pair con args) rhs := arg_0__ in
-             pair (pair con args) (deAnnotate rhs) in
-           match arg_0__ with
-           | AnnType t => Mk_Type t
-           | AnnCoercion co => Mk_Coercion co
-           | AnnVar v => Mk_Var v
-           | AnnLit lit => Lit lit
-           | AnnLam binder body => Lam binder (deAnnotate body)
-           | AnnApp fun_ arg => App (deAnnotate fun_) (deAnnotate arg)
-           | AnnCast e (pair _ co) => Cast (deAnnotate e) co
-           | AnnLet bind body => Let (deAnnBind bind) (deAnnotate body)
-           | AnnCase scrut v t alts =>
-               Case (deAnnotate scrut) v t (GHC.Base.map deAnnAlt alts)
-           end with deAnnBind {b} {annot} (arg_0__ : AnnBind b annot) : Bind b
-                      := let deAnnotate {bndr} {annot} (arg_0__ : AnnExpr bndr annot) : Expr bndr :=
-                           let 'pair _ e := arg_0__ in
-                           deAnnotate' e in
-                         match arg_0__ with
-                         | AnnNonRec var rhs => NonRec var (deAnnotate rhs)
-                         | AnnRec pairs =>
-                             Rec (let cont_2__ arg_3__ :=
-                                    let 'pair v rhs := arg_3__ in
-                                    cons (pair v (deAnnotate rhs)) nil in
-                                  Coq.Lists.List.flat_map cont_2__ pairs)
-                         end for deAnnotate'.
-
-Definition deAnnotate {bndr} {annot} : AnnExpr bndr annot -> Expr bndr :=
-  fun '(pair _ e) => deAnnotate' e.
-
-Definition deAnnBind : forall {b} {annot}, AnnBind b annot -> Bind b :=
-  fix deAnnotate' {bndr} {annot} (arg_0__ : AnnExpr' bndr annot) : Expr bndr
-        := let deAnnotate {bndr} {annot} (arg_0__ : AnnExpr bndr annot) : Expr bndr :=
-             let 'pair _ e := arg_0__ in
-             deAnnotate' e in
-           let deAnnAlt {bndr} {annot} (arg_0__ : AnnAlt bndr annot) : Alt bndr :=
-             let 'pair (pair con args) rhs := arg_0__ in
-             pair (pair con args) (deAnnotate rhs) in
-           match arg_0__ with
-           | AnnType t => Mk_Type t
-           | AnnCoercion co => Mk_Coercion co
-           | AnnVar v => Mk_Var v
-           | AnnLit lit => Lit lit
-           | AnnLam binder body => Lam binder (deAnnotate body)
-           | AnnApp fun_ arg => App (deAnnotate fun_) (deAnnotate arg)
-           | AnnCast e (pair _ co) => Cast (deAnnotate e) co
-           | AnnLet bind body => Let (deAnnBind bind) (deAnnotate body)
-           | AnnCase scrut v t alts =>
-               Case (deAnnotate scrut) v t (GHC.Base.map deAnnAlt alts)
-           end with deAnnBind {b} {annot} (arg_0__ : AnnBind b annot) : Bind b
-                      := let deAnnotate {bndr} {annot} (arg_0__ : AnnExpr bndr annot) : Expr bndr :=
-                           let 'pair _ e := arg_0__ in
-                           deAnnotate' e in
-                         match arg_0__ with
-                         | AnnNonRec var rhs => NonRec var (deAnnotate rhs)
-                         | AnnRec pairs =>
-                             Rec (let cont_2__ arg_3__ :=
-                                    let 'pair v rhs := arg_3__ in
-                                    cons (pair v (deAnnotate rhs)) nil in
-                                  Coq.Lists.List.flat_map cont_2__ pairs)
-                         end for deAnnBind.
-
-Definition deAnnAlt {bndr} {annot} : AnnAlt bndr annot -> Alt bndr :=
-  fun '(pair (pair con args) rhs) => pair (pair con args) (deAnnotate rhs).
-
-Definition dVarSetToVarSet : DVarSet -> VarSet :=
-  fun x => x.
-
-Definition dVarSetMinusVarSet : DVarSet -> VarSet -> DVarSet :=
-  UniqSet.minusUniqSet.
-
-Definition dVarSetIntersectVarSet : DVarSet -> VarSet -> DVarSet :=
-  UniqSet.intersectUniqSets.
-
-Definition dVarSetElems : DVarSet -> list Var :=
-  UniqSet.nonDetEltsUniqSet.
-
-Definition dVarEnvElts {a} : DVarEnv a -> list a :=
-  UniqFM.eltsUFM.
-
-Definition collectValBinders : CoreExpr -> (list Id * CoreExpr)%type :=
-  fun expr =>
-    let fix go arg_0__ arg_1__
-              := let j_3__ :=
-                   match arg_0__, arg_1__ with
-                   | ids, body => pair (GHC.List.reverse ids) body
-                   end in
-                 match arg_0__, arg_1__ with
-                 | ids, Lam b e => if isId b : bool then go (cons b ids) e else j_3__
-                 | _, _ => j_3__
-                 end in
-    go nil expr.
-
-Definition collectTyBinders : CoreExpr -> (list TyVar * CoreExpr)%type :=
-  fun expr =>
-    let fix go arg_0__ arg_1__
-              := let j_3__ :=
-                   match arg_0__, arg_1__ with
-                   | tvs, e => pair (GHC.List.reverse tvs) e
-                   end in
-                 match arg_0__, arg_1__ with
-                 | tvs, Lam b e => if isTyVar b : bool then go (cons b tvs) e else j_3__
-                 | _, _ => j_3__
-                 end in
-    go nil expr.
-
-Definition collectTyAndValBinders
-   : CoreExpr -> (list TyVar * list Id * CoreExpr)%type :=
-  fun expr =>
-    let 'pair tvs body1 := collectTyBinders expr in
-    let 'pair ids body := collectValBinders body1 in
-    pair (pair tvs ids) body.
-
-Definition collectNBinders {b} : nat -> Expr b -> (list b * Expr b)%type :=
-  fun orig_n orig_expr =>
-    let fix go arg_0__ arg_1__ arg_2__
-              := match arg_0__, arg_1__, arg_2__ with
-                 | num_3__, bs, expr =>
-                     if num_3__ GHC.Base.== #0 : bool then pair (GHC.List.reverse bs) expr else
-                     match arg_0__, arg_1__, arg_2__ with
-                     | n, bs, Lam b e => go (n GHC.Num.- #1) (cons b bs) e
-                     | _, _, _ =>
-                         Panic.panicStr (GHC.Base.hs_string__ "collectNBinders") Panic.someSDoc
-                     end
-                 end in
-    go orig_n nil orig_expr.
-
-(* Skipping definition `Core.collectNAnnBndrs' *)
-
-Definition collectBinders {b} : Expr b -> (list b * Expr b)%type :=
-  fun expr =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | bs, Lam b e => go (cons b bs) e
-                 | bs, e => pair (GHC.List.reverse bs) e
-                 end in
-    go nil expr.
-
-Definition collectArgsTicks {b}
-   : (Tickish Id -> bool) ->
-     Expr b -> (Expr b * list (Arg b) * list (Tickish Id))%type :=
-  fun skipTick expr =>
-    let fix go arg_0__ arg_1__ arg_2__
-              := match arg_0__, arg_1__, arg_2__ with
-                 | App f a, as_, ts => go f (cons a as_) ts
-                 | e, as_, ts => pair (pair e as_) (GHC.List.reverse ts)
-                 end in
-    go expr nil nil.
-
-Definition collectArgs {b} : Expr b -> (Expr b * list (Arg b))%type :=
-  fun expr =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | App f a, as_ => go f (cons a as_)
-                 | e, as_ => pair e as_
-                 end in
-    go expr nil.
-
-Program Definition collectAnnBndrs {bndr} {annot}
-           : AnnExpr bndr annot -> (list bndr * AnnExpr bndr annot)%type :=
-          fun e =>
-            let collect :=
-              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
-                               size_AnnExpr' (snd arg_1__)) _ (fun arg_0__ arg_1__ collect =>
-                               match arg_0__, arg_1__ with
-                               | bs, pair _ (AnnLam b body) => collect (cons b bs) body
-                               | bs, body => pair (GHC.List.reverse bs) body
-                               end) in
-            collect nil e.
-
-Program Definition collectAnnArgsTicks {b} {a}
-           : (Tickish Var -> bool) ->
-             AnnExpr b a -> (AnnExpr b a * list (AnnExpr b a) * list (Tickish Var))%type :=
-          fun tickishOk expr =>
-            let go :=
-              GHC.Wf.wfFix3 Coq.Init.Peano.lt (fun arg_0__ arg_1__ arg_2__ =>
-                               size_AnnExpr' (snd arg_0__)) _ (fun arg_0__ arg_1__ arg_2__ go =>
-                               match arg_0__, arg_1__, arg_2__ with
-                               | pair _ (AnnApp f a), as_, ts => go f (cons a as_) ts
-                               | e, as_, ts => pair (pair e as_) (GHC.List.reverse ts)
-                               end) in
-            go expr nil nil.
-Solve Obligations with (solve_collectAnnArgsTicks).
-
-Program Definition collectAnnArgs {b} {a}
-           : AnnExpr b a -> (AnnExpr b a * list (AnnExpr b a))%type :=
-          fun expr =>
-            let go :=
-              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
-                               size_AnnExpr' (snd arg_0__)) _ (fun arg_0__ arg_1__ go =>
-                               match arg_0__, arg_1__ with
-                               | pair _ (AnnApp f a), as_ => go f (cons a as_)
-                               | e, as_ => pair e as_
-                               end) in
-            go expr nil.
-Solve Obligations with (solve_collectAnnArgsTicks).
-
-(* Skipping definition `Core.coVarDetails' *)
-
-Definition cmpAltCon : AltCon -> AltCon -> comparison :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | DEFAULT, DEFAULT => Eq
-    | DEFAULT, _ => Lt
-    | DataAlt d1, DataAlt d2 => GHC.Base.compare (dataConTag d1) (dataConTag d2)
-    | DataAlt _, DEFAULT => Gt
-    | LitAlt l1, LitAlt l2 => GHC.Base.compare l1 l2
-    | LitAlt _, DEFAULT => Gt
-    | con1, con2 =>
-        Panic.warnPprTrace (true) (GHC.Base.hs_string__
-                            "ghc/compiler/coreSyn/CoreSyn.hs") #1700 (GHC.Base.mappend (GHC.Base.mappend
-                                                                                        (Datatypes.id
-                                                                                         (GHC.Base.hs_string__
-                                                                                          "Comparing incomparable AltCons"))
-                                                                                        Panic.someSDoc) Panic.someSDoc)
-        Lt
-    end.
-
-Definition cmpAlt {a} {b}
-   : (AltCon * a * b)%type -> (AltCon * a * b)%type -> comparison :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | pair (pair con1 _) _, pair (pair con2 _) _ => cmpAltCon con1 con2
-    end.
-
-Definition ltAlt {a} {b}
-   : (AltCon * a * b)%type -> (AltCon * a * b)%type -> bool :=
-  fun a1 a2 => (cmpAlt a1 a2) GHC.Base.== Lt.
-
-Definition chooseOrphanAnchor (local_names : list Name.Name) : IsOrphan :=
-  match GHC.Base.map Name.nameOccName local_names with
-  | cons hd tl => NotOrphan (Data.Foldable.foldr GHC.Base.min hd tl)
-  | nil => Mk_IsOrphan
-  end.
-
-Definition canUnfold : Unfolding -> bool :=
-  fun arg_0__ => false.
-
-Definition boringCxtOk : bool :=
-  true.
-
-Definition boringCxtNotOk : bool :=
-  false.
-
-(* Skipping definition `Core.bootUnfolding' *)
-
-Definition bindersOf {b} : Bind b -> list b :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | NonRec binder _ => cons binder nil
-    | Rec pairs =>
-        let cont_2__ arg_3__ := let 'pair binder _ := arg_3__ in cons binder nil in
-        Coq.Lists.List.flat_map cont_2__ pairs
-    end.
-
-Definition bindersOfBinds {b} : list (Bind b) -> list b :=
-  fun binds =>
-    Data.Foldable.foldr (Coq.Init.Datatypes.app GHC.Base.∘ bindersOf) nil binds.
-
-Definition binderVar {tv} {argf} : TyVarBndr tv argf -> tv :=
-  fun '(TvBndr v _) => v.
-
-Definition binderVars {tv} {argf} : list (TyVarBndr tv argf) -> list tv :=
-  fun tvbs => GHC.Base.map binderVar tvbs.
-
-Definition binderKind {argf} : TyVarBndr TyVar argf -> Kind :=
-  fun '(TvBndr tv _) => tyVarKind tv.
-
-Definition binderArgFlag {tv} {argf} : TyVarBndr tv argf -> argf :=
-  fun '(TvBndr _ argf) => argf.
-
-(* Skipping definition `Core.applyTypeToArg' *)
-
-Definition anyVarSet : (Var -> bool) -> VarSet -> bool :=
-  UniqSet.uniqSetAny.
-
-Definition anyDVarSet :=
-  anyVarSet.
-
-Definition anyDVarEnv {a} : (a -> bool) -> DVarEnv a -> bool :=
-  UniqFM.anyUFM.
-
-Definition allVarSet : (Var -> bool) -> VarSet -> bool :=
-  UniqSet.uniqSetAll.
-
-Definition allDVarSet :=
-  allVarSet.
-
-Definition addRnInScopeSet : RnEnv2 -> VarSet -> RnEnv2 :=
-  fun env vs =>
-    if isEmptyVarSet vs : bool then env else
-    let 'RV2 envL_0__ envR_1__ in_scope_2__ := env in
-    RV2 envL_0__ envR_1__ (extendInScopeSetSet (in_scope env) vs).
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__InScopeSet' *)
-
 Local Definition Eq___ArgFlag_op_zeze__ : ArgFlag -> ArgFlag -> bool :=
   fun arg_0__ arg_1__ =>
     match arg_0__, arg_1__ with
@@ -6238,72 +2552,6 @@ Program Instance Eq___ArgFlag : GHC.Base.Eq_ ArgFlag :=
 
 (* Skipping all instances of class `Data.Data.Data', including
    `Core.Data__TyVarBndr' *)
-
-Local Definition HasOccName__Var_occName : Var -> OccName.OccName :=
-  Name.nameOccName GHC.Base.∘ varName.
-
-Program Instance HasOccName__Var : OccName.HasOccName Var :=
-  fun _ k__ => k__ {| OccName.occName__ := HasOccName__Var_occName |}.
-
-(* Skipping all instances of class `Data.Data.Data', including
-   `Core.Data__Var' *)
-
-Local Definition Ord__Var_op_zl__ : Var -> Var -> bool :=
-  fun a b => realUnique a GHC.Base.< realUnique b.
-
-Local Definition Ord__Var_op_zlze__ : Var -> Var -> bool :=
-  fun a b => realUnique a GHC.Base.<= realUnique b.
-
-Local Definition Ord__Var_op_zg__ : Var -> Var -> bool :=
-  fun a b => realUnique a GHC.Base.> realUnique b.
-
-Local Definition Ord__Var_op_zgze__ : Var -> Var -> bool :=
-  fun a b => realUnique a GHC.Base.>= realUnique b.
-
-Local Definition Ord__Var_compare : Var -> Var -> comparison :=
-  fun a b => nonDetCmpVar a b.
-
-Local Definition Ord__Var_max : Var -> Var -> Var :=
-  fun x y => if Ord__Var_op_zlze__ x y : bool then y else x.
-
-Local Definition Ord__Var_min : Var -> Var -> Var :=
-  fun x y => if Ord__Var_op_zlze__ x y : bool then x else y.
-
-Program Instance Ord__Var : GHC.Base.Ord Var :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zl____ := Ord__Var_op_zl__ ;
-           GHC.Base.op_zlze____ := Ord__Var_op_zlze__ ;
-           GHC.Base.op_zg____ := Ord__Var_op_zg__ ;
-           GHC.Base.op_zgze____ := Ord__Var_op_zgze__ ;
-           GHC.Base.compare__ := Ord__Var_compare ;
-           GHC.Base.max__ := Ord__Var_max ;
-           GHC.Base.min__ := Ord__Var_min |}.
-
-Local Definition NamedThing__Var_getName : Var -> Name.Name :=
-  varName.
-
-Local Definition NamedThing__Var_getOccName : Var -> OccName.OccName :=
-  fun n => Name.nameOccName (NamedThing__Var_getName n).
-
-Program Instance NamedThing__Var : Name.NamedThing Var :=
-  fun _ k__ =>
-    k__ {| Name.getName__ := NamedThing__Var_getName ;
-           Name.getOccName__ := NamedThing__Var_getOccName |}.
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__Var' *)
-
-(* Skipping all instances of class `Binary.Binary', including
-   `Core.Binary__ArgFlag' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__ArgFlag' *)
-
-(* Skipping all instances of class `Binary.Binary', including
-   `Core.Binary__TyVarBndr' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__TyVarBndr__ArgFlag__11' *)
 
 Local Definition Eq___EqRel_op_zeze__ : EqRel -> EqRel -> bool :=
   fun arg_0__ arg_1__ =>
@@ -6387,9 +2635,6 @@ Program Instance Eq___TypeOrdering : GHC.Base.Eq_ TypeOrdering :=
 
 (* Skipping all instances of class `GHC.Enum.Bounded', including
    `Core.Bounded__TypeOrdering' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__EqRel' *)
 
 Local Definition Eq___Injectivity_op_zeze__
    : Injectivity -> Injectivity -> bool :=
@@ -6480,64 +2725,6 @@ Program Instance Eq___TyConFlavour : GHC.Base.Eq_ TyConFlavour :=
     k__ {| GHC.Base.op_zeze____ := Eq___TyConFlavour_op_zeze__ ;
            GHC.Base.op_zsze____ := Eq___TyConFlavour_op_zsze__ |}.
 
-(* Skipping all instances of class `Binary.Binary', including
-   `Core.Binary__TyConBndrVis' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__TyVarBndr__TyConBndrVis__11' *)
-
-(* Skipping all instances of class `Binary.Binary', including
-   `Core.Binary__Injectivity' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__FamTyConFlav' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__PrimElemRep' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__PrimRep' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__TyConFlavour' *)
-
-(* Skipping all instances of class `Data.Data.Data', including
-   `Core.Data__TyCon' *)
-
-Local Definition NamedThing__TyCon_getName : TyCon -> Name.Name :=
-  tyConName.
-
-Local Definition NamedThing__TyCon_getOccName : TyCon -> OccName.OccName :=
-  fun n => Name.nameOccName (NamedThing__TyCon_getName n).
-
-Program Instance NamedThing__TyCon : Name.NamedThing TyCon :=
-  fun _ k__ =>
-    k__ {| Name.getName__ := NamedThing__TyCon_getName ;
-           Name.getOccName__ := NamedThing__TyCon_getOccName |}.
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__TyCon' *)
-
-Local Definition Uniquable__TyCon_getUnique : TyCon -> Unique.Unique :=
-  fun tc => tyConUnique tc.
-
-Program Instance Uniquable__TyCon : Unique.Uniquable TyCon :=
-  fun _ k__ => k__ {| Unique.getUnique__ := Uniquable__TyCon_getUnique |}.
-
-Local Definition Eq___TyCon_op_zeze__ : TyCon -> TyCon -> bool :=
-  fun a b => Unique.getUnique a GHC.Base.== Unique.getUnique b.
-
-Local Definition Eq___TyCon_op_zsze__ : TyCon -> TyCon -> bool :=
-  fun a b => Unique.getUnique a GHC.Base./= Unique.getUnique b.
-
-Program Instance Eq___TyCon : GHC.Base.Eq_ TyCon :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___TyCon_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___TyCon_op_zsze__ |}.
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__AlgTyConFlav' *)
-
 Local Definition Eq___TyLit_op_zeze__ : TyLit -> TyLit -> bool :=
   fun arg_0__ arg_1__ =>
     match arg_0__, arg_1__ with
@@ -6624,55 +2811,6 @@ Program Instance Ord__TyLit : GHC.Base.Ord TyLit :=
 (* Skipping all instances of class `Data.Data.Data', including
    `Core.Data__TyBinder' *)
 
-(* Skipping instance `Core.NamedThing__TyThing' of class `Name.NamedThing' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__TyThing' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__TyLit' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__Coercion' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__Type_' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__CoercionHole' *)
-
-(* Skipping all instances of class `Data.Data.Data', including
-   `Core.Data__CoercionHole' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__UnivCoProvenance' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__TyBinder' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__TCvSubst' *)
-
-(* Skipping all instances of class `Data.Data.Data', including
-   `Core.Data__PatSyn' *)
-
-(* Skipping all instances of class `Outputable.OutputableBndr', including
-   `Core.OutputableBndr__PatSyn' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__PatSyn' *)
-
-Local Definition NamedThing__PatSyn_getName : PatSyn -> Name.Name :=
-  patSynName.
-
-Local Definition NamedThing__PatSyn_getOccName : PatSyn -> OccName.OccName :=
-  fun n => Name.nameOccName (NamedThing__PatSyn_getName n).
-
-Program Instance NamedThing__PatSyn : Name.NamedThing PatSyn :=
-  fun _ k__ =>
-    k__ {| Name.getName__ := NamedThing__PatSyn_getName ;
-           Name.getOccName__ := NamedThing__PatSyn_getOccName |}.
-
 Local Definition Uniquable__PatSyn_getUnique : PatSyn -> Unique.Unique :=
   psUnique.
 
@@ -6689,6 +2827,23 @@ Program Instance Eq___PatSyn : GHC.Base.Eq_ PatSyn :=
   fun _ k__ =>
     k__ {| GHC.Base.op_zeze____ := Eq___PatSyn_op_zeze__ ;
            GHC.Base.op_zsze____ := Eq___PatSyn_op_zsze__ |}.
+
+Local Definition Uniquable__TyCon_getUnique : TyCon -> Unique.Unique :=
+  fun tc => tyConUnique tc.
+
+Program Instance Uniquable__TyCon : Unique.Uniquable TyCon :=
+  fun _ k__ => k__ {| Unique.getUnique__ := Uniquable__TyCon_getUnique |}.
+
+Local Definition Eq___TyCon_op_zeze__ : TyCon -> TyCon -> bool :=
+  fun a b => Unique.getUnique a GHC.Base.== Unique.getUnique b.
+
+Local Definition Eq___TyCon_op_zsze__ : TyCon -> TyCon -> bool :=
+  fun a b => Unique.getUnique a GHC.Base./= Unique.getUnique b.
+
+Program Instance Eq___TyCon : GHC.Base.Eq_ TyCon :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___TyCon_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___TyCon_op_zsze__ |}.
 
 Local Definition Eq___RecSelParent_op_zeze__
    : RecSelParent -> RecSelParent -> bool :=
@@ -6779,21 +2934,6 @@ Program Instance Eq___LevityInfo : GHC.Base.Eq_ LevityInfo :=
     k__ {| GHC.Base.op_zeze____ := Eq___LevityInfo_op_zeze__ ;
            GHC.Base.op_zsze____ := Eq___LevityInfo_op_zsze__ |}.
 
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__RecSelParent' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__CafInfo' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__TickBoxOp' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__IdDetails' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__LevityInfo' *)
-
 Local Definition Eq___JointDmd_op_zeze__ {inst_s} {inst_u} `{GHC.Base.Eq_
   inst_s} `{GHC.Base.Eq_ inst_u}
    : JointDmd inst_s inst_u -> JointDmd inst_s inst_u -> bool :=
@@ -6806,15 +2946,6 @@ Local Definition Eq___JointDmd_op_zsze__ {inst_s} {inst_u} `{GHC.Base.Eq_
   inst_s} `{GHC.Base.Eq_ inst_u}
    : JointDmd inst_s inst_u -> JointDmd inst_s inst_u -> bool :=
   fun x y => negb (Eq___JointDmd_op_zeze__ x y).
-
-Program Instance Eq___JointDmd {s} {u} `{GHC.Base.Eq_ s} `{GHC.Base.Eq_ u}
-   : GHC.Base.Eq_ (JointDmd s u) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___JointDmd_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___JointDmd_op_zsze__ |}.
-
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Core.Show__JointDmd' *)
 
 Local Definition Eq___ExnStr_op_zeze__ : ExnStr -> ExnStr -> bool :=
   fun arg_0__ arg_1__ =>
@@ -6831,9 +2962,6 @@ Program Instance Eq___ExnStr : GHC.Base.Eq_ ExnStr :=
   fun _ k__ =>
     k__ {| GHC.Base.op_zeze____ := Eq___ExnStr_op_zeze__ ;
            GHC.Base.op_zsze____ := Eq___ExnStr_op_zsze__ |}.
-
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Core.Show__ExnStr' *)
 
 Local Definition Eq___Str_op_zeze__ {inst_s} `{GHC.Base.Eq_ inst_s}
    : Str inst_s -> Str inst_s -> bool :=
@@ -6854,9 +2982,6 @@ Program Instance Eq___Str {s} `{GHC.Base.Eq_ s} : GHC.Base.Eq_ (Str s) :=
     k__ {| GHC.Base.op_zeze____ := Eq___Str_op_zeze__ ;
            GHC.Base.op_zsze____ := Eq___Str_op_zsze__ |}.
 
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Core.Show__Str' *)
-
 Local Definition Eq___StrDmd_op_zeze__ : StrDmd -> StrDmd -> bool :=
   fix StrDmd_eq x y
         := let eq' : GHC.Base.Eq_ StrDmd := GHC.Base.eq_default StrDmd_eq in
@@ -6876,14 +3001,83 @@ Program Instance Eq___StrDmd : GHC.Base.Eq_ StrDmd :=
     k__ {| GHC.Base.op_zeze____ := Eq___StrDmd_op_zeze__ ;
            GHC.Base.op_zsze____ := Eq___StrDmd_op_zsze__ |}.
 
+Program Instance Eq___JointDmd {s} {u} `{GHC.Base.Eq_ s} `{GHC.Base.Eq_ u}
+   : GHC.Base.Eq_ (JointDmd s u) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___JointDmd_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___JointDmd_op_zsze__ |}.
+
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Core.Show__JointDmd' *)
+
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Core.Show__ExnStr' *)
+
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Core.Show__Str' *)
+
 (* Skipping all instances of class `GHC.Show.Show', including
    `Core.Show__StrDmd' *)
+
+Local Definition Eq___Count_op_zeze__ : Count -> Count -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | One, One => true
+    | Many, Many => true
+    | _, _ => false
+    end.
+
+Local Definition Eq___Count_op_zsze__ : Count -> Count -> bool :=
+  fun x y => negb (Eq___Count_op_zeze__ x y).
+
+Program Instance Eq___Count : GHC.Base.Eq_ Count :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___Count_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___Count_op_zsze__ |}.
 
 (* Skipping all instances of class `GHC.Show.Show', including
    `Core.Show__Count' *)
 
+Local Definition Eq___Use_op_zeze__ {inst_u} `{GHC.Base.Eq_ inst_u}
+   : Use inst_u -> Use inst_u -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Abs, Abs => true
+    | Mk_Use a1 a2, Mk_Use b1 b2 =>
+        (andb ((a1 GHC.Base.== b1)) ((a2 GHC.Base.== b2)))
+    | _, _ => false
+    end.
+
+Local Definition Eq___Use_op_zsze__ {inst_u} `{GHC.Base.Eq_ inst_u}
+   : Use inst_u -> Use inst_u -> bool :=
+  fun x y => negb (Eq___Use_op_zeze__ x y).
+
+Program Instance Eq___Use {u} `{GHC.Base.Eq_ u} : GHC.Base.Eq_ (Use u) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___Use_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___Use_op_zsze__ |}.
+
 (* Skipping all instances of class `GHC.Show.Show', including
    `Core.Show__Use' *)
+
+Local Definition Eq___UseDmd_op_zeze__ : UseDmd -> UseDmd -> bool :=
+  fix UseDmd_eq x y
+        := let eq' : GHC.Base.Eq_ UseDmd := GHC.Base.eq_default UseDmd_eq in
+           match x, y with
+           | UCall a1 a2, UCall b1 b2 => andb (a1 GHC.Base.== b1) (a2 GHC.Base.== b2)
+           | UProd a1, UProd b1 => a1 GHC.Base.== b1
+           | UHead, UHead => true
+           | Used, Used => true
+           | _, _ => false
+           end.
+
+Local Definition Eq___UseDmd_op_zsze__ : UseDmd -> UseDmd -> bool :=
+  fun x y => negb (Eq___UseDmd_op_zeze__ x y).
+
+Program Instance Eq___UseDmd : GHC.Base.Eq_ UseDmd :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___UseDmd_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___UseDmd_op_zsze__ |}.
 
 (* Skipping all instances of class `GHC.Show.Show', including
    `Core.Show__UseDmd' *)
@@ -6958,72 +3152,6 @@ Program Instance Eq___StrictSig : GHC.Base.Eq_ StrictSig :=
     k__ {| GHC.Base.op_zeze____ := Eq___StrictSig_op_zeze__ ;
            GHC.Base.op_zsze____ := Eq___StrictSig_op_zsze__ |}.
 
-(* Skipping all instances of class `Binary.Binary', including
-   `Core.Binary__JointDmd' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__JointDmd' *)
-
-(* Skipping all instances of class `Binary.Binary', including
-   `Core.Binary__ExnStr' *)
-
-(* Skipping all instances of class `Binary.Binary', including
-   `Core.Binary__ArgStr' *)
-
-(* Skipping all instances of class `Binary.Binary', including
-   `Core.Binary__StrDmd' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__ArgStr' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__StrDmd' *)
-
-(* Skipping all instances of class `Binary.Binary', including
-   `Core.Binary__Count' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__Count' *)
-
-(* Skipping all instances of class `Binary.Binary', including
-   `Core.Binary__UseDmd' *)
-
-(* Skipping all instances of class `Binary.Binary', including
-   `Core.Binary__ArgUse' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__UseDmd' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__ArgUse' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__TypeShape' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__Termination' *)
-
-(* Skipping all instances of class `Binary.Binary', including
-   `Core.Binary__CPRResult' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__CPRResult' *)
-
-(* Skipping all instances of class `Binary.Binary', including
-   `Core.Binary__DmdResult' *)
-
-(* Skipping all instances of class `Binary.Binary', including
-   `Core.Binary__DmdType' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__DmdType' *)
-
-(* Skipping all instances of class `Binary.Binary', including
-   `Core.Binary__StrictSig' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__StrictSig' *)
-
 (* Skipping all instances of class `Data.Data.Data', including
    `Core.Data__HsImplBang' *)
 
@@ -7073,50 +3201,6 @@ Program Instance Eq___SrcUnpackedness : GHC.Base.Eq_ SrcUnpackedness :=
 
 (* Skipping all instances of class `Data.Data.Data', including
    `Core.Data__HsSrcBang' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__HsImplBang' *)
-
-(* Skipping all instances of class `Binary.Binary', including
-   `Core.Binary__SrcStrictness' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__SrcStrictness' *)
-
-(* Skipping all instances of class `Binary.Binary', including
-   `Core.Binary__SrcUnpackedness' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__SrcUnpackedness' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__HsSrcBang' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__StrictnessMark' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__EqSpec' *)
-
-(* Skipping all instances of class `Data.Data.Data', including
-   `Core.Data__DataCon' *)
-
-(* Skipping all instances of class `Outputable.OutputableBndr', including
-   `Core.OutputableBndr__DataCon' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__DataCon' *)
-
-Local Definition NamedThing__DataCon_getName : DataCon -> Name.Name :=
-  dcName.
-
-Local Definition NamedThing__DataCon_getOccName : DataCon -> OccName.OccName :=
-  fun n => Name.nameOccName (NamedThing__DataCon_getName n).
-
-Program Instance NamedThing__DataCon : Name.NamedThing DataCon :=
-  fun _ k__ =>
-    k__ {| Name.getName__ := NamedThing__DataCon_getName ;
-           Name.getOccName__ := NamedThing__DataCon_getOccName |}.
 
 Local Definition Uniquable__DataCon_getUnique : DataCon -> Unique.Unique :=
   dcUnique.
@@ -7340,7 +3424,247 @@ Program Instance Eq___UnfoldingGuidance : GHC.Base.Eq_ UnfoldingGuidance :=
            GHC.Base.op_zsze____ := Eq___UnfoldingGuidance_op_zsze__ |}.
 
 (* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__AltCon' *)
+   `Core.Outputable__EqSpec' *)
+
+Local Definition NamedThing__DataCon_getName : DataCon -> Name.Name :=
+  dcName.
+
+Local Definition NamedThing__DataCon_getOccName : DataCon -> OccName.OccName :=
+  fun n => Name.nameOccName (NamedThing__DataCon_getName n).
+
+Program Instance NamedThing__DataCon : Name.NamedThing DataCon :=
+  fun _ k__ =>
+    k__ {| Name.getName__ := NamedThing__DataCon_getName ;
+           Name.getOccName__ := NamedThing__DataCon_getOccName |}.
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__DataCon' *)
+
+(* Skipping all instances of class `Outputable.OutputableBndr', including
+   `Core.OutputableBndr__DataCon' *)
+
+(* Skipping all instances of class `Data.Data.Data', including
+   `Core.Data__DataCon' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__HsSrcBang' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__HsImplBang' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__SrcStrictness' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__SrcUnpackedness' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__StrictnessMark' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `Core.Binary__SrcStrictness' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `Core.Binary__SrcUnpackedness' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__JointDmd' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__StrDmd' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__ArgStr' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__ArgUse' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__UseDmd' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__Count' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__TypeShape' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__Termination' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__CPRResult' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__DmdType' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__StrictSig' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `Core.Binary__StrDmd' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `Core.Binary__ExnStr' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `Core.Binary__ArgStr' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `Core.Binary__Count' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `Core.Binary__ArgUse' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `Core.Binary__UseDmd' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `Core.Binary__JointDmd' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `Core.Binary__StrictSig' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `Core.Binary__DmdType' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `Core.Binary__DmdResult' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `Core.Binary__CPRResult' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__RecSelParent' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__IdDetails' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__CafInfo' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__TickBoxOp' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__LevityInfo' *)
+
+Axiom patSynName : PatSyn -> Name.Name.
+
+Local Definition NamedThing__PatSyn_getName : PatSyn -> Name.Name :=
+  patSynName.
+
+Local Definition NamedThing__PatSyn_getOccName : PatSyn -> OccName.OccName :=
+  fun n => Name.nameOccName (NamedThing__PatSyn_getName n).
+
+Program Instance NamedThing__PatSyn : Name.NamedThing PatSyn :=
+  fun _ k__ =>
+    k__ {| Name.getName__ := NamedThing__PatSyn_getName ;
+           Name.getOccName__ := NamedThing__PatSyn_getOccName |}.
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__PatSyn' *)
+
+(* Skipping all instances of class `Outputable.OutputableBndr', including
+   `Core.OutputableBndr__PatSyn' *)
+
+(* Skipping all instances of class `Data.Data.Data', including
+   `Core.Data__PatSyn' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__Var' *)
+
+Local Definition NamedThing__Var_getName : Var -> Name.Name :=
+  varName.
+
+Local Definition NamedThing__Var_getOccName : Var -> OccName.OccName :=
+  fun n => Name.nameOccName (NamedThing__Var_getName n).
+
+Program Instance NamedThing__Var : Name.NamedThing Var :=
+  fun _ k__ =>
+    k__ {| Name.getName__ := NamedThing__Var_getName ;
+           Name.getOccName__ := NamedThing__Var_getOccName |}.
+
+Definition varUnique : Var -> Unique.Unique :=
+  fun var => Unique.mkUniqueGrimily (realUnique var).
+
+Local Definition Uniquable__Var_getUnique : Var -> Unique.Unique :=
+  varUnique.
+
+Program Instance Uniquable__Var : Unique.Uniquable Var :=
+  fun _ k__ => k__ {| Unique.getUnique__ := Uniquable__Var_getUnique |}.
+
+Local Definition Eq___Var_op_zeze__ : Var -> Var -> bool :=
+  fun a b => realUnique a GHC.Base.== realUnique b.
+
+Local Definition Eq___Var_op_zsze__ : Var -> Var -> bool :=
+  fun x y => negb (Eq___Var_op_zeze__ x y).
+
+Program Instance Eq___Var : GHC.Base.Eq_ Var :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___Var_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___Var_op_zsze__ |}.
+
+Local Definition Ord__Var_op_zl__ : Var -> Var -> bool :=
+  fun a b => realUnique a GHC.Base.< realUnique b.
+
+Local Definition Ord__Var_op_zlze__ : Var -> Var -> bool :=
+  fun a b => realUnique a GHC.Base.<= realUnique b.
+
+Local Definition Ord__Var_op_zg__ : Var -> Var -> bool :=
+  fun a b => realUnique a GHC.Base.> realUnique b.
+
+Local Definition Ord__Var_op_zgze__ : Var -> Var -> bool :=
+  fun a b => realUnique a GHC.Base.>= realUnique b.
+
+Definition nonDetCmpVar : Var -> Var -> comparison :=
+  fun a b => Unique.nonDetCmpUnique (varUnique a) (varUnique b).
+
+Local Definition Ord__Var_compare : Var -> Var -> comparison :=
+  fun a b => nonDetCmpVar a b.
+
+Local Definition Ord__Var_max : Var -> Var -> Var :=
+  fun x y => if Ord__Var_op_zlze__ x y : bool then y else x.
+
+Local Definition Ord__Var_min : Var -> Var -> Var :=
+  fun x y => if Ord__Var_op_zlze__ x y : bool then x else y.
+
+Program Instance Ord__Var : GHC.Base.Ord Var :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zl____ := Ord__Var_op_zl__ ;
+           GHC.Base.op_zlze____ := Ord__Var_op_zlze__ ;
+           GHC.Base.op_zg____ := Ord__Var_op_zg__ ;
+           GHC.Base.op_zgze____ := Ord__Var_op_zgze__ ;
+           GHC.Base.compare__ := Ord__Var_compare ;
+           GHC.Base.max__ := Ord__Var_max ;
+           GHC.Base.min__ := Ord__Var_min |}.
+
+(* Skipping all instances of class `Data.Data.Data', including
+   `Core.Data__Var' *)
+
+Local Definition HasOccName__Var_occName : Var -> OccName.OccName :=
+  Name.nameOccName GHC.Base.∘ varName.
+
+Program Instance HasOccName__Var : OccName.HasOccName Var :=
+  fun _ k__ => k__ {| OccName.occName__ := HasOccName__Var_occName |}.
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__TyVarBndr__ArgFlag__11' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__ArgFlag' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `Core.Binary__TyVarBndr' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `Core.Binary__ArgFlag' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__InScopeSet' *)
+
+Axiom dataConTag : DataCon -> BasicTypes.ConTag.
+
+Axiom dataConTyCon : DataCon -> TyCon.
 
 Local Definition Ord__AltCon_compare : AltCon -> AltCon -> comparison :=
   fun arg_0__ arg_1__ =>
@@ -7391,16 +3715,27 @@ Program Instance Ord__AltCon : GHC.Base.Ord AltCon :=
    `Core.Binary__IsOrphan' *)
 
 (* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__AltCon' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
    `Core.Outputable__TaggedBndr' *)
 
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__LiftingContext' *)
+Local Definition Eq___Class_op_zeze__ : Class -> Class -> bool :=
+  fun c1 c2 => classKey c1 GHC.Base.== classKey c2.
 
-(* Skipping all instances of class `Data.Data.Data', including
-   `Core.Data__Class' *)
+Local Definition Eq___Class_op_zsze__ : Class -> Class -> bool :=
+  fun c1 c2 => classKey c1 GHC.Base./= classKey c2.
 
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Core.Outputable__Class' *)
+Program Instance Eq___Class : GHC.Base.Eq_ Class :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___Class_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___Class_op_zsze__ |}.
+
+Local Definition Uniquable__Class_getUnique : Class -> Unique.Unique :=
+  fun c => classKey c.
+
+Program Instance Uniquable__Class : Unique.Uniquable Class :=
+  fun _ k__ => k__ {| Unique.getUnique__ := Uniquable__Class_getUnique |}.
 
 Local Definition NamedThing__Class_getName : Class -> Name.Name :=
   fun clas => className clas.
@@ -7413,22 +3748,3687 @@ Program Instance NamedThing__Class : Name.NamedThing Class :=
     k__ {| Name.getName__ := NamedThing__Class_getName ;
            Name.getOccName__ := NamedThing__Class_getOccName |}.
 
-Local Definition Uniquable__Class_getUnique : Class -> Unique.Unique :=
-  fun c => classKey c.
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__Class' *)
 
-Program Instance Uniquable__Class : Unique.Uniquable Class :=
-  fun _ k__ => k__ {| Unique.getUnique__ := Uniquable__Class_getUnique |}.
+(* Skipping all instances of class `Data.Data.Data', including
+   `Core.Data__Class' *)
 
-Local Definition Eq___Class_op_zeze__ : Class -> Class -> bool :=
-  fun c1 c2 => classKey c1 GHC.Base.== classKey c2.
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__LiftingContext' *)
 
-Local Definition Eq___Class_op_zsze__ : Class -> Class -> bool :=
-  fun c1 c2 => classKey c1 GHC.Base./= classKey c2.
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__TyThing' *)
 
-Program Instance Eq___Class : GHC.Base.Eq_ Class :=
+(* Skipping instance `Core.NamedThing__TyThing' of class `Name.NamedThing' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__UnivCoProvenance' *)
+
+(* Skipping all instances of class `Data.Data.Data', including
+   `Core.Data__CoercionHole' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__CoercionHole' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__TCvSubst' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__Type_' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__TyLit' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__TyBinder' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__Coercion' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__TyVarBndr__TyConBndrVis__11' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `Core.Binary__TyConBndrVis' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__AlgTyConFlav' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__FamTyConFlav' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__PrimRep' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__PrimElemRep' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__TyCon' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__TyConFlavour' *)
+
+Local Definition NamedThing__TyCon_getName : TyCon -> Name.Name :=
+  tyConName.
+
+Local Definition NamedThing__TyCon_getOccName : TyCon -> OccName.OccName :=
+  fun n => Name.nameOccName (NamedThing__TyCon_getName n).
+
+Program Instance NamedThing__TyCon : Name.NamedThing TyCon :=
   fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___Class_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___Class_op_zsze__ |}.
+    k__ {| Name.getName__ := NamedThing__TyCon_getName ;
+           Name.getOccName__ := NamedThing__TyCon_getOccName |}.
+
+(* Skipping all instances of class `Data.Data.Data', including
+   `Core.Data__TyCon' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `Core.Binary__Injectivity' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Core.Outputable__EqRel' *)
+
+Axiom mkEqSpec : TyVar -> Type_ -> EqSpec.
+
+Axiom eqSpecTyVar : EqSpec -> TyVar.
+
+Axiom eqSpecType : EqSpec -> Type_.
+
+Axiom eqSpecPair : EqSpec -> (TyVar * Type_)%type.
+
+Axiom eqSpecPreds : list EqSpec -> ThetaType.
+
+Axiom substEqSpec : TCvSubst -> EqSpec -> EqSpec.
+
+Axiom filterEqSpec : list EqSpec -> list TyVar -> list TyVar.
+
+Axiom eqHsBang : HsImplBang -> HsImplBang -> bool.
+
+Axiom isBanged : HsImplBang -> bool.
+
+Axiom isSrcStrict : SrcStrictness -> bool.
+
+Axiom isSrcUnpacked : SrcUnpackedness -> bool.
+
+Axiom isMarkedStrict : StrictnessMark -> bool.
+
+Axiom mkDataCon : Name.Name ->
+                  bool ->
+                  TyConRepName ->
+                  list HsSrcBang ->
+                  list FieldLabel.FieldLabel ->
+                  list TyVar ->
+                  list TyVar ->
+                  list TyVarBinder ->
+                  list EqSpec ->
+                  ThetaType ->
+                  list Type_ ->
+                  Type_ -> RuntimeRepInfo -> TyCon -> ThetaType -> Id -> DataConRep -> DataCon.
+
+(* Skipping definition `Core.mkCleanAnonTyConBinders' *)
+
+(* Skipping definition `Core.freshNames' *)
+
+Axiom dataConName : DataCon -> Name.Name.
+
+Axiom dataConTagZ : DataCon -> BasicTypes.ConTagZ.
+
+Axiom dataConOrigTyCon : DataCon -> TyCon.
+
+Axiom dataConRepType : DataCon -> Type_.
+
+Axiom dataConIsInfix : DataCon -> bool.
+
+Axiom dataConUnivTyVars : DataCon -> list TyVar.
+
+Axiom dataConExTyVars : DataCon -> list TyVar.
+
+Axiom dataConUnivAndExTyVars : DataCon -> list TyVar.
+
+Axiom dataConUserTyVars : DataCon -> list TyVar.
+
+Axiom dataConUserTyVarBinders : DataCon -> list TyVarBinder.
+
+Axiom dataConEqSpec : DataCon -> list EqSpec.
+
+Axiom dataConTheta : DataCon -> ThetaType.
+
+Axiom dataConWorkId : DataCon -> Id.
+
+Axiom dataConWrapId_maybe : DataCon -> option Id.
+
+Axiom dataConWrapId : DataCon -> Id.
+
+Axiom dataConImplicitTyThings : DataCon -> list TyThing.
+
+Axiom dataConFieldLabels : DataCon -> list FieldLabel.FieldLabel.
+
+Axiom dataConFieldType : DataCon -> FieldLabel.FieldLabelString -> Type_.
+
+Axiom dataConFieldType_maybe : DataCon ->
+                               FieldLabel.FieldLabelString -> option (FieldLabel.FieldLabel * Type_)%type.
+
+Axiom dataConSrcBangs : DataCon -> list HsSrcBang.
+
+Axiom dataConSourceArity : DataCon -> BasicTypes.Arity.
+
+Axiom dataConRepArity : DataCon -> BasicTypes.Arity.
+
+Axiom isNullarySrcDataCon : DataCon -> bool.
+
+Axiom isNullaryRepDataCon : DataCon -> bool.
+
+Axiom dataConRepStrictness : DataCon -> list StrictnessMark.
+
+Axiom dataConImplBangs : DataCon -> list HsImplBang.
+
+Axiom dataConBoxer : DataCon -> option DataConBoxer.
+
+Axiom dataConSig : DataCon ->
+                   (list TyVar * ThetaType * list Type_ * Type_)%type.
+
+Axiom dataConInstSig : DataCon ->
+                       list Type_ -> (list TyVar * ThetaType * list Type_)%type.
+
+Axiom dataConFullSig : DataCon ->
+                       (list TyVar * list TyVar * list EqSpec * ThetaType * list Type_ * Type_)%type.
+
+Axiom dataConOrigResTy : DataCon -> Type_.
+
+Axiom dataConStupidTheta : DataCon -> ThetaType.
+
+Axiom dataConUserType : DataCon -> Type_.
+
+Axiom dataConInstArgTys : DataCon -> list Type_ -> list Type_.
+
+Axiom dataConInstOrigArgTys : DataCon -> list Type_ -> list Type_.
+
+Axiom dataConOrigArgTys : DataCon -> list Type_.
+
+Axiom dataConRepArgTys : DataCon -> list Type_.
+
+(* Skipping definition `Core.dataConIdentity' *)
+
+Axiom isTupleDataCon : DataCon -> bool.
+
+Axiom isUnboxedTupleCon : DataCon -> bool.
+
+Axiom isUnboxedSumCon : DataCon -> bool.
+
+Axiom isVanillaDataCon : DataCon -> bool.
+
+Axiom specialPromotedDc : DataCon -> bool.
+
+Axiom isLegacyPromotableDataCon : DataCon -> bool.
+
+Axiom isLegacyPromotableTyCon : TyCon -> bool.
+
+Axiom classDataCon : Class -> DataCon.
+
+Axiom dataConCannotMatch : list Type_ -> DataCon -> bool.
+
+Axiom dataConUserTyVarsArePermuted : DataCon -> bool.
+
+Axiom promoteDataCon : DataCon -> TyCon.
+
+Axiom splitDataProductType_maybe : Type_ ->
+                                   option (TyCon * list Type_ * DataCon * list Type_)%type.
+
+Axiom buildAlgTyCon : Name.Name ->
+                      list TyVar ->
+                      list Role ->
+                      option CType -> ThetaType -> AlgTyConRhs -> bool -> AlgTyConFlav -> TyCon.
+
+Axiom buildSynTyCon : Name.Name ->
+                      list TyConBinder -> Kind -> list Role -> Type_ -> TyCon.
+
+Axiom getStrDmd : forall {s} {u}, JointDmd s u -> s.
+
+Axiom getUseDmd : forall {s} {u}, JointDmd s u -> u.
+
+Axiom mkJointDmd : forall {s} {u}, s -> u -> JointDmd s u.
+
+Axiom mkJointDmds : forall {s} {u}, list s -> list u -> list (JointDmd s u).
+
+Axiom strBot : ArgStr.
+
+Axiom strTop : ArgStr.
+
+Axiom mkSCall : StrDmd -> StrDmd.
+
+Axiom mkSProd : list ArgStr -> StrDmd.
+
+Axiom isLazy : ArgStr -> bool.
+
+Axiom isHyperStr : ArgStr -> bool.
+
+Axiom lubArgStr : ArgStr -> ArgStr -> ArgStr.
+
+Axiom lubExnStr : ExnStr -> ExnStr -> ExnStr.
+
+Axiom lubStr : StrDmd -> StrDmd -> StrDmd.
+
+Axiom bothArgStr : ArgStr -> ArgStr -> ArgStr.
+
+Axiom bothExnStr : ExnStr -> ExnStr -> ExnStr.
+
+Axiom bothStr : StrDmd -> StrDmd -> StrDmd.
+
+Definition seqStrDmd : StrDmd -> unit :=
+  fun x => tt.
+
+Definition seqStrDmdList : list ArgStr -> unit :=
+  fun x => tt.
+
+Definition seqArgStr : ArgStr -> unit :=
+  fun x => tt.
+
+Axiom splitArgStrProdDmd : nat -> ArgStr -> option (list ArgStr).
+
+Axiom splitStrProdDmd : nat -> StrDmd -> option (list ArgStr).
+
+Axiom useBot : ArgUse.
+
+Axiom useTop : ArgUse.
+
+Axiom mkUCall : Count -> UseDmd -> UseDmd.
+
+Axiom mkUProd : list ArgUse -> UseDmd.
+
+Axiom lubCount : Count -> Count -> Count.
+
+Axiom lubArgUse : ArgUse -> ArgUse -> ArgUse.
+
+Axiom lubUse : UseDmd -> UseDmd -> UseDmd.
+
+Axiom bothArgUse : ArgUse -> ArgUse -> ArgUse.
+
+Axiom bothUse : UseDmd -> UseDmd -> UseDmd.
+
+Axiom peelUseCall : UseDmd -> option (Count * UseDmd)%type.
+
+(* Skipping definition `Core.addCaseBndrDmd' *)
+
+Axiom markReusedDmd : ArgUse -> ArgUse.
+
+Axiom markReused : UseDmd -> UseDmd.
+
+Axiom isUsedMU : ArgUse -> bool.
+
+Axiom isUsedU : UseDmd -> bool.
+
+Definition seqUseDmd : UseDmd -> unit :=
+  fun x => tt.
+
+Definition seqArgUseList : list ArgUse -> unit :=
+  fun x => tt.
+
+Definition seqArgUse : ArgUse -> unit :=
+  fun x => tt.
+
+Axiom splitUseProdDmd : nat -> UseDmd -> option (list ArgUse).
+
+Axiom useCount : forall {u}, Use u -> Count.
+
+Axiom bothCleanDmd : CleanDemand -> CleanDemand -> CleanDemand.
+
+Axiom mkHeadStrict : CleanDemand -> CleanDemand.
+
+Axiom mkOnceUsedDmd : CleanDemand -> Demand.
+
+Axiom mkManyUsedDmd : CleanDemand -> Demand.
+
+Axiom evalDmd : Demand.
+
+Axiom mkProdDmd : list Demand -> CleanDemand.
+
+Axiom mkCallDmd : CleanDemand -> CleanDemand.
+
+Axiom mkWorkerDemand : nat -> Demand.
+
+Axiom cleanEvalDmd : CleanDemand.
+
+Axiom cleanEvalProdDmd : BasicTypes.Arity -> CleanDemand.
+
+Axiom lubDmd : Demand -> Demand -> Demand.
+
+Axiom bothDmd : Demand -> Demand -> Demand.
+
+Axiom strictApply1Dmd : Demand.
+
+Axiom catchArgDmd : Demand.
+
+Axiom lazyApply1Dmd : Demand.
+
+Axiom lazyApply2Dmd : Demand.
+
+Axiom absDmd : Demand.
+
+Axiom topDmd : Demand.
+
+Axiom botDmd : Demand.
+
+Axiom seqDmd : Demand.
+
+Axiom oneifyDmd : Demand -> Demand.
+
+Axiom isTopDmd : Demand -> bool.
+
+Axiom isAbsDmd : Demand -> bool.
+
+Axiom isSeqDmd : Demand -> bool.
+
+Axiom isUsedOnce : Demand -> bool.
+
+Definition seqDemand : Demand -> unit :=
+  fun x => tt.
+
+Definition seqDemandList : list Demand -> unit :=
+  fun x => tt.
+
+Axiom isStrictDmd : Demand -> bool.
+
+Axiom isWeakDmd : Demand -> bool.
+
+Axiom cleanUseDmd_maybe : Demand -> option UseDmd.
+
+Axiom splitFVs : bool -> DmdEnv -> (DmdEnv * DmdEnv)%type.
+
+(* Skipping definition `Core.trimToType' *)
+
+Axiom splitProdDmd_maybe : Demand -> option (list Demand).
+
+Axiom lubCPR : CPRResult -> CPRResult -> CPRResult.
+
+Axiom lubDmdResult : DmdResult -> DmdResult -> DmdResult.
+
+Axiom bothDmdResult : DmdResult -> Termination unit -> DmdResult.
+
+Definition seqDmdResult : DmdResult -> unit :=
+  fun x => tt.
+
+Definition seqCPRResult : CPRResult -> unit :=
+  fun x => tt.
+
+Axiom topRes : DmdResult.
+
+Axiom exnRes : DmdResult.
+
+Axiom botRes : DmdResult.
+
+Axiom cprSumRes : BasicTypes.ConTag -> DmdResult.
+
+Axiom cprProdRes : list DmdType -> DmdResult.
+
+Axiom vanillaCprProdRes : BasicTypes.Arity -> DmdResult.
+
+Axiom isTopRes : DmdResult -> bool.
+
+Axiom isBotRes : DmdResult -> bool.
+
+Axiom trimCPRInfo : bool -> bool -> DmdResult -> DmdResult.
+
+Axiom returnsCPR_maybe : DmdResult -> option BasicTypes.ConTag.
+
+Axiom retCPR_maybe : CPRResult -> option BasicTypes.ConTag.
+
+Axiom defaultDmd : forall {r}, Termination r -> Demand.
+
+Axiom resTypeArgDmd : forall {r}, Termination r -> Demand.
+
+Axiom lubDmdType : DmdType -> DmdType -> DmdType.
+
+Axiom mkBothDmdArg : DmdEnv -> BothDmdArg.
+
+Axiom toBothDmdArg : DmdType -> BothDmdArg.
+
+Axiom bothDmdType : DmdType -> BothDmdArg -> DmdType.
+
+Axiom emptyDmdEnv : VarEnv Demand.
+
+Axiom nopDmdType : DmdType.
+
+Axiom botDmdType : DmdType.
+
+Axiom exnDmdType : DmdType.
+
+Axiom cprProdDmdType : BasicTypes.Arity -> DmdType.
+
+Axiom isTopDmdType : DmdType -> bool.
+
+Axiom mkDmdType : DmdEnv -> list Demand -> DmdResult -> DmdType.
+
+Axiom dmdTypeDepth : DmdType -> BasicTypes.Arity.
+
+Axiom removeDmdTyArgs : DmdType -> DmdType.
+
+Axiom ensureArgs : BasicTypes.Arity -> DmdType -> DmdType.
+
+Definition seqDmdType : DmdType -> unit :=
+  fun x => tt.
+
+Definition seqDmdEnv : DmdEnv -> unit :=
+  fun x => tt.
+
+Axiom splitDmdTy : DmdType -> (Demand * DmdType)%type.
+
+Axiom deferAfterIO : DmdType -> DmdType.
+
+Axiom strictenDmd : Demand -> CleanDemand.
+
+(* Skipping definition `Core.toCleanDmd' *)
+
+Axiom postProcessDmdType : DmdShell -> DmdType -> BothDmdArg.
+
+Axiom postProcessDmdResult : Str unit -> DmdResult -> DmdResult.
+
+Axiom postProcessDmdEnv : DmdShell -> DmdEnv -> DmdEnv.
+
+Axiom reuseEnv : DmdEnv -> DmdEnv.
+
+Axiom postProcessUnsat : DmdShell -> DmdType -> DmdType.
+
+Axiom postProcessDmd : DmdShell -> Demand -> Demand.
+
+Axiom markExnStr : ArgStr -> ArgStr.
+
+Axiom peelCallDmd : CleanDemand -> (CleanDemand * DmdShell)%type.
+
+Axiom peelManyCalls : nat -> CleanDemand -> DmdShell.
+
+Axiom peelFV : DmdType -> Var -> (DmdType * Demand)%type.
+
+Axiom addDemand : Demand -> DmdType -> DmdType.
+
+Axiom findIdDemand : DmdType -> Var -> Demand.
+
+(* Skipping definition `Core.pprIfaceStrictSig' *)
+
+Axiom mkStrictSig : DmdType -> StrictSig.
+
+Axiom mkClosedStrictSig : list Demand -> DmdResult -> StrictSig.
+
+Axiom splitStrictSig : StrictSig -> (list Demand * DmdResult)%type.
+
+Axiom increaseStrictSigArity : nat -> StrictSig -> StrictSig.
+
+Axiom isTopSig : StrictSig -> bool.
+
+Axiom hasDemandEnvSig : StrictSig -> bool.
+
+Axiom strictSigDmdEnv : StrictSig -> DmdEnv.
+
+Axiom isBottomingSig : StrictSig -> bool.
+
+Axiom nopSig : StrictSig.
+
+Axiom botSig : StrictSig.
+
+Axiom exnSig : StrictSig.
+
+Axiom cprProdSig : BasicTypes.Arity -> StrictSig.
+
+Definition seqStrictSig : StrictSig -> unit :=
+  fun x => tt.
+
+Axiom dmdTransformSig : StrictSig -> CleanDemand -> DmdType.
+
+Axiom dmdTransformDataConSig : BasicTypes.Arity ->
+                               StrictSig -> CleanDemand -> DmdType.
+
+Axiom dmdTransformDictSelSig : StrictSig -> CleanDemand -> DmdType.
+
+Axiom argsOneShots : StrictSig ->
+                     BasicTypes.Arity -> list (list BasicTypes.OneShotInfo).
+
+Axiom saturatedByOneShots : nat -> Demand -> bool.
+
+Axiom argOneShots : Demand -> list BasicTypes.OneShotInfo.
+
+Axiom appIsBottom : StrictSig -> nat -> bool.
+
+Axiom zapUsageEnvSig : StrictSig -> StrictSig.
+
+Axiom zapUsageDemand : Demand -> Demand.
+
+Axiom zapUsedOnceDemand : Demand -> Demand.
+
+Axiom zapUsedOnceSig : StrictSig -> StrictSig.
+
+Axiom killUsageDemand : DynFlags.DynFlags -> Demand -> Demand.
+
+Axiom killUsageSig : DynFlags.DynFlags -> StrictSig -> StrictSig.
+
+Axiom killFlags : DynFlags.DynFlags -> option KillFlags.
+
+Axiom kill_usage : KillFlags -> Demand -> Demand.
+
+Axiom zap_musg : KillFlags -> ArgUse -> ArgUse.
+
+Axiom zap_usg : KillFlags -> UseDmd -> UseDmd.
+
+(* Skipping definition `Core.strictifyDictDmd' *)
+
+Axiom mkPatSyn : Name.Name ->
+                 bool ->
+                 (list TyVarBinder * ThetaType)%type ->
+                 (list TyVarBinder * ThetaType)%type ->
+                 list Type_ ->
+                 Type_ ->
+                 (Id * bool)%type ->
+                 option (Id * bool)%type -> list FieldLabel.FieldLabel -> PatSyn.
+
+Axiom patSynIsInfix : PatSyn -> bool.
+
+Axiom patSynArity : PatSyn -> BasicTypes.Arity.
+
+Axiom patSynArgs : PatSyn -> list Type_.
+
+Axiom patSynFieldLabels : PatSyn -> list FieldLabel.FieldLabel.
+
+Axiom patSynFieldType : PatSyn -> FieldLabel.FieldLabelString -> Type_.
+
+Axiom patSynUnivTyVarBinders : PatSyn -> list TyVarBinder.
+
+Axiom patSynExTyVars : PatSyn -> list TyVar.
+
+Axiom patSynExTyVarBinders : PatSyn -> list TyVarBinder.
+
+Axiom patSynSig : PatSyn ->
+                  (list TyVar * ThetaType * list TyVar * ThetaType * list Type_ * Type_)%type.
+
+Axiom patSynMatcher : PatSyn -> (Id * bool)%type.
+
+Axiom patSynBuilder : PatSyn -> option (Id * bool)%type.
+
+Axiom tidyPatSynIds : (Id -> Id) -> PatSyn -> PatSyn.
+
+Axiom patSynInstArgTys : PatSyn -> list Type_ -> list Type_.
+
+Axiom patSynInstResTy : PatSyn -> list Type_ -> Type_.
+
+(* Skipping definition `Core.pprPatSynType' *)
+
+Axiom classMinimalDef : Class -> ClassMinimalDef.
+
+Axiom mkClass : Name.Name ->
+                list TyVar ->
+                list (FunDep TyVar) ->
+                list PredType ->
+                list Id ->
+                list ClassATItem -> list ClassOpItem -> ClassMinimalDef -> TyCon -> Class.
+
+Axiom mkAbstractClass : Name.Name ->
+                        list TyVar -> list (FunDep TyVar) -> TyCon -> Class.
+
+Axiom classArity : Class -> BasicTypes.Arity.
+
+Axiom classAllSelIds : Class -> list Id.
+
+(* Skipping definition `Core.classSCSelId' *)
+
+Axiom classMethods : Class -> list Id.
+
+Axiom classOpItems : Class -> list ClassOpItem.
+
+Axiom classATs : Class -> list TyCon.
+
+Axiom classATItems : Class -> list ClassATItem.
+
+Axiom classSCTheta : Class -> list PredType.
+
+Axiom classTvsFds : Class -> (list TyVar * list (FunDep TyVar))%type.
+
+Axiom classHasFds : Class -> bool.
+
+Axiom classBigSig : Class ->
+                    (list TyVar * list PredType * list Id * list ClassOpItem)%type.
+
+Axiom classExtraBigSig : Class ->
+                         (list TyVar * list (FunDep TyVar) * list PredType * list Id * list ClassATItem *
+                          list ClassOpItem)%type.
+
+Axiom isAbstractClass : Class -> bool.
+
+(* Skipping definition `Core.pprDefMethInfo' *)
+
+(* Skipping definition `Core.pprFundeps' *)
+
+(* Skipping definition `Core.pprFunDep' *)
+
+Axiom coVarName : CoVar -> Name.Name.
+
+Axiom setCoVarUnique : CoVar -> Unique.Unique -> CoVar.
+
+Axiom setCoVarName : CoVar -> Name.Name -> CoVar.
+
+Axiom pprCoAxiom : forall {br}, CoAxiom br -> GHC.Base.String.
+
+Axiom pprCoAxBranch : forall {br}, CoAxiom br -> CoAxBranch -> GHC.Base.String.
+
+Axiom pprCoAxBranchHdr : forall {br},
+                         CoAxiom br -> BranchIndex -> GHC.Base.String.
+
+Axiom ppr_co_ax_branch : forall {br},
+                         (TyCon -> Type_ -> GHC.Base.String) ->
+                         CoAxiom br -> CoAxBranch -> GHC.Base.String.
+
+Axiom decomposeCo : BasicTypes.Arity -> Coercion -> list Coercion.
+
+Axiom decomposeFunCo : Coercion -> (Coercion * Coercion)%type.
+
+Axiom getCoVar_maybe : Coercion -> option CoVar.
+
+Axiom splitTyConAppCo_maybe : Coercion -> option (TyCon * list Coercion)%type.
+
+Axiom splitAppCo_maybe : Coercion -> option (Coercion * Coercion)%type.
+
+Axiom splitFunCo_maybe : Coercion -> option (Coercion * Coercion)%type.
+
+Axiom splitForAllCo_maybe : Coercion ->
+                            option (TyVar * Coercion * Coercion)%type.
+
+Axiom coVarTypes : CoVar -> Pair.Pair Type_.
+
+Axiom coVarKindsTypesRole : CoVar -> (Kind * Kind * Type_ * Type_ * Role)%type.
+
+Axiom coVarKind : CoVar -> Type_.
+
+Axiom coVarRole : CoVar -> Role.
+
+Axiom mkCoercionType : Role -> Type_ -> Type_ -> Type_.
+
+Axiom mkHeteroCoercionType : Role -> Kind -> Kind -> Type_ -> Type_ -> Type_.
+
+Axiom mkRuntimeRepCo : forall `{Util.HasDebugCallStack}, Coercion -> Coercion.
+
+Axiom isReflCoVar_maybe : CoVar -> option Coercion.
+
+Axiom isReflCo : Coercion -> bool.
+
+Axiom isReflCo_maybe : Coercion -> option (Type_ * Role)%type.
+
+Axiom isReflexiveCo : Coercion -> bool.
+
+Axiom isReflexiveCo_maybe : Coercion -> option (Type_ * Role)%type.
+
+Axiom mkReflCo : Role -> Type_ -> Coercion.
+
+Axiom mkRepReflCo : Type_ -> Coercion.
+
+Axiom mkNomReflCo : Type_ -> Coercion.
+
+Axiom mkTyConAppCo : forall `{Util.HasDebugCallStack},
+                     Role -> TyCon -> list Coercion -> Coercion.
+
+Axiom mkFunCo : Role -> Coercion -> Coercion -> Coercion.
+
+Axiom mkFunCos : Role -> list Coercion -> Coercion -> Coercion.
+
+Axiom mkAppCo : Coercion -> Coercion -> Coercion.
+
+Axiom mkAppCos : Coercion -> list Coercion -> Coercion.
+
+Axiom mkTransAppCo : Role ->
+                     Coercion ->
+                     Type_ -> Type_ -> Role -> Coercion -> Type_ -> Type_ -> Role -> Coercion.
+
+Axiom mkForAllCo : TyVar -> Coercion -> Coercion -> Coercion.
+
+Axiom mkForAllCos : list (TyVar * Coercion)%type -> Coercion -> Coercion.
+
+Axiom mkHomoForAllCos : list TyVar -> Coercion -> Coercion.
+
+Axiom mkHomoForAllCos_NoRefl : list TyVar -> Coercion -> Coercion.
+
+(* Skipping definition `Core.mkCoVarCo' *)
+
+(* Skipping definition `Core.mkCoVarCos' *)
+
+Axiom isCoVar_maybe : Coercion -> option CoVar.
+
+Axiom mkAxInstCo : forall {br},
+                   Role -> CoAxiom br -> BranchIndex -> list Type_ -> list Coercion -> Coercion.
+
+Axiom mkAxiomInstCo : CoAxiom Branched ->
+                      BranchIndex -> list Coercion -> Coercion.
+
+Axiom mkUnbranchedAxInstCo : Role ->
+                             CoAxiom Unbranched -> list Type_ -> list Coercion -> Coercion.
+
+Axiom mkAxInstRHS : forall {br},
+                    CoAxiom br -> BranchIndex -> list Type_ -> list Coercion -> Type_.
+
+Axiom mkUnbranchedAxInstRHS : CoAxiom Unbranched ->
+                              list Type_ -> list Coercion -> Type_.
+
+Axiom mkAxInstLHS : forall {br},
+                    CoAxiom br -> BranchIndex -> list Type_ -> list Coercion -> Type_.
+
+Axiom mkUnbranchedAxInstLHS : CoAxiom Unbranched ->
+                              list Type_ -> list Coercion -> Type_.
+
+Axiom mkUnsafeCo : Role -> Type_ -> Type_ -> Coercion.
+
+Axiom mkHoleCo : CoercionHole -> Coercion.
+
+Axiom mkUnivCo : UnivCoProvenance -> Role -> Type_ -> Type_ -> Coercion.
+
+Axiom mkSymCo : Coercion -> Coercion.
+
+Axiom mkTransCo : Coercion -> Coercion -> Coercion.
+
+Axiom mkNthCoRole : Role -> nat -> Coercion -> Coercion.
+
+Axiom mkNthCo : nat -> Coercion -> Coercion.
+
+Axiom mkLRCo : BasicTypes.LeftOrRight -> Coercion -> Coercion.
+
+Axiom mkInstCo : Coercion -> Coercion -> Coercion.
+
+Axiom mkCoherenceCo : Coercion -> Coercion -> Coercion.
+
+Axiom mkCoherenceRightCo : Coercion -> Coercion -> Coercion.
+
+Axiom mkCoherenceLeftCo : Coercion -> Coercion -> Coercion.
+
+Axiom mkKindCo : Coercion -> Coercion.
+
+Axiom mkSubCo : Coercion -> Coercion.
+
+Axiom downgradeRole_maybe : Role -> Role -> Coercion -> option Coercion.
+
+Axiom downgradeRole : Role -> Role -> Coercion -> Coercion.
+
+(* Skipping definition `Core.maybeSubCo' *)
+
+Axiom mkAxiomRuleCo : CoAxiomRule -> list Coercion -> Coercion.
+
+Axiom mkProofIrrelCo : Role -> Coercion -> Coercion -> Coercion -> Coercion.
+
+Axiom setNominalRole_maybe : Coercion -> option Coercion.
+
+Axiom mkPhantomCo : Coercion -> Type_ -> Type_ -> Coercion.
+
+Axiom mkHomoPhantomCo : Type_ -> Type_ -> Coercion.
+
+Axiom toPhantomCo : Coercion -> Coercion.
+
+Axiom applyRoles : TyCon -> list Coercion -> list Coercion.
+
+Axiom tyConRolesX : Role -> TyCon -> list Role.
+
+Axiom tyConRolesRepresentational : TyCon -> list Role.
+
+Axiom nthRole : Role -> TyCon -> nat -> Role.
+
+Axiom ltRole : Role -> Role -> bool.
+
+Axiom promoteCoercion : Coercion -> Coercion.
+
+Axiom instCoercion : Pair.Pair Type_ -> Coercion -> Coercion -> option Coercion.
+
+Axiom instCoercions : Coercion -> list Coercion -> option Coercion.
+
+Axiom castCoercionKind : Coercion -> Coercion -> Coercion -> Coercion.
+
+Axiom mkPiCos : Role -> list Var -> Coercion -> Coercion.
+
+Axiom mkPiCo : Role -> Var -> Coercion -> Coercion.
+
+Axiom mkCoCast : Coercion -> Coercion -> Coercion.
+
+Axiom instNewTyCon_maybe : TyCon ->
+                           list Type_ -> option (Type_ * Coercion)%type.
+
+Axiom mapStepResult : forall {ev1} {ev2},
+                      (ev1 -> ev2) -> NormaliseStepResult ev1 -> NormaliseStepResult ev2.
+
+Axiom composeSteppers : forall {ev},
+                        NormaliseStepper ev -> NormaliseStepper ev -> NormaliseStepper ev.
+
+Axiom unwrapNewTypeStepper : NormaliseStepper Coercion.
+
+Axiom topNormaliseTypeX : forall {ev},
+                          NormaliseStepper ev -> (ev -> ev -> ev) -> Type_ -> option (ev * Type_)%type.
+
+Axiom topNormaliseNewType_maybe : Type_ -> option (Coercion * Type_)%type.
+
+Axiom eqCoercion : Coercion -> Coercion -> bool.
+
+Axiom eqCoercionX : RnEnv2 -> Coercion -> Coercion -> bool.
+
+Axiom liftCoSubstWithEx : Role ->
+                          list TyVar ->
+                          list Coercion ->
+                          list TyVar -> list Type_ -> ((Type_ -> Coercion) * list Type_)%type.
+
+Axiom liftCoSubstWith : Role ->
+                        list TyCoVar -> list Coercion -> Type_ -> Coercion.
+
+Axiom liftCoSubst : forall `{Util.HasDebugCallStack},
+                    Role -> LiftingContext -> Type_ -> Coercion.
+
+Axiom emptyLiftingContext : InScopeSet -> LiftingContext.
+
+Axiom mkLiftingContext : list (TyCoVar * Coercion)%type -> LiftingContext.
+
+Axiom mkSubstLiftingContext : TCvSubst -> LiftingContext.
+
+Axiom extendLiftingContext : LiftingContext ->
+                             TyVar -> Coercion -> LiftingContext.
+
+Axiom extendLiftingContextEx : LiftingContext ->
+                               list (TyVar * Type_)%type -> LiftingContext.
+
+Axiom zapLiftingContext : LiftingContext -> LiftingContext.
+
+Axiom substForAllCoBndrCallbackLC : bool ->
+                                    (Coercion -> Coercion) ->
+                                    LiftingContext -> TyVar -> Coercion -> (LiftingContext * TyVar * Coercion)%type.
+
+Axiom ty_co_subst : LiftingContext -> Role -> Type_ -> Coercion.
+
+Axiom liftCoSubstTyVar : LiftingContext -> Role -> TyVar -> option Coercion.
+
+Axiom liftCoSubstVarBndr : LiftingContext ->
+                           TyVar -> (LiftingContext * TyVar * Coercion)%type.
+
+Axiom liftCoSubstVarBndrCallback : forall {a},
+                                   (LiftingContext -> Type_ -> (Coercion * a)%type) ->
+                                   LiftingContext -> TyVar -> (LiftingContext * TyVar * Coercion * a)%type.
+
+Axiom isMappedByLC : TyCoVar -> LiftingContext -> bool.
+
+Axiom substLeftCo : LiftingContext -> Coercion -> Coercion.
+
+Axiom substRightCo : LiftingContext -> Coercion -> Coercion.
+
+Axiom swapLiftCoEnv : LiftCoEnv -> LiftCoEnv.
+
+Axiom lcSubstLeft : LiftingContext -> TCvSubst.
+
+Axiom lcSubstRight : LiftingContext -> TCvSubst.
+
+Axiom liftEnvSubstLeft : TCvSubst -> LiftCoEnv -> TCvSubst.
+
+Axiom liftEnvSubstRight : TCvSubst -> LiftCoEnv -> TCvSubst.
+
+Axiom liftEnvSubst : (forall {a}, Pair.Pair a -> a) ->
+                     TCvSubst -> LiftCoEnv -> TCvSubst.
+
+Axiom lcTCvSubst : LiftingContext -> TCvSubst.
+
+Axiom lcInScopeSet : LiftingContext -> InScopeSet.
+
+Axiom seqCo : Coercion -> unit.
+
+Axiom seqProv : UnivCoProvenance -> unit.
+
+Axiom seqCos : list Coercion -> unit.
+
+Axiom coercionType : Coercion -> Type_.
+
+Axiom coercionKind : Coercion -> Pair.Pair Type_.
+
+Axiom coercionKinds : list Coercion -> Pair.Pair (list Type_).
+
+Axiom coercionKindRole : Coercion -> (Pair.Pair Type_ * Role)%type.
+
+Axiom coercionRole : Coercion -> Role.
+
+Axiom pprShortTyThing : TyThing -> GHC.Base.String.
+
+Axiom pprTyThingCategory : TyThing -> GHC.Base.String.
+
+Axiom tyThingCategory : TyThing -> GHC.Base.String.
+
+Axiom delBinderVar : VarSet -> TyVarBinder -> VarSet.
+
+Axiom isInvisibleBinder : TyBinder -> bool.
+
+Axiom isVisibleBinder : TyBinder -> bool.
+
+(* Skipping definition `Core.mkTyVarTy' *)
+
+(* Skipping definition `Core.mkTyVarTys' *)
+
+Axiom mkFunTy : Type_ -> Type_ -> Type_.
+
+Axiom mkFunTys : list Type_ -> Type_ -> Type_.
+
+Axiom mkForAllTy : TyVar -> ArgFlag -> Type_ -> Type_.
+
+Axiom mkForAllTys : list TyVarBinder -> Type_ -> Type_.
+
+Axiom mkPiTy : TyBinder -> Type_ -> Type_.
+
+Axiom mkPiTys : list TyBinder -> Type_ -> Type_.
+
+Axiom isCoercionType : Type_ -> bool.
+
+Axiom mkTyConTy : TyCon -> Type_.
+
+Axiom is_TYPE : (Type_ -> bool) -> Kind -> bool.
+
+Axiom isLiftedTypeKind : Kind -> bool.
+
+Axiom isUnliftedTypeKind : Kind -> bool.
+
+Axiom isRuntimeRepTy : Type_ -> bool.
+
+Axiom isRuntimeRepVar : TyVar -> bool.
+
+Axiom coHoleCoVar : CoercionHole -> CoVar.
+
+Axiom tyCoVarsOfType : Type_ -> TyCoVarSet.
+
+Axiom tyCoVarsOfTypeDSet : Type_ -> DTyCoVarSet.
+
+Axiom tyCoVarsOfTypeList : Type_ -> list TyCoVar.
+
+(* Skipping definition `Core.tyCoFVsOfType' *)
+
+(* Skipping definition `Core.tyCoFVsBndr' *)
+
+Axiom tyCoVarsOfTypes : list Type_ -> TyCoVarSet.
+
+Axiom tyCoVarsOfTypesSet : TyVarEnv Type_ -> TyCoVarSet.
+
+Axiom tyCoVarsOfTypesDSet : list Type_ -> DTyCoVarSet.
+
+Axiom tyCoVarsOfTypesList : list Type_ -> list TyCoVar.
+
+(* Skipping definition `Core.tyCoFVsOfTypes' *)
+
+Axiom tyCoVarsOfCo : Coercion -> TyCoVarSet.
+
+Axiom tyCoVarsOfCoDSet : Coercion -> DTyCoVarSet.
+
+Axiom tyCoVarsOfCoList : Coercion -> list TyCoVar.
+
+(* Skipping definition `Core.tyCoFVsOfCo' *)
+
+(* Skipping definition `Core.tyCoFVsOfCoVar' *)
+
+Axiom tyCoVarsOfProv : UnivCoProvenance -> TyCoVarSet.
+
+(* Skipping definition `Core.tyCoFVsOfProv' *)
+
+Axiom tyCoVarsOfCos : list Coercion -> TyCoVarSet.
+
+Axiom tyCoVarsOfCosSet : CoVarEnv Coercion -> TyCoVarSet.
+
+(* Skipping definition `Core.tyCoFVsOfCos' *)
+
+Axiom coVarsOfType : Type_ -> CoVarSet.
+
+Axiom coVarsOfTypes : list Type_ -> TyCoVarSet.
+
+Axiom coVarsOfCo : Coercion -> CoVarSet.
+
+Axiom coVarsOfCoVar : CoVar -> CoVarSet.
+
+Axiom coVarsOfProv : UnivCoProvenance -> CoVarSet.
+
+Axiom coVarsOfCos : list Coercion -> CoVarSet.
+
+Axiom closeOverKinds : TyVarSet -> TyVarSet.
+
+(* Skipping definition `Core.closeOverKindsFV' *)
+
+Axiom closeOverKindsList : list TyVar -> list TyVar.
+
+Axiom closeOverKindsDSet : DTyVarSet -> DTyVarSet.
+
+(* Skipping definition `Core.injectiveVarsOfBinder' *)
+
+(* Skipping definition `Core.injectiveVarsOfType' *)
+
+Axiom noFreeVarsOfType : Type_ -> bool.
+
+Axiom noFreeVarsOfCo : Coercion -> bool.
+
+Axiom noFreeVarsOfProv : UnivCoProvenance -> bool.
+
+Axiom emptyTvSubstEnv : TvSubstEnv.
+
+Axiom emptyCvSubstEnv : CvSubstEnv.
+
+Axiom composeTCvSubstEnv : InScopeSet ->
+                           (TvSubstEnv * CvSubstEnv)%type ->
+                           (TvSubstEnv * CvSubstEnv)%type -> (TvSubstEnv * CvSubstEnv)%type.
+
+Axiom composeTCvSubst : TCvSubst -> TCvSubst -> TCvSubst.
+
+Axiom emptyTCvSubst : TCvSubst.
+
+Axiom mkEmptyTCvSubst : InScopeSet -> TCvSubst.
+
+Axiom isEmptyTCvSubst : TCvSubst -> bool.
+
+Axiom mkTCvSubst : InScopeSet -> (TvSubstEnv * CvSubstEnv)%type -> TCvSubst.
+
+Axiom mkTvSubst : InScopeSet -> TvSubstEnv -> TCvSubst.
+
+Axiom getTvSubstEnv : TCvSubst -> TvSubstEnv.
+
+Axiom getCvSubstEnv : TCvSubst -> CvSubstEnv.
+
+Axiom getTCvInScope : TCvSubst -> InScopeSet.
+
+Axiom getTCvSubstRangeFVs : TCvSubst -> VarSet.
+
+Axiom isInScope : Var -> TCvSubst -> bool.
+
+Axiom notElemTCvSubst : Var -> TCvSubst -> bool.
+
+Axiom setTvSubstEnv : TCvSubst -> TvSubstEnv -> TCvSubst.
+
+Axiom setCvSubstEnv : TCvSubst -> CvSubstEnv -> TCvSubst.
+
+Axiom zapTCvSubst : TCvSubst -> TCvSubst.
+
+Axiom extendTCvInScope : TCvSubst -> Var -> TCvSubst.
+
+Axiom extendTCvInScopeList : TCvSubst -> list Var -> TCvSubst.
+
+Axiom extendTCvInScopeSet : TCvSubst -> VarSet -> TCvSubst.
+
+Axiom extendTCvSubst : TCvSubst -> TyCoVar -> Type_ -> TCvSubst.
+
+Axiom extendTvSubst : TCvSubst -> TyVar -> Type_ -> TCvSubst.
+
+Axiom extendTvSubstBinderAndInScope : TCvSubst -> TyBinder -> Type_ -> TCvSubst.
+
+Axiom extendTvSubstWithClone : TCvSubst -> TyVar -> TyVar -> TCvSubst.
+
+Axiom extendCvSubst : TCvSubst -> CoVar -> Coercion -> TCvSubst.
+
+Axiom extendCvSubstWithClone : TCvSubst -> CoVar -> CoVar -> TCvSubst.
+
+Axiom extendTvSubstAndInScope : TCvSubst -> TyVar -> Type_ -> TCvSubst.
+
+Axiom extendTvSubstList : TCvSubst -> list Var -> list Type_ -> TCvSubst.
+
+Axiom unionTCvSubst : TCvSubst -> TCvSubst -> TCvSubst.
+
+Axiom mkTyCoInScopeSet : list Type_ -> list Coercion -> InScopeSet.
+
+Axiom zipTvSubst : list TyVar -> list Type_ -> TCvSubst.
+
+Axiom zipCvSubst : list CoVar -> list Coercion -> TCvSubst.
+
+Axiom mkTvSubstPrs : list (TyVar * Type_)%type -> TCvSubst.
+
+Axiom zipTyEnv : list TyVar -> list Type_ -> TvSubstEnv.
+
+Axiom zipCoEnv : list CoVar -> list Coercion -> CvSubstEnv.
+
+Axiom substTyWith : forall `{Util.HasDebugCallStack},
+                    list TyVar -> list Type_ -> Type_ -> Type_.
+
+Axiom substTyWithUnchecked : list TyVar -> list Type_ -> Type_ -> Type_.
+
+Axiom substTyWithInScope : InScopeSet ->
+                           list TyVar -> list Type_ -> Type_ -> Type_.
+
+Axiom substCoWith : forall `{Util.HasDebugCallStack},
+                    list TyVar -> list Type_ -> Coercion -> Coercion.
+
+Axiom substCoWithUnchecked : list TyVar -> list Type_ -> Coercion -> Coercion.
+
+Axiom substTyWithCoVars : list CoVar -> list Coercion -> Type_ -> Type_.
+
+Axiom substTysWith : list TyVar -> list Type_ -> list Type_ -> list Type_.
+
+Axiom substTysWithCoVars : list CoVar ->
+                           list Coercion -> list Type_ -> list Type_.
+
+Axiom substTyAddInScope : TCvSubst -> Type_ -> Type_.
+
+Axiom isValidTCvSubst : TCvSubst -> bool.
+
+Axiom checkValidSubst : forall {a},
+                        forall `{Util.HasDebugCallStack},
+                        TCvSubst -> list Type_ -> list Coercion -> a -> a.
+
+Axiom substTy : forall `{Util.HasDebugCallStack}, TCvSubst -> Type_ -> Type_.
+
+Axiom substTyUnchecked : TCvSubst -> Type_ -> Type_.
+
+Axiom substTys : forall `{Util.HasDebugCallStack},
+                 TCvSubst -> list Type_ -> list Type_.
+
+Axiom substTysUnchecked : TCvSubst -> list Type_ -> list Type_.
+
+Axiom substTheta : forall `{Util.HasDebugCallStack},
+                   TCvSubst -> ThetaType -> ThetaType.
+
+Axiom substThetaUnchecked : TCvSubst -> ThetaType -> ThetaType.
+
+Axiom subst_ty : TCvSubst -> Type_ -> Type_.
+
+Axiom substTyVar : TCvSubst -> TyVar -> Type_.
+
+Axiom substTyVars : TCvSubst -> list TyVar -> list Type_.
+
+Axiom lookupTyVar : TCvSubst -> TyVar -> option Type_.
+
+Axiom substCo : forall `{Util.HasDebugCallStack},
+                TCvSubst -> Coercion -> Coercion.
+
+Axiom substCoUnchecked : TCvSubst -> Coercion -> Coercion.
+
+Axiom substCos : forall `{Util.HasDebugCallStack},
+                 TCvSubst -> list Coercion -> list Coercion.
+
+Axiom subst_co : TCvSubst -> Coercion -> Coercion.
+
+Axiom substForAllCoBndr : TCvSubst ->
+                          TyVar -> Coercion -> (TCvSubst * TyVar * Coercion)%type.
+
+Axiom substForAllCoBndrUnchecked : TCvSubst ->
+                                   TyVar -> Coercion -> (TCvSubst * TyVar * Coercion)%type.
+
+Axiom substForAllCoBndrCallback : bool ->
+                                  (Coercion -> Coercion) ->
+                                  TCvSubst -> TyVar -> Coercion -> (TCvSubst * TyVar * Coercion)%type.
+
+Axiom substCoVar : TCvSubst -> CoVar -> Coercion.
+
+Axiom substCoVars : TCvSubst -> list CoVar -> list Coercion.
+
+Axiom lookupCoVar : TCvSubst -> Var -> option Coercion.
+
+Axiom substTyVarBndr : forall `{Util.HasDebugCallStack},
+                       TCvSubst -> TyVar -> (TCvSubst * TyVar)%type.
+
+Axiom substTyVarBndrUnchecked : TCvSubst -> TyVar -> (TCvSubst * TyVar)%type.
+
+Axiom substTyVarBndrCallback : (TCvSubst -> Type_ -> Type_) ->
+                               TCvSubst -> TyVar -> (TCvSubst * TyVar)%type.
+
+Axiom substCoVarBndr : TCvSubst -> CoVar -> (TCvSubst * CoVar)%type.
+
+Axiom cloneTyVarBndr : TCvSubst ->
+                       TyVar -> Unique.Unique -> (TCvSubst * TyVar)%type.
+
+Axiom cloneTyVarBndrs : TCvSubst ->
+                        list TyVar -> UniqSupply.UniqSupply -> (TCvSubst * list TyVar)%type.
+
+Axiom pprType : Type_ -> GHC.Base.String.
+
+Axiom pprParendType : Type_ -> GHC.Base.String.
+
+Axiom pprPrecType : BasicTypes.TyPrec -> Type_ -> GHC.Base.String.
+
+Axiom pprTyLit : TyLit -> GHC.Base.String.
+
+Axiom pprKind : Kind -> GHC.Base.String.
+
+Axiom pprParendKind : Kind -> GHC.Base.String.
+
+(* Skipping definition `Core.tidyToIfaceTypeSty' *)
+
+(* Skipping definition `Core.tidyToIfaceType' *)
+
+Axiom pprCo : Coercion -> GHC.Base.String.
+
+Axiom pprParendCo : Coercion -> GHC.Base.String.
+
+(* Skipping definition `Core.tidyToIfaceCoSty' *)
+
+(* Skipping definition `Core.tidyToIfaceCo' *)
+
+Axiom pprClassPred : Class -> list Type_ -> GHC.Base.String.
+
+Axiom pprTheta : ThetaType -> GHC.Base.String.
+
+Axiom pprParendTheta : ThetaType -> GHC.Base.String.
+
+Axiom pprThetaArrowTy : ThetaType -> GHC.Base.String.
+
+Axiom pprSigmaType : Type_ -> GHC.Base.String.
+
+Axiom pprForAll : list TyVarBinder -> GHC.Base.String.
+
+Axiom pprUserForAll : list TyVarBinder -> GHC.Base.String.
+
+Axiom pprTvBndrs : list TyVarBinder -> GHC.Base.String.
+
+Axiom pprTvBndr : TyVarBinder -> GHC.Base.String.
+
+Axiom pprTyVars : list TyVar -> GHC.Base.String.
+
+Axiom pprTyVar : TyVar -> GHC.Base.String.
+
+Axiom debugPprType : Type_ -> GHC.Base.String.
+
+Axiom debug_ppr_ty : BasicTypes.TyPrec -> Type_ -> GHC.Base.String.
+
+Axiom pprDataCons : TyCon -> GHC.Base.String.
+
+Axiom pprDataConWithArgs : DataCon -> GHC.Base.String.
+
+Axiom pprTypeApp : TyCon -> list Type_ -> GHC.Base.String.
+
+Axiom ppSuggestExplicitKinds : GHC.Base.String.
+
+Axiom tidyTyCoVarBndrs : TidyEnv ->
+                         list TyCoVar -> (TidyEnv * list TyCoVar)%type.
+
+Axiom tidyTyCoVarBndr : TidyEnv -> TyCoVar -> (TidyEnv * TyCoVar)%type.
+
+Axiom getHelpfulOccName : TyCoVar -> OccName.OccName.
+
+Axiom tidyTyVarBinder : forall {vis},
+                        TidyEnv -> TyVarBndr TyVar vis -> (TidyEnv * TyVarBndr TyVar vis)%type.
+
+Axiom tidyTyVarBinders : forall {vis},
+                         TidyEnv ->
+                         list (TyVarBndr TyVar vis) -> (TidyEnv * list (TyVarBndr TyVar vis))%type.
+
+Axiom tidyFreeTyCoVars : TidyEnv -> list TyCoVar -> TidyEnv.
+
+Axiom tidyOpenTyCoVars : TidyEnv ->
+                         list TyCoVar -> (TidyEnv * list TyCoVar)%type.
+
+Axiom tidyOpenTyCoVar : TidyEnv -> TyCoVar -> (TidyEnv * TyCoVar)%type.
+
+Axiom tidyTyVarOcc : TidyEnv -> TyVar -> TyVar.
+
+Axiom tidyTypes : TidyEnv -> list Type_ -> list Type_.
+
+Axiom tidyType : TidyEnv -> Type_ -> Type_.
+
+Axiom mkForAllTys' : list (TyVar * ArgFlag)%type -> Type_ -> Type_.
+
+Axiom splitForAllTys' : Type_ -> (list TyVar * list ArgFlag * Type_)%type.
+
+Axiom tidyOpenTypes : TidyEnv -> list Type_ -> (TidyEnv * list Type_)%type.
+
+Axiom tidyOpenType : TidyEnv -> Type_ -> (TidyEnv * Type_)%type.
+
+Axiom tidyTopType : Type_ -> Type_.
+
+Axiom tidyOpenKind : TidyEnv -> Kind -> (TidyEnv * Kind)%type.
+
+Axiom tidyKind : TidyEnv -> Kind -> Kind.
+
+Axiom tidyCo : TidyEnv -> Coercion -> Coercion.
+
+Axiom tidyCos : TidyEnv -> list Coercion -> list Coercion.
+
+Axiom typeSize : Type_ -> nat.
+
+Axiom coercionSize : Coercion -> nat.
+
+Axiom provSize : UnivCoProvenance -> nat.
+
+Axiom mkAnonTyConBinder : TyVar -> TyConBinder.
+
+Axiom mkAnonTyConBinders : list TyVar -> list TyConBinder.
+
+Axiom mkNamedTyConBinder : ArgFlag -> TyVar -> TyConBinder.
+
+Axiom mkNamedTyConBinders : ArgFlag -> list TyVar -> list TyConBinder.
+
+Axiom tyConBinderArgFlag : TyConBinder -> ArgFlag.
+
+Axiom isNamedTyConBinder : TyConBinder -> bool.
+
+Axiom isVisibleTyConBinder : forall {tv}, TyVarBndr tv TyConBndrVis -> bool.
+
+Axiom isVisibleTcbVis : TyConBndrVis -> bool.
+
+Axiom isInvisibleTyConBinder : forall {tv}, TyVarBndr tv TyConBndrVis -> bool.
+
+Axiom mkTyConKind : list TyConBinder -> Kind -> Kind.
+
+Axiom tyConTyVarBinders : list TyConBinder -> list TyVarBinder.
+
+Axiom tyConVisibleTyVars : TyCon -> list TyVar.
+
+Axiom visibleDataCons : AlgTyConRhs -> list DataCon.
+
+Axiom okParent : Name.Name -> AlgTyConFlav -> bool.
+
+Axiom isNoParent : AlgTyConFlav -> bool.
+
+Axiom tyConRepName_maybe : TyCon -> option TyConRepName.
+
+Axiom mkPrelTyConRepName : Name.Name -> TyConRepName.
+
+Axiom tyConRepModOcc : Module.Module ->
+                       OccName.OccName -> (Module.Module * OccName.OccName)%type.
+
+Axiom isVoidRep : PrimRep -> bool.
+
+Axiom isGcPtrRep : PrimRep -> bool.
+
+(* Skipping definition `Core.primRepSizeB' *)
+
+Axiom primElemRepSizeB : PrimElemRep -> nat.
+
+Axiom primRepIsFloat : PrimRep -> option bool.
+
+Axiom tyConFieldLabels : TyCon -> list FieldLabel.FieldLabel.
+
+Axiom tyConFieldLabelEnv : TyCon -> FieldLabel.FieldLabelEnv.
+
+Axiom lookupTyConFieldLabel : FieldLabel.FieldLabelString ->
+                              TyCon -> option FieldLabel.FieldLabel.
+
+Axiom fieldsOfAlgTcRhs : AlgTyConRhs -> FieldLabel.FieldLabelEnv.
+
+Axiom mkFunTyCon : Name.Name -> list TyConBinder -> Name.Name -> TyCon.
+
+Axiom mkAlgTyCon : Name.Name ->
+                   list TyConBinder ->
+                   Kind ->
+                   list Role ->
+                   option CType -> list PredType -> AlgTyConRhs -> AlgTyConFlav -> bool -> TyCon.
+
+Axiom mkClassTyCon : Name.Name ->
+                     list TyConBinder -> list Role -> AlgTyConRhs -> Class -> Name.Name -> TyCon.
+
+Axiom mkTupleTyCon : Name.Name ->
+                     list TyConBinder ->
+                     Kind ->
+                     BasicTypes.Arity -> DataCon -> BasicTypes.TupleSort -> AlgTyConFlav -> TyCon.
+
+Axiom mkSumTyCon : Name.Name ->
+                   list TyConBinder ->
+                   Kind -> BasicTypes.Arity -> list TyVar -> list DataCon -> AlgTyConFlav -> TyCon.
+
+Axiom mkTcTyCon : Name.Name ->
+                  list TyConBinder ->
+                  Kind -> list (Name.Name * TyVar)%type -> TyConFlavour -> TyCon.
+
+Axiom mkPrimTyCon : Name.Name -> list TyConBinder -> Kind -> list Role -> TyCon.
+
+Axiom mkKindTyCon : Name.Name ->
+                    list TyConBinder -> Kind -> list Role -> Name.Name -> TyCon.
+
+Axiom mkLiftedPrimTyCon : Name.Name ->
+                          list TyConBinder -> Kind -> list Role -> TyCon.
+
+Axiom mkPrimTyCon' : Name.Name ->
+                     list TyConBinder -> Kind -> list Role -> bool -> option TyConRepName -> TyCon.
+
+Axiom mkSynonymTyCon : Name.Name ->
+                       list TyConBinder -> Kind -> list Role -> Type_ -> bool -> bool -> TyCon.
+
+Axiom mkFamilyTyCon : Name.Name ->
+                      list TyConBinder ->
+                      Kind ->
+                      option Name.Name -> FamTyConFlav -> option Class -> Injectivity -> TyCon.
+
+Axiom mkPromotedDataCon : DataCon ->
+                          Name.Name ->
+                          TyConRepName ->
+                          list TyConBinder -> Kind -> list Role -> RuntimeRepInfo -> TyCon.
+
+Axiom isFunTyCon : TyCon -> bool.
+
+Axiom isAbstractTyCon : TyCon -> bool.
+
+Axiom makeRecoveryTyCon : TyCon -> TyCon.
+
+Axiom isPrimTyCon : TyCon -> bool.
+
+Axiom isUnliftedTyCon : TyCon -> bool.
+
+Axiom isAlgTyCon : TyCon -> bool.
+
+Axiom isVanillaAlgTyCon : TyCon -> bool.
+
+Axiom isDataTyCon : TyCon -> bool.
+
+Axiom isInjectiveTyCon : TyCon -> Role -> bool.
+
+Axiom isGenerativeTyCon : TyCon -> Role -> bool.
+
+Axiom isGenInjAlgRhs : AlgTyConRhs -> bool.
+
+Axiom isNewTyCon : TyCon -> bool.
+
+Axiom unwrapNewTyCon_maybe : TyCon ->
+                             option (list TyVar * Type_ * CoAxiom Unbranched)%type.
+
+Axiom unwrapNewTyConEtad_maybe : TyCon ->
+                                 option (list TyVar * Type_ * CoAxiom Unbranched)%type.
+
+Axiom isProductTyCon : TyCon -> bool.
+
+Axiom isDataProductTyCon_maybe : TyCon -> option DataCon.
+
+Axiom isDataSumTyCon_maybe : TyCon -> option (list DataCon).
+
+Axiom isTypeSynonymTyCon : TyCon -> bool.
+
+Axiom isTauTyCon : TyCon -> bool.
+
+Axiom isFamFreeTyCon : TyCon -> bool.
+
+Axiom mightBeUnsaturatedTyCon : TyCon -> bool.
+
+Axiom isGadtSyntaxTyCon : TyCon -> bool.
+
+Axiom isEnumerationTyCon : TyCon -> bool.
+
+Axiom isFamilyTyCon : TyCon -> bool.
+
+Axiom isOpenFamilyTyCon : TyCon -> bool.
+
+Axiom isTypeFamilyTyCon : TyCon -> bool.
+
+Axiom isDataFamilyTyCon : TyCon -> bool.
+
+Axiom isOpenTypeFamilyTyCon : TyCon -> bool.
+
+Axiom isClosedSynFamilyTyConWithAxiom_maybe : TyCon ->
+                                              option (CoAxiom Branched).
+
+Axiom tyConInjectivityInfo : TyCon -> Injectivity.
+
+Axiom isBuiltInSynFamTyCon_maybe : TyCon -> option BuiltInSynFamily.
+
+Axiom isDataFamFlav : FamTyConFlav -> bool.
+
+Axiom isTyConAssoc : TyCon -> bool.
+
+Axiom tyConAssoc_maybe : TyCon -> option Class.
+
+Axiom isTupleTyCon : TyCon -> bool.
+
+Axiom tyConTuple_maybe : TyCon -> option BasicTypes.TupleSort.
+
+Axiom isUnboxedTupleTyCon : TyCon -> bool.
+
+Axiom isBoxedTupleTyCon : TyCon -> bool.
+
+Axiom isUnboxedSumTyCon : TyCon -> bool.
+
+Axiom isPromotedTupleTyCon : TyCon -> bool.
+
+Axiom isPromotedDataCon : TyCon -> bool.
+
+Axiom isPromotedDataCon_maybe : TyCon -> option DataCon.
+
+Axiom isKindTyCon : TyCon -> bool.
+
+Axiom kindTyConKeys : UniqSet.UniqSet Unique.Unique.
+
+Axiom isLiftedTypeKindTyConName : Name.Name -> bool.
+
+Axiom isImplicitTyCon : TyCon -> bool.
+
+Axiom tyConCType_maybe : TyCon -> option CType.
+
+Axiom isTcTyCon : TyCon -> bool.
+
+Axiom isTcLevPoly : TyCon -> bool.
+
+Axiom expandSynTyCon_maybe : forall {tyco},
+                             TyCon ->
+                             list tyco -> option (list (TyVar * tyco)%type * Type_ * list tyco)%type.
+
+Axiom isTyConWithSrcDataCons : TyCon -> bool.
+
+Axiom tyConDataCons : TyCon -> list DataCon.
+
+Axiom tyConDataCons_maybe : TyCon -> option (list DataCon).
+
+Axiom tyConSingleDataCon_maybe : TyCon -> option DataCon.
+
+Axiom tyConSingleDataCon : TyCon -> DataCon.
+
+Axiom tyConSingleAlgDataCon_maybe : TyCon -> option DataCon.
+
+Axiom tyConFamilySize : TyCon -> nat.
+
+Axiom tyConFamilySizeAtMost : TyCon -> nat -> bool.
+
+Axiom algTyConRhs : TyCon -> AlgTyConRhs.
+
+Axiom tyConFamilyResVar_maybe : TyCon -> option Name.Name.
+
+Axiom tyConRoles : TyCon -> list Role.
+
+Axiom newTyConRhs : TyCon -> (list TyVar * Type_)%type.
+
+Axiom newTyConEtadArity : TyCon -> nat.
+
+Axiom newTyConEtadRhs : TyCon -> (list TyVar * Type_)%type.
+
+Axiom newTyConCo_maybe : TyCon -> option (CoAxiom Unbranched).
+
+Axiom newTyConCo : TyCon -> CoAxiom Unbranched.
+
+Axiom newTyConDataCon_maybe : TyCon -> option DataCon.
+
+Axiom tyConStupidTheta : TyCon -> list PredType.
+
+Axiom synTyConDefn_maybe : TyCon -> option (list TyVar * Type_)%type.
+
+Axiom synTyConRhs_maybe : TyCon -> option Type_.
+
+Axiom famTyConFlav_maybe : TyCon -> option FamTyConFlav.
+
+Axiom isClassTyCon : TyCon -> bool.
+
+Axiom tyConClass_maybe : TyCon -> option Class.
+
+Axiom tyConATs : TyCon -> list TyCon.
+
+Axiom isFamInstTyCon : TyCon -> bool.
+
+Axiom tyConFamInstSig_maybe : TyCon ->
+                              option (TyCon * list Type_ * CoAxiom Unbranched)%type.
+
+Axiom tyConFamInst_maybe : TyCon -> option (TyCon * list Type_)%type.
+
+Axiom tyConFamilyCoercion_maybe : TyCon -> option (CoAxiom Unbranched).
+
+Axiom tyConRuntimeRepInfo : TyCon -> RuntimeRepInfo.
+
+Axiom tyConFlavour : TyCon -> TyConFlavour.
+
+Axiom tcFlavourCanBeUnsaturated : TyConFlavour -> bool.
+
+Axiom tcFlavourIsOpen : TyConFlavour -> bool.
+
+Axiom pprPromotionQuote : TyCon -> GHC.Base.String.
+
+Axiom initRecTc : RecTcChecker.
+
+Axiom checkRecTc : RecTcChecker -> TyCon -> option RecTcChecker.
+
+Axiom tyConSkolem : TyCon -> bool.
+
+Axiom coreView : Type_ -> option Type_.
+
+Axiom tcView : Type_ -> option Type_.
+
+Axiom expandTypeSynonyms : Type_ -> Type_.
+
+Axiom mapType : forall {m} {env},
+                forall `{GHC.Base.Monad m}, TyCoMapper env m -> env -> Type_ -> m Type_.
+
+Axiom mapCoercion : forall {m} {env},
+                    forall `{GHC.Base.Monad m}, TyCoMapper env m -> env -> Coercion -> m Coercion.
+
+Axiom getTyVar : GHC.Base.String -> Type_ -> TyVar.
+
+Axiom isTyVarTy : Type_ -> bool.
+
+Axiom getTyVar_maybe : Type_ -> option TyVar.
+
+Axiom getCastedTyVar_maybe : Type_ -> option (TyVar * CoercionN)%type.
+
+Axiom repGetTyVar_maybe : Type_ -> option TyVar.
+
+Axiom mkAppTy : Type_ -> Type_ -> Type_.
+
+Axiom mkAppTys : Type_ -> list Type_ -> Type_.
+
+Axiom splitAppTy_maybe : Type_ -> option (Type_ * Type_)%type.
+
+Axiom repSplitAppTy_maybe : forall `{Util.HasDebugCallStack},
+                            Type_ -> option (Type_ * Type_)%type.
+
+Axiom tcRepSplitAppTy_maybe : Type_ -> option (Type_ * Type_)%type.
+
+Axiom tcSplitTyConApp_maybe : forall `{Util.HasDebugCallStack},
+                              Type_ -> option (TyCon * list Type_)%type.
+
+Axiom tcRepSplitTyConApp_maybe : forall `{Util.HasDebugCallStack},
+                                 Type_ -> option (TyCon * list Type_)%type.
+
+Axiom splitAppTy : Type_ -> (Type_ * Type_)%type.
+
+Axiom splitAppTys : Type_ -> (Type_ * list Type_)%type.
+
+Axiom repSplitAppTys : forall `{Util.HasDebugCallStack},
+                       Type_ -> (Type_ * list Type_)%type.
+
+Axiom mkNumLitTy : GHC.Num.Integer -> Type_.
+
+Axiom isNumLitTy : Type_ -> option GHC.Num.Integer.
+
+Axiom mkStrLitTy : FastString.FastString -> Type_.
+
+Axiom isStrLitTy : Type_ -> option FastString.FastString.
+
+Axiom userTypeError_maybe : Type_ -> option Type_.
+
+Axiom pprUserTypeErrorTy : Type_ -> GHC.Base.String.
+
+Axiom isFunTy : Type_ -> bool.
+
+Axiom splitFunTy : Type_ -> (Type_ * Type_)%type.
+
+Axiom splitFunTy_maybe : Type_ -> option (Type_ * Type_)%type.
+
+Axiom splitFunTys : Type_ -> (list Type_ * Type_)%type.
+
+Axiom funResultTy : Type_ -> Type_.
+
+Axiom funArgTy : Type_ -> Type_.
+
+Axiom piResultTy : forall `{Util.HasDebugCallStack}, Type_ -> Type_ -> Type_.
+
+Axiom piResultTy_maybe : Type_ -> Type_ -> option Type_.
+
+Axiom piResultTys : forall `{Util.HasDebugCallStack},
+                    Type_ -> list Type_ -> Type_.
+
+Axiom applyTysX : list TyVar -> Type_ -> list Type_ -> Type_.
+
+Axiom mkTyConApp : TyCon -> list Type_ -> Type_.
+
+Axiom tyConAppTyConPicky_maybe : Type_ -> option TyCon.
+
+Axiom tyConAppTyCon_maybe : Type_ -> option TyCon.
+
+Axiom tyConAppTyCon : Type_ -> TyCon.
+
+Axiom tyConAppArgs_maybe : Type_ -> option (list Type_).
+
+Axiom tyConAppArgs : Type_ -> list Type_.
+
+Axiom tyConAppArgN : nat -> Type_ -> Type_.
+
+Axiom splitTyConApp : Type_ -> (TyCon * list Type_)%type.
+
+Axiom splitTyConApp_maybe : forall `{Util.HasDebugCallStack},
+                            Type_ -> option (TyCon * list Type_)%type.
+
+Axiom repSplitTyConApp_maybe : forall `{Util.HasDebugCallStack},
+                               Type_ -> option (TyCon * list Type_)%type.
+
+Axiom splitListTyConApp_maybe : Type_ -> option Type_.
+
+Axiom nextRole : Type_ -> Role.
+
+Axiom newTyConInstRhs : TyCon -> list Type_ -> Type_.
+
+Axiom splitCastTy_maybe : Type_ -> option (Type_ * Coercion)%type.
+
+Axiom mkCastTy : Type_ -> Coercion -> Type_.
+
+Axiom tyConBindersTyBinders : list TyConBinder -> list TyBinder.
+
+Axiom mkCoercionTy : Coercion -> Type_.
+
+Axiom isCoercionTy : Type_ -> bool.
+
+Axiom isCoercionTy_maybe : Type_ -> option Coercion.
+
+Axiom stripCoercionTy : Type_ -> Coercion.
+
+Axiom mkInvForAllTy : TyVar -> Type_ -> Type_.
+
+Axiom mkInvForAllTys : list TyVar -> Type_ -> Type_.
+
+Axiom mkSpecForAllTys : list TyVar -> Type_ -> Type_.
+
+Axiom mkVisForAllTys : list TyVar -> Type_ -> Type_.
+
+Axiom mkLamType : Var -> Type_ -> Type_.
+
+Axiom mkLamTypes : list Var -> Type_ -> Type_.
+
+Axiom mkTyConBindersPreferAnon : list TyVar -> Type_ -> list TyConBinder.
+
+Axiom splitForAllTys : Type_ -> (list TyVar * Type_)%type.
+
+Axiom splitForAllTyVarBndrs : Type_ -> (list TyVarBinder * Type_)%type.
+
+Axiom isForAllTy : Type_ -> bool.
+
+Axiom isPiTy : Type_ -> bool.
+
+Axiom splitForAllTy : Type_ -> (TyVar * Type_)%type.
+
+Axiom dropForAlls : Type_ -> Type_.
+
+Axiom splitForAllTy_maybe : Type_ -> option (TyVar * Type_)%type.
+
+Axiom splitPiTy_maybe : Type_ -> option (TyBinder * Type_)%type.
+
+Axiom splitPiTy : Type_ -> (TyBinder * Type_)%type.
+
+Axiom splitPiTys : Type_ -> (list TyBinder * Type_)%type.
+
+Axiom splitPiTysInvisible : Type_ -> (list TyBinder * Type_)%type.
+
+Axiom filterOutInvisibleTypes : TyCon -> list Type_ -> list Type_.
+
+Axiom partitionInvisibles : forall {a},
+                            TyCon -> (a -> Type_) -> list a -> (list a * list a)%type.
+
+Axiom isTauTy : Type_ -> bool.
+
+Axiom mkAnonBinder : Type_ -> TyBinder.
+
+Axiom isAnonTyBinder : TyBinder -> bool.
+
+Axiom isNamedTyBinder : TyBinder -> bool.
+
+Axiom tyBinderType : TyBinder -> Type_.
+
+Axiom binderRelevantType_maybe : TyBinder -> option Type_.
+
+Axiom caseBinder : forall {a},
+                   TyBinder -> (TyVarBinder -> a) -> (Type_ -> a) -> a.
+
+Axiom isPredTy : Type_ -> bool.
+
+Axiom isClassPred : PredType -> bool.
+
+Axiom isEqPred : PredType -> bool.
+
+Axiom isNomEqPred : PredType -> bool.
+
+Axiom isIPPred : PredType -> bool.
+
+Axiom isIPTyCon : TyCon -> bool.
+
+Axiom isIPClass : Class -> bool.
+
+Axiom isCTupleClass : Class -> bool.
+
+Axiom isIPPred_maybe : Type_ -> option (FastString.FastString * Type_)%type.
+
+Axiom mkPrimEqPredRole : Role -> Type_ -> Type_ -> PredType.
+
+Axiom mkPrimEqPred : Type_ -> Type_ -> Type_.
+
+Axiom mkHeteroPrimEqPred : Kind -> Kind -> Type_ -> Type_ -> Type_.
+
+Axiom mkHeteroReprPrimEqPred : Kind -> Kind -> Type_ -> Type_ -> Type_.
+
+Axiom splitCoercionType_maybe : Type_ -> option (Type_ * Type_)%type.
+
+Axiom mkReprPrimEqPred : Type_ -> Type_ -> Type_.
+
+Axiom equalityTyCon : Role -> TyCon.
+
+Axiom mkClassPred : Class -> list Type_ -> PredType.
+
+Axiom isDictTy : Type_ -> bool.
+
+Axiom isDictLikeTy : Type_ -> bool.
+
+Axiom eqRelRole : EqRel -> Role.
+
+Axiom classifyPredType : PredType -> PredTree.
+
+Axiom getClassPredTys : PredType -> (Class * list Type_)%type.
+
+Axiom getClassPredTys_maybe : PredType -> option (Class * list Type_)%type.
+
+Axiom getEqPredTys : PredType -> (Type_ * Type_)%type.
+
+Axiom getEqPredTys_maybe : PredType -> option (Role * Type_ * Type_)%type.
+
+Axiom getEqPredRole : PredType -> Role.
+
+Axiom predTypeEqRel : PredType -> EqRel.
+
+Axiom toposortTyVars : list TyCoVar -> list TyCoVar.
+
+Axiom dVarSetElemsWellScoped : DVarSet -> list Var.
+
+Axiom tyCoVarsOfTypeWellScoped : Type_ -> list TyVar.
+
+Axiom tyCoVarsOfTypesWellScoped : list Type_ -> list TyVar.
+
+Axiom mkFamilyTyConApp : TyCon -> list Type_ -> Type_.
+
+Axiom coAxNthLHS : forall {br}, CoAxiom br -> nat -> Type_.
+
+Axiom pprSourceTyCon : TyCon -> GHC.Base.String.
+
+Axiom isFamFreeTy : Type_ -> bool.
+
+Axiom isLiftedType_maybe : forall `{Util.HasDebugCallStack},
+                           Type_ -> option bool.
+
+Axiom isUnliftedType : forall `{Util.HasDebugCallStack}, Type_ -> bool.
+
+Axiom isRuntimeRepKindedTy : Type_ -> bool.
+
+Axiom dropRuntimeRepArgs : list Type_ -> list Type_.
+
+Axiom getRuntimeRep_maybe : forall `{Util.HasDebugCallStack},
+                            Type_ -> option Type_.
+
+Axiom getRuntimeRep : forall `{Util.HasDebugCallStack}, Type_ -> Type_.
+
+Axiom getRuntimeRepFromKind : forall `{Util.HasDebugCallStack}, Type_ -> Type_.
+
+Axiom getRuntimeRepFromKind_maybe : forall `{Util.HasDebugCallStack},
+                                    Type_ -> option Type_.
+
+Axiom isUnboxedTupleType : Type_ -> bool.
+
+Axiom isUnboxedSumType : Type_ -> bool.
+
+Axiom isAlgType : Type_ -> bool.
+
+Axiom isDataFamilyAppType : Type_ -> bool.
+
+Axiom isStrictType : forall `{Util.HasDebugCallStack}, Type_ -> bool.
+
+Axiom isPrimitiveType : Type_ -> bool.
+
+Axiom isValidJoinPointType : BasicTypes.JoinArity -> Type_ -> bool.
+
+Axiom seqType : Type_ -> unit.
+
+Axiom seqTypes : list Type_ -> unit.
+
+Axiom eqType : Type_ -> Type_ -> bool.
+
+Axiom eqTypeX : RnEnv2 -> Type_ -> Type_ -> bool.
+
+Axiom eqTypes : list Type_ -> list Type_ -> bool.
+
+Axiom eqVarBndrs : RnEnv2 -> list Var -> list Var -> option RnEnv2.
+
+Axiom nonDetCmpType : Type_ -> Type_ -> comparison.
+
+Axiom nonDetCmpTypes : list Type_ -> list Type_ -> comparison.
+
+Axiom nonDetCmpTypeX : RnEnv2 -> Type_ -> Type_ -> comparison.
+
+Axiom nonDetCmpTypesX : RnEnv2 -> list Type_ -> list Type_ -> comparison.
+
+Axiom nonDetCmpTc : TyCon -> TyCon -> comparison.
+
+Axiom typeKind : forall `{Util.HasDebugCallStack}, Type_ -> Kind.
+
+Axiom typeLiteralKind : TyLit -> Kind.
+
+Axiom isTypeLevPoly : Type_ -> bool.
+
+Axiom resultIsLevPoly : Type_ -> bool.
+
+Axiom tyConsOfType : Type_ -> UniqSet.UniqSet TyCon.
+
+Axiom synTyConResKind : TyCon -> Kind.
+
+Axiom splitVisVarsOfType : Type_ -> Pair.Pair TyCoVarSet.
+
+Axiom splitVisVarsOfTypes : list Type_ -> Pair.Pair TyCoVarSet.
+
+Axiom modifyJoinResTy : nat -> (Type_ -> Type_) -> Type_ -> Type_.
+
+Axiom setJoinResTy : nat -> Type_ -> Type_ -> Type_.
+
+(* Skipping definition `Core.coVarDetails' *)
+
+Definition isCoVarDetails : IdDetails -> bool :=
+  fun arg_0__ => false.
+
+Definition isJoinIdDetails_maybe : IdDetails -> option BasicTypes.JoinArity :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Mk_JoinId join_arity => Some join_arity
+    | _ => None
+    end.
+
+(* Skipping definition `Core.pprIdDetails' *)
+
+Definition setRuleInfo : IdInfo -> RuleInfo -> IdInfo :=
+  fun info sp =>
+    GHC.Prim.seq sp (let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__
+                        cafInfo_3__ oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__
+                        demandInfo_8__ callArityInfo_9__ levityInfo_10__ := info in
+                  Mk_IdInfo arityInfo_0__ sp unfoldingInfo_2__ cafInfo_3__ oneShotInfo_4__
+                            inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
+                            callArityInfo_9__ levityInfo_10__).
+
+Definition setInlinePragInfo : IdInfo -> BasicTypes.InlinePragma -> IdInfo :=
+  fun info pr =>
+    GHC.Prim.seq pr (let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__
+                        cafInfo_3__ oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__
+                        demandInfo_8__ callArityInfo_9__ levityInfo_10__ := info in
+                  Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
+                            oneShotInfo_4__ pr occInfo_6__ strictnessInfo_7__ demandInfo_8__
+                            callArityInfo_9__ levityInfo_10__).
+
+Definition setOccInfo : IdInfo -> BasicTypes.OccInfo -> IdInfo :=
+  fun info oc =>
+    GHC.Prim.seq oc (let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__
+                        cafInfo_3__ oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__
+                        demandInfo_8__ callArityInfo_9__ levityInfo_10__ := info in
+                  Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
+                            oneShotInfo_4__ inlinePragInfo_5__ oc strictnessInfo_7__ demandInfo_8__
+                            callArityInfo_9__ levityInfo_10__).
+
+Definition setUnfoldingInfo : IdInfo -> Unfolding -> IdInfo :=
+  fun info uf =>
+    let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
+       oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
+       callArityInfo_9__ levityInfo_10__ := info in
+    Mk_IdInfo arityInfo_0__ ruleInfo_1__ uf cafInfo_3__ oneShotInfo_4__
+              inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
+              callArityInfo_9__ levityInfo_10__.
+
+Definition setArityInfo : IdInfo -> ArityInfo -> IdInfo :=
+  fun info ar =>
+    let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
+       oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
+       callArityInfo_9__ levityInfo_10__ := info in
+    Mk_IdInfo ar ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__ oneShotInfo_4__
+              inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
+              callArityInfo_9__ levityInfo_10__.
+
+Definition setCallArityInfo : IdInfo -> ArityInfo -> IdInfo :=
+  fun info ar =>
+    let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
+       oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
+       callArityInfo_9__ levityInfo_10__ := info in
+    Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
+              oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
+              ar levityInfo_10__.
+
+Definition setCafInfo : IdInfo -> CafInfo -> IdInfo :=
+  fun info caf =>
+    let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
+       oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
+       callArityInfo_9__ levityInfo_10__ := info in
+    Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ caf oneShotInfo_4__
+              inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
+              callArityInfo_9__ levityInfo_10__.
+
+Definition setOneShotInfo : IdInfo -> BasicTypes.OneShotInfo -> IdInfo :=
+  fun info lb =>
+    let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
+       oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
+       callArityInfo_9__ levityInfo_10__ := info in
+    Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__ lb
+              inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
+              callArityInfo_9__ levityInfo_10__.
+
+Definition setDemandInfo : IdInfo -> Demand -> IdInfo :=
+  fun info dd =>
+    GHC.Prim.seq dd (let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__
+                        cafInfo_3__ oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__
+                        demandInfo_8__ callArityInfo_9__ levityInfo_10__ := info in
+                  Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
+                            oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ dd
+                            callArityInfo_9__ levityInfo_10__).
+
+Definition setStrictnessInfo : IdInfo -> StrictSig -> IdInfo :=
+  fun info dd =>
+    GHC.Prim.seq dd (let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__
+                        cafInfo_3__ oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__
+                        demandInfo_8__ callArityInfo_9__ levityInfo_10__ := info in
+                  Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
+                            oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ dd demandInfo_8__
+                            callArityInfo_9__ levityInfo_10__).
+
+Definition emptyRuleInfo :=
+  EmptyRuleInfo.
+
+Definition noUnfolding : Unfolding :=
+  NoUnfolding.
+
+Definition unknownArity : BasicTypes.Arity :=
+  #0.
+
+Definition vanillaCafInfo : CafInfo :=
+  MayHaveCafRefs.
+
+Definition vanillaIdInfo : IdInfo :=
+  Mk_IdInfo unknownArity emptyRuleInfo noUnfolding vanillaCafInfo
+            BasicTypes.NoOneShotInfo BasicTypes.defaultInlinePragma BasicTypes.noOccInfo
+            nopSig topDmd unknownArity NoLevityInfo.
+
+Definition noCafIdInfo : IdInfo :=
+  setCafInfo vanillaIdInfo NoCafRefs.
+
+(* Skipping definition `Core.ppArityInfo' *)
+
+(* Skipping definition `Core.pprStrictness' *)
+
+Definition isEmptyRuleInfo : RuleInfo -> bool :=
+  fun x => true.
+
+Definition emptyDVarSet : DVarSet :=
+  UniqSet.emptyUniqSet.
+
+Definition ruleInfoFreeVars : RuleInfo -> DVarSet :=
+  fun x => emptyDVarSet.
+
+Definition ruleInfoRules : RuleInfo -> list CoreRule :=
+  fun x => nil.
+
+Definition setRuleInfoHead : Name.Name -> RuleInfo -> RuleInfo :=
+  fun x y => EmptyRuleInfo.
+
+Definition mayHaveCafRefs : CafInfo -> bool :=
+  fun arg_0__ => match arg_0__ with | MayHaveCafRefs => true | _ => false end.
+
+(* Skipping definition `Core.ppCafInfo' *)
+
+Definition zapLamInfo : IdInfo -> option IdInfo :=
+  fun '((Mk_IdInfo _ _ _ _ _ _ occ _ demand _ _ as info)) =>
+    let is_safe_dmd := fun dmd => negb (isStrictDmd dmd) in
+    let safe_occ :=
+      match occ with
+      | BasicTypes.OneOcc _ _ _ _ =>
+          match occ with
+          | BasicTypes.ManyOccs _ =>
+              GHC.Err.error (GHC.Base.hs_string__ "Partial record update")
+          | BasicTypes.IAmDead =>
+              GHC.Err.error (GHC.Base.hs_string__ "Partial record update")
+          | BasicTypes.OneOcc occ_in_lam_2__ occ_one_br_3__ occ_int_cxt_4__
+          occ_tail_5__ =>
+              BasicTypes.OneOcc true occ_one_br_3__ occ_int_cxt_4__ BasicTypes.NoTailCallInfo
+          | BasicTypes.IAmALoopBreaker _ _ =>
+              GHC.Err.error (GHC.Base.hs_string__ "Partial record update")
+          end
+      | BasicTypes.IAmALoopBreaker _ _ =>
+          match occ with
+          | BasicTypes.ManyOccs occ_tail_12__ =>
+              BasicTypes.ManyOccs BasicTypes.NoTailCallInfo
+          | BasicTypes.IAmDead =>
+              GHC.Err.error (GHC.Base.hs_string__ "Partial record update")
+          | BasicTypes.OneOcc occ_in_lam_13__ occ_one_br_14__ occ_int_cxt_15__
+          occ_tail_16__ =>
+              BasicTypes.OneOcc occ_in_lam_13__ occ_one_br_14__ occ_int_cxt_15__
+                                BasicTypes.NoTailCallInfo
+          | BasicTypes.IAmALoopBreaker occ_rules_only_17__ occ_tail_18__ =>
+              BasicTypes.IAmALoopBreaker occ_rules_only_17__ BasicTypes.NoTailCallInfo
+          end
+      | _other => occ
+      end in
+    let is_safe_occ :=
+      fun arg_27__ =>
+        let 'occ := arg_27__ in
+        if BasicTypes.isAlwaysTailCalled occ : bool then false else
+        match arg_27__ with
+        | BasicTypes.OneOcc in_lam _ _ _ => in_lam
+        | _other => true
+        end in
+    if andb (is_safe_occ occ) (is_safe_dmd demand) : bool then None else
+    Some (let 'Mk_IdInfo arityInfo_31__ ruleInfo_32__ unfoldingInfo_33__
+             cafInfo_34__ oneShotInfo_35__ inlinePragInfo_36__ occInfo_37__
+             strictnessInfo_38__ demandInfo_39__ callArityInfo_40__ levityInfo_41__ :=
+            info in
+          Mk_IdInfo arityInfo_31__ ruleInfo_32__ unfoldingInfo_33__ cafInfo_34__
+                    oneShotInfo_35__ inlinePragInfo_36__ safe_occ strictnessInfo_38__ topDmd
+                    callArityInfo_40__ levityInfo_41__).
+
+Definition zapDemandInfo : IdInfo -> option IdInfo :=
+  fun info =>
+    Some (let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
+             oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
+             callArityInfo_9__ levityInfo_10__ := info in
+          Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
+                    oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ topDmd
+                    callArityInfo_9__ levityInfo_10__).
+
+Definition zapUsageInfo : IdInfo -> option IdInfo :=
+  fun info =>
+    Some (let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
+             oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
+             callArityInfo_9__ levityInfo_10__ := info in
+          Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
+                    oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__
+                    (zapUsageDemand (demandInfo info)) callArityInfo_9__ levityInfo_10__).
+
+Definition zapUsageEnvInfo : IdInfo -> option IdInfo :=
+  fun info =>
+    if hasDemandEnvSig (strictnessInfo info) : bool
+    then Some (let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__
+                  cafInfo_3__ oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__
+                  demandInfo_8__ callArityInfo_9__ levityInfo_10__ := info in
+               Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
+                         oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ (zapUsageEnvSig (strictnessInfo
+                                                                                         info)) demandInfo_8__
+                         callArityInfo_9__ levityInfo_10__) else
+    None.
+
+Definition zapUsedOnceInfo : IdInfo -> option IdInfo :=
+  fun info =>
+    Some (let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
+             oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
+             callArityInfo_9__ levityInfo_10__ := info in
+          Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
+                    oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ (zapUsedOnceSig (strictnessInfo
+                                                                                    info)) (zapUsedOnceDemand
+                     (demandInfo info)) callArityInfo_9__ levityInfo_10__).
+
+Definition isFragileUnfolding : Unfolding -> bool :=
+  fun arg_0__ => false.
+
+Definition zapFragileUnfolding : Unfolding -> Unfolding :=
+  fun unf => if isFragileUnfolding unf : bool then noUnfolding else unf.
+
+Definition zapFragileInfo : IdInfo -> option IdInfo :=
+  fun '((Mk_IdInfo _ _ unf _ _ _ occ _ _ _ _ as info)) =>
+    let new_unf := zapFragileUnfolding unf in
+    GHC.Prim.seq new_unf (Some (setOccInfo (setUnfoldingInfo (setRuleInfo info
+                                                                          emptyRuleInfo) new_unf)
+                                           (BasicTypes.zapFragileOcc occ))).
+
+Definition zapTailCallInfo : IdInfo -> option IdInfo :=
+  fun info =>
+    let 'occ := occInfo info in
+    let safe_occ :=
+      match occ with
+      | BasicTypes.ManyOccs occ_tail_1__ =>
+          BasicTypes.ManyOccs BasicTypes.NoTailCallInfo
+      | BasicTypes.IAmDead =>
+          GHC.Err.error (GHC.Base.hs_string__ "Partial record update")
+      | BasicTypes.OneOcc occ_in_lam_2__ occ_one_br_3__ occ_int_cxt_4__
+      occ_tail_5__ =>
+          BasicTypes.OneOcc occ_in_lam_2__ occ_one_br_3__ occ_int_cxt_4__
+                            BasicTypes.NoTailCallInfo
+      | BasicTypes.IAmALoopBreaker occ_rules_only_6__ occ_tail_7__ =>
+          BasicTypes.IAmALoopBreaker occ_rules_only_6__ BasicTypes.NoTailCallInfo
+      end in
+    if BasicTypes.isAlwaysTailCalled occ : bool
+    then Some (setOccInfo info safe_occ) else
+    None.
+
+Definition zapCallArityInfo : IdInfo -> IdInfo :=
+  fun info => setCallArityInfo info #0.
+
+Definition setNeverLevPoly `{Util.HasDebugCallStack}
+   : IdInfo -> Type_ -> IdInfo :=
+  fun info ty =>
+    if andb Util.debugIsOn (negb (negb (resultIsLevPoly ty))) : bool
+    then (GHC.Err.error Panic.someSDoc)
+    else let 'Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
+            oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
+            callArityInfo_9__ levityInfo_10__ := info in
+         Mk_IdInfo arityInfo_0__ ruleInfo_1__ unfoldingInfo_2__ cafInfo_3__
+                   oneShotInfo_4__ inlinePragInfo_5__ occInfo_6__ strictnessInfo_7__ demandInfo_8__
+                   callArityInfo_9__ NeverLevityPolymorphic.
+
+(* Skipping definition `Core.setLevityInfoWithType' *)
+
+Definition isNeverLevPolyIdInfo : IdInfo -> bool :=
+  fun info =>
+    match levityInfo info with
+    | NeverLevityPolymorphic => true
+    | _ => false
+    end.
+
+(* Skipping definition `Core.ppr_debug' *)
+
+(* Skipping definition `Core.ppr_id_scope' *)
+
+Definition setVarUnique : Var -> Unique.Unique -> Var :=
+  fun var uniq =>
+    let 'Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__ id_details_4__
+       id_info_5__ := var in
+    Mk_Id (Name.setNameUnique (varName var) uniq) (Unique.getKey uniq) varType_2__
+          idScope_3__ id_details_4__ id_info_5__.
+
+Definition setVarName : Var -> Name.Name -> Var :=
+  fun var new_name =>
+    let 'Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__ id_details_4__
+       id_info_5__ := var in
+    Mk_Id new_name (Unique.getKey (Unique.getUnique new_name)) varType_2__
+          idScope_3__ id_details_4__ id_info_5__.
+
+Definition setVarType : Id -> Type_ -> Id :=
+  fun id ty =>
+    let 'Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__ id_details_4__
+       id_info_5__ := id in
+    Mk_Id varName_0__ realUnique_1__ ty idScope_3__ id_details_4__ id_info_5__.
+
+Definition updateVarType : (Type_ -> Type_) -> Id -> Id :=
+  fun f id =>
+    let 'Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__ id_details_4__
+       id_info_5__ := id in
+    Mk_Id varName_0__ realUnique_1__ (f (varType id)) idScope_3__ id_details_4__
+          id_info_5__.
+
+Definition updateVarTypeM {m} `{GHC.Base.Monad m}
+   : (Type_ -> m Type_) -> Id -> m Id :=
+  fun f id =>
+    f (varType id) GHC.Base.>>=
+    (fun ty' =>
+       GHC.Base.return_ (let 'Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__
+                            id_details_4__ id_info_5__ := id in
+                         Mk_Id varName_0__ realUnique_1__ ty' idScope_3__ id_details_4__ id_info_5__)).
+
+Definition isVisibleArgFlag : ArgFlag -> bool :=
+  fun arg_0__ => match arg_0__ with | Required => true | _ => false end.
+
+Definition isInvisibleArgFlag : ArgFlag -> bool :=
+  negb GHC.Base.∘ isVisibleArgFlag.
+
+Definition sameVis : ArgFlag -> ArgFlag -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Required, Required => true
+    | Required, _ => false
+    | _, Required => false
+    | _, _ => true
+    end.
+
+Definition binderVar {tv} {argf} : TyVarBndr tv argf -> tv :=
+  fun '(TvBndr v _) => v.
+
+Definition binderVars {tv} {argf} : list (TyVarBndr tv argf) -> list tv :=
+  fun tvbs => GHC.Base.map binderVar tvbs.
+
+Definition binderArgFlag {tv} {argf} : TyVarBndr tv argf -> argf :=
+  fun '(TvBndr _ argf) => argf.
+
+Definition tyVarKind : TyVar -> Kind :=
+  varType.
+
+Definition binderKind {argf} : TyVarBndr TyVar argf -> Kind :=
+  fun '(TvBndr tv _) => tyVarKind tv.
+
+Definition mkTyVarBinder : ArgFlag -> Var -> TyVarBinder :=
+  fun vis var => TvBndr var vis.
+
+Definition mkTyVarBinders : ArgFlag -> list TyVar -> list TyVarBinder :=
+  fun vis => GHC.Base.map (mkTyVarBinder vis).
+
+Definition tyVarName : TyVar -> Name.Name :=
+  varName.
+
+Definition setTyVarUnique : TyVar -> Unique.Unique -> TyVar :=
+  setVarUnique.
+
+Definition setTyVarName : TyVar -> Name.Name -> TyVar :=
+  setVarName.
+
+Definition setTyVarKind : TyVar -> Kind -> TyVar :=
+  fun tv k =>
+    let 'Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__ id_details_4__
+       id_info_5__ := tv in
+    Mk_Id varName_0__ realUnique_1__ k idScope_3__ id_details_4__ id_info_5__.
+
+Definition updateTyVarKind : (Kind -> Kind) -> TyVar -> TyVar :=
+  fun update tv =>
+    let 'Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__ id_details_4__
+       id_info_5__ := tv in
+    Mk_Id varName_0__ realUnique_1__ (update (tyVarKind tv)) idScope_3__
+          id_details_4__ id_info_5__.
+
+Definition updateTyVarKindM {m} `{(GHC.Base.Monad m)}
+   : (Kind -> m Kind) -> TyVar -> m TyVar :=
+  fun update tv =>
+    update (tyVarKind tv) GHC.Base.>>=
+    (fun k' =>
+       GHC.Base.return_ (let 'Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__
+                            id_details_4__ id_info_5__ := tv in
+                         Mk_Id varName_0__ realUnique_1__ k' idScope_3__ id_details_4__ id_info_5__)).
+
+(* Skipping definition `Core.mkTyVar' *)
+
+(* Skipping definition `Core.mkTcTyVar' *)
+
+(* Skipping definition `Core.tcTyVarDetails' *)
+
+(* Skipping definition `Core.setTcTyVarDetails' *)
+
+Definition idInfo `{Util.HasDebugCallStack} : Id -> IdInfo :=
+  fun '(Mk_Id _ _ _ _ _ info) => info.
+
+Definition idDetails : Id -> IdDetails :=
+  fun '(Mk_Id _ _ _ _ details _) => details.
+
+Definition mk_id : Name.Name -> Type_ -> IdScope -> IdDetails -> IdInfo -> Id :=
+  fun name ty scope details info =>
+    Mk_Id name (Unique.getKey (Name.nameUnique name)) ty scope details info.
+
+Definition mkGlobalVar : IdDetails -> Name.Name -> Type_ -> IdInfo -> Id :=
+  fun details name ty info => mk_id name ty GlobalId details info.
+
+Definition mkLocalVar : IdDetails -> Name.Name -> Type_ -> IdInfo -> Id :=
+  fun details name ty info => mk_id name ty (LocalId NotExported) details info.
+
+(* Skipping definition `Core.mkCoVar' *)
+
+Definition mkExportedLocalVar
+   : IdDetails -> Name.Name -> Type_ -> IdInfo -> Id :=
+  fun details name ty info => mk_id name ty (LocalId Exported) details info.
+
+Definition lazySetIdInfo : Id -> IdInfo -> Var :=
+  fun id info =>
+    let 'Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__ id_details_4__
+       id_info_5__ := id in
+    Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__ id_details_4__ info.
+
+Definition setIdDetails : Id -> IdDetails -> Id :=
+  fun id details =>
+    let 'Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__ id_details_4__
+       id_info_5__ := id in
+    Mk_Id varName_0__ realUnique_1__ varType_2__ idScope_3__ details id_info_5__.
+
+(* Skipping definition `Core.globaliseId' *)
+
+(* Skipping definition `Core.setIdExported' *)
+
+(* Skipping definition `Core.setIdNotExported' *)
+
+Definition isTyVar : Var -> bool :=
+  fun arg_0__ => false.
+
+Definition isTcTyVar : Var -> bool :=
+  fun arg_0__ => false.
+
+Definition isCoVar : Var -> bool :=
+  fun '(Mk_Id _ _ _ _ details _) => isCoVarDetails details.
+
+Definition isTyCoVar : Var -> bool :=
+  fun v => orb (isTyVar v) (isCoVar v).
+
+Definition isId : Var -> bool :=
+  fun '(Mk_Id _ _ _ _ _ _) => true.
+
+Definition isNonCoVarId : Var -> bool :=
+  fun '(Mk_Id _ _ _ _ details _) => negb (isCoVarDetails details).
+
+Definition isLocalId : Var -> bool :=
+  fun v => Unique.isLocalUnique (varUnique v).
+
+Definition isGlobalId : Var -> bool :=
+  fun v => negb (Unique.isLocalUnique (varUnique v)).
+
+Definition isLocalVar : Var -> bool :=
+  fun v => negb (isGlobalId v).
+
+Definition mustHaveLocalBinding : Var -> bool :=
+  fun var => isLocalVar var.
+
+Axiom isExportedId : Var -> bool.
+
+Definition emptyVarSet : VarSet :=
+  UniqSet.emptyUniqSet.
+
+Definition emptyInScopeSet : InScopeSet :=
+  InScope emptyVarSet #1.
+
+Definition getInScopeVars : InScopeSet -> VarSet :=
+  fun '(InScope vs _) => vs.
+
+Definition mkInScopeSet : VarSet -> InScopeSet :=
+  fun in_scope => InScope in_scope #1.
+
+Definition extendDVarEnv {a} : DVarEnv a -> Var -> a -> DVarEnv a :=
+  UniqFM.addToUFM.
+
+Definition extendVarEnv {a} : VarEnv a -> Var -> a -> VarEnv a :=
+  UniqFM.addToUFM.
+
+Definition extendDVarEnvList {a}
+   : DVarEnv a -> list (Var * a)%type -> DVarEnv a :=
+  UniqFM.addListToUFM.
+
+Definition extendVarEnvList {a} : VarEnv a -> list (Var * a)%type -> VarEnv a :=
+  UniqFM.addListToUFM.
+
+Definition extendDVarEnv_C {a}
+   : (a -> a -> a) -> DVarEnv a -> Var -> a -> DVarEnv a :=
+  UniqFM.addToUFM_C.
+
+Definition extendVarEnv_Acc {a} {b}
+   : (a -> b -> b) -> (a -> b) -> VarEnv b -> Var -> a -> VarEnv b :=
+  UniqFM.addToUFM_Acc.
+
+Definition extendVarEnv_C {a}
+   : (a -> a -> a) -> VarEnv a -> Var -> a -> VarEnv a :=
+  UniqFM.addToUFM_C.
+
+Definition extendVarEnv_Directly {a}
+   : VarEnv a -> Unique.Unique -> a -> VarEnv a :=
+  UniqFM.addToUFM_Directly.
+
+Definition extendVarSet : VarSet -> Var -> VarSet :=
+  UniqSet.addOneToUniqSet.
+
+Definition extendInScopeSet : InScopeSet -> Var -> InScopeSet :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | InScope in_scope n, v => InScope (extendVarSet in_scope v) (n GHC.Num.+ #1)
+    end.
+
+Definition extendInScopeSetList : InScopeSet -> list Var -> InScopeSet :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | InScope in_scope n, vs =>
+        InScope (Data.Foldable.foldl (fun s v => extendVarSet s v) in_scope vs) (n
+                                                                                 GHC.Num.+
+                                                                                 Coq.Lists.List.length vs)
+    end.
+
+Definition unionVarSet : VarSet -> VarSet -> VarSet :=
+  UniqSet.unionUniqSets.
+
+Definition extendInScopeSetSet : InScopeSet -> VarSet -> InScopeSet :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | InScope in_scope n, vs =>
+        InScope (unionVarSet in_scope vs) (n GHC.Num.+ UniqSet.sizeUniqSet vs)
+    end.
+
+Definition alterDVarEnv {a}
+   : (option a -> option a) -> DVarEnv a -> Var -> DVarEnv a :=
+  UniqFM.alterUFM.
+
+Definition alterVarEnv {a}
+   : (option a -> option a) -> VarEnv a -> Var -> VarEnv a :=
+  UniqFM.alterUFM.
+
+Definition delDVarEnv {a} : DVarEnv a -> Var -> DVarEnv a :=
+  UniqFM.delFromUFM.
+
+Definition delVarEnv {a} : VarEnv a -> Var -> VarEnv a :=
+  UniqFM.delFromUFM.
+
+Definition delDVarEnvList {a} : DVarEnv a -> list Var -> DVarEnv a :=
+  UniqFM.delListFromUFM.
+
+Definition delVarEnvList {a} : VarEnv a -> list Var -> VarEnv a :=
+  UniqFM.delListFromUFM.
+
+Definition delDVarSet : DVarSet -> Var -> DVarSet :=
+  UniqSet.delOneFromUniqSet.
+
+Definition delVarSet : VarSet -> Var -> VarSet :=
+  UniqSet.delOneFromUniqSet.
+
+Definition delInScopeSet : InScopeSet -> Var -> InScopeSet :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | InScope in_scope n, v => InScope (delVarSet in_scope v) n
+    end.
+
+Definition delDVarSetList : DVarSet -> list Var -> DVarSet :=
+  UniqSet.delListFromUniqSet.
+
+Definition delVarSetList : VarSet -> list Var -> VarSet :=
+  UniqSet.delListFromUniqSet.
+
+Definition delVarEnv_Directly {a} : VarEnv a -> Unique.Unique -> VarEnv a :=
+  UniqFM.delFromUFM_Directly.
+
+Definition delVarSetByKey : VarSet -> Unique.Unique -> VarSet :=
+  UniqSet.delOneFromUniqSet_Directly.
+
+Definition elemDVarEnv {a} : Var -> DVarEnv a -> bool :=
+  UniqFM.elemUFM.
+
+Definition elemVarEnv {a} : Var -> VarEnv a -> bool :=
+  UniqFM.elemUFM.
+
+Definition elemDVarSet : Var -> DVarSet -> bool :=
+  UniqSet.elementOfUniqSet.
+
+Definition elemVarSet : Var -> VarSet -> bool :=
+  UniqSet.elementOfUniqSet.
+
+Definition elemInScopeSet : Var -> InScopeSet -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | v, InScope in_scope _ => elemVarSet v in_scope
+    end.
+
+Definition lookupDVarEnv {a} : DVarEnv a -> Var -> option a :=
+  UniqFM.lookupUFM.
+
+Definition lookupVarEnv {a} : VarEnv a -> Var -> option a :=
+  UniqFM.lookupUFM.
+
+Definition lookupVarEnv_Directly {a} : VarEnv a -> Unique.Unique -> option a :=
+  UniqFM.lookupUFM_Directly.
+
+Definition lookupVarEnv_NF {a} `{_ : GHC.Err.Default a} (env : VarEnv a) id
+   : a :=
+  match lookupVarEnv env id with
+  | Some xx => xx
+  | None => GHC.Err.default
+  end.
+
+Definition lookupVarSet : VarSet -> Var -> option Var :=
+  UniqSet.lookupUniqSet.
+
+Definition lookupInScope : InScopeSet -> Var -> option Var :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | InScope in_scope _, v => lookupVarSet in_scope v
+    end.
+
+Definition lookupVarSetByName : VarSet -> Name.Name -> option Var :=
+  UniqSet.lookupUniqSet.
+
+Definition lookupVarSet_Directly : VarSet -> Unique.Unique -> option Var :=
+  UniqSet.lookupUniqSet_Directly.
+
+Definition lookupInScope_Directly : InScopeSet -> Unique.Unique -> option Var :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | InScope in_scope _, uniq => lookupVarSet_Directly in_scope uniq
+    end.
+
+Definition unionInScope : InScopeSet -> InScopeSet -> InScopeSet :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | InScope s1 _, InScope s2 n2 => InScope (unionVarSet s1 s2) n2
+    end.
+
+Definition isEmptyVarSet : VarSet -> bool :=
+  UniqSet.isEmptyUniqSet.
+
+Definition minusVarSet : VarSet -> VarSet -> VarSet :=
+  UniqSet.minusUniqSet.
+
+Definition subVarSet : VarSet -> VarSet -> bool :=
+  fun s1 s2 => isEmptyVarSet (minusVarSet s1 s2).
+
+Definition varSetInScope : VarSet -> InScopeSet -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | vars, InScope s1 _ => subVarSet vars s1
+    end.
+
+Axiom uniqAway : InScopeSet -> Var -> Var.
+
+Definition elemVarSetByKey : Unique.Unique -> VarSet -> bool :=
+  UniqSet.elemUniqSet_Directly.
+
+Definition mkDVarEnv {a} : list (Var * a)%type -> DVarEnv a :=
+  UniqFM.listToUFM.
+
+Definition mkVarEnv {a} : list (Var * a)%type -> VarEnv a :=
+  UniqFM.listToUFM.
+
+Definition mkDVarSet : list Var -> DVarSet :=
+  UniqSet.mkUniqSet.
+
+Definition mkVarSet : list Var -> VarSet :=
+  UniqSet.mkUniqSet.
+
+Definition uniqAway' : InScopeSet -> Var -> Var :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | InScope set n, var =>
+        let orig_unique := Unique.getUnique var in
+        let try :=
+          GHC.DeferredFix.deferredFix1 (fun try k =>
+                                          let uniq := Unique.deriveUnique orig_unique (BinNat.N.of_nat n GHC.Num.* k) in
+                                          let msg :=
+                                            GHC.Base.mappend (GHC.Base.mappend (GHC.Base.mappend Panic.someSDoc
+                                                                                                 (Datatypes.id
+                                                                                                  (GHC.Base.hs_string__
+                                                                                                   "tries")))
+                                                                               Panic.someSDoc) Panic.someSDoc in
+                                          if andb Util.debugIsOn (k GHC.Base.> #1000) : bool
+                                          then Panic.panicStr (GHC.Base.hs_string__ "uniqAway loop:") msg else
+                                          if elemVarSetByKey uniq set : bool then try (k GHC.Num.+ #1) else
+                                          if k GHC.Base.> #3 : bool then setVarUnique var uniq else
+                                          setVarUnique var uniq) in
+        try #1
+    end.
+
+Definition emptyVarEnv {a} : VarEnv a :=
+  UniqFM.emptyUFM.
+
+Definition mkRnEnv2 : InScopeSet -> RnEnv2 :=
+  fun vars => RV2 emptyVarEnv emptyVarEnv vars.
+
+Definition addRnInScopeSet : RnEnv2 -> VarSet -> RnEnv2 :=
+  fun env vs =>
+    if isEmptyVarSet vs : bool then env else
+    let 'RV2 envL_0__ envR_1__ in_scope_2__ := env in
+    RV2 envL_0__ envR_1__ (extendInScopeSetSet (in_scope env) vs).
+
+Definition rnInScope : Var -> RnEnv2 -> bool :=
+  fun x env => elemInScopeSet x (in_scope env).
+
+Definition rnInScopeSet : RnEnv2 -> InScopeSet :=
+  in_scope.
+
+Definition rnEnvL : RnEnv2 -> VarEnv Var :=
+  envL.
+
+Definition rnEnvR : RnEnv2 -> VarEnv Var :=
+  envR.
+
+Definition rnBndr2_var : RnEnv2 -> Var -> Var -> (RnEnv2 * Var)%type :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | RV2 envL envR in_scope, bL, bR =>
+        let new_b :=
+          if negb (elemInScopeSet bL in_scope) : bool then bL else
+          if negb (elemInScopeSet bR in_scope) : bool then bR else
+          uniqAway' in_scope bL in
+        pair (RV2 (extendVarEnv envL bL new_b) (extendVarEnv envR bR new_b)
+                  (extendInScopeSet in_scope new_b)) new_b
+    end.
+
+Definition rnBndr2 : RnEnv2 -> Var -> Var -> RnEnv2 :=
+  fun env bL bR => Data.Tuple.fst (rnBndr2_var env bL bR).
+
+Definition rnBndrs2 : RnEnv2 -> list Var -> list Var -> RnEnv2 :=
+  fun env bsL bsR => Util.foldl2 rnBndr2 env bsL bsR.
+
+Definition rnBndrL : RnEnv2 -> Var -> (RnEnv2 * Var)%type :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | RV2 envL envR in_scope, bL =>
+        let new_b := uniqAway in_scope bL in
+        pair (RV2 (extendVarEnv envL bL new_b) envR (extendInScopeSet in_scope new_b))
+             new_b
+    end.
+
+Definition rnBndrR : RnEnv2 -> Var -> (RnEnv2 * Var)%type :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | RV2 envL envR in_scope, bR =>
+        let new_b := uniqAway in_scope bR in
+        pair (RV2 envL (extendVarEnv envR bR new_b) (extendInScopeSet in_scope new_b))
+             new_b
+    end.
+
+Definition rnEtaL : RnEnv2 -> Var -> (RnEnv2 * Var)%type :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | RV2 envL envR in_scope, bL =>
+        let new_b := uniqAway in_scope bL in
+        pair (RV2 (extendVarEnv envL bL new_b) (extendVarEnv envR new_b new_b)
+                  (extendInScopeSet in_scope new_b)) new_b
+    end.
+
+Definition rnEtaR : RnEnv2 -> Var -> (RnEnv2 * Var)%type :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | RV2 envL envR in_scope, bR =>
+        let new_b := uniqAway in_scope bR in
+        pair (RV2 (extendVarEnv envL new_b new_b) (extendVarEnv envR bR new_b)
+                  (extendInScopeSet in_scope new_b)) new_b
+    end.
+
+Definition delBndrL : RnEnv2 -> Var -> RnEnv2 :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | (RV2 env _ in_scope as rn), v =>
+        let 'RV2 envL_2__ envR_3__ in_scope_4__ := rn in
+        RV2 (delVarEnv env v) envR_3__ (extendInScopeSet in_scope v)
+    end.
+
+Definition delBndrR : RnEnv2 -> Var -> RnEnv2 :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | (RV2 _ env in_scope as rn), v =>
+        let 'RV2 envL_2__ envR_3__ in_scope_4__ := rn in
+        RV2 envL_2__ (delVarEnv env v) (extendInScopeSet in_scope v)
+    end.
+
+Definition delBndrsL : RnEnv2 -> list Var -> RnEnv2 :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | (RV2 env _ in_scope as rn), v =>
+        let 'RV2 envL_2__ envR_3__ in_scope_4__ := rn in
+        RV2 (delVarEnvList env v) envR_3__ (extendInScopeSetList in_scope v)
+    end.
+
+Definition delBndrsR : RnEnv2 -> list Var -> RnEnv2 :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | (RV2 _ env in_scope as rn), v =>
+        let 'RV2 envL_2__ envR_3__ in_scope_4__ := rn in
+        RV2 envL_2__ (delVarEnvList env v) (extendInScopeSetList in_scope v)
+    end.
+
+Definition rnOccL : RnEnv2 -> Var -> Var :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | RV2 env _ _, v => Maybes.orElse (lookupVarEnv env v) v
+    end.
+
+Definition rnOccR : RnEnv2 -> Var -> Var :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | RV2 _ env _, v => Maybes.orElse (lookupVarEnv env v) v
+    end.
+
+Definition rnOccL_maybe : RnEnv2 -> Var -> option Var :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | RV2 env _ _, v => lookupVarEnv env v
+    end.
+
+Definition rnOccR_maybe : RnEnv2 -> Var -> option Var :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | RV2 _ env _, v => lookupVarEnv env v
+    end.
+
+Definition inRnEnvL : RnEnv2 -> Var -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | RV2 env _ _, v => elemVarEnv v env
+    end.
+
+Definition inRnEnvR : RnEnv2 -> Var -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | RV2 _ env _, v => elemVarEnv v env
+    end.
+
+Definition lookupRnInScope : RnEnv2 -> Var -> Var :=
+  fun env v => Maybes.orElse (lookupInScope (in_scope env) v) v.
+
+Definition nukeRnEnvL : RnEnv2 -> RnEnv2 :=
+  fun '(RV2 envL_0__ envR_1__ in_scope_2__) =>
+    RV2 emptyVarEnv envR_1__ in_scope_2__.
+
+Definition nukeRnEnvR : RnEnv2 -> RnEnv2 :=
+  fun '(RV2 envL_0__ envR_1__ in_scope_2__) =>
+    RV2 envL_0__ emptyVarEnv in_scope_2__.
+
+Definition rnSwap : RnEnv2 -> RnEnv2 :=
+  fun '(RV2 envL envR in_scope) => RV2 envR envL in_scope.
+
+Definition emptyTidyEnv : TidyEnv :=
+  pair OccName.emptyTidyOccEnv emptyVarEnv.
+
+Definition elemVarEnvByKey {a} : Unique.Unique -> VarEnv a -> bool :=
+  UniqFM.elemUFM_Directly.
+
+Definition disjointVarEnv {a} : VarEnv a -> VarEnv a -> bool :=
+  UniqFM.disjointUFM.
+
+Definition plusVarEnv_C {a}
+   : (a -> a -> a) -> VarEnv a -> VarEnv a -> VarEnv a :=
+  UniqFM.plusUFM_C.
+
+Definition plusVarEnv_CD {a}
+   : (a -> a -> a) -> VarEnv a -> a -> VarEnv a -> a -> VarEnv a :=
+  UniqFM.plusUFM_CD.
+
+Definition plusMaybeVarEnv_C {a}
+   : (a -> a -> option a) -> VarEnv a -> VarEnv a -> VarEnv a :=
+  UniqFM.plusMaybeUFM_C.
+
+Definition minusVarEnv {a} {b} : VarEnv a -> VarEnv b -> VarEnv a :=
+  UniqFM.minusUFM.
+
+Definition isEmptyVarEnv {a} : VarEnv a -> bool :=
+  UniqFM.isNullUFM.
+
+Definition intersectsVarEnv {a} : VarEnv a -> VarEnv a -> bool :=
+  fun e1 e2 => negb (isEmptyVarEnv (UniqFM.intersectUFM e1 e2)).
+
+Definition plusVarEnv {a} : VarEnv a -> VarEnv a -> VarEnv a :=
+  UniqFM.plusUFM.
+
+Definition plusVarEnvList {a} : list (VarEnv a) -> VarEnv a :=
+  UniqFM.plusUFMList.
+
+Definition filterVarEnv {a} : (a -> bool) -> VarEnv a -> VarEnv a :=
+  UniqFM.filterUFM.
+
+Definition lookupWithDefaultVarEnv {a} : VarEnv a -> a -> Var -> a :=
+  UniqFM.lookupWithDefaultUFM.
+
+Definition mapVarEnv {a} {b} : (a -> b) -> VarEnv a -> VarEnv b :=
+  UniqFM.mapUFM.
+
+Definition mkVarEnv_Directly {a} : list (Unique.Unique * a)%type -> VarEnv a :=
+  UniqFM.listToUFM_Directly.
+
+Definition unitDVarEnv {a} : Var -> a -> DVarEnv a :=
+  UniqFM.unitUFM.
+
+Definition unitVarEnv {a} : Var -> a -> VarEnv a :=
+  UniqFM.unitUFM.
+
+Definition filterVarEnv_Directly {a}
+   : (Unique.Unique -> a -> bool) -> VarEnv a -> VarEnv a :=
+  UniqFM.filterUFM_Directly.
+
+Definition partitionVarEnv {a}
+   : (a -> bool) -> VarEnv a -> (VarEnv a * VarEnv a)%type :=
+  UniqFM.partitionUFM.
+
+Definition restrictVarEnv {a} : VarEnv a -> VarSet -> VarEnv a :=
+  fun env vs =>
+    let keep :=
+      fun arg_0__ arg_1__ =>
+        match arg_0__, arg_1__ with
+        | u, _ => elemVarSetByKey u vs
+        end in
+    filterVarEnv_Directly keep env.
+
+Definition zipVarEnv {a} : list Var -> list a -> VarEnv a :=
+  fun tyvars tys =>
+    mkVarEnv (Util.zipEqual (GHC.Base.hs_string__ "zipVarEnv") tyvars tys).
+
+Definition modifyVarEnv {a} : (a -> a) -> VarEnv a -> Var -> VarEnv a :=
+  fun mangle_fn env key =>
+    match (lookupVarEnv env key) with
+    | None => env
+    | Some xx => extendVarEnv env key (mangle_fn xx)
+    end.
+
+Definition modifyVarEnv_Directly {a}
+   : (a -> a) -> UniqFM.UniqFM a -> Unique.Unique -> UniqFM.UniqFM a :=
+  fun mangle_fn env key =>
+    match (UniqFM.lookupUFM_Directly env key) with
+    | None => env
+    | Some xx => UniqFM.addToUFM_Directly env key (mangle_fn xx)
+    end.
+
+Definition emptyDVarEnv {a} : DVarEnv a :=
+  UniqFM.emptyUFM.
+
+Definition dVarEnvElts {a} : DVarEnv a -> list a :=
+  UniqFM.eltsUFM.
+
+Definition minusDVarEnv {a} {a'} : DVarEnv a -> DVarEnv a' -> DVarEnv a :=
+  UniqFM.minusUFM.
+
+Definition foldDVarEnv {a} {b} : (a -> b -> b) -> b -> DVarEnv a -> b :=
+  UniqFM.nonDetFoldUFM.
+
+Definition mapDVarEnv {a} {b} : (a -> b) -> DVarEnv a -> DVarEnv b :=
+  UniqFM.mapUFM.
+
+Definition filterDVarEnv {a} : (a -> bool) -> DVarEnv a -> DVarEnv a :=
+  UniqFM.filterUFM.
+
+Definition plusDVarEnv {a} : DVarEnv a -> DVarEnv a -> DVarEnv a :=
+  UniqFM.plusUFM.
+
+Definition plusDVarEnv_C {a}
+   : (a -> a -> a) -> DVarEnv a -> DVarEnv a -> DVarEnv a :=
+  UniqFM.plusUFM_C.
+
+Definition isEmptyDVarEnv {a} : DVarEnv a -> bool :=
+  UniqFM.isNullUFM.
+
+Definition modifyDVarEnv {a} : (a -> a) -> DVarEnv a -> Var -> DVarEnv a :=
+  fun mangle_fn env key =>
+    match (lookupDVarEnv env key) with
+    | None => env
+    | Some xx => extendDVarEnv env key (mangle_fn xx)
+    end.
+
+Definition partitionDVarEnv {a}
+   : (a -> bool) -> DVarEnv a -> (DVarEnv a * DVarEnv a)%type :=
+  UniqFM.partitionUFM.
+
+Definition anyDVarEnv {a} : (a -> bool) -> DVarEnv a -> bool :=
+  UniqFM.anyUFM.
+
+Definition unitDVarSet : Var -> DVarSet :=
+  UniqSet.unitUniqSet.
+
+Definition unitVarSet : Var -> VarSet :=
+  UniqSet.unitUniqSet.
+
+Definition extendDVarSet : DVarSet -> Var -> DVarSet :=
+  UniqSet.addOneToUniqSet.
+
+Definition extendDVarSetList : DVarSet -> list Var -> DVarSet :=
+  UniqSet.addListToUniqSet.
+
+Definition extendVarSetList : VarSet -> list Var -> VarSet :=
+  UniqSet.addListToUniqSet.
+
+Definition intersectVarSet : VarSet -> VarSet -> VarSet :=
+  UniqSet.intersectUniqSets.
+
+Definition unionVarSets : list VarSet -> VarSet :=
+  UniqSet.unionManyUniqSets.
+
+Definition sizeVarSet : VarSet -> nat :=
+  UniqSet.sizeUniqSet.
+
+Definition filterVarSet : (Var -> bool) -> VarSet -> VarSet :=
+  UniqSet.filterUniqSet.
+
+(* Skipping definition `Core.partitionVarSet' *)
+
+Definition mapUnionVarSet {a} : (a -> VarSet) -> list a -> VarSet :=
+  fun get_set xs =>
+    Data.Foldable.foldr (unionVarSet GHC.Base.∘ get_set) emptyVarSet xs.
+
+Definition disjointVarSet : VarSet -> VarSet -> bool :=
+  fun s1 s2 => UniqFM.disjointUFM (UniqSet.getUniqSet s1) (UniqSet.getUniqSet s2).
+
+Definition intersectsVarSet : VarSet -> VarSet -> bool :=
+  fun s1 s2 => negb (disjointVarSet s1 s2).
+
+Definition anyVarSet : (Var -> bool) -> VarSet -> bool :=
+  UniqSet.uniqSetAny.
+
+Definition allVarSet : (Var -> bool) -> VarSet -> bool :=
+  UniqSet.uniqSetAll.
+
+(* Skipping definition `Core.mapVarSet' *)
+
+Definition fixVarSet : (VarSet -> VarSet) -> VarSet -> VarSet :=
+  GHC.DeferredFix.deferredFix2 (fun fixVarSet
+                                (fn : (VarSet -> VarSet))
+                                (vars : VarSet) =>
+                                  let new_vars := fn vars in
+                                  if subVarSet new_vars vars : bool then vars else
+                                  fixVarSet fn new_vars).
+
+Definition transCloVarSet : (VarSet -> VarSet) -> VarSet -> VarSet :=
+  fun fn seeds =>
+    let go : VarSet -> VarSet -> VarSet :=
+      GHC.DeferredFix.deferredFix1 (fun go (acc candidates : VarSet) =>
+                                      let new_vs := minusVarSet (fn candidates) acc in
+                                      if isEmptyVarSet new_vs : bool then acc else
+                                      go (unionVarSet acc new_vs) new_vs) in
+    go seeds seeds.
+
+Definition seqVarSet : VarSet -> unit :=
+  fun s => GHC.Prim.seq (sizeVarSet s) tt.
+
+(* Skipping definition `Core.pluralVarSet' *)
+
+(* Skipping definition `Core.pprVarSet' *)
+
+Definition dVarSetElems : DVarSet -> list Var :=
+  UniqSet.nonDetEltsUniqSet.
+
+Definition isEmptyDVarSet : DVarSet -> bool :=
+  UniqSet.isEmptyUniqSet.
+
+Definition minusDVarSet : DVarSet -> DVarSet -> DVarSet :=
+  UniqSet.minusUniqSet.
+
+Definition subDVarSet : DVarSet -> DVarSet -> bool :=
+  fun s1 s2 => isEmptyDVarSet (minusDVarSet s1 s2).
+
+Definition unionDVarSet : DVarSet -> DVarSet -> DVarSet :=
+  UniqSet.unionUniqSets.
+
+Definition unionDVarSets : list DVarSet -> DVarSet :=
+  UniqSet.unionManyUniqSets.
+
+Definition mapUnionDVarSet {a} : (a -> DVarSet) -> list a -> DVarSet :=
+  fun get_set xs =>
+    Data.Foldable.foldr (unionDVarSet GHC.Base.∘ get_set) emptyDVarSet xs.
+
+Definition intersectDVarSet : DVarSet -> DVarSet -> DVarSet :=
+  UniqSet.intersectUniqSets.
+
+Definition dVarSetIntersectVarSet : DVarSet -> VarSet -> DVarSet :=
+  UniqSet.intersectUniqSets.
+
+Definition disjointDVarSet :=
+  disjointVarSet.
+
+Definition intersectsDVarSet : DVarSet -> DVarSet -> bool :=
+  fun s1 s2 => negb (disjointDVarSet s1 s2).
+
+Definition dVarSetMinusVarSet : DVarSet -> VarSet -> DVarSet :=
+  UniqSet.minusUniqSet.
+
+Definition foldDVarSet {a} : (Var -> a -> a) -> a -> DVarSet -> a :=
+  UniqSet.nonDetFoldUniqSet.
+
+Definition anyDVarSet :=
+  anyVarSet.
+
+Definition allDVarSet :=
+  allVarSet.
+
+Definition filterDVarSet : (Var -> bool) -> DVarSet -> DVarSet :=
+  UniqSet.filterUniqSet.
+
+Definition sizeDVarSet : DVarSet -> nat :=
+  UniqSet.sizeUniqSet.
+
+Definition partitionDVarSet
+   : (Var -> bool) -> DVarSet -> (DVarSet * DVarSet)%type :=
+  UniqSet.partitionUniqSet.
+
+Definition seqDVarSet : DVarSet -> unit :=
+  fun s => GHC.Prim.seq (sizeDVarSet s) tt.
+
+Definition dVarSetToVarSet : DVarSet -> VarSet :=
+  fun x => x.
+
+Definition transCloDVarSet : (DVarSet -> DVarSet) -> DVarSet -> DVarSet :=
+  fun fn seeds =>
+    let go : DVarSet -> DVarSet -> DVarSet :=
+      GHC.DeferredFix.deferredFix1 (fun go (acc candidates : DVarSet) =>
+                                      let new_vs := minusDVarSet (fn candidates) acc in
+                                      if isEmptyDVarSet new_vs : bool then acc else
+                                      go (unionDVarSet acc new_vs) new_vs) in
+    go seeds seeds.
+
+Axiom tickishCounts : forall {id}, Tickish id -> bool.
+
+Definition tickishScoped {id} : Tickish id -> TickishScoping :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | (ProfNote _ _ _ as n) =>
+        if profNoteScope n : bool then CostCentreScope else
+        NoScope
+    | HpcTick _ _ => NoScope
+    | Breakpoint _ _ => CostCentreScope
+    | SourceNote _ _ => SoftScope
+    end.
+
+Definition tickishScopesLike {id} : Tickish id -> TickishScoping -> bool :=
+  fun t scope =>
+    let like :=
+      fun arg_0__ arg_1__ =>
+        match arg_0__, arg_1__ with
+        | NoScope, _ => true
+        | _, NoScope => false
+        | SoftScope, _ => true
+        | _, SoftScope => false
+        | CostCentreScope, _ => true
+        end in
+    like (tickishScoped t) scope.
+
+Definition tickishFloatable {id} : Tickish id -> bool :=
+  fun t => andb (tickishScopesLike t SoftScope) (negb (tickishCounts t)).
+
+(* Skipping definition `Core.tickishCanSplit' *)
+
+(* Skipping definition `Core.mkNoCount' *)
+
+(* Skipping definition `Core.mkNoScope' *)
+
+Axiom tickishIsCode : forall {id}, Tickish id -> bool.
+
+Definition tickishPlace {id} : Tickish id -> TickishPlacement :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | (ProfNote _ _ _ as n) =>
+        if profNoteCount n : bool then PlaceRuntime else
+        PlaceCostCentre
+    | HpcTick _ _ => PlaceRuntime
+    | Breakpoint _ _ => PlaceRuntime
+    | SourceNote _ _ => PlaceNonLam
+    end.
+
+(* Skipping definition `Core.tickishContains' *)
+
+Definition isOrphan : IsOrphan -> bool :=
+  fun arg_0__ => match arg_0__ with | Mk_IsOrphan => true | _ => false end.
+
+Definition notOrphan : IsOrphan -> bool :=
+  fun arg_0__ => match arg_0__ with | NotOrphan _ => true | _ => false end.
+
+Definition chooseOrphanAnchor (local_names : list Name.Name) : IsOrphan :=
+  match GHC.Base.map Name.nameOccName local_names with
+  | cons hd tl => NotOrphan (Data.Foldable.foldr GHC.Base.min hd tl)
+  | nil => Mk_IsOrphan
+  end.
+
+Definition mkRuleEnv : RuleBase -> list Module.Module -> RuleEnv :=
+  fun rules vis_orphs => Mk_RuleEnv rules (Module.mkModuleSet vis_orphs).
+
+Definition emptyRuleEnv : RuleEnv :=
+  Mk_RuleEnv NameEnv.emptyNameEnv Module.emptyModuleSet.
+
+Definition isBuiltinRule : CoreRule -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | BuiltinRule _ _ _ _ => true
+    | _ => false
+    end.
+
+Definition isAutoRule : CoreRule -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | BuiltinRule _ _ _ _ => false
+    | Rule _ _ _ _ _ _ _ is_auto _ _ _ => is_auto
+    end.
+
+Definition ruleArity : CoreRule -> nat :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | BuiltinRule _ _ n _ => n
+    | Rule _ _ _ _ _ args _ _ _ _ _ => Coq.Lists.List.length args
+    end.
+
+Definition ruleName : CoreRule -> BasicTypes.RuleName :=
+  ru_name.
+
+Definition ruleModule : CoreRule -> option Module.Module :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Rule _ _ _ _ _ _ _ _ ru_origin _ _ => Some ru_origin
+    | BuiltinRule _ _ _ _ => None
+    end.
+
+Definition ruleActivation : CoreRule -> BasicTypes.Activation :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | BuiltinRule _ _ _ _ => BasicTypes.AlwaysActive
+    | Rule _ act _ _ _ _ _ _ _ _ _ => act
+    end.
+
+Definition ruleIdName : CoreRule -> Name.Name :=
+  ru_fn.
+
+Definition isLocalRule : CoreRule -> bool :=
+  ru_local.
+
+Definition setRuleIdName : Name.Name -> CoreRule -> CoreRule :=
+  fun nm ru =>
+    match ru with
+    | Rule ru_name_0__ ru_act_1__ ru_fn_2__ ru_rough_3__ ru_bndrs_4__ ru_args_5__
+    ru_rhs_6__ ru_auto_7__ ru_origin_8__ ru_orphan_9__ ru_local_10__ =>
+        Rule ru_name_0__ ru_act_1__ nm ru_rough_3__ ru_bndrs_4__ ru_args_5__ ru_rhs_6__
+             ru_auto_7__ ru_origin_8__ ru_orphan_9__ ru_local_10__
+    | BuiltinRule ru_name_11__ ru_fn_12__ ru_nargs_13__ ru_try_14__ =>
+        BuiltinRule ru_name_11__ nm ru_nargs_13__ ru_try_14__
+    end.
+
+Definition needSaturated : bool :=
+  false.
+
+Definition unSaturatedOk : bool :=
+  true.
+
+Definition boringCxtOk : bool :=
+  true.
+
+Definition boringCxtNotOk : bool :=
+  false.
+
+(* Skipping definition `Core.evaldUnfolding' *)
+
+(* Skipping definition `Core.bootUnfolding' *)
+
+(* Skipping definition `Core.mkOtherCon' *)
+
+Definition isStableSource : UnfoldingSource -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | InlineCompulsory => true
+    | InlineStable => true
+    | InlineRhs => false
+    end.
+
+Axiom unfoldingTemplate : Unfolding -> CoreExpr.
+
+Definition maybeUnfoldingTemplate : Unfolding -> option CoreExpr :=
+  fun arg_0__ => None.
+
+Definition otherCons : Unfolding -> list AltCon :=
+  fun arg_0__ => nil.
+
+Definition isValueUnfolding : Unfolding -> bool :=
+  fun arg_0__ => false.
+
+Definition isEvaldUnfolding : Unfolding -> bool :=
+  fun arg_0__ => false.
+
+Definition isConLikeUnfolding : Unfolding -> bool :=
+  fun arg_0__ => false.
+
+Definition isCheapUnfolding : Unfolding -> bool :=
+  fun arg_0__ => false.
+
+Definition isExpandableUnfolding : Unfolding -> bool :=
+  fun arg_0__ => false.
+
+Definition expandUnfolding_maybe : Unfolding -> option CoreExpr :=
+  fun arg_0__ => None.
+
+Definition isCompulsoryUnfolding : Unfolding -> bool :=
+  fun arg_0__ => false.
+
+Definition isStableUnfolding : Unfolding -> bool :=
+  fun arg_0__ => false.
+
+Definition hasSomeUnfolding : Unfolding -> bool :=
+  fun '(NoUnfolding) => false.
+
+Definition isBootUnfolding : Unfolding -> bool :=
+  fun arg_0__ => false.
+
+Definition neverUnfoldGuidance : UnfoldingGuidance -> bool :=
+  fun arg_0__ => match arg_0__ with | UnfNever => true | _ => false end.
+
+Definition canUnfold : Unfolding -> bool :=
+  fun arg_0__ => false.
+
+Definition cmpAltCon : AltCon -> AltCon -> comparison :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | DEFAULT, DEFAULT => Eq
+    | DEFAULT, _ => Lt
+    | DataAlt d1, DataAlt d2 => GHC.Base.compare (dataConTag d1) (dataConTag d2)
+    | DataAlt _, DEFAULT => Gt
+    | LitAlt l1, LitAlt l2 => GHC.Base.compare l1 l2
+    | LitAlt _, DEFAULT => Gt
+    | con1, con2 =>
+        Panic.warnPprTrace (true) (GHC.Base.hs_string__
+                            "ghc/compiler/coreSyn/CoreSyn.hs") #1700 (GHC.Base.mappend (GHC.Base.mappend
+                                                                                        (Datatypes.id
+                                                                                         (GHC.Base.hs_string__
+                                                                                          "Comparing incomparable AltCons"))
+                                                                                        Panic.someSDoc) Panic.someSDoc)
+        Lt
+    end.
+
+Definition cmpAlt {a} {b}
+   : (AltCon * a * b)%type -> (AltCon * a * b)%type -> comparison :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | pair (pair con1 _) _, pair (pair con2 _) _ => cmpAltCon con1 con2
+    end.
+
+Definition ltAlt {a} {b}
+   : (AltCon * a * b)%type -> (AltCon * a * b)%type -> bool :=
+  fun a1 a2 => (cmpAlt a1 a2) GHC.Base.== Lt.
+
+Fixpoint deTagExpr {t} (arg_0__ : TaggedExpr t) : CoreExpr
+           := let deTagBind (arg_0__ : TaggedBind t) : CoreBind :=
+                match arg_0__ with
+                | NonRec (TB b _) rhs => NonRec b (deTagExpr rhs)
+                | Rec prs =>
+                    Rec (let cont_2__ arg_3__ :=
+                           let 'pair (TB b _) rhs := arg_3__ in
+                           cons (pair b (deTagExpr rhs)) nil in
+                         Coq.Lists.List.flat_map cont_2__ prs)
+                end in
+              let deTagAlt (arg_0__ : TaggedAlt t) : CoreAlt :=
+                let 'pair (pair con bndrs) rhs := arg_0__ in
+                pair (pair con (let cont_1__ arg_2__ := let 'TB b _ := arg_2__ in cons b nil in
+                            Coq.Lists.List.flat_map cont_1__ bndrs)) (deTagExpr rhs) in
+              match arg_0__ with
+              | Mk_Var v => Mk_Var v
+              | Lit l => Lit l
+              | Mk_Type ty => Mk_Type ty
+              | Mk_Coercion co => Mk_Coercion co
+              | App e1 e2 => App (deTagExpr e1) (deTagExpr e2)
+              | Lam (TB b _) e => Lam b (deTagExpr e)
+              | Let bind body => Let (deTagBind bind) (deTagExpr body)
+              | Case e (TB b _) ty alts =>
+                  Case (deTagExpr e) b ty (GHC.Base.map deTagAlt alts)
+              | Cast e co => Cast (deTagExpr e) co
+              end.
+
+Definition deTagBind {t} : TaggedBind t -> CoreBind :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | NonRec (TB b _) rhs => NonRec b (deTagExpr rhs)
+    | Rec prs =>
+        Rec (let cont_2__ arg_3__ :=
+               let 'pair (TB b _) rhs := arg_3__ in
+               cons (pair b (deTagExpr rhs)) nil in
+             Coq.Lists.List.flat_map cont_2__ prs)
+    end.
+
+Definition deTagAlt {t} : TaggedAlt t -> CoreAlt :=
+  fun '(pair (pair con bndrs) rhs) =>
+    pair (pair con (let cont_1__ arg_2__ := let 'TB b _ := arg_2__ in cons b nil in
+                Coq.Lists.List.flat_map cont_1__ bndrs)) (deTagExpr rhs).
+
+Definition mkApps {b} : Expr b -> list (Arg b) -> Expr b :=
+  fun f args => Data.Foldable.foldl App f args.
+
+Definition mkCoApps {b} : Expr b -> list Coercion -> Expr b :=
+  fun f args => Data.Foldable.foldl (fun e a => App e (Mk_Coercion a)) f args.
+
+Definition varToCoreExpr {b} : CoreBndr -> Expr b :=
+  fun v =>
+    if andb Util.debugIsOn (negb (true)) : bool
+    then (Panic.assertPanic (GHC.Base.hs_string__ "ghc/compiler/coreSyn/CoreSyn.hs")
+          #1920)
+    else Mk_Var v.
+
+Definition mkVarApps {b} : Expr b -> list Var -> Expr b :=
+  fun f vars => Data.Foldable.foldl (fun e a => App e (varToCoreExpr a)) f vars.
+
+Definition mkConApp {b} : DataCon -> list (Arg b) -> Expr b :=
+  fun con args => mkApps (Mk_Var (dataConWorkId con)) args.
+
+Definition mkTyArg {b} : Type_ -> Expr b :=
+  fun ty =>
+    match isCoercionTy_maybe ty with
+    | Some co => Mk_Coercion co
+    | _ => Mk_Type ty
+    end.
+
+Definition mkTyApps {b} : Expr b -> list Type_ -> Expr b :=
+  fun f args => Data.Foldable.foldl (fun e a => App e (mkTyArg a)) f args.
+
+Definition mkConApp2 {b} : DataCon -> list Type_ -> list Var -> Expr b :=
+  fun con tys arg_ids =>
+    mkApps (mkApps (Mk_Var (dataConWorkId con)) (GHC.Base.map Mk_Type tys))
+           (GHC.Base.map varToCoreExpr arg_ids).
+
+(* Skipping definition `Core.mkIntLit' *)
+
+(* Skipping definition `Core.mkIntLitInt' *)
+
+(* Skipping definition `Core.mkWordLit' *)
+
+(* Skipping definition `Core.mkWordLitWord' *)
+
+(* Skipping definition `Core.mkWord64LitWord64' *)
+
+(* Skipping definition `Core.mkInt64LitInt64' *)
+
+Definition mkCharLit {b} : GHC.Char.Char -> Expr b :=
+  fun c => Lit (mkMachChar c).
+
+Definition mkStringLit {b} : GHC.Base.String -> Expr b :=
+  fun s => Lit (mkMachString s).
+
+Definition mkFloatLit {b} : GHC.Real.Rational -> Expr b :=
+  fun f => Lit (mkMachFloat f).
+
+(* Skipping definition `Core.mkFloatLitFloat' *)
+
+Definition mkDoubleLit {b} : GHC.Real.Rational -> Expr b :=
+  fun d => Lit (mkMachDouble d).
+
+(* Skipping definition `Core.mkDoubleLitDouble' *)
+
+Definition mkLams {b} : list b -> Expr b -> Expr b :=
+  fun binders body => Data.Foldable.foldr Lam body binders.
+
+Definition mkLet {b} : Bind b -> Expr b -> Expr b :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Rec nil, body => body
+    | bind, body => Let bind body
+    end.
+
+Definition mkLets {b} : list (Bind b) -> Expr b -> Expr b :=
+  fun binds body => Data.Foldable.foldr mkLet body binds.
+
+Definition mkLetNonRec {b} : b -> Expr b -> Expr b -> Expr b :=
+  fun b rhs body => Let (NonRec b rhs) body.
+
+Definition mkLetRec {b} : list (b * Expr b)%type -> Expr b -> Expr b :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | nil, body => body
+    | bs, body => Let (Rec bs) body
+    end.
+
+Definition mkTyBind : TyVar -> Type_ -> CoreBind :=
+  fun tv ty => NonRec tv (Mk_Type ty).
+
+Definition mkCoBind : CoVar -> Coercion -> CoreBind :=
+  fun cv co => NonRec cv (Mk_Coercion co).
+
+Definition varsToCoreExprs {b} : list CoreBndr -> list (Expr b) :=
+  fun vs => GHC.Base.map varToCoreExpr vs.
+
+(* Skipping definition `Core.applyTypeToArg' *)
+
+(* Skipping definition `Core.exprToType' *)
+
+Definition exprToCoercion_maybe : CoreExpr -> option Coercion :=
+  fun arg_0__ => match arg_0__ with | Mk_Coercion co => Some co | _ => None end.
+
+Definition bindersOf {b} : Bind b -> list b :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | NonRec binder _ => cons binder nil
+    | Rec pairs =>
+        let cont_2__ arg_3__ := let 'pair binder _ := arg_3__ in cons binder nil in
+        Coq.Lists.List.flat_map cont_2__ pairs
+    end.
+
+Definition bindersOfBinds {b} : list (Bind b) -> list b :=
+  fun binds =>
+    Data.Foldable.foldr (Coq.Init.Datatypes.app GHC.Base.∘ bindersOf) nil binds.
+
+Definition rhssOfBind {b} : Bind b -> list (Expr b) :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | NonRec _ rhs => cons rhs nil
+    | Rec pairs =>
+        let cont_2__ arg_3__ := let 'pair _ rhs := arg_3__ in cons rhs nil in
+        Coq.Lists.List.flat_map cont_2__ pairs
+    end.
+
+Definition rhssOfAlts {b} : list (Alt b) -> list (Expr b) :=
+  fun alts =>
+    let cont_0__ arg_1__ := let 'pair (pair _ _) e := arg_1__ in cons e nil in
+    Coq.Lists.List.flat_map cont_0__ alts.
+
+Fixpoint flattenBinds {b} (arg_0__ : list (Bind b)) : list (b * Expr b)%type
+           := match arg_0__ with
+              | cons (NonRec b r) binds => cons (pair b r) (flattenBinds binds)
+              | cons (Rec prs1) binds => Coq.Init.Datatypes.app prs1 (flattenBinds binds)
+              | nil => nil
+              end.
+
+Definition collectBinders {b} : Expr b -> (list b * Expr b)%type :=
+  fun expr =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | bs, Lam b e => go (cons b bs) e
+                 | bs, e => pair (GHC.List.reverse bs) e
+                 end in
+    go nil expr.
+
+Definition collectTyBinders : CoreExpr -> (list TyVar * CoreExpr)%type :=
+  fun expr =>
+    let fix go arg_0__ arg_1__
+              := let j_3__ :=
+                   match arg_0__, arg_1__ with
+                   | tvs, e => pair (GHC.List.reverse tvs) e
+                   end in
+                 match arg_0__, arg_1__ with
+                 | tvs, Lam b e => if isTyVar b : bool then go (cons b tvs) e else j_3__
+                 | _, _ => j_3__
+                 end in
+    go nil expr.
+
+Definition collectValBinders : CoreExpr -> (list Id * CoreExpr)%type :=
+  fun expr =>
+    let fix go arg_0__ arg_1__
+              := let j_3__ :=
+                   match arg_0__, arg_1__ with
+                   | ids, body => pair (GHC.List.reverse ids) body
+                   end in
+                 match arg_0__, arg_1__ with
+                 | ids, Lam b e => if isId b : bool then go (cons b ids) e else j_3__
+                 | _, _ => j_3__
+                 end in
+    go nil expr.
+
+Definition collectTyAndValBinders
+   : CoreExpr -> (list TyVar * list Id * CoreExpr)%type :=
+  fun expr =>
+    let 'pair tvs body1 := collectTyBinders expr in
+    let 'pair ids body := collectValBinders body1 in
+    pair (pair tvs ids) body.
+
+Definition collectNBinders {b} : nat -> Expr b -> (list b * Expr b)%type :=
+  fun orig_n orig_expr =>
+    let fix go arg_0__ arg_1__ arg_2__
+              := match arg_0__, arg_1__, arg_2__ with
+                 | num_3__, bs, expr =>
+                     if num_3__ GHC.Base.== #0 : bool then pair (GHC.List.reverse bs) expr else
+                     match arg_0__, arg_1__, arg_2__ with
+                     | n, bs, Lam b e => go (n GHC.Num.- #1) (cons b bs) e
+                     | _, _, _ =>
+                         Panic.panicStr (GHC.Base.hs_string__ "collectNBinders") Panic.someSDoc
+                     end
+                 end in
+    go orig_n nil orig_expr.
+
+Definition collectArgs {b} : Expr b -> (Expr b * list (Arg b))%type :=
+  fun expr =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | App f a, as_ => go f (cons a as_)
+                 | e, as_ => pair e as_
+                 end in
+    go expr nil.
+
+Definition collectArgsTicks {b}
+   : (Tickish Id -> bool) ->
+     Expr b -> (Expr b * list (Arg b) * list (Tickish Id))%type :=
+  fun skipTick expr =>
+    let fix go arg_0__ arg_1__ arg_2__
+              := match arg_0__, arg_1__, arg_2__ with
+                 | App f a, as_, ts => go f (cons a as_) ts
+                 | e, as_, ts => pair (pair e as_) (GHC.List.reverse ts)
+                 end in
+    go expr nil nil.
+
+Definition isRuntimeVar : Var -> bool :=
+  isId.
+
+Definition isTypeArg {b} : Expr b -> bool :=
+  fun arg_0__ => match arg_0__ with | Mk_Type _ => true | _ => false end.
+
+Definition isValArg {b} : Expr b -> bool :=
+  fun e => negb (isTypeArg e).
+
+Definition isRuntimeArg : CoreExpr -> bool :=
+  isValArg.
+
+Definition isTyCoArg {b} : Expr b -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Mk_Type _ => true
+    | Mk_Coercion _ => true
+    | _ => false
+    end.
+
+Definition valBndrCount : list CoreBndr -> nat :=
+  Util.count isId.
+
+Definition valArgCount {b} : list (Arg b) -> nat :=
+  Util.count isValArg.
+
+Program Definition collectAnnArgs {b} {a}
+           : AnnExpr b a -> (AnnExpr b a * list (AnnExpr b a))%type :=
+          fun expr =>
+            let go :=
+              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
+                               size_AnnExpr' (snd arg_0__)) _ (fun arg_0__ arg_1__ go =>
+                               match arg_0__, arg_1__ with
+                               | pair _ (AnnApp f a), as_ => go f (cons a as_)
+                               | e, as_ => pair e as_
+                               end) in
+            go expr nil.
+Solve Obligations with (solve_collectAnnArgsTicks).
+
+Program Definition collectAnnArgsTicks {b} {a}
+           : (Tickish Var -> bool) ->
+             AnnExpr b a -> (AnnExpr b a * list (AnnExpr b a) * list (Tickish Var))%type :=
+          fun tickishOk expr =>
+            let go :=
+              GHC.Wf.wfFix3 Coq.Init.Peano.lt (fun arg_0__ arg_1__ arg_2__ =>
+                               size_AnnExpr' (snd arg_0__)) _ (fun arg_0__ arg_1__ arg_2__ go =>
+                               match arg_0__, arg_1__, arg_2__ with
+                               | pair _ (AnnApp f a), as_, ts => go f (cons a as_) ts
+                               | e, as_, ts => pair (pair e as_) (GHC.List.reverse ts)
+                               end) in
+            go expr nil nil.
+Solve Obligations with (solve_collectAnnArgsTicks).
+
+Definition deAnnotate'
+   : forall {bndr} {annot}, AnnExpr' bndr annot -> Expr bndr :=
+  fix deAnnotate' {bndr} {annot} (arg_0__ : AnnExpr' bndr annot) : Expr bndr
+        := let deAnnotate {bndr} {annot} (arg_0__ : AnnExpr bndr annot) : Expr bndr :=
+             let 'pair _ e := arg_0__ in
+             deAnnotate' e in
+           let deAnnAlt {bndr} {annot} (arg_0__ : AnnAlt bndr annot) : Alt bndr :=
+             let 'pair (pair con args) rhs := arg_0__ in
+             pair (pair con args) (deAnnotate rhs) in
+           match arg_0__ with
+           | AnnType t => Mk_Type t
+           | AnnCoercion co => Mk_Coercion co
+           | AnnVar v => Mk_Var v
+           | AnnLit lit => Lit lit
+           | AnnLam binder body => Lam binder (deAnnotate body)
+           | AnnApp fun_ arg => App (deAnnotate fun_) (deAnnotate arg)
+           | AnnCast e (pair _ co) => Cast (deAnnotate e) co
+           | AnnLet bind body => Let (deAnnBind bind) (deAnnotate body)
+           | AnnCase scrut v t alts =>
+               Case (deAnnotate scrut) v t (GHC.Base.map deAnnAlt alts)
+           end with deAnnBind {b} {annot} (arg_0__ : AnnBind b annot) : Bind b
+                      := let deAnnotate {bndr} {annot} (arg_0__ : AnnExpr bndr annot) : Expr bndr :=
+                           let 'pair _ e := arg_0__ in
+                           deAnnotate' e in
+                         match arg_0__ with
+                         | AnnNonRec var rhs => NonRec var (deAnnotate rhs)
+                         | AnnRec pairs =>
+                             Rec (let cont_2__ arg_3__ :=
+                                    let 'pair v rhs := arg_3__ in
+                                    cons (pair v (deAnnotate rhs)) nil in
+                                  Coq.Lists.List.flat_map cont_2__ pairs)
+                         end for deAnnotate'.
+
+Definition deAnnotate {bndr} {annot} : AnnExpr bndr annot -> Expr bndr :=
+  fun '(pair _ e) => deAnnotate' e.
+
+Definition deAnnAlt {bndr} {annot} : AnnAlt bndr annot -> Alt bndr :=
+  fun '(pair (pair con args) rhs) => pair (pair con args) (deAnnotate rhs).
+
+Definition deAnnBind : forall {b} {annot}, AnnBind b annot -> Bind b :=
+  fix deAnnotate' {bndr} {annot} (arg_0__ : AnnExpr' bndr annot) : Expr bndr
+        := let deAnnotate {bndr} {annot} (arg_0__ : AnnExpr bndr annot) : Expr bndr :=
+             let 'pair _ e := arg_0__ in
+             deAnnotate' e in
+           let deAnnAlt {bndr} {annot} (arg_0__ : AnnAlt bndr annot) : Alt bndr :=
+             let 'pair (pair con args) rhs := arg_0__ in
+             pair (pair con args) (deAnnotate rhs) in
+           match arg_0__ with
+           | AnnType t => Mk_Type t
+           | AnnCoercion co => Mk_Coercion co
+           | AnnVar v => Mk_Var v
+           | AnnLit lit => Lit lit
+           | AnnLam binder body => Lam binder (deAnnotate body)
+           | AnnApp fun_ arg => App (deAnnotate fun_) (deAnnotate arg)
+           | AnnCast e (pair _ co) => Cast (deAnnotate e) co
+           | AnnLet bind body => Let (deAnnBind bind) (deAnnotate body)
+           | AnnCase scrut v t alts =>
+               Case (deAnnotate scrut) v t (GHC.Base.map deAnnAlt alts)
+           end with deAnnBind {b} {annot} (arg_0__ : AnnBind b annot) : Bind b
+                      := let deAnnotate {bndr} {annot} (arg_0__ : AnnExpr bndr annot) : Expr bndr :=
+                           let 'pair _ e := arg_0__ in
+                           deAnnotate' e in
+                         match arg_0__ with
+                         | AnnNonRec var rhs => NonRec var (deAnnotate rhs)
+                         | AnnRec pairs =>
+                             Rec (let cont_2__ arg_3__ :=
+                                    let 'pair v rhs := arg_3__ in
+                                    cons (pair v (deAnnotate rhs)) nil in
+                                  Coq.Lists.List.flat_map cont_2__ pairs)
+                         end for deAnnBind.
+
+Program Definition collectAnnBndrs {bndr} {annot}
+           : AnnExpr bndr annot -> (list bndr * AnnExpr bndr annot)%type :=
+          fun e =>
+            let collect :=
+              GHC.Wf.wfFix2 Coq.Init.Peano.lt (fun arg_0__ arg_1__ =>
+                               size_AnnExpr' (snd arg_1__)) _ (fun arg_0__ arg_1__ collect =>
+                               match arg_0__, arg_1__ with
+                               | bs, pair _ (AnnLam b body) => collect (cons b bs) body
+                               | bs, body => pair (GHC.List.reverse bs) body
+                               end) in
+            collect nil e.
+
+(* Skipping definition `Core.collectNAnnBndrs' *)
 
 (* External variables:
      BranchIndex Branched BuiltInSynFamily CType CoAxBranch CoAxiom CoAxiomRule

--- a/examples/ghc/lib/CoreArity.v
+++ b/examples/ghc/lib/CoreArity.v
@@ -49,75 +49,75 @@ Definition ae_ped_bot (arg_0__ : ArityEnv) :=
 
 (* Converted value declarations: *)
 
-Axiom vanillaArityType : ArityType.
+(* Skipping all instances of class `Outputable.Outputable', including
+   `CoreArity.Outputable__ArityType' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `CoreArity.Outputable__EtaInfo' *)
+
+Axiom manifestArity : Core.CoreExpr -> BasicTypes.Arity.
+
+Axiom joinRhsArity : Core.CoreExpr -> BasicTypes.JoinArity.
+
+Axiom exprArity : Core.CoreExpr -> BasicTypes.Arity.
 
 Axiom typeArity : AxiomatizedTypes.Type_ -> list BasicTypes.OneShotInfo.
 
-Axiom subst_expr : CoreSubst.Subst -> Core.CoreExpr -> Core.CoreExpr.
+Axiom exprBotStrictness_maybe : Core.CoreExpr ->
+                                option (BasicTypes.Arity * Core.StrictSig)%type.
+
+Axiom vanillaArityType : ArityType.
+
+Axiom exprEtaExpandArity : DynFlags.DynFlags ->
+                           Core.CoreExpr -> BasicTypes.Arity.
+
+Axiom getBotArity : ArityType -> option BasicTypes.Arity.
+
+Axiom mk_cheap_fn : DynFlags.DynFlags -> CoreUtils.CheapAppFun -> CheapFun.
+
+Axiom findRhsArity : DynFlags.DynFlags ->
+                     Core.Id -> Core.CoreExpr -> BasicTypes.Arity -> (BasicTypes.Arity * bool)%type.
+
+Axiom arityLam : Core.Id -> ArityType -> ArityType.
+
+Axiom floatIn : bool -> ArityType -> ArityType.
+
+Axiom arityApp : ArityType -> bool -> ArityType.
+
+Axiom andArityType : ArityType -> ArityType -> ArityType.
+
+Axiom arityType : ArityEnv -> Core.CoreExpr -> ArityType.
+
+Axiom etaExpand : BasicTypes.Arity -> Core.CoreExpr -> Core.CoreExpr.
 
 Axiom pushCoercion : AxiomatizedTypes.Coercion -> list EtaInfo -> list EtaInfo.
 
-Axiom mk_cheap_fn : DynFlags.DynFlags -> CoreUtils.CheapAppFun -> CheapFun.
+Axiom etaInfoAbs : list EtaInfo -> Core.CoreExpr -> Core.CoreExpr.
+
+Axiom etaInfoApp : CoreSubst.Subst ->
+                   Core.CoreExpr -> list EtaInfo -> Core.CoreExpr.
+
+Axiom etaInfoAppTy : AxiomatizedTypes.Type_ ->
+                     list EtaInfo -> AxiomatizedTypes.Type_.
 
 Axiom mkEtaWW : BasicTypes.Arity ->
                 Core.CoreExpr ->
                 Core.InScopeSet ->
                 AxiomatizedTypes.Type_ -> (Core.InScopeSet * list EtaInfo)%type.
 
-Axiom manifestArity : Core.CoreExpr -> BasicTypes.Arity.
-
-Axiom joinRhsArity : Core.CoreExpr -> BasicTypes.JoinArity.
-
-Axiom getBotArity : ArityType -> option BasicTypes.Arity.
-
-Axiom freshEtaId : nat ->
-                   Core.TCvSubst -> AxiomatizedTypes.Type_ -> (Core.TCvSubst * Core.Id)%type.
-
-Axiom floatIn : bool -> ArityType -> ArityType.
-
-Axiom findRhsArity : DynFlags.DynFlags ->
-                     Core.Id -> Core.CoreExpr -> BasicTypes.Arity -> (BasicTypes.Arity * bool)%type.
-
-Axiom exprEtaExpandArity : DynFlags.DynFlags ->
-                           Core.CoreExpr -> BasicTypes.Arity.
-
-Axiom exprBotStrictness_maybe : Core.CoreExpr ->
-                                option (BasicTypes.Arity * Core.StrictSig)%type.
-
-Axiom exprArity : Core.CoreExpr -> BasicTypes.Arity.
-
-Axiom etaInfoAppTy : AxiomatizedTypes.Type_ ->
-                     list EtaInfo -> AxiomatizedTypes.Type_.
-
-Axiom etaInfoApp : CoreSubst.Subst ->
-                   Core.CoreExpr -> list EtaInfo -> Core.CoreExpr.
-
-Axiom etaInfoAbs : list EtaInfo -> Core.CoreExpr -> Core.CoreExpr.
-
-Axiom etaExpandToJoinPointRule : BasicTypes.JoinArity ->
-                                 Core.CoreRule -> Core.CoreRule.
+Axiom subst_expr : CoreSubst.Subst -> Core.CoreExpr -> Core.CoreExpr.
 
 Axiom etaExpandToJoinPoint : BasicTypes.JoinArity ->
                              Core.CoreExpr -> (list Core.CoreBndr * Core.CoreExpr)%type.
 
-Axiom etaExpand : BasicTypes.Arity -> Core.CoreExpr -> Core.CoreExpr.
+Axiom etaExpandToJoinPointRule : BasicTypes.JoinArity ->
+                                 Core.CoreRule -> Core.CoreRule.
 
 Axiom etaBodyForJoinPoint : nat ->
                             Core.CoreExpr -> (list Core.CoreBndr * Core.CoreExpr)%type.
 
-Axiom arityType : ArityEnv -> Core.CoreExpr -> ArityType.
-
-Axiom arityLam : Core.Id -> ArityType -> ArityType.
-
-Axiom arityApp : ArityType -> bool -> ArityType.
-
-Axiom andArityType : ArityType -> ArityType -> ArityType.
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `CoreArity.Outputable__ArityType' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `CoreArity.Outputable__EtaInfo' *)
+Axiom freshEtaId : nat ->
+                   Core.TCvSubst -> AxiomatizedTypes.Type_ -> (Core.TCvSubst * Core.Id)%type.
 
 (* External variables:
      bool list nat op_zt__ option AxiomatizedTypes.Coercion AxiomatizedTypes.Type_

--- a/examples/ghc/lib/CoreFVs.v
+++ b/examples/ghc/lib/CoreFVs.v
@@ -54,119 +54,26 @@ Definition CoreAltWithFVs :=
 Definition varTypeTyCoFVs : Core.Var -> FV.FV :=
   fun var => FV.emptyFV.
 
-Definition varTypeTyCoVars : Core.Var -> Core.TyCoVarSet :=
-  fun var => FV.fvVarSet (varTypeTyCoFVs var).
-
-Definition unionFVss : list Core.DVarSet -> Core.DVarSet :=
-  Core.unionDVarSets.
-
-Definition unionFVs : Core.DVarSet -> Core.DVarSet -> Core.DVarSet :=
-  Core.unionDVarSet.
-
-Definition tickish_fvs : Core.Tickish Core.Id -> FV.FV :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Core.Breakpoint _ ids => FV.mkFVs ids
-    | _ => FV.emptyFV
-    end.
-
-(* Skipping definition `CoreFVs.stableUnfoldingVars' *)
-
-Definition stableUnfoldingFVs : Core.Unfolding -> option FV.FV :=
-  fun '(_other) => None.
-
-(* Skipping definition `CoreFVs.orphNamesOfTypes' *)
-
-(* Skipping definition `CoreFVs.orphNamesOfType' *)
-
-(* Skipping definition `CoreFVs.orphNamesOfTyCon' *)
-
-Definition orphNamesOfThings {a}
-   : (a -> NameSet.NameSet) -> list a -> NameSet.NameSet :=
-  fun f =>
-    Data.Foldable.foldr (NameSet.unionNameSet GHC.Base.∘ f) NameSet.emptyNameSet.
-
-(* Skipping definition `CoreFVs.orphNamesOfProv' *)
-
-(* Skipping definition `CoreFVs.orphNamesOfFamInst' *)
-
-(* Skipping definition `CoreFVs.orphNamesOfCos' *)
-
-(* Skipping definition `CoreFVs.orphNamesOfCoCon' *)
-
-(* Skipping definition `CoreFVs.orphNamesOfCoAxBranches' *)
-
-(* Skipping definition `CoreFVs.orphNamesOfCoAxBranch' *)
-
-(* Skipping definition `CoreFVs.orphNamesOfCo' *)
-
-(* Skipping definition `CoreFVs.orphNamesOfAxiom' *)
-
-Definition noFVs : Core.VarSet :=
-  Core.emptyVarSet.
-
-Definition idUnfoldingFVs : Core.Id -> FV.FV :=
-  fun id => Maybes.orElse (stableUnfoldingFVs (Id.realIdUnfolding id)) FV.emptyFV.
-
-Definition idUnfoldingVars : Core.Id -> Core.VarSet :=
-  fun id => FV.fvVarSet (idUnfoldingFVs id).
-
-Definition idRuleFVs : Core.Id -> FV.FV :=
-  fun id => FV.emptyFV.
-
-Definition idRuleVars : Core.Id -> Core.VarSet :=
-  fun id => FV.fvVarSet (idRuleFVs id).
-
-Definition freeVarsOfAnn : FVAnn -> Core.DIdSet :=
-  fun fvs => fvs.
-
-Definition freeVarsOf : CoreExprWithFVs -> Core.DIdSet :=
-  fun '(pair fvs _) => fvs.
-
-(* Skipping definition `CoreFVs.exprsOrphNames' *)
-
-(* Skipping definition `CoreFVs.exprOrphNames' *)
-
-Definition dVarTypeTyCoVars : Core.Var -> Core.DTyCoVarSet :=
-  fun var => FV.fvDVarSet (varTypeTyCoFVs var).
-
-Definition delBinderFV : Core.Var -> Core.DVarSet -> Core.DVarSet :=
-  fun b s => unionFVs (Core.delDVarSet s b) (dVarTypeTyCoVars b).
-
-Definition delBindersFV : list Core.Var -> Core.DVarSet -> Core.DVarSet :=
-  fun bs fvs => Data.Foldable.foldr delBinderFV fvs bs.
-
-Definition bndrRuleAndUnfoldingFVs : Core.Id -> FV.FV :=
-  fun id =>
-    if Core.isId id : bool then FV.unionFV (idRuleFVs id) (idUnfoldingFVs id) else
-    FV.emptyFV.
-
-Definition bndrRuleAndUnfoldingVarsDSet : Core.Id -> Core.DVarSet :=
-  fun id => FV.fvDVarSet (bndrRuleAndUnfoldingFVs id).
-
-Definition idFVs : Core.Id -> FV.FV :=
-  fun id =>
-    if andb Util.debugIsOn (negb (Core.isId id)) : bool
-    then (Panic.assertPanic (GHC.Base.hs_string__ "ghc/compiler/coreSyn/CoreFVs.hs")
-          #629)
-    else FV.unionFV (varTypeTyCoFVs id) (bndrRuleAndUnfoldingFVs id).
-
-Definition dIdFreeVars : Core.Id -> Core.DVarSet :=
-  fun id => FV.fvDVarSet (idFVs id).
-
-Definition idFreeVars : Core.Id -> Core.VarSet :=
-  fun id =>
-    if andb Util.debugIsOn (negb (Core.isId id)) : bool
-    then (Panic.assertPanic (GHC.Base.hs_string__ "ghc/compiler/coreSyn/CoreFVs.hs")
-          #622)
-    else FV.fvVarSet (idFVs id).
-
 Definition addBndr : Core.CoreBndr -> FV.FV -> FV.FV :=
   fun bndr fv fv_cand in_scope acc =>
     (FV.unionFV (varTypeTyCoFVs bndr) (FV.delFV bndr fv)) fv_cand in_scope acc.
 
 Definition addBndrs : list Core.CoreBndr -> FV.FV -> FV.FV :=
   fun bndrs fv => Data.Foldable.foldr addBndr fv bndrs.
+
+Definition idRuleFVs : Core.Id -> FV.FV :=
+  fun id => FV.emptyFV.
+
+Definition stableUnfoldingFVs : Core.Unfolding -> option FV.FV :=
+  fun '(_other) => None.
+
+Definition idUnfoldingFVs : Core.Id -> FV.FV :=
+  fun id => Maybes.orElse (stableUnfoldingFVs (Id.realIdUnfolding id)) FV.emptyFV.
+
+Definition bndrRuleAndUnfoldingFVs : Core.Id -> FV.FV :=
+  fun id =>
+    if Core.isId id : bool then FV.unionFV (idRuleFVs id) (idUnfoldingFVs id) else
+    FV.emptyFV.
 
 Fixpoint expr_fvs `(arg_0__ : Core.CoreExpr) arg_1__ arg_2__ arg_3__
            := match arg_0__, arg_1__, arg_2__, arg_3__ with
@@ -212,15 +119,6 @@ Definition exprFreeVarsDSet : Core.CoreExpr -> Core.DVarSet :=
 Definition exprFreeVarsList : Core.CoreExpr -> list Core.Var :=
   FV.fvVarList GHC.Base.∘ exprFVs.
 
-Definition exprsFVs : list Core.CoreExpr -> FV.FV :=
-  fun exprs => FV.mapUnionFV exprFVs exprs.
-
-Definition exprsFreeVars : list Core.CoreExpr -> Core.VarSet :=
-  FV.fvVarSet GHC.Base.∘ exprsFVs.
-
-Definition exprsFreeVarsList : list Core.CoreExpr -> list Core.Var :=
-  FV.fvVarList GHC.Base.∘ exprsFVs.
-
 Definition exprSomeFreeVars
    : FV.InterestingVarFun -> Core.CoreExpr -> Core.VarSet :=
   fun fv_cand e => FV.fvVarSet (FV.filterFV fv_cand (expr_fvs e)).
@@ -242,10 +140,6 @@ Definition exprSomeFreeVarsList
 Definition exprFreeIdsList : Core.CoreExpr -> list Core.Id :=
   exprSomeFreeVarsList Core.isLocalId.
 
-Definition exprsSomeFreeVars
-   : FV.InterestingVarFun -> list Core.CoreExpr -> Core.VarSet :=
-  fun fv_cand es => FV.fvVarSet (FV.filterFV fv_cand (FV.mapUnionFV expr_fvs es)).
-
 Definition exprsSomeFreeVarsDSet
    : FV.InterestingVarFun -> list Core.CoreExpr -> Core.DVarSet :=
   fun fv_cand e => FV.fvDVarSet (FV.filterFV fv_cand (FV.mapUnionFV expr_fvs e)).
@@ -261,8 +155,84 @@ Definition exprsSomeFreeVarsList
 Definition exprsFreeIdsList : list Core.CoreExpr -> list Core.Id :=
   exprsSomeFreeVarsList Core.isLocalId.
 
+Definition exprsFVs : list Core.CoreExpr -> FV.FV :=
+  fun exprs => FV.mapUnionFV exprFVs exprs.
+
+Definition exprsFreeVars : list Core.CoreExpr -> Core.VarSet :=
+  FV.fvVarSet GHC.Base.∘ exprsFVs.
+
+Definition exprsFreeVarsList : list Core.CoreExpr -> list Core.Var :=
+  FV.fvVarList GHC.Base.∘ exprsFVs.
+
+Definition rhs_fvs : (Core.Id * Core.CoreExpr)%type -> FV.FV :=
+  fun '(pair bndr rhs) =>
+    FV.unionFV (expr_fvs rhs) (bndrRuleAndUnfoldingFVs bndr).
+
+Definition bindFreeVars : Core.CoreBind -> Core.VarSet :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Core.NonRec b r =>
+        FV.fvVarSet (FV.filterFV Core.isLocalVar (rhs_fvs (pair b r)))
+    | Core.Rec prs =>
+        FV.fvVarSet (FV.filterFV Core.isLocalVar (addBndrs (GHC.Base.map Data.Tuple.fst
+                                                            prs) (FV.mapUnionFV rhs_fvs prs)))
+    end.
+
+Definition exprsSomeFreeVars
+   : FV.InterestingVarFun -> list Core.CoreExpr -> Core.VarSet :=
+  fun fv_cand es => FV.fvVarSet (FV.filterFV fv_cand (FV.mapUnionFV expr_fvs es)).
+
 Definition exprs_fvs : list Core.CoreExpr -> FV.FV :=
   fun exprs => FV.mapUnionFV expr_fvs exprs.
+
+Definition tickish_fvs : Core.Tickish Core.Id -> FV.FV :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Core.Breakpoint _ ids => FV.mkFVs ids
+    | _ => FV.emptyFV
+    end.
+
+(* Skipping definition `CoreFVs.exprOrphNames' *)
+
+(* Skipping definition `CoreFVs.exprsOrphNames' *)
+
+(* Skipping definition `CoreFVs.orphNamesOfTyCon' *)
+
+(* Skipping definition `CoreFVs.orphNamesOfType' *)
+
+Definition orphNamesOfThings {a}
+   : (a -> NameSet.NameSet) -> list a -> NameSet.NameSet :=
+  fun f =>
+    Data.Foldable.foldr (NameSet.unionNameSet GHC.Base.∘ f) NameSet.emptyNameSet.
+
+(* Skipping definition `CoreFVs.orphNamesOfTypes' *)
+
+(* Skipping definition `CoreFVs.orphNamesOfCo' *)
+
+(* Skipping definition `CoreFVs.orphNamesOfProv' *)
+
+(* Skipping definition `CoreFVs.orphNamesOfCos' *)
+
+(* Skipping definition `CoreFVs.orphNamesOfCoCon' *)
+
+(* Skipping definition `CoreFVs.orphNamesOfAxiom' *)
+
+(* Skipping definition `CoreFVs.orphNamesOfCoAxBranches' *)
+
+(* Skipping definition `CoreFVs.orphNamesOfCoAxBranch' *)
+
+(* Skipping definition `CoreFVs.orphNamesOfFamInst' *)
+
+Definition noFVs : Core.VarSet :=
+  Core.emptyVarSet.
+
+Definition ruleRhsFreeVars : Core.CoreRule -> Core.VarSet :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Core.BuiltinRule _ _ _ _ => noFVs
+    | Core.Rule _ _ _ _ bndrs _ rhs _ _ _ _ =>
+        FV.fvVarSet (FV.filterFV Core.isLocalVar (addBndrs bndrs (expr_fvs rhs)))
+    end.
 
 Definition ruleFVs : Core.CoreRule -> FV.FV :=
   fun arg_0__ =>
@@ -275,28 +245,11 @@ Definition ruleFVs : Core.CoreRule -> FV.FV :=
 Definition ruleFreeVars : Core.CoreRule -> Core.VarSet :=
   FV.fvVarSet GHC.Base.∘ ruleFVs.
 
-Definition rulesFreeVars : list Core.CoreRule -> Core.VarSet :=
-  fun rules => Core.mapUnionVarSet ruleFreeVars rules.
-
 Definition rulesFVs : list Core.CoreRule -> FV.FV :=
   FV.mapUnionFV ruleFVs.
 
 Definition rulesFreeVarsDSet : list Core.CoreRule -> Core.DVarSet :=
   fun rules => FV.fvDVarSet (rulesFVs rules).
-
-Definition ruleLhsFVIds : Core.CoreRule -> FV.FV :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Core.BuiltinRule _ _ _ _ => FV.emptyFV
-    | Core.Rule _ _ _ _ bndrs args _ _ _ _ _ =>
-        FV.filterFV Core.isLocalId (addBndrs bndrs (exprs_fvs args))
-    end.
-
-Definition ruleLhsFreeIds : Core.CoreRule -> Core.VarSet :=
-  FV.fvVarSet GHC.Base.∘ ruleLhsFVIds.
-
-Definition ruleLhsFreeIdsList : Core.CoreRule -> list Core.Var :=
-  FV.fvVarList GHC.Base.∘ ruleLhsFVIds.
 
 Definition idRuleRhsVars
    : (BasicTypes.Activation -> bool) -> Core.Id -> Core.VarSet :=
@@ -314,27 +267,22 @@ Definition idRuleRhsVars
         end in
     Core.mapUnionVarSet get_fvs (Id.idCoreRules id).
 
-Definition rhs_fvs : (Core.Id * Core.CoreExpr)%type -> FV.FV :=
-  fun '(pair bndr rhs) =>
-    FV.unionFV (expr_fvs rhs) (bndrRuleAndUnfoldingFVs bndr).
+Definition rulesFreeVars : list Core.CoreRule -> Core.VarSet :=
+  fun rules => Core.mapUnionVarSet ruleFreeVars rules.
 
-Definition bindFreeVars : Core.CoreBind -> Core.VarSet :=
+Definition ruleLhsFVIds : Core.CoreRule -> FV.FV :=
   fun arg_0__ =>
     match arg_0__ with
-    | Core.NonRec b r =>
-        FV.fvVarSet (FV.filterFV Core.isLocalVar (rhs_fvs (pair b r)))
-    | Core.Rec prs =>
-        FV.fvVarSet (FV.filterFV Core.isLocalVar (addBndrs (GHC.Base.map Data.Tuple.fst
-                                                            prs) (FV.mapUnionFV rhs_fvs prs)))
+    | Core.BuiltinRule _ _ _ _ => FV.emptyFV
+    | Core.Rule _ _ _ _ bndrs args _ _ _ _ _ =>
+        FV.filterFV Core.isLocalId (addBndrs bndrs (exprs_fvs args))
     end.
 
-Definition ruleRhsFreeVars : Core.CoreRule -> Core.VarSet :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Core.BuiltinRule _ _ _ _ => noFVs
-    | Core.Rule _ _ _ _ bndrs _ rhs _ _ _ _ =>
-        FV.fvVarSet (FV.filterFV Core.isLocalVar (addBndrs bndrs (expr_fvs rhs)))
-    end.
+Definition ruleLhsFreeIds : Core.CoreRule -> Core.VarSet :=
+  FV.fvVarSet GHC.Base.∘ ruleLhsFVIds.
+
+Definition ruleLhsFreeIdsList : Core.CoreRule -> list Core.Var :=
+  FV.fvVarList GHC.Base.∘ ruleLhsFVIds.
 
 Definition vectsFreeVars : list Core.CoreVect -> Core.VarSet :=
   let vectFreeVars :=
@@ -348,67 +296,60 @@ Definition vectsFreeVars : list Core.CoreVect -> Core.VarSet :=
       end in
   Core.mapUnionVarSet vectFreeVars.
 
+Definition freeVarsOf : CoreExprWithFVs -> Core.DIdSet :=
+  fun '(pair fvs _) => fvs.
+
+Definition freeVarsOfAnn : FVAnn -> Core.DIdSet :=
+  fun fvs => fvs.
+
 Definition aFreeVar : Core.Var -> Core.DVarSet :=
   Core.unitDVarSet.
 
-Definition freeVars : Core.CoreExpr -> CoreExprWithFVs :=
-  fix freeVars (arg_0__ : Core.CoreExpr) : CoreExprWithFVs
-        := match arg_0__ with
-           | Core.Mk_Var v =>
-               let ty_fvs := dVarTypeTyCoVars v in
-               if Core.isLocalVar v : bool
-               then pair (unionFVs (aFreeVar v) ty_fvs) (Core.AnnVar v) else
-               pair Core.emptyDVarSet (Core.AnnVar v)
-           | Core.Lit lit => pair Core.emptyDVarSet (Core.AnnLit lit)
-           | Core.Lam b body =>
-               let b_ty := Id.idType b in
-               let b_fvs := Core.emptyDVarSet in
-               let '(pair body_fvs _ as body') := freeVars body in
-               pair (unionFVs b_fvs (delBinderFV b body_fvs)) (Core.AnnLam b body')
-           | Core.App fun_ arg =>
-               let arg' := freeVars arg in
-               let fun' := freeVars fun_ in
-               pair (unionFVs (freeVarsOf fun') (freeVarsOf arg')) (Core.AnnApp fun' arg')
-           | Core.Case scrut bndr ty alts =>
-               let fv_alt :=
-                 fun '(pair (pair con args) rhs) =>
-                   let rhs2 := freeVars rhs in
-                   pair (delBindersFV args (freeVarsOf rhs2)) (pair (pair con args) rhs2) in
-               let 'pair alts_fvs_s alts2 := NestedRecursionHelpers.mapAndUnzipFix fv_alt
-                                               alts in
-               let alts_fvs := unionFVss alts_fvs_s in
-               let scrut2 := freeVars scrut in
-               pair (unionFVs (unionFVs (delBinderFV bndr alts_fvs) (freeVarsOf scrut2))
-                              Core.emptyDVarSet) (Core.AnnCase scrut2 bndr ty alts2)
-           | Core.Let bind body =>
-               let body2 := freeVars body in
-               let 'pair bind2 bind_fvs := freeVarsBind bind (freeVarsOf body2) in
-               pair bind_fvs (Core.AnnLet bind2 body2)
-           | Core.Cast expr co =>
-               let cfvs := Core.emptyDVarSet in
-               let expr2 := freeVars expr in
-               pair (unionFVs (freeVarsOf expr2) cfvs) (Core.AnnCast expr2 (pair cfvs co))
-           | Core.Mk_Type ty => pair Core.emptyDVarSet (Core.AnnType ty)
-           | Core.Mk_Coercion co => pair Core.emptyDVarSet (Core.AnnCoercion co)
-           end with freeVarsBind (arg_0__ : Core.CoreBind) (arg_1__ : Core.DVarSet)
-                      : (CoreBindWithFVs * Core.DVarSet)%type
-                      := match arg_0__, arg_1__ with
-                         | Core.NonRec binder rhs, body_fvs =>
-                             let body_fvs2 := delBinderFV binder body_fvs in
-                             let rhs2 := freeVars rhs in
-                             pair (Core.AnnNonRec binder rhs2) (unionFVs (unionFVs (freeVarsOf rhs2)
-                                                                                   body_fvs2)
-                                                                         (bndrRuleAndUnfoldingVarsDSet binder))
-                         | Core.Rec binds, body_fvs =>
-                             let 'pair binders rhss := GHC.List.unzip binds in
-                             let rhss2 := GHC.Base.map (freeVars GHC.Base.∘ snd) binds in
-                             let rhs_body_fvs :=
-                               Data.Foldable.foldr (unionFVs GHC.Base.∘ freeVarsOf) body_fvs rhss2 in
-                             let binders_fvs :=
-                               FV.fvDVarSet (FV.mapUnionFV bndrRuleAndUnfoldingFVs binders) in
-                             let all_fvs := unionFVs rhs_body_fvs binders_fvs in
-                             pair (Core.AnnRec (GHC.List.zip binders rhss2)) (delBindersFV binders all_fvs)
-                         end for freeVars.
+Definition unionFVs : Core.DVarSet -> Core.DVarSet -> Core.DVarSet :=
+  Core.unionDVarSet.
+
+Definition unionFVss : list Core.DVarSet -> Core.DVarSet :=
+  Core.unionDVarSets.
+
+Definition dVarTypeTyCoVars : Core.Var -> Core.DTyCoVarSet :=
+  fun var => FV.fvDVarSet (varTypeTyCoFVs var).
+
+Definition delBinderFV : Core.Var -> Core.DVarSet -> Core.DVarSet :=
+  fun b s => unionFVs (Core.delDVarSet s b) (dVarTypeTyCoVars b).
+
+Definition delBindersFV : list Core.Var -> Core.DVarSet -> Core.DVarSet :=
+  fun bs fvs => Data.Foldable.foldr delBinderFV fvs bs.
+
+Definition varTypeTyCoVars : Core.Var -> Core.TyCoVarSet :=
+  fun var => FV.fvVarSet (varTypeTyCoFVs var).
+
+Definition idFVs : Core.Id -> FV.FV :=
+  fun id =>
+    if andb Util.debugIsOn (negb (Core.isId id)) : bool
+    then (Panic.assertPanic (GHC.Base.hs_string__ "ghc/compiler/coreSyn/CoreFVs.hs")
+          #629)
+    else FV.unionFV (varTypeTyCoFVs id) (bndrRuleAndUnfoldingFVs id).
+
+Definition idFreeVars : Core.Id -> Core.VarSet :=
+  fun id =>
+    if andb Util.debugIsOn (negb (Core.isId id)) : bool
+    then (Panic.assertPanic (GHC.Base.hs_string__ "ghc/compiler/coreSyn/CoreFVs.hs")
+          #622)
+    else FV.fvVarSet (idFVs id).
+
+Definition dIdFreeVars : Core.Id -> Core.DVarSet :=
+  fun id => FV.fvDVarSet (idFVs id).
+
+Definition bndrRuleAndUnfoldingVarsDSet : Core.Id -> Core.DVarSet :=
+  fun id => FV.fvDVarSet (bndrRuleAndUnfoldingFVs id).
+
+Definition idRuleVars : Core.Id -> Core.VarSet :=
+  fun id => FV.fvVarSet (idRuleFVs id).
+
+Definition idUnfoldingVars : Core.Id -> Core.VarSet :=
+  fun id => FV.fvVarSet (idUnfoldingFVs id).
+
+(* Skipping definition `CoreFVs.stableUnfoldingVars' *)
 
 Definition freeVarsBind
    : Core.CoreBind -> Core.DVarSet -> (CoreBindWithFVs * Core.DVarSet)%type :=
@@ -469,6 +410,65 @@ Definition freeVarsBind
                              let all_fvs := unionFVs rhs_body_fvs binders_fvs in
                              pair (Core.AnnRec (GHC.List.zip binders rhss2)) (delBindersFV binders all_fvs)
                          end for freeVarsBind.
+
+Definition freeVars : Core.CoreExpr -> CoreExprWithFVs :=
+  fix freeVars (arg_0__ : Core.CoreExpr) : CoreExprWithFVs
+        := match arg_0__ with
+           | Core.Mk_Var v =>
+               let ty_fvs := dVarTypeTyCoVars v in
+               if Core.isLocalVar v : bool
+               then pair (unionFVs (aFreeVar v) ty_fvs) (Core.AnnVar v) else
+               pair Core.emptyDVarSet (Core.AnnVar v)
+           | Core.Lit lit => pair Core.emptyDVarSet (Core.AnnLit lit)
+           | Core.Lam b body =>
+               let b_ty := Id.idType b in
+               let b_fvs := Core.emptyDVarSet in
+               let '(pair body_fvs _ as body') := freeVars body in
+               pair (unionFVs b_fvs (delBinderFV b body_fvs)) (Core.AnnLam b body')
+           | Core.App fun_ arg =>
+               let arg' := freeVars arg in
+               let fun' := freeVars fun_ in
+               pair (unionFVs (freeVarsOf fun') (freeVarsOf arg')) (Core.AnnApp fun' arg')
+           | Core.Case scrut bndr ty alts =>
+               let fv_alt :=
+                 fun '(pair (pair con args) rhs) =>
+                   let rhs2 := freeVars rhs in
+                   pair (delBindersFV args (freeVarsOf rhs2)) (pair (pair con args) rhs2) in
+               let 'pair alts_fvs_s alts2 := NestedRecursionHelpers.mapAndUnzipFix fv_alt
+                                               alts in
+               let alts_fvs := unionFVss alts_fvs_s in
+               let scrut2 := freeVars scrut in
+               pair (unionFVs (unionFVs (delBinderFV bndr alts_fvs) (freeVarsOf scrut2))
+                              Core.emptyDVarSet) (Core.AnnCase scrut2 bndr ty alts2)
+           | Core.Let bind body =>
+               let body2 := freeVars body in
+               let 'pair bind2 bind_fvs := freeVarsBind bind (freeVarsOf body2) in
+               pair bind_fvs (Core.AnnLet bind2 body2)
+           | Core.Cast expr co =>
+               let cfvs := Core.emptyDVarSet in
+               let expr2 := freeVars expr in
+               pair (unionFVs (freeVarsOf expr2) cfvs) (Core.AnnCast expr2 (pair cfvs co))
+           | Core.Mk_Type ty => pair Core.emptyDVarSet (Core.AnnType ty)
+           | Core.Mk_Coercion co => pair Core.emptyDVarSet (Core.AnnCoercion co)
+           end with freeVarsBind (arg_0__ : Core.CoreBind) (arg_1__ : Core.DVarSet)
+                      : (CoreBindWithFVs * Core.DVarSet)%type
+                      := match arg_0__, arg_1__ with
+                         | Core.NonRec binder rhs, body_fvs =>
+                             let body_fvs2 := delBinderFV binder body_fvs in
+                             let rhs2 := freeVars rhs in
+                             pair (Core.AnnNonRec binder rhs2) (unionFVs (unionFVs (freeVarsOf rhs2)
+                                                                                   body_fvs2)
+                                                                         (bndrRuleAndUnfoldingVarsDSet binder))
+                         | Core.Rec binds, body_fvs =>
+                             let 'pair binders rhss := GHC.List.unzip binds in
+                             let rhss2 := GHC.Base.map (freeVars GHC.Base.∘ snd) binds in
+                             let rhs_body_fvs :=
+                               Data.Foldable.foldr (unionFVs GHC.Base.∘ freeVarsOf) body_fvs rhss2 in
+                             let binders_fvs :=
+                               FV.fvDVarSet (FV.mapUnionFV bndrRuleAndUnfoldingFVs binders) in
+                             let all_fvs := unionFVs rhs_body_fvs binders_fvs in
+                             pair (Core.AnnRec (GHC.List.zip binders rhss2)) (delBindersFV binders all_fvs)
+                         end for freeVars.
 
 (* External variables:
      None andb bool cons list negb op_zt__ option pair snd BasicTypes.Activation

--- a/examples/ghc/lib/CoreMonad.v
+++ b/examples/ghc/lib/CoreMonad.v
@@ -236,123 +236,17 @@ Definition unCoreM {a} (arg_0__ : CoreM a) :=
 
 (* Converted value declarations: *)
 
-Axiom zeroSimplCount : DynFlags.DynFlags -> SimplCount.
-
-Axiom write : CoreWriter -> CoreM unit.
-
-Axiom warnMsg : GHC.Base.String -> CoreM unit.
-
-Axiom tickToTag : Tick -> nat.
-
-Axiom tickString : Tick -> GHC.Base.String.
-
-(* Skipping definition `CoreMonad.thNameToGhcName' *)
-
-Axiom simplCountN : SimplCount -> nat.
-
-Axiom runWhen : bool -> CoreToDo -> CoreToDo.
-
-Axiom runMaybe : forall {a}, option a -> (a -> CoreToDo) -> CoreToDo.
-
-(* Skipping definition `CoreMonad.runCoreM' *)
-
-Axiom reinitializeGlobals : CoreM unit.
-
-Axiom read : forall {a}, (CoreReader -> a) -> CoreM a.
-
-Axiom putMsgS : GHC.Base.String -> CoreM unit.
-
-Axiom putMsg : GHC.Base.String -> CoreM unit.
-
-Axiom pprTickGroup : list (Tick * nat)%type -> GHC.Base.String.
-
-Axiom pprTickCts : Tick -> GHC.Base.String.
-
-Axiom pprTickCounts : Data.Map.Internal.Map Tick nat -> GHC.Base.String.
-
-Axiom pprSimplCount : SimplCount -> GHC.Base.String.
-
-Axiom pprPassDetails : CoreToDo -> GHC.Base.String.
-
-Axiom pprFloatOutSwitches : FloatOutSwitches -> GHC.Base.String.
-
-Axiom plusWriter : CoreWriter -> CoreWriter -> CoreWriter.
-
-Axiom plusSimplCount : SimplCount -> SimplCount -> SimplCount.
-
-Axiom nop : forall {a},
-            CoreState -> a -> CoreIOEnv (a * CoreState * CoreWriter)%type.
-
-(* Skipping definition `CoreMonad.msg' *)
-
-Axiom modifyS : (CoreState -> CoreState) -> CoreM unit.
-
-(* Skipping definition `CoreMonad.liftIOWithCount' *)
-
-Axiom liftIOEnv : forall {a}, CoreIOEnv a -> CoreM a.
-
-Axiom isZeroSimplCount : SimplCount -> bool.
-
-Axiom hasDetailedCounts : SimplCount -> bool.
-
-Axiom getVisibleOrphanMods : CoreM Module.ModuleSet.
-
-Axiom getVerboseSimplStats : (bool -> GHC.Base.String) -> GHC.Base.String.
-
-Axiom getSrcSpanM : CoreM SrcLoc.SrcSpan.
-
-Axiom getS : forall {a}, (CoreState -> a) -> CoreM a.
-
-Axiom getRuleBase : CoreM Core.RuleBase.
-
-(* Skipping definition `CoreMonad.getPrintUnqualified' *)
-
-(* Skipping definition `CoreMonad.getPackageFamInstEnv' *)
-
-(* Skipping definition `CoreMonad.getOrigNameCache' *)
-
-(* Skipping definition `CoreMonad.getHscEnv' *)
-
-(* Skipping definition `CoreMonad.getFirstAnnotations' *)
-
-(* Skipping definition `CoreMonad.getAnnotations' *)
-
-Axiom fatalErrorMsgS : GHC.Base.String -> CoreM unit.
-
-Axiom fatalErrorMsg : GHC.Base.String -> CoreM unit.
-
-Axiom errorMsgS : GHC.Base.String -> CoreM unit.
-
-Axiom errorMsg : GHC.Base.String -> CoreM unit.
-
-Axiom emptyWriter : DynFlags.DynFlags -> CoreWriter.
-
-Axiom dumpIfSet_dyn : DynFlags.DumpFlag ->
-                      GHC.Base.String -> GHC.Base.String -> CoreM unit.
-
-Axiom doSimplTick : DynFlags.DynFlags -> Tick -> SimplCount -> SimplCount.
-
-Axiom doFreeSimplTick : Tick -> SimplCount -> SimplCount.
-
-Axiom debugTraceMsgS : GHC.Base.String -> CoreM unit.
-
-Axiom debugTraceMsg : GHC.Base.String -> CoreM unit.
-
-Axiom cmpTick : Tick -> Tick -> comparison.
-
-Axiom cmpEqTick : Tick -> Tick -> comparison.
-
-(* Skipping definition `CoreMonad.bindsOnlyPass' *)
-
-Axiom addTick : TickCounts -> Tick -> TickCounts.
-
-Axiom addSimplCount : SimplCount -> CoreM unit.
+(* Skipping all instances of class `Outputable.Outputable', including
+   `CoreMonad.Outputable__CoreToDo' *)
 
 (* Skipping all instances of class `Outputable.Outputable', including
    `CoreMonad.Outputable__SimplMode' *)
 
 (* Skipping all instances of class `Outputable.Outputable', including
    `CoreMonad.Outputable__FloatOutSwitches' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `CoreMonad.Outputable__Tick' *)
 
 Instance Eq___Tick : GHC.Base.Eq_ Tick.
 Proof.
@@ -361,23 +255,6 @@ Admitted.
 Instance Ord__Tick : GHC.Base.Ord Tick.
 Proof.
 Admitted.
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `CoreMonad.Outputable__Tick' *)
-
-(* Skipping all instances of class `HscTypes.MonadThings', including
-   `CoreMonad.MonadThings__CoreM' *)
-
-Instance HasModule__CoreM : Module.HasModule CoreM.
-Proof.
-Admitted.
-
-Instance HasDynFlags__CoreM : DynFlags.HasDynFlags CoreM.
-Proof.
-Admitted.
-
-(* Skipping all instances of class `Control.Monad.IO.Class.MonadIO', including
-   `CoreMonad.MonadIO__CoreM' *)
 
 Instance Functor__CoreM : GHC.Base.Functor CoreM.
 Proof.
@@ -391,18 +268,141 @@ Instance Monad__CoreM : GHC.Base.Monad CoreM.
 Proof.
 Admitted.
 
-Instance MonadUnique__CoreM : UniqSupply.MonadUnique CoreM.
-Proof.
-Admitted.
+(* Skipping all instances of class `GHC.Base.Alternative', including
+   `CoreMonad.Alternative__CoreM' *)
 
 (* Skipping all instances of class `GHC.Base.MonadPlus', including
    `CoreMonad.MonadPlus__CoreM' *)
 
-(* Skipping all instances of class `GHC.Base.Alternative', including
-   `CoreMonad.Alternative__CoreM' *)
+Instance MonadUnique__CoreM : UniqSupply.MonadUnique CoreM.
+Proof.
+Admitted.
 
-(* Skipping all instances of class `Outputable.Outputable', including
-   `CoreMonad.Outputable__CoreToDo' *)
+(* Skipping all instances of class `Control.Monad.IO.Class.MonadIO', including
+   `CoreMonad.MonadIO__CoreM' *)
+
+Instance HasDynFlags__CoreM : DynFlags.HasDynFlags CoreM.
+Proof.
+Admitted.
+
+Instance HasModule__CoreM : Module.HasModule CoreM.
+Proof.
+Admitted.
+
+(* Skipping all instances of class `HscTypes.MonadThings', including
+   `CoreMonad.MonadThings__CoreM' *)
+
+Axiom pprPassDetails : CoreToDo -> GHC.Base.String.
+
+Axiom pprFloatOutSwitches : FloatOutSwitches -> GHC.Base.String.
+
+Axiom runWhen : bool -> CoreToDo -> CoreToDo.
+
+Axiom runMaybe : forall {a}, option a -> (a -> CoreToDo) -> CoreToDo.
+
+(* Skipping definition `CoreMonad.bindsOnlyPass' *)
+
+Axiom getVerboseSimplStats : (bool -> GHC.Base.String) -> GHC.Base.String.
+
+Axiom simplCountN : SimplCount -> nat.
+
+Axiom zeroSimplCount : DynFlags.DynFlags -> SimplCount.
+
+Axiom isZeroSimplCount : SimplCount -> bool.
+
+Axiom hasDetailedCounts : SimplCount -> bool.
+
+Axiom doFreeSimplTick : Tick -> SimplCount -> SimplCount.
+
+Axiom doSimplTick : DynFlags.DynFlags -> Tick -> SimplCount -> SimplCount.
+
+Axiom addTick : TickCounts -> Tick -> TickCounts.
+
+Axiom plusSimplCount : SimplCount -> SimplCount -> SimplCount.
+
+Axiom pprSimplCount : SimplCount -> GHC.Base.String.
+
+Axiom pprTickCounts : Data.Map.Internal.Map Tick nat -> GHC.Base.String.
+
+Axiom pprTickGroup : list (Tick * nat)%type -> GHC.Base.String.
+
+Axiom tickToTag : Tick -> nat.
+
+Axiom tickString : Tick -> GHC.Base.String.
+
+Axiom pprTickCts : Tick -> GHC.Base.String.
+
+Axiom cmpTick : Tick -> Tick -> comparison.
+
+Axiom cmpEqTick : Tick -> Tick -> comparison.
+
+Axiom emptyWriter : DynFlags.DynFlags -> CoreWriter.
+
+Axiom plusWriter : CoreWriter -> CoreWriter -> CoreWriter.
+
+(* Skipping definition `CoreMonad.runCoreM' *)
+
+Axiom nop : forall {a},
+            CoreState -> a -> CoreIOEnv (a * CoreState * CoreWriter)%type.
+
+Axiom read : forall {a}, (CoreReader -> a) -> CoreM a.
+
+Axiom getS : forall {a}, (CoreState -> a) -> CoreM a.
+
+Axiom modifyS : (CoreState -> CoreState) -> CoreM unit.
+
+Axiom write : CoreWriter -> CoreM unit.
+
+Axiom liftIOEnv : forall {a}, CoreIOEnv a -> CoreM a.
+
+(* Skipping definition `CoreMonad.liftIOWithCount' *)
+
+(* Skipping definition `CoreMonad.getHscEnv' *)
+
+Axiom getRuleBase : CoreM Core.RuleBase.
+
+Axiom getVisibleOrphanMods : CoreM Module.ModuleSet.
+
+(* Skipping definition `CoreMonad.getPrintUnqualified' *)
+
+Axiom getSrcSpanM : CoreM SrcLoc.SrcSpan.
+
+Axiom addSimplCount : SimplCount -> CoreM unit.
+
+(* Skipping definition `CoreMonad.getOrigNameCache' *)
+
+(* Skipping definition `CoreMonad.getPackageFamInstEnv' *)
+
+Axiom reinitializeGlobals : CoreM unit.
+
+(* Skipping definition `CoreMonad.getAnnotations' *)
+
+(* Skipping definition `CoreMonad.getFirstAnnotations' *)
+
+(* Skipping definition `CoreMonad.msg' *)
+
+Axiom putMsgS : GHC.Base.String -> CoreM unit.
+
+Axiom putMsg : GHC.Base.String -> CoreM unit.
+
+Axiom errorMsgS : GHC.Base.String -> CoreM unit.
+
+Axiom errorMsg : GHC.Base.String -> CoreM unit.
+
+Axiom warnMsg : GHC.Base.String -> CoreM unit.
+
+Axiom fatalErrorMsgS : GHC.Base.String -> CoreM unit.
+
+Axiom fatalErrorMsg : GHC.Base.String -> CoreM unit.
+
+Axiom debugTraceMsgS : GHC.Base.String -> CoreM unit.
+
+Axiom debugTraceMsg : GHC.Base.String -> CoreM unit.
+
+Axiom dumpIfSet_dyn : DynFlags.DumpFlag ->
+                      GHC.Base.String -> GHC.Base.String -> CoreM unit.
+
+(* Skipping definition `CoreMonad.thNameToGhcName' *)
 
 (* External variables:
      Type bool comparison list nat op_zt__ option unit BasicTypes.CompilerPhase

--- a/examples/ghc/lib/CoreSubst.v
+++ b/examples/ghc/lib/CoreSubst.v
@@ -49,81 +49,116 @@ Instance Default_Subst : GHC.Err.Default Subst :=
 
 (* Converted value declarations: *)
 
-Definition zapSubstEnv : Subst -> Subst :=
-  fun '(Mk_Subst in_scope _ _ _) =>
-    Mk_Subst in_scope emptyVarEnv emptyVarEnv emptyVarEnv.
+(* Skipping all instances of class `Outputable.Outputable', including
+   `CoreSubst.Outputable__Subst' *)
 
-Definition substUnfolding : Subst -> Unfolding -> Unfolding :=
-  fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | _, unf => unf end.
+Definition isEmptySubst : Subst -> bool :=
+  fun '(Mk_Subst _ id_env tv_env cv_env) =>
+    andb (isEmptyVarEnv id_env) (andb (isEmptyVarEnv tv_env) (isEmptyVarEnv
+                                       cv_env)).
 
-Definition substTyVarBndr : Subst -> TyVar -> (Subst * TyVar)%type :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_Subst in_scope id_env tv_env cv_env, tv =>
-        let 'pair (Mk_TCvSubst in_scope' tv_env' cv_env') tv' := substTyVarBndr
-                                                                   (Mk_TCvSubst in_scope tv_env cv_env) tv in
-        pair (Mk_Subst in_scope' id_env tv_env' cv_env') tv'
-    end.
+Definition emptySubst : Subst :=
+  Mk_Subst emptyInScopeSet emptyVarEnv emptyVarEnv emptyVarEnv.
 
-Axiom substSpec : Subst -> Id -> RuleInfo -> RuleInfo.
-
-Definition substInScope : Subst -> InScopeSet :=
-  fun '(Mk_Subst in_scope _ _ _) => in_scope.
-
-Definition substIdInfo : Subst -> Id -> IdInfo -> option IdInfo :=
-  fun subst new_id info =>
-    let old_unf := unfoldingInfo info in
-    let old_rules := ruleInfo info in
-    let nothing_to_do :=
-      andb (isEmptyRuleInfo old_rules) (negb (isFragileUnfolding old_unf)) in
-    if nothing_to_do : bool then None else
-    Some (setUnfoldingInfo (setRuleInfo info (substSpec subst new_id old_rules))
-                           (substUnfolding subst old_unf)).
-
-Definition substCoVarBndr : Subst -> TyVar -> (Subst * TyVar)%type :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_Subst in_scope id_env tv_env cv_env, cv =>
-        let 'pair (Mk_TCvSubst in_scope' tv_env' cv_env') cv' := substCoVarBndr
-                                                                   (Mk_TCvSubst in_scope tv_env cv_env) cv in
-        pair (Mk_Subst in_scope' id_env tv_env' cv_env') cv'
-    end.
-
-Definition setInScope : Subst -> InScopeSet -> Subst :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_Subst _ ids tvs cvs, in_scope => Mk_Subst in_scope ids tvs cvs
-    end.
+Definition mkEmptySubst : InScopeSet -> Subst :=
+  fun in_scope => Mk_Subst in_scope emptyVarEnv emptyVarEnv emptyVarEnv.
 
 Definition mkSubst
    : InScopeSet -> TvSubstEnv -> CvSubstEnv -> IdSubstEnv -> Subst :=
   fun in_scope tvs cvs ids => Mk_Subst in_scope ids tvs cvs.
 
-Definition mkOpenSubst : InScopeSet -> list (Var * CoreArg)%type -> Subst :=
-  fun in_scope pairs =>
-    Mk_Subst in_scope (mkVarEnv (let cont_0__ arg_1__ :=
-                                   let 'pair id e := arg_1__ in
-                                   if isId id : bool then cons (pair id e) nil else
-                                   nil in
-                                 Coq.Lists.List.flat_map cont_0__ pairs)) (mkVarEnv (let cont_2__ arg_3__ :=
-                                                                                       match arg_3__ with
-                                                                                       | pair tv (Mk_Type ty) =>
-                                                                                           cons (pair tv ty) nil
-                                                                                       | _ => nil
-                                                                                       end in
-                                                                                     Coq.Lists.List.flat_map cont_2__
-                                                                                                             pairs))
-    (mkVarEnv (let cont_4__ arg_5__ :=
-                 match arg_5__ with
-                 | pair v (Mk_Coercion co) => cons (pair v co) nil
-                 | _ => nil
-                 end in
-               Coq.Lists.List.flat_map cont_4__ pairs)).
+Definition substInScope : Subst -> InScopeSet :=
+  fun '(Mk_Subst in_scope _ _ _) => in_scope.
 
-Definition mkEmptySubst : InScopeSet -> Subst :=
-  fun in_scope => Mk_Subst in_scope emptyVarEnv emptyVarEnv emptyVarEnv.
+Definition zapSubstEnv : Subst -> Subst :=
+  fun '(Mk_Subst in_scope _ _ _) =>
+    Mk_Subst in_scope emptyVarEnv emptyVarEnv emptyVarEnv.
 
-(* Skipping definition `CoreSubst.lookupTCvSubst' *)
+Definition extendIdSubst : Subst -> Id -> CoreExpr -> Subst :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | Mk_Subst in_scope ids tvs cvs, v, r =>
+        if andb Util.debugIsOn (negb (isNonCoVarId v)) : bool
+        then (GHC.Err.error Panic.someSDoc)
+        else Mk_Subst in_scope (extendVarEnv ids v r) tvs cvs
+    end.
+
+Definition extendIdSubstList : Subst -> list (Id * CoreExpr)%type -> Subst :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_Subst in_scope ids tvs cvs, prs =>
+        if andb Util.debugIsOn (negb (Data.Foldable.all (isNonCoVarId ∘ Data.Tuple.fst)
+                                      prs)) : bool
+        then (Panic.assertPanic (GHC.Base.hs_string__
+                                 "ghc/compiler/coreSyn/CoreSubst.hs") #204)
+        else Mk_Subst in_scope (extendVarEnvList ids prs) tvs cvs
+    end.
+
+Definition extendTvSubst : Subst -> TyVar -> AxiomatizedTypes.Type_ -> Subst :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | Mk_Subst in_scope ids tvs cvs, tv, ty =>
+        if andb Util.debugIsOn (negb (isTyVar tv)) : bool
+        then (Panic.assertPanic (GHC.Base.hs_string__
+                                 "ghc/compiler/coreSyn/CoreSubst.hs") #214)
+        else Mk_Subst in_scope ids (extendVarEnv tvs tv ty) cvs
+    end.
+
+Definition extendTvSubstList
+   : Subst -> list (TyVar * AxiomatizedTypes.Type_)%type -> Subst :=
+  fun subst vrs =>
+    let extend :=
+      fun arg_0__ arg_1__ =>
+        match arg_0__, arg_1__ with
+        | subst, pair v r => extendTvSubst subst v r
+        end in
+    Data.Foldable.foldl' extend subst vrs.
+
+Definition extendCvSubst
+   : Subst -> CoVar -> AxiomatizedTypes.Coercion -> Subst :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | Mk_Subst in_scope ids tvs cvs, v, r =>
+        if andb Util.debugIsOn (negb (isCoVar v)) : bool
+        then (Panic.assertPanic (GHC.Base.hs_string__
+                                 "ghc/compiler/coreSyn/CoreSubst.hs") #228)
+        else Mk_Subst in_scope ids tvs (extendVarEnv cvs v r)
+    end.
+
+Definition extendSubst : Subst -> Var -> CoreArg -> Subst :=
+  fun subst var arg =>
+    match arg with
+    | Mk_Type ty =>
+        if andb Util.debugIsOn (negb (isTyVar var)) : bool
+        then (Panic.assertPanic (GHC.Base.hs_string__
+                                 "ghc/compiler/coreSyn/CoreSubst.hs") #237)
+        else extendTvSubst subst var ty
+    | Mk_Coercion co =>
+        if andb Util.debugIsOn (negb (isCoVar var)) : bool
+        then (Panic.assertPanic (GHC.Base.hs_string__
+                                 "ghc/compiler/coreSyn/CoreSubst.hs") #238)
+        else extendCvSubst subst var co
+    | _ =>
+        if andb Util.debugIsOn (negb (isId var)) : bool
+        then (Panic.assertPanic (GHC.Base.hs_string__
+                                 "ghc/compiler/coreSyn/CoreSubst.hs") #239)
+        else extendIdSubst subst var arg
+    end.
+
+Definition extendSubstWithVar : Subst -> Var -> Var -> Subst :=
+  fun subst v1 v2 =>
+    if andb Util.debugIsOn (negb (isId v2)) : bool
+    then (Panic.assertPanic (GHC.Base.hs_string__
+                             "ghc/compiler/coreSyn/CoreSubst.hs") #245)
+    else extendIdSubst subst v1 (Mk_Var v2).
+
+Fixpoint extendSubstList (arg_0__ : Subst) (arg_1__ : list (Var * CoreArg)%type)
+           : Subst
+           := match arg_0__, arg_1__ with
+              | subst, nil => subst
+              | subst, cons (pair var rhs) prs =>
+                  extendSubstList (extendSubst subst var rhs) prs
+              end.
 
 Definition lookupIdSubst : String -> Subst -> Id -> CoreExpr :=
   fun arg_0__ arg_1__ arg_2__ =>
@@ -146,35 +181,45 @@ Definition lookupIdSubst : String -> Subst -> Id -> CoreExpr :=
         end
     end.
 
-Definition substDVarSet : Subst -> DVarSet -> DVarSet :=
-  fun subst fvs =>
-    let subst_fv :=
-      fun subst fv acc =>
-        if isId fv : bool
-        then CoreFVs.expr_fvs (lookupIdSubst (Datatypes.id (GHC.Base.hs_string__
-                                                            "substDVarSet")) subst fv) isLocalVar emptyVarSet acc else
-        FV.emptyFV (const true) emptyVarSet acc in
-    mkDVarSet (Data.Tuple.fst (Data.Foldable.foldr (subst_fv subst) (pair nil
-                                                                          emptyVarSet) (dVarSetElems fvs))).
+(* Skipping definition `CoreSubst.lookupTCvSubst' *)
 
-Definition substIdOcc : Subst -> Id -> Id :=
-  fun subst v =>
-    match lookupIdSubst (Datatypes.id (GHC.Base.hs_string__ "substIdOcc")) subst
-            v with
-    | Mk_Var v' => v'
-    | other => Panic.panicStr (GHC.Base.hs_string__ "substIdOcc") (Panic.someSDoc)
-    end.
-
-Definition substTickish : Subst -> Tickish Id -> Tickish Id :=
+Definition delBndr : Subst -> Var -> Subst :=
   fun arg_0__ arg_1__ =>
     match arg_0__, arg_1__ with
-    | subst, Breakpoint n ids =>
-        let do_one :=
-          CoreUtils.getIdFromTrivialExpr ∘
-          lookupIdSubst (Datatypes.id (GHC.Base.hs_string__ "subst_tickish")) subst in
-        Breakpoint n (map do_one ids)
-    | _subst, other => other
+    | Mk_Subst in_scope ids tvs cvs, v =>
+        if isCoVar v : bool then Mk_Subst in_scope ids tvs (delVarEnv cvs v) else
+        if isTyVar v : bool then Mk_Subst in_scope ids (delVarEnv tvs v) cvs else
+        Mk_Subst in_scope (delVarEnv ids v) tvs cvs
     end.
+
+Definition delBndrs : Subst -> list Var -> Subst :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_Subst in_scope ids tvs cvs, vs =>
+        Mk_Subst in_scope (delVarEnvList ids vs) (delVarEnvList tvs vs) (delVarEnvList
+                                                                         cvs vs)
+    end.
+
+Definition mkOpenSubst : InScopeSet -> list (Var * CoreArg)%type -> Subst :=
+  fun in_scope pairs =>
+    Mk_Subst in_scope (mkVarEnv (let cont_0__ arg_1__ :=
+                                   let 'pair id e := arg_1__ in
+                                   if isId id : bool then cons (pair id e) nil else
+                                   nil in
+                                 Coq.Lists.List.flat_map cont_0__ pairs)) (mkVarEnv (let cont_2__ arg_3__ :=
+                                                                                       match arg_3__ with
+                                                                                       | pair tv (Mk_Type ty) =>
+                                                                                           cons (pair tv ty) nil
+                                                                                       | _ => nil
+                                                                                       end in
+                                                                                     Coq.Lists.List.flat_map cont_2__
+                                                                                                             pairs))
+    (mkVarEnv (let cont_4__ arg_5__ :=
+                 match arg_5__ with
+                 | pair v (Mk_Coercion co) => cons (pair v co) nil
+                 | _ => nil
+                 end in
+               Coq.Lists.List.flat_map cont_4__ pairs)).
 
 Definition isInScope : Var -> Subst -> bool :=
   fun arg_0__ arg_1__ =>
@@ -182,22 +227,59 @@ Definition isInScope : Var -> Subst -> bool :=
     | v, Mk_Subst in_scope _ _ _ => elemInScopeSet v in_scope
     end.
 
-Definition isEmptySubst : Subst -> bool :=
-  fun '(Mk_Subst _ id_env tv_env cv_env) =>
-    andb (isEmptyVarEnv id_env) (andb (isEmptyVarEnv tv_env) (isEmptyVarEnv
-                                       cv_env)).
+Definition addInScopeSet : Subst -> VarSet -> Subst :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_Subst in_scope ids tvs cvs, vs =>
+        Mk_Subst (extendInScopeSetSet in_scope vs) ids tvs cvs
+    end.
 
-Definition substUnfoldingSC : Subst -> Unfolding -> Unfolding :=
-  fun subst unf =>
-    if isEmptySubst subst : bool then unf else
-    substUnfolding subst unf.
+Definition extendInScope : Subst -> Var -> Subst :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_Subst in_scope ids tvs cvs, v =>
+        Mk_Subst (extendInScopeSet in_scope v) (delVarEnv ids v) (delVarEnv tvs v)
+        (delVarEnv cvs v)
+    end.
+
+Definition extendInScopeList : Subst -> list Var -> Subst :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_Subst in_scope ids tvs cvs, vs =>
+        Mk_Subst (extendInScopeSetList in_scope vs) (delVarEnvList ids vs)
+        (delVarEnvList tvs vs) (delVarEnvList cvs vs)
+    end.
+
+Definition extendInScopeIds : Subst -> list Id -> Subst :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_Subst in_scope ids tvs cvs, vs =>
+        Mk_Subst (extendInScopeSetList in_scope vs) (delVarEnvList ids vs) tvs cvs
+    end.
+
+Definition setInScope : Subst -> InScopeSet -> Subst :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_Subst _ ids tvs cvs, in_scope => Mk_Subst in_scope ids tvs cvs
+    end.
+
+Axiom substSpec : Subst -> Id -> RuleInfo -> RuleInfo.
+
+Definition substUnfolding : Subst -> Unfolding -> Unfolding :=
+  fun arg_0__ arg_1__ => match arg_0__, arg_1__ with | _, unf => unf end.
+
+Definition substIdInfo : Subst -> Id -> IdInfo -> option IdInfo :=
+  fun subst new_id info =>
+    let old_unf := unfoldingInfo info in
+    let old_rules := ruleInfo info in
+    let nothing_to_do :=
+      andb (isEmptyRuleInfo old_rules) (negb (isFragileUnfolding old_unf)) in
+    if nothing_to_do : bool then None else
+    Some (setUnfoldingInfo (setRuleInfo info (substSpec subst new_id old_rules))
+                           (substUnfolding subst old_unf)).
 
 Definition getTCvSubst : Subst -> TCvSubst :=
   fun '(Mk_Subst in_scope _ tenv cenv) => Mk_TCvSubst in_scope tenv cenv.
-
-Definition substCo
-   : Subst -> AxiomatizedTypes.Coercion -> AxiomatizedTypes.Coercion :=
-  fun subst co => substCo (getTCvSubst subst) co.
 
 Definition substTy
    : Subst -> AxiomatizedTypes.Type_ -> AxiomatizedTypes.Type_ :=
@@ -229,67 +311,16 @@ Definition substBndr : Subst -> Var -> (Subst * Var)%type :=
 Definition substBndrs : Subst -> list Var -> (Subst * list Var)%type :=
   fun subst bndrs => mapAccumL substBndr subst bndrs.
 
+Definition substCo
+   : Subst -> AxiomatizedTypes.Coercion -> AxiomatizedTypes.Coercion :=
+  fun subst co => substCo (getTCvSubst subst) co.
+
 Definition substRecBndrs : Subst -> list Id -> (Subst * list Id)%type :=
   fun subst bndrs =>
     let 'pair new_subst new_bndrs := mapAccumL (substIdBndr (Datatypes.id
                                                              (GHC.Base.hs_string__ "rec-bndr")) (GHC.Err.error
                                                              Panic.someSDoc)) subst bndrs in
     pair new_subst new_bndrs.
-
-Definition substBind : Subst -> CoreBind -> (Subst * CoreBind)%type :=
-  fix subst_expr (doc : String) (subst : Subst) (expr : CoreExpr) : CoreExpr
-        := let go_alt :=
-             fun arg_0__ arg_1__ =>
-               match arg_0__, arg_1__ with
-               | subst, pair (pair con bndrs) rhs =>
-                   let 'pair subst' bndrs' := substBndrs subst bndrs in
-                   pair (pair con bndrs') (subst_expr doc subst' rhs)
-               end in
-           let fix go arg_5__
-                     := match arg_5__ with
-                        | Mk_Var v => lookupIdSubst (doc) subst v
-                        | Mk_Type ty => Mk_Type (substTy subst ty)
-                        | Mk_Coercion co => Mk_Coercion (substCo subst co)
-                        | Lit lit => Lit lit
-                        | App fun_ arg => App (go fun_) (go arg)
-                        | Cast e co => Cast (go e) (substCo subst co)
-                        | Lam bndr body =>
-                            let 'pair subst' bndr' := substBndr subst bndr in
-                            Lam bndr' (subst_expr doc subst' body)
-                        | Let bind body =>
-                            let 'pair subst' bind' := substBind subst bind in
-                            Let bind' (subst_expr doc subst' body)
-                        | Case scrut bndr ty alts =>
-                            let 'pair subst' bndr' := substBndr subst bndr in
-                            Case (go scrut) bndr' (substTy subst ty) (map (go_alt subst') alts)
-                        end in
-           go expr with substBind (arg_0__ : Subst) (arg_1__ : CoreBind) : (Subst *
-                                                                            CoreBind)%type
-                          := match arg_0__, arg_1__ with
-                             | subst, NonRec bndr rhs =>
-                                 let 'pair subst' bndr' := substBndr subst bndr in
-                                 pair subst' (NonRec bndr' (subst_expr (Datatypes.id (GHC.Base.hs_string__
-                                                                                      "substBind")) subst rhs))
-                             | subst, Rec pairs =>
-                                 let 'pair bndrs rhss := unzip pairs in
-                                 let 'pair subst' bndrs' := substRecBndrs subst bndrs in
-                                 let rhss' :=
-                                   map (fun ps =>
-                                          subst_expr (Datatypes.id (GHC.Base.hs_string__ "substBind")) subst' (snd ps))
-                                       pairs in
-                                 pair subst' (Rec (zip bndrs' rhss'))
-                             end for substBind.
-
-Definition substIdType : Subst -> Id -> Id :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | (Mk_Subst _ _ tv_env cv_env as subst), id =>
-        let old_ty := Id.idType id in
-        if orb (andb (isEmptyVarEnv tv_env) (isEmptyVarEnv cv_env)) (noFreeVarsOfType
-                old_ty) : bool
-        then id else
-        Id.setIdType id (substTy subst old_ty)
-    end.
 
 Definition subst_expr : String -> Subst -> CoreExpr -> CoreExpr :=
   fix subst_expr (doc : String) (subst : Subst) (expr : CoreExpr) : CoreExpr
@@ -335,6 +366,58 @@ Definition subst_expr : String -> Subst -> CoreExpr -> CoreExpr :=
                                  pair subst' (Rec (zip bndrs' rhss'))
                              end for subst_expr.
 
+Definition substExprSC : String -> Subst -> CoreExpr -> CoreExpr :=
+  fun doc subst orig_expr =>
+    if isEmptySubst subst : bool then orig_expr else
+    subst_expr doc subst orig_expr.
+
+Definition substExpr : String -> Subst -> CoreExpr -> CoreExpr :=
+  fun doc subst orig_expr => subst_expr doc subst orig_expr.
+
+Definition substBind : Subst -> CoreBind -> (Subst * CoreBind)%type :=
+  fix subst_expr (doc : String) (subst : Subst) (expr : CoreExpr) : CoreExpr
+        := let go_alt :=
+             fun arg_0__ arg_1__ =>
+               match arg_0__, arg_1__ with
+               | subst, pair (pair con bndrs) rhs =>
+                   let 'pair subst' bndrs' := substBndrs subst bndrs in
+                   pair (pair con bndrs') (subst_expr doc subst' rhs)
+               end in
+           let fix go arg_5__
+                     := match arg_5__ with
+                        | Mk_Var v => lookupIdSubst (doc) subst v
+                        | Mk_Type ty => Mk_Type (substTy subst ty)
+                        | Mk_Coercion co => Mk_Coercion (substCo subst co)
+                        | Lit lit => Lit lit
+                        | App fun_ arg => App (go fun_) (go arg)
+                        | Cast e co => Cast (go e) (substCo subst co)
+                        | Lam bndr body =>
+                            let 'pair subst' bndr' := substBndr subst bndr in
+                            Lam bndr' (subst_expr doc subst' body)
+                        | Let bind body =>
+                            let 'pair subst' bind' := substBind subst bind in
+                            Let bind' (subst_expr doc subst' body)
+                        | Case scrut bndr ty alts =>
+                            let 'pair subst' bndr' := substBndr subst bndr in
+                            Case (go scrut) bndr' (substTy subst ty) (map (go_alt subst') alts)
+                        end in
+           go expr with substBind (arg_0__ : Subst) (arg_1__ : CoreBind) : (Subst *
+                                                                            CoreBind)%type
+                          := match arg_0__, arg_1__ with
+                             | subst, NonRec bndr rhs =>
+                                 let 'pair subst' bndr' := substBndr subst bndr in
+                                 pair subst' (NonRec bndr' (subst_expr (Datatypes.id (GHC.Base.hs_string__
+                                                                                      "substBind")) subst rhs))
+                             | subst, Rec pairs =>
+                                 let 'pair bndrs rhss := unzip pairs in
+                                 let 'pair subst' bndrs' := substRecBndrs subst bndrs in
+                                 let rhss' :=
+                                   map (fun ps =>
+                                          subst_expr (Datatypes.id (GHC.Base.hs_string__ "substBind")) subst' (snd ps))
+                                       pairs in
+                                 pair subst' (Rec (zip bndrs' rhss'))
+                             end for substBind.
+
 Definition substBindSC : Subst -> CoreBind -> (Subst * CoreBind)%type :=
   fun subst bind =>
     if negb (isEmptySubst subst) : bool then substBind subst bind else
@@ -352,8 +435,104 @@ Definition substBindSC : Subst -> CoreBind -> (Subst * CoreBind)%type :=
         pair subst' (Rec (zip bndrs' rhss'))
     end.
 
-Definition substExpr : String -> Subst -> CoreExpr -> CoreExpr :=
-  fun doc subst orig_expr => subst_expr doc subst orig_expr.
+Definition deShadowBinds : CoreProgram -> CoreProgram :=
+  fun binds => Data.Tuple.snd (mapAccumL substBind emptySubst binds).
+
+Definition substIdType : Subst -> Id -> Id :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | (Mk_Subst _ _ tv_env cv_env as subst), id =>
+        let old_ty := Id.idType id in
+        if orb (andb (isEmptyVarEnv tv_env) (isEmptyVarEnv cv_env)) (noFreeVarsOfType
+                old_ty) : bool
+        then id else
+        Id.setIdType id (substTy subst old_ty)
+    end.
+
+Definition clone_id
+   : Subst -> Subst -> (Id * Unique.Unique)%type -> (Subst * Id)%type :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | rec_subst, (Mk_Subst in_scope idvs tvs cvs as subst), pair old_id uniq =>
+        let id1 := setVarUnique old_id uniq in
+        let id2 := substIdType subst id1 in
+        let new_id :=
+          Id.maybeModifyIdInfo (substIdInfo rec_subst id2 (idInfo old_id)) id2 in
+        let 'pair new_idvs new_cvs := pair (extendVarEnv idvs old_id (Mk_Var new_id))
+                                           cvs in
+        pair (Mk_Subst (extendInScopeSet in_scope new_id) new_idvs tvs new_cvs) new_id
+    end.
+
+Definition cloneIdBndr
+   : Subst -> UniqSupply.UniqSupply -> Id -> (Subst * Id)%type :=
+  fun subst us old_id =>
+    clone_id subst subst (pair old_id (UniqSupply.uniqFromSupply us)).
+
+Definition cloneIdBndrs
+   : Subst -> UniqSupply.UniqSupply -> list Id -> (Subst * list Id)%type :=
+  fun subst us ids =>
+    mapAccumL (clone_id subst) subst (zip ids (UniqSupply.uniqsFromSupply us)).
+
+Definition cloneTyVarBndr
+   : Subst -> TyVar -> Unique.Unique -> (Subst * TyVar)%type :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | Mk_Subst in_scope id_env tv_env cv_env, tv, uniq =>
+        let 'pair (Mk_TCvSubst in_scope' tv_env' cv_env') tv' := cloneTyVarBndr
+                                                                   (Mk_TCvSubst in_scope tv_env cv_env) tv uniq in
+        pair (Mk_Subst in_scope' id_env tv_env' cv_env') tv'
+    end.
+
+Definition cloneBndr : Subst -> Unique.Unique -> Var -> (Subst * Var)%type :=
+  fun subst uniq v =>
+    if isTyVar v : bool then cloneTyVarBndr subst v uniq else
+    clone_id subst subst (pair v uniq).
+
+Definition cloneBndrs
+   : Subst -> UniqSupply.UniqSupply -> list Var -> (Subst * list Var)%type :=
+  fun subst us vs =>
+    mapAccumL (fun arg_0__ arg_1__ =>
+                 match arg_0__, arg_1__ with
+                 | subst, pair v u => cloneBndr subst u v
+                 end) subst (zip vs (UniqSupply.uniqsFromSupply us)).
+
+Definition cloneRecIdBndrs
+   : Subst -> UniqSupply.UniqSupply -> list Id -> (Subst * list Id)%type :=
+  fun subst us ids =>
+    let 'pair subst' ids' := mapAccumL (clone_id (GHC.Err.error Panic.someSDoc))
+                               subst (zip ids (UniqSupply.uniqsFromSupply us)) in
+    pair subst' ids'.
+
+Definition substTyVarBndr : Subst -> TyVar -> (Subst * TyVar)%type :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_Subst in_scope id_env tv_env cv_env, tv =>
+        let 'pair (Mk_TCvSubst in_scope' tv_env' cv_env') tv' := substTyVarBndr
+                                                                   (Mk_TCvSubst in_scope tv_env cv_env) tv in
+        pair (Mk_Subst in_scope' id_env tv_env' cv_env') tv'
+    end.
+
+Definition substCoVarBndr : Subst -> TyVar -> (Subst * TyVar)%type :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_Subst in_scope id_env tv_env cv_env, cv =>
+        let 'pair (Mk_TCvSubst in_scope' tv_env' cv_env') cv' := substCoVarBndr
+                                                                   (Mk_TCvSubst in_scope tv_env cv_env) cv in
+        pair (Mk_Subst in_scope' id_env tv_env' cv_env') cv'
+    end.
+
+Definition substUnfoldingSC : Subst -> Unfolding -> Unfolding :=
+  fun subst unf =>
+    if isEmptySubst subst : bool then unf else
+    substUnfolding subst unf.
+
+Definition substIdOcc : Subst -> Id -> Id :=
+  fun subst v =>
+    match lookupIdSubst (Datatypes.id (GHC.Base.hs_string__ "substIdOcc")) subst
+            v with
+    | Mk_Var v' => v'
+    | other => Panic.panicStr (GHC.Base.hs_string__ "substIdOcc") (Panic.someSDoc)
+    end.
 
 Definition substRule
    : Subst -> (Name.Name -> Name.Name) -> CoreRule -> CoreRule :=
@@ -387,206 +566,27 @@ Definition substRulesForImportedIds : Subst -> list CoreRule -> list CoreRule :=
         (Panic.someSDoc) in
     map (substRule subst not_needed) rules.
 
-Definition substExprSC : String -> Subst -> CoreExpr -> CoreExpr :=
-  fun doc subst orig_expr =>
-    if isEmptySubst subst : bool then orig_expr else
-    subst_expr doc subst orig_expr.
+Definition substDVarSet : Subst -> DVarSet -> DVarSet :=
+  fun subst fvs =>
+    let subst_fv :=
+      fun subst fv acc =>
+        if isId fv : bool
+        then CoreFVs.expr_fvs (lookupIdSubst (Datatypes.id (GHC.Base.hs_string__
+                                                            "substDVarSet")) subst fv) isLocalVar emptyVarSet acc else
+        FV.emptyFV (const true) emptyVarSet acc in
+    mkDVarSet (Data.Tuple.fst (Data.Foldable.foldr (subst_fv subst) (pair nil
+                                                                          emptyVarSet) (dVarSetElems fvs))).
 
-Definition extendTvSubst : Subst -> TyVar -> AxiomatizedTypes.Type_ -> Subst :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | Mk_Subst in_scope ids tvs cvs, tv, ty =>
-        if andb Util.debugIsOn (negb (isTyVar tv)) : bool
-        then (Panic.assertPanic (GHC.Base.hs_string__
-                                 "ghc/compiler/coreSyn/CoreSubst.hs") #214)
-        else Mk_Subst in_scope ids (extendVarEnv tvs tv ty) cvs
-    end.
-
-Definition extendTvSubstList
-   : Subst -> list (TyVar * AxiomatizedTypes.Type_)%type -> Subst :=
-  fun subst vrs =>
-    let extend :=
-      fun arg_0__ arg_1__ =>
-        match arg_0__, arg_1__ with
-        | subst, pair v r => extendTvSubst subst v r
-        end in
-    Data.Foldable.foldl' extend subst vrs.
-
-Definition extendInScopeList : Subst -> list Var -> Subst :=
+Definition substTickish : Subst -> Tickish Id -> Tickish Id :=
   fun arg_0__ arg_1__ =>
     match arg_0__, arg_1__ with
-    | Mk_Subst in_scope ids tvs cvs, vs =>
-        Mk_Subst (extendInScopeSetList in_scope vs) (delVarEnvList ids vs)
-        (delVarEnvList tvs vs) (delVarEnvList cvs vs)
+    | subst, Breakpoint n ids =>
+        let do_one :=
+          CoreUtils.getIdFromTrivialExpr ∘
+          lookupIdSubst (Datatypes.id (GHC.Base.hs_string__ "subst_tickish")) subst in
+        Breakpoint n (map do_one ids)
+    | _subst, other => other
     end.
-
-Definition extendInScopeIds : Subst -> list Id -> Subst :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_Subst in_scope ids tvs cvs, vs =>
-        Mk_Subst (extendInScopeSetList in_scope vs) (delVarEnvList ids vs) tvs cvs
-    end.
-
-Definition extendInScope : Subst -> Var -> Subst :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_Subst in_scope ids tvs cvs, v =>
-        Mk_Subst (extendInScopeSet in_scope v) (delVarEnv ids v) (delVarEnv tvs v)
-        (delVarEnv cvs v)
-    end.
-
-Definition extendIdSubstList : Subst -> list (Id * CoreExpr)%type -> Subst :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_Subst in_scope ids tvs cvs, prs =>
-        if andb Util.debugIsOn (negb (Data.Foldable.all (isNonCoVarId ∘ Data.Tuple.fst)
-                                      prs)) : bool
-        then (Panic.assertPanic (GHC.Base.hs_string__
-                                 "ghc/compiler/coreSyn/CoreSubst.hs") #204)
-        else Mk_Subst in_scope (extendVarEnvList ids prs) tvs cvs
-    end.
-
-Definition extendIdSubst : Subst -> Id -> CoreExpr -> Subst :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | Mk_Subst in_scope ids tvs cvs, v, r =>
-        if andb Util.debugIsOn (negb (isNonCoVarId v)) : bool
-        then (GHC.Err.error Panic.someSDoc)
-        else Mk_Subst in_scope (extendVarEnv ids v r) tvs cvs
-    end.
-
-Definition extendSubstWithVar : Subst -> Var -> Var -> Subst :=
-  fun subst v1 v2 =>
-    if andb Util.debugIsOn (negb (isId v2)) : bool
-    then (Panic.assertPanic (GHC.Base.hs_string__
-                             "ghc/compiler/coreSyn/CoreSubst.hs") #245)
-    else extendIdSubst subst v1 (Mk_Var v2).
-
-Definition extendCvSubst
-   : Subst -> CoVar -> AxiomatizedTypes.Coercion -> Subst :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | Mk_Subst in_scope ids tvs cvs, v, r =>
-        if andb Util.debugIsOn (negb (isCoVar v)) : bool
-        then (Panic.assertPanic (GHC.Base.hs_string__
-                                 "ghc/compiler/coreSyn/CoreSubst.hs") #228)
-        else Mk_Subst in_scope ids tvs (extendVarEnv cvs v r)
-    end.
-
-Definition extendSubst : Subst -> Var -> CoreArg -> Subst :=
-  fun subst var arg =>
-    match arg with
-    | Mk_Type ty =>
-        if andb Util.debugIsOn (negb (isTyVar var)) : bool
-        then (Panic.assertPanic (GHC.Base.hs_string__
-                                 "ghc/compiler/coreSyn/CoreSubst.hs") #237)
-        else extendTvSubst subst var ty
-    | Mk_Coercion co =>
-        if andb Util.debugIsOn (negb (isCoVar var)) : bool
-        then (Panic.assertPanic (GHC.Base.hs_string__
-                                 "ghc/compiler/coreSyn/CoreSubst.hs") #238)
-        else extendCvSubst subst var co
-    | _ =>
-        if andb Util.debugIsOn (negb (isId var)) : bool
-        then (Panic.assertPanic (GHC.Base.hs_string__
-                                 "ghc/compiler/coreSyn/CoreSubst.hs") #239)
-        else extendIdSubst subst var arg
-    end.
-
-Fixpoint extendSubstList (arg_0__ : Subst) (arg_1__ : list (Var * CoreArg)%type)
-           : Subst
-           := match arg_0__, arg_1__ with
-              | subst, nil => subst
-              | subst, cons (pair var rhs) prs =>
-                  extendSubstList (extendSubst subst var rhs) prs
-              end.
-
-Definition emptySubst : Subst :=
-  Mk_Subst emptyInScopeSet emptyVarEnv emptyVarEnv emptyVarEnv.
-
-Definition delBndrs : Subst -> list Var -> Subst :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_Subst in_scope ids tvs cvs, vs =>
-        Mk_Subst in_scope (delVarEnvList ids vs) (delVarEnvList tvs vs) (delVarEnvList
-                                                                         cvs vs)
-    end.
-
-Definition delBndr : Subst -> Var -> Subst :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_Subst in_scope ids tvs cvs, v =>
-        if isCoVar v : bool then Mk_Subst in_scope ids tvs (delVarEnv cvs v) else
-        if isTyVar v : bool then Mk_Subst in_scope ids (delVarEnv tvs v) cvs else
-        Mk_Subst in_scope (delVarEnv ids v) tvs cvs
-    end.
-
-Definition deShadowBinds : CoreProgram -> CoreProgram :=
-  fun binds => Data.Tuple.snd (mapAccumL substBind emptySubst binds).
-
-Definition clone_id
-   : Subst -> Subst -> (Id * Unique.Unique)%type -> (Subst * Id)%type :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | rec_subst, (Mk_Subst in_scope idvs tvs cvs as subst), pair old_id uniq =>
-        let id1 := setVarUnique old_id uniq in
-        let id2 := substIdType subst id1 in
-        let new_id :=
-          Id.maybeModifyIdInfo (substIdInfo rec_subst id2 (idInfo old_id)) id2 in
-        let 'pair new_idvs new_cvs := pair (extendVarEnv idvs old_id (Mk_Var new_id))
-                                           cvs in
-        pair (Mk_Subst (extendInScopeSet in_scope new_id) new_idvs tvs new_cvs) new_id
-    end.
-
-Definition cloneTyVarBndr
-   : Subst -> TyVar -> Unique.Unique -> (Subst * TyVar)%type :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | Mk_Subst in_scope id_env tv_env cv_env, tv, uniq =>
-        let 'pair (Mk_TCvSubst in_scope' tv_env' cv_env') tv' := cloneTyVarBndr
-                                                                   (Mk_TCvSubst in_scope tv_env cv_env) tv uniq in
-        pair (Mk_Subst in_scope' id_env tv_env' cv_env') tv'
-    end.
-
-Definition cloneRecIdBndrs
-   : Subst -> UniqSupply.UniqSupply -> list Id -> (Subst * list Id)%type :=
-  fun subst us ids =>
-    let 'pair subst' ids' := mapAccumL (clone_id (GHC.Err.error Panic.someSDoc))
-                               subst (zip ids (UniqSupply.uniqsFromSupply us)) in
-    pair subst' ids'.
-
-Definition cloneIdBndrs
-   : Subst -> UniqSupply.UniqSupply -> list Id -> (Subst * list Id)%type :=
-  fun subst us ids =>
-    mapAccumL (clone_id subst) subst (zip ids (UniqSupply.uniqsFromSupply us)).
-
-Definition cloneIdBndr
-   : Subst -> UniqSupply.UniqSupply -> Id -> (Subst * Id)%type :=
-  fun subst us old_id =>
-    clone_id subst subst (pair old_id (UniqSupply.uniqFromSupply us)).
-
-Definition cloneBndr : Subst -> Unique.Unique -> Var -> (Subst * Var)%type :=
-  fun subst uniq v =>
-    if isTyVar v : bool then cloneTyVarBndr subst v uniq else
-    clone_id subst subst (pair v uniq).
-
-Definition cloneBndrs
-   : Subst -> UniqSupply.UniqSupply -> list Var -> (Subst * list Var)%type :=
-  fun subst us vs =>
-    mapAccumL (fun arg_0__ arg_1__ =>
-                 match arg_0__, arg_1__ with
-                 | subst, pair v u => cloneBndr subst u v
-                 end) subst (zip vs (UniqSupply.uniqsFromSupply us)).
-
-Definition addInScopeSet : Subst -> VarSet -> Subst :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_Subst in_scope ids tvs cvs, vs =>
-        Mk_Subst (extendInScopeSetSet in_scope vs) ids tvs cvs
-    end.
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `CoreSubst.Outputable__Subst' *)
 
 (* External variables:
      App Breakpoint BuiltinRule Case Cast CoVar CoreArg CoreBind CoreExpr CoreProgram

--- a/examples/ghc/lib/CoreUtils.v
+++ b/examples/ghc/lib/CoreUtils.v
@@ -48,34 +48,145 @@ Definition CheapAppFun :=
 
 (* Converted value declarations: *)
 
-Axiom tryEtaReduce : list Core.Var -> Core.CoreExpr -> option Core.CoreExpr.
+Axiom exprType : Core.CoreExpr -> AxiomatizedTypes.Type_.
 
-Definition trimConArgs
-   : Core.AltCon -> list Core.CoreArg -> list Core.CoreArg :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Core.DEFAULT, args =>
-        if andb Util.debugIsOn (negb (Data.Foldable.null args)) : bool
-        then (Panic.assertPanic (GHC.Base.hs_string__
-                                 "ghc/compiler/coreSyn/CoreUtils.hs") #600)
-        else nil
-    | Core.LitAlt _, args =>
-        if andb Util.debugIsOn (negb (Data.Foldable.null args)) : bool
-        then (Panic.assertPanic (GHC.Base.hs_string__
-                                 "ghc/compiler/coreSyn/CoreUtils.hs") #601)
-        else nil
-    | Core.DataAlt dc, args => Util.dropList (Core.dataConUnivTyVars dc) args
-    end.
+Axiom coreAltType : Core.CoreAlt -> AxiomatizedTypes.Type_.
+
+Axiom coreAltsType : list Core.CoreAlt -> AxiomatizedTypes.Type_.
+
+Axiom isExprLevPoly : Core.CoreExpr -> bool.
+
+Axiom applyTypeToArgs : Core.CoreExpr ->
+                        AxiomatizedTypes.Type_ -> list Core.CoreExpr -> AxiomatizedTypes.Type_.
+
+Fixpoint mkCast (arg_0__ : Core.CoreExpr) (arg_1__ : AxiomatizedTypes.Coercion)
+           : Core.CoreExpr
+           := match arg_0__, arg_1__ with
+              | e, co =>
+                  if (if andb Util.debugIsOn (negb (Core.coercionRole co GHC.Base.==
+                                                    AxiomatizedTypes.Representational)) : bool
+                      then (GHC.Err.error (GHC.Base.mappend (GHC.Base.mappend (GHC.Base.mappend
+                                                                               (GHC.Base.mappend (GHC.Base.mappend
+                                                                                                  (Datatypes.id
+                                                                                                   (GHC.Base.hs_string__
+                                                                                                    "coercion"))
+                                                                                                  Panic.someSDoc)
+                                                                                                 Panic.someSDoc)
+                                                                               Panic.someSDoc) (Datatypes.id
+                                                                               (GHC.Base.hs_string__ "has wrong role")))
+                                                            Panic.someSDoc))
+                      else Core.isReflCo co) : bool
+                  then e else
+                  let j_7__ :=
+                    match arg_0__, arg_1__ with
+                    | Core.Cast expr co2, co =>
+                        Panic.warnPprTrace (let 'Pair.Mk_Pair _from_ty2 to_ty2 := Core.coercionKind
+                                                                                    co2 in
+                                            let 'Pair.Mk_Pair from_ty _to_ty := Core.coercionKind co in
+                                            negb (Core.eqType from_ty to_ty2)) (GHC.Base.hs_string__
+                                            "ghc/compiler/coreSyn/CoreUtils.hs") #279 (Panic.someSDoc) (mkCast expr
+                                                                                                               (Core.mkTransCo
+                                                                                                                co2 co))
+                    | expr, co =>
+                        let 'Pair.Mk_Pair from_ty _to_ty := Core.coercionKind co in
+                        Panic.warnPprTrace (negb (Core.eqType from_ty (exprType expr)))
+                                           (GHC.Base.hs_string__ "ghc/compiler/coreSyn/CoreUtils.hs") #290
+                                           (GHC.Base.mappend (GHC.Base.mappend (GHC.Base.mappend (GHC.Base.mappend
+                                                                                                  (Datatypes.id
+                                                                                                   (GHC.Base.hs_string__
+                                                                                                    "Trying to coerce"))
+                                                                                                  (Datatypes.id
+                                                                                                   (GHC.Base.hs_string__
+                                                                                                    "(")))
+                                                                                                 Panic.someSDoc)
+                                                                               Panic.someSDoc) (Datatypes.id
+                                                              (GHC.Base.hs_string__ ")"))) (Core.Cast expr co)
+                    end in
+                  match arg_0__, arg_1__ with
+                  | Core.Mk_Coercion e_co, co =>
+                      if Core.isCoercionType (Pair.pSnd (Core.coercionKind co)) : bool
+                      then Core.Mk_Coercion (Core.mkCoCast e_co co) else
+                      j_7__
+                  | _, _ => j_7__
+                  end
+              end.
+
+(* Skipping definition `CoreUtils.mkTick' *)
+
+(* Skipping definition `CoreUtils.mkTicks' *)
+
+Definition isSaturatedConApp : Core.CoreExpr -> bool :=
+  fun e =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | Core.App f a, as_ => go f (cons a as_)
+                 | Core.Mk_Var fun_, args =>
+                     andb (Id.isConLikeId fun_) (Id.idArity fun_ GHC.Base.== Core.valArgCount args)
+                 | Core.Cast f _, as_ => go f as_
+                 | _, _ => false
+                 end in
+    go e nil.
+
+(* Skipping definition `CoreUtils.mkTickNoHNF' *)
 
 (* Skipping definition `CoreUtils.tickHNFArgs' *)
 
-(* Skipping definition `CoreUtils.stripTicksTopT' *)
+(* Skipping definition `CoreUtils.stripTicksTop' *)
 
 Definition stripTicksTopE {b}
    : (Core.Tickish Core.Id -> bool) -> Core.Expr b -> Core.Expr b :=
   fun p => let go := fun '(other) => other in go.
 
-(* Skipping definition `CoreUtils.stripTicksTop' *)
+(* Skipping definition `CoreUtils.stripTicksTopT' *)
+
+Definition stripTicksE {b}
+   : (Core.Tickish Core.Id -> bool) -> Core.Expr b -> Core.Expr b :=
+  fun p expr =>
+    let go :=
+      fix go arg_0__
+            := let go_a (arg_14__ : Core.Alt b) : Core.Alt b :=
+                 let 'pair (pair c bs) e := arg_14__ in
+                 pair (pair c bs) (go e) in
+               match arg_0__ with
+               | Core.App e a => Core.App (go e) (go a)
+               | Core.Lam b e => Core.Lam b (go e)
+               | Core.Let b e => Core.Let (go_bs b) (go e)
+               | Core.Case e b t as_ => Core.Case (go e) b t (GHC.Base.map go_a as_)
+               | Core.Cast e c => Core.Cast (go e) c
+               | other => other
+               end with go_bs arg_7__
+                          := let go_b (arg_11__ : b * Core.Expr b) : b * Core.Expr b :=
+                               let 'pair b e := arg_11__ in
+                               pair b (go e) in
+                             match arg_7__ with
+                             | Core.NonRec b e => Core.NonRec b (go e)
+                             | Core.Rec bs => Core.Rec (GHC.Base.map go_b bs)
+                             end for go in
+    let go_bs :=
+      fix go arg_0__
+            := let go_a (arg_14__ : Core.Alt b) : Core.Alt b :=
+                 let 'pair (pair c bs) e := arg_14__ in
+                 pair (pair c bs) (go e) in
+               match arg_0__ with
+               | Core.App e a => Core.App (go e) (go a)
+               | Core.Lam b e => Core.Lam b (go e)
+               | Core.Let b e => Core.Let (go_bs b) (go e)
+               | Core.Case e b t as_ => Core.Case (go e) b t (GHC.Base.map go_a as_)
+               | Core.Cast e c => Core.Cast (go e) c
+               | other => other
+               end with go_bs arg_7__
+                          := let go_b (arg_11__ : b * Core.Expr b) : b * Core.Expr b :=
+                               let 'pair b e := arg_11__ in
+                               pair b (go e) in
+                             match arg_7__ with
+                             | Core.NonRec b e => Core.NonRec b (go e)
+                             | Core.Rec bs => Core.Rec (GHC.Base.map go_b bs)
+                             end for go_bs in
+    let go_b : b * Core.Expr b -> b * Core.Expr b :=
+      fun '(pair b e) => pair b (go e) in
+    let go_a : Core.Alt b -> Core.Alt b :=
+      fun '(pair (pair c bs) e) => pair (pair c bs) (go e) in
+    go expr.
 
 Definition stripTicksT {b}
    : (Core.Tickish Core.Id -> bool) ->
@@ -131,67 +242,12 @@ Definition stripTicksT {b}
       fun '(pair (pair _ _) e) => go e in
     OrdList.fromOL (go expr).
 
-Definition stripTicksE {b}
-   : (Core.Tickish Core.Id -> bool) -> Core.Expr b -> Core.Expr b :=
-  fun p expr =>
-    let go :=
-      fix go arg_0__
-            := let go_a (arg_14__ : Core.Alt b) : Core.Alt b :=
-                 let 'pair (pair c bs) e := arg_14__ in
-                 pair (pair c bs) (go e) in
-               match arg_0__ with
-               | Core.App e a => Core.App (go e) (go a)
-               | Core.Lam b e => Core.Lam b (go e)
-               | Core.Let b e => Core.Let (go_bs b) (go e)
-               | Core.Case e b t as_ => Core.Case (go e) b t (GHC.Base.map go_a as_)
-               | Core.Cast e c => Core.Cast (go e) c
-               | other => other
-               end with go_bs arg_7__
-                          := let go_b (arg_11__ : b * Core.Expr b) : b * Core.Expr b :=
-                               let 'pair b e := arg_11__ in
-                               pair b (go e) in
-                             match arg_7__ with
-                             | Core.NonRec b e => Core.NonRec b (go e)
-                             | Core.Rec bs => Core.Rec (GHC.Base.map go_b bs)
-                             end for go in
-    let go_bs :=
-      fix go arg_0__
-            := let go_a (arg_14__ : Core.Alt b) : Core.Alt b :=
-                 let 'pair (pair c bs) e := arg_14__ in
-                 pair (pair c bs) (go e) in
-               match arg_0__ with
-               | Core.App e a => Core.App (go e) (go a)
-               | Core.Lam b e => Core.Lam b (go e)
-               | Core.Let b e => Core.Let (go_bs b) (go e)
-               | Core.Case e b t as_ => Core.Case (go e) b t (GHC.Base.map go_a as_)
-               | Core.Cast e c => Core.Cast (go e) c
-               | other => other
-               end with go_bs arg_7__
-                          := let go_b (arg_11__ : b * Core.Expr b) : b * Core.Expr b :=
-                               let 'pair b e := arg_11__ in
-                               pair b (go e) in
-                             match arg_7__ with
-                             | Core.NonRec b e => Core.NonRec b (go e)
-                             | Core.Rec bs => Core.Rec (GHC.Base.map go_b bs)
-                             end for go_bs in
-    let go_b : b * Core.Expr b -> b * Core.Expr b :=
-      fun '(pair b e) => pair b (go e) in
-    let go_a : Core.Alt b -> Core.Alt b :=
-      fun '(pair (pair c bs) e) => pair (pair c bs) (go e) in
-    go expr.
+Axiom bindNonRec : Core.Id -> Core.CoreExpr -> Core.CoreExpr -> Core.CoreExpr.
 
-(* Skipping definition `CoreUtils.rhsIsStatic' *)
+Axiom exprOkForSpeculation : Core.CoreExpr -> bool.
 
-Axiom refineDefaultAlt : list Unique.Unique ->
-                         Core.TyCon ->
-                         list AxiomatizedTypes.Type_ ->
-                         list Core.AltCon -> list Core.CoreAlt -> (bool * list Core.CoreAlt)%type.
-
-(* Skipping definition `CoreUtils.mkTicks' *)
-
-(* Skipping definition `CoreUtils.mkTickNoHNF' *)
-
-(* Skipping definition `CoreUtils.mkTick' *)
+Definition needsCaseBinding : AxiomatizedTypes.Type_ -> Core.CoreExpr -> bool :=
+  fun ty rhs => andb (Core.isUnliftedType ty) (negb (exprOkForSpeculation rhs)).
 
 Definition mkAltExpr
    : Core.AltCon ->
@@ -206,107 +262,6 @@ Definition mkAltExpr
     | Core.DEFAULT, _, _ => Panic.panic (GHC.Base.hs_string__ "mkAltExpr DEFAULT")
     end.
 
-Definition mergeAlts {a} {b}
-   : list (Core.AltCon * a * b)%type ->
-     list (Core.AltCon * a * b)%type -> list (Core.AltCon * a * b)%type :=
-  GHC.DeferredFix.deferredFix1 (fun mergeAlts
-                                (arg_0__ arg_1__ : list (Core.AltCon * a * b)%type) =>
-                                  match arg_0__, arg_1__ with
-                                  | nil, as2 => as2
-                                  | as1, nil => as1
-                                  | cons a1 as1, cons a2 as2 =>
-                                      match Core.cmpAlt a1 a2 with
-                                      | Lt => cons a1 (mergeAlts as1 (cons a2 as2))
-                                      | Eq => cons a1 (mergeAlts as1 as2)
-                                      | Gt => cons a2 (mergeAlts (cons a1 as1) as2)
-                                      end
-                                  end).
-
-Definition locBind
-   : GHC.Base.String ->
-     Core.Var -> Core.Var -> list GHC.Base.String -> list GHC.Base.String :=
-  fun loc b1 b2 diffs =>
-    let bindLoc :=
-      if b1 GHC.Base.== b2 : bool then Panic.someSDoc else
-      GHC.Base.mappend (GHC.Base.mappend Panic.someSDoc Panic.someSDoc)
-                       Panic.someSDoc in
-    let addLoc := fun d => d in GHC.Base.map addLoc diffs.
-
-Definition isWorkFreeApp : CheapAppFun :=
-  fun fn n_val_args =>
-    if n_val_args GHC.Base.== #0 : bool then true else
-    if n_val_args GHC.Base.< Id.idArity fn : bool then true else
-    match Core.idDetails fn with
-    | Core.DataConWorkId _ => true
-    | _ => false
-    end.
-
-Definition isSaturatedConApp : Core.CoreExpr -> bool :=
-  fun e =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | Core.App f a, as_ => go f (cons a as_)
-                 | Core.Mk_Var fun_, args =>
-                     andb (Id.isConLikeId fun_) (Id.idArity fun_ GHC.Base.== Core.valArgCount args)
-                 | Core.Cast f _, as_ => go f as_
-                 | _, _ => false
-                 end in
-    go e nil.
-
-Definition isJoinBind : Core.CoreBind -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Core.NonRec b _ => Id.isJoinId b
-    | Core.Rec (cons (pair b _) _) => Id.isJoinId b
-    | _ => false
-    end.
-
-Axiom isExprLevPoly : Core.CoreExpr -> bool.
-
-Axiom isExpandableApp : CheapAppFun.
-
-Definition isEmptyTy : AxiomatizedTypes.Type_ -> bool :=
-  fun ty =>
-    match Core.splitTyConApp_maybe ty with
-    | Some (pair tc inst_tys) =>
-        match Core.tyConDataCons_maybe tc with
-        | Some dcs =>
-            if Data.Foldable.all (Core.dataConCannotMatch inst_tys) dcs : bool
-            then true else
-            false
-        | _ => false
-        end
-    | _ => false
-    end.
-
-Axiom isDivOp : AxiomatizedTypes.PrimOp -> bool.
-
-Definition isDefaultAlt {a} {b} : (Core.AltCon * a * b)%type -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | pair (pair Core.DEFAULT _) _ => true
-    | _ => false
-    end.
-
-Axiom isCheapApp : CheapAppFun.
-
-Definition getIdFromTrivialExpr_maybe : Core.CoreExpr -> option Core.Id :=
-  fun e =>
-    let fix go arg_0__
-              := match arg_0__ with
-                 | Core.Mk_Var v => Some v
-                 | Core.App f t => if negb (Core.isRuntimeArg t) : bool then go f else None
-                 | Core.Cast e _ => go e
-                 | Core.Lam b e => if negb (Core.isRuntimeVar b) : bool then go e else None
-                 | _ => None
-                 end in
-    go e.
-
-Definition getIdFromTrivialExpr : Core.CoreExpr -> Core.Id :=
-  fun e =>
-    Data.Maybe.fromMaybe (Panic.panicStr (GHC.Base.hs_string__
-                                          "getIdFromTrivialExpr") (Panic.someSDoc)) (getIdFromTrivialExpr_maybe e).
-
 Definition findDefault {a} {b}
    : list (Core.AltCon * list a * b)%type ->
      (list (Core.AltCon * list a * b)%type * option b)%type :=
@@ -318,6 +273,22 @@ Definition findDefault {a} {b}
                                  "ghc/compiler/coreSyn/CoreUtils.hs") #519)
         else pair alts (Some rhs)
     | alts => pair alts None
+    end.
+
+Definition addDefault {a} {b}
+   : list (Core.AltCon * list a * b)%type ->
+     option b -> list (Core.AltCon * list a * b)%type :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | alts, None => alts
+    | alts, Some rhs => cons (pair (pair Core.DEFAULT nil) rhs) alts
+    end.
+
+Definition isDefaultAlt {a} {b} : (Core.AltCon * a * b)%type -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | pair (pair Core.DEFAULT _) _ => true
+    | _ => false
     end.
 
 Definition findAlt {a} {b}
@@ -343,68 +314,74 @@ Definition findAlt {a} {b}
     | _ => go alts None
     end.
 
-Axiom expr_ok : (AxiomatizedTypes.PrimOp -> bool) -> Core.CoreExpr -> bool.
+Definition mergeAlts {a} {b}
+   : list (Core.AltCon * a * b)%type ->
+     list (Core.AltCon * a * b)%type -> list (Core.AltCon * a * b)%type :=
+  GHC.DeferredFix.deferredFix1 (fun mergeAlts
+                                (arg_0__ arg_1__ : list (Core.AltCon * a * b)%type) =>
+                                  match arg_0__, arg_1__ with
+                                  | nil, as2 => as2
+                                  | as1, nil => as1
+                                  | cons a1 as1, cons a2 as2 =>
+                                      match Core.cmpAlt a1 a2 with
+                                      | Lt => cons a1 (mergeAlts as1 (cons a2 as2))
+                                      | Eq => cons a1 (mergeAlts as1 as2)
+                                      | Gt => cons a2 (mergeAlts (cons a1 as1) as2)
+                                      end
+                                  end).
 
-Axiom exprType : Core.CoreExpr -> AxiomatizedTypes.Type_.
+Definition trimConArgs
+   : Core.AltCon -> list Core.CoreArg -> list Core.CoreArg :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Core.DEFAULT, args =>
+        if andb Util.debugIsOn (negb (Data.Foldable.null args)) : bool
+        then (Panic.assertPanic (GHC.Base.hs_string__
+                                 "ghc/compiler/coreSyn/CoreUtils.hs") #600)
+        else nil
+    | Core.LitAlt _, args =>
+        if andb Util.debugIsOn (negb (Data.Foldable.null args)) : bool
+        then (Panic.assertPanic (GHC.Base.hs_string__
+                                 "ghc/compiler/coreSyn/CoreUtils.hs") #601)
+        else nil
+    | Core.DataAlt dc, args => Util.dropList (Core.dataConUnivTyVars dc) args
+    end.
 
-Fixpoint mkCast (arg_0__ : Core.CoreExpr) (arg_1__ : AxiomatizedTypes.Coercion)
-           : Core.CoreExpr
-           := match arg_0__, arg_1__ with
-              | e, co =>
-                  if (if andb Util.debugIsOn (negb (Core.coercionRole co GHC.Base.==
-                                                    AxiomatizedTypes.Representational)) : bool
-                      then (GHC.Err.error (GHC.Base.mappend (GHC.Base.mappend (GHC.Base.mappend
-                                                                               (GHC.Base.mappend (GHC.Base.mappend
-                                                                                                  (Datatypes.id
-                                                                                                   (GHC.Base.hs_string__
-                                                                                                    "coercion"))
-                                                                                                  Panic.someSDoc)
-                                                                                                 Panic.someSDoc)
-                                                                               Panic.someSDoc) (Datatypes.id
-                                                                               (GHC.Base.hs_string__ "has wrong role")))
-                                                            Panic.someSDoc))
-                      else Core.isReflCo co) : bool
-                  then e else
-                  let j_7__ :=
-                    match arg_0__, arg_1__ with
-                    | Core.Cast expr co2, co =>
-                        Panic.warnPprTrace (let 'Pair.Mk_Pair _from_ty2 to_ty2 := Core.coercionKind
-                                                                                    co2 in
-                                            let 'Pair.Mk_Pair from_ty _to_ty := Core.coercionKind co in
-                                            negb (Core.eqType from_ty to_ty2)) (GHC.Base.hs_string__
-                                            "ghc/compiler/coreSyn/CoreUtils.hs") #279 (Panic.someSDoc) (mkCast expr
-                                                                                                               (Core.mkTransCo
-                                                                                                                co2 co))
-                    | expr, co =>
-                        let 'Pair.Mk_Pair from_ty _to_ty := Core.coercionKind co in
-                        Panic.warnPprTrace (negb (Core.eqType from_ty (exprType expr)))
-                                           (GHC.Base.hs_string__ "ghc/compiler/coreSyn/CoreUtils.hs") #290
-                                           (GHC.Base.mappend (GHC.Base.mappend (GHC.Base.mappend (GHC.Base.mappend
-                                                                                                  (Datatypes.id
-                                                                                                   (GHC.Base.hs_string__
-                                                                                                    "Trying to coerce"))
-                                                                                                  (Datatypes.id
-                                                                                                   (GHC.Base.hs_string__
-                                                                                                    "(")))
-                                                                                                 Panic.someSDoc)
-                                                                               Panic.someSDoc) (Datatypes.id
-                                                              (GHC.Base.hs_string__ ")"))) (Core.Cast expr co)
-                    end in
-                  match arg_0__, arg_1__ with
-                  | Core.Mk_Coercion e_co, co =>
-                      if Core.isCoercionType (Pair.pSnd (Core.coercionKind co)) : bool
-                      then Core.Mk_Coercion (Core.mkCoCast e_co co) else
-                      j_7__
-                  | _, _ => j_7__
-                  end
-              end.
+Definition filterAlts {a}
+   : Core.TyCon ->
+     list AxiomatizedTypes.Type_ ->
+     list Core.AltCon ->
+     list (Core.AltCon * list Core.Var * a)%type ->
+     (list Core.AltCon * list (Core.AltCon * list Core.Var * a)%type)%type :=
+  fun _tycon inst_tys imposs_cons alts =>
+    let impossible_alt {a} {b}
+     : list AxiomatizedTypes.Type_ -> (Core.AltCon * a * b)%type -> bool :=
+      fun arg_0__ arg_1__ =>
+        match arg_0__, arg_1__ with
+        | _, pair (pair con _) _ =>
+            if Data.Foldable.elem con imposs_cons : bool then true else
+            match arg_0__, arg_1__ with
+            | inst_tys, pair (pair (Core.DataAlt con) _) _ =>
+                Core.dataConCannotMatch inst_tys con
+            | _, _ => false
+            end
+        end in
+    let 'pair alts_wo_default maybe_deflt := findDefault alts in
+    let alt_cons :=
+      let cont_7__ arg_8__ := let 'pair (pair con _) _ := arg_8__ in cons con nil in
+      Coq.Lists.List.flat_map cont_7__ alts_wo_default in
+    let imposs_deflt_cons :=
+      Data.OldList.nub (Coq.Init.Datatypes.app imposs_cons alt_cons) in
+    let trimmed_alts := Util.filterOut (impossible_alt inst_tys) alts_wo_default in
+    pair imposs_deflt_cons (addDefault trimmed_alts maybe_deflt).
 
-Axiom exprOkForSpeculation : Core.CoreExpr -> bool.
+Axiom refineDefaultAlt : list Unique.Unique ->
+                         Core.TyCon ->
+                         list AxiomatizedTypes.Type_ ->
+                         list Core.AltCon -> list Core.CoreAlt -> (bool * list Core.CoreAlt)%type.
 
-Definition needsCaseBinding : AxiomatizedTypes.Type_ -> Core.CoreExpr -> bool :=
-  fun ty rhs => andb (Core.isUnliftedType ty) (negb (exprOkForSpeculation rhs)).
-
-Axiom exprOkForSideEffects : Core.CoreExpr -> bool.
+Axiom combineIdenticalAlts : list Core.AltCon ->
+                             list Core.CoreAlt -> (bool * list Core.AltCon * list Core.CoreAlt)%type.
 
 Fixpoint exprIsTrivial (arg_0__ : Core.CoreExpr) : bool
            := match arg_0__ with
@@ -419,19 +396,155 @@ Fixpoint exprIsTrivial (arg_0__ : Core.CoreExpr) : bool
               | _ => false
               end.
 
-Definition exprIsTickedString_maybe : Core.CoreExpr -> option GHC.Base.String :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Core.Lit (Literal.MachStr bs) => Some bs
-    | _ => None
+Definition getIdFromTrivialExpr_maybe : Core.CoreExpr -> option Core.Id :=
+  fun e =>
+    let fix go arg_0__
+              := match arg_0__ with
+                 | Core.Mk_Var v => Some v
+                 | Core.App f t => if negb (Core.isRuntimeArg t) : bool then go f else None
+                 | Core.Cast e _ => go e
+                 | Core.Lam b e => if negb (Core.isRuntimeVar b) : bool then go e else None
+                 | _ => None
+                 end in
+    go e.
+
+Definition getIdFromTrivialExpr : Core.CoreExpr -> Core.Id :=
+  fun e =>
+    Data.Maybe.fromMaybe (Panic.panicStr (GHC.Base.hs_string__
+                                          "getIdFromTrivialExpr") (Panic.someSDoc)) (getIdFromTrivialExpr_maybe e).
+
+Definition isEmptyTy : AxiomatizedTypes.Type_ -> bool :=
+  fun ty =>
+    match Core.splitTyConApp_maybe ty with
+    | Some (pair tc inst_tys) =>
+        match Core.tyConDataCons_maybe tc with
+        | Some dcs =>
+            if Data.Foldable.all (Core.dataConCannotMatch inst_tys) dcs : bool
+            then true else
+            false
+        | _ => false
+        end
+    | _ => false
     end.
 
-Definition exprIsTickedString : Core.CoreExpr -> bool :=
-  Data.Maybe.isJust GHC.Base.∘ exprIsTickedString_maybe.
+Definition exprIsBottom : Core.CoreExpr -> bool :=
+  fun e =>
+    let fix go arg_0__ arg_1__
+              := let j_3__ :=
+                   match arg_0__, arg_1__ with
+                   | _, Core.Case _ _ _ alts => Data.Foldable.null alts
+                   | _, _ => false
+                   end in
+                 match arg_0__, arg_1__ with
+                 | n, Core.Mk_Var v => andb (Id.isBottomingId v) (n GHC.Base.>= Id.idArity v)
+                 | n, Core.App e a =>
+                     if Core.isTypeArg a : bool then go n e else
+                     go (n GHC.Num.+ #1) e
+                 | n, Core.Cast e _ => go n e
+                 | n, Core.Let _ e => go n e
+                 | n, Core.Lam v e => if Core.isTyVar v : bool then go n e else j_3__
+                 | _, _ => j_3__
+                 end in
+    if isEmptyTy (exprType e) : bool then true else
+    go #0 e.
 
-Definition exprIsTopLevelBindable
-   : Core.CoreExpr -> AxiomatizedTypes.Type_ -> bool :=
-  fun expr ty => orb (negb (Core.isUnliftedType ty)) (exprIsTickedString expr).
+Definition dupAppSize : nat :=
+  #8.
+
+Definition exprIsDupable : DynFlags.DynFlags -> Core.CoreExpr -> bool :=
+  fun dflags e =>
+    let decrement : nat -> option nat :=
+      fun arg_0__ =>
+        let 'num_1__ := arg_0__ in
+        if num_1__ GHC.Base.== #0 : bool then None else
+        let 'n := arg_0__ in
+        Some (n GHC.Num.- #1) in
+    let go : nat -> Core.CoreExpr -> option nat :=
+      fix go (arg_6__ : nat) (arg_7__ : Core.CoreExpr) : option nat
+            := match arg_6__, arg_7__ with
+               | n, Core.Mk_Type _ => Some n
+               | n, Core.Mk_Coercion _ => Some n
+               | n, Core.Mk_Var _ => decrement n
+               | n, Core.Cast e _ => go n e
+               | n, Core.App f a => match go n a with | Some n' => go n' f | _ => None end
+               | n, Core.Lit lit =>
+                   if Literal.litIsDupable dflags lit : bool then decrement n else
+                   None
+               | _, _ => None
+               end in
+    Data.Maybe.isJust (go dupAppSize e).
+
+Definition exprIsCheapX : CheapAppFun -> Core.CoreExpr -> bool :=
+  fun ok_app e =>
+    let fix go arg_1__ arg_2__
+              := let ok e := go #0 e in
+                 match arg_1__, arg_2__ with
+                 | n, Core.Mk_Var v => ok_app v n
+                 | _, Core.Lit _ => true
+                 | _, Core.Mk_Type _ => true
+                 | _, Core.Mk_Coercion _ => true
+                 | n, Core.Cast e _ => go n e
+                 | n, Core.Case scrut _ _ alts =>
+                     andb (ok scrut) (Data.Foldable.and (let cont_5__ arg_6__ :=
+                                                           let 'pair (pair _ _) rhs := arg_6__ in
+                                                           cons (go n rhs) nil in
+                                                         Coq.Lists.List.flat_map cont_5__ alts))
+                 | n, Core.Lam x e =>
+                     if Core.isRuntimeVar x : bool
+                     then orb (n GHC.Base.== #0) (go (n GHC.Num.- #1) e) else
+                     go n e
+                 | n, Core.App f e =>
+                     if Core.isRuntimeArg e : bool then andb (go (n GHC.Num.+ #1) f) (ok e) else
+                     go n f
+                 | n, Core.Let (Core.NonRec _ r) e => andb (go n e) (ok r)
+                 | n, Core.Let (Core.Rec prs) e =>
+                     andb (go n e) (Data.Foldable.all (ok GHC.Base.∘ Data.Tuple.snd) prs)
+                 end in
+    let ok := fun e => go #0 e in ok e.
+
+Axiom isCheapApp : CheapAppFun.
+
+Definition exprIsCheap : Core.CoreExpr -> bool :=
+  exprIsCheapX isCheapApp.
+
+Axiom isExpandableApp : CheapAppFun.
+
+Definition exprIsExpandable : Core.CoreExpr -> bool :=
+  exprIsCheapX isExpandableApp.
+
+Definition isWorkFreeApp : CheapAppFun :=
+  fun fn n_val_args =>
+    if n_val_args GHC.Base.== #0 : bool then true else
+    if n_val_args GHC.Base.< Id.idArity fn : bool then true else
+    match Core.idDetails fn with
+    | Core.DataConWorkId _ => true
+    | _ => false
+    end.
+
+Definition exprIsWorkFree : Core.CoreExpr -> bool :=
+  exprIsCheapX isWorkFreeApp.
+
+Axiom exprOkForSideEffects : Core.CoreExpr -> bool.
+
+Axiom expr_ok : (AxiomatizedTypes.PrimOp -> bool) -> Core.CoreExpr -> bool.
+
+Axiom app_ok : (AxiomatizedTypes.PrimOp -> bool) ->
+               Core.Id -> list Core.CoreExpr -> bool.
+
+Definition altsAreExhaustive {b} : list (Core.Alt b) -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | nil => false
+    | cons (pair (pair con1 _) _) alts =>
+        match con1 with
+        | Core.DEFAULT => true
+        | Core.LitAlt _ => false
+        | Core.DataAlt c =>
+            Util.lengthIs alts (Core.tyConFamilySize (Core.dataConTyCon c) GHC.Num.- #1)
+        end
+    end.
+
+Axiom isDivOp : AxiomatizedTypes.PrimOp -> bool.
 
 Definition exprIsHNFlike
    : (Core.Var -> bool) -> (Core.Unfolding -> bool) -> Core.CoreExpr -> bool :=
@@ -471,63 +584,39 @@ Definition exprIsHNF : Core.CoreExpr -> bool :=
 Definition exprIsConLike : Core.CoreExpr -> bool :=
   exprIsHNFlike Id.isConLikeId Core.isConLikeUnfolding.
 
-Definition exprIsCheapX : CheapAppFun -> Core.CoreExpr -> bool :=
-  fun ok_app e =>
-    let fix go arg_1__ arg_2__
-              := let ok e := go #0 e in
-                 match arg_1__, arg_2__ with
-                 | n, Core.Mk_Var v => ok_app v n
-                 | _, Core.Lit _ => true
-                 | _, Core.Mk_Type _ => true
-                 | _, Core.Mk_Coercion _ => true
-                 | n, Core.Cast e _ => go n e
-                 | n, Core.Case scrut _ _ alts =>
-                     andb (ok scrut) (Data.Foldable.and (let cont_5__ arg_6__ :=
-                                                           let 'pair (pair _ _) rhs := arg_6__ in
-                                                           cons (go n rhs) nil in
-                                                         Coq.Lists.List.flat_map cont_5__ alts))
-                 | n, Core.Lam x e =>
-                     if Core.isRuntimeVar x : bool
-                     then orb (n GHC.Base.== #0) (go (n GHC.Num.- #1) e) else
-                     go n e
-                 | n, Core.App f e =>
-                     if Core.isRuntimeArg e : bool then andb (go (n GHC.Num.+ #1) f) (ok e) else
-                     go n f
-                 | n, Core.Let (Core.NonRec _ r) e => andb (go n e) (ok r)
-                 | n, Core.Let (Core.Rec prs) e =>
-                     andb (go n e) (Data.Foldable.all (ok GHC.Base.∘ Data.Tuple.snd) prs)
-                 end in
-    let ok := fun e => go #0 e in ok e.
+Definition exprIsTickedString_maybe : Core.CoreExpr -> option GHC.Base.String :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Core.Lit (Literal.MachStr bs) => Some bs
+    | _ => None
+    end.
 
-Definition exprIsExpandable : Core.CoreExpr -> bool :=
-  exprIsCheapX isExpandableApp.
+Definition exprIsTickedString : Core.CoreExpr -> bool :=
+  Data.Maybe.isJust GHC.Base.∘ exprIsTickedString_maybe.
 
-Definition exprIsWorkFree : Core.CoreExpr -> bool :=
-  exprIsCheapX isWorkFreeApp.
+Definition exprIsTopLevelBindable
+   : Core.CoreExpr -> AxiomatizedTypes.Type_ -> bool :=
+  fun expr ty => orb (negb (Core.isUnliftedType ty)) (exprIsTickedString expr).
 
-Definition exprIsCheap : Core.CoreExpr -> bool :=
-  exprIsCheapX isCheapApp.
+Axiom dataConRepInstPat : list Unique.Unique ->
+                          Core.DataCon ->
+                          list AxiomatizedTypes.Type_ -> (list Core.TyVar * list Core.Id)%type.
 
-Definition exprIsBottom : Core.CoreExpr -> bool :=
-  fun e =>
-    let fix go arg_0__ arg_1__
-              := let j_3__ :=
-                   match arg_0__, arg_1__ with
-                   | _, Core.Case _ _ _ alts => Data.Foldable.null alts
-                   | _, _ => false
-                   end in
-                 match arg_0__, arg_1__ with
-                 | n, Core.Mk_Var v => andb (Id.isBottomingId v) (n GHC.Base.>= Id.idArity v)
-                 | n, Core.App e a =>
-                     if Core.isTypeArg a : bool then go n e else
-                     go (n GHC.Num.+ #1) e
-                 | n, Core.Cast e _ => go n e
-                 | n, Core.Let _ e => go n e
-                 | n, Core.Lam v e => if Core.isTyVar v : bool then go n e else j_3__
-                 | _, _ => j_3__
-                 end in
-    if isEmptyTy (exprType e) : bool then true else
-    go #0 e.
+Axiom dataConRepFSInstPat : list FastString.FastString ->
+                            list Unique.Unique ->
+                            Core.DataCon ->
+                            list AxiomatizedTypes.Type_ -> (list Core.TyVar * list Core.Id)%type.
+
+Axiom dataConInstPat : list FastString.FastString ->
+                       list Unique.Unique ->
+                       Core.DataCon ->
+                       list AxiomatizedTypes.Type_ -> (list Core.TyVar * list Core.Id)%type.
+
+Axiom cheapEqExpr' : forall {b},
+                     (Core.Tickish Core.Id -> bool) -> Core.Expr b -> Core.Expr b -> bool.
+
+Definition cheapEqExpr {b} : Core.Expr b -> Core.Expr b -> bool :=
+  cheapEqExpr' (GHC.Base.const false).
 
 Fixpoint exprIsBig {b} (arg_0__ : Core.Expr b) : bool
            := match arg_0__ with
@@ -540,16 +629,6 @@ Fixpoint exprIsBig {b} (arg_0__ : Core.Expr b) : bool
               | Core.Cast e _ => exprIsBig e
               | _ => true
               end.
-
-Definition eqTickish
-   : Core.RnEnv2 -> Core.Tickish Core.Id -> Core.Tickish Core.Id -> bool :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | env, Core.Breakpoint lid lids, Core.Breakpoint rid rids =>
-        andb (lid GHC.Base.== rid) (GHC.Base.map (Core.rnOccL env) lids GHC.Base.==
-              GHC.Base.map (Core.rnOccR env) rids)
-    | _, l, r => l GHC.Base.== r
-    end.
 
 Definition eqExpr : Core.InScopeSet -> Core.CoreExpr -> Core.CoreExpr -> bool :=
   fun in_scope e1 e2 =>
@@ -599,36 +678,15 @@ Definition eqExpr : Core.InScopeSet -> Core.CoreExpr -> Core.CoreExpr -> bool :=
         end in
     go (Core.mkRnEnv2 in_scope) e1 e2.
 
-Definition dupAppSize : nat :=
-  #8.
-
-Definition exprIsDupable : DynFlags.DynFlags -> Core.CoreExpr -> bool :=
-  fun dflags e =>
-    let decrement : nat -> option nat :=
-      fun arg_0__ =>
-        let 'num_1__ := arg_0__ in
-        if num_1__ GHC.Base.== #0 : bool then None else
-        let 'n := arg_0__ in
-        Some (n GHC.Num.- #1) in
-    let go : nat -> Core.CoreExpr -> option nat :=
-      fix go (arg_6__ : nat) (arg_7__ : Core.CoreExpr) : option nat
-            := match arg_6__, arg_7__ with
-               | n, Core.Mk_Type _ => Some n
-               | n, Core.Mk_Coercion _ => Some n
-               | n, Core.Mk_Var _ => decrement n
-               | n, Core.Cast e _ => go n e
-               | n, Core.App f a => match go n a with | Some n' => go n' f | _ => None end
-               | n, Core.Lit lit =>
-                   if Literal.litIsDupable dflags lit : bool then decrement n else
-                   None
-               | _, _ => None
-               end in
-    Data.Maybe.isJust (go dupAppSize e).
-
-Axiom diffUnfold : Core.RnEnv2 ->
-                   Core.Unfolding -> Core.Unfolding -> list GHC.Base.String.
-
-Axiom diffIdInfo : Core.RnEnv2 -> Core.Var -> Core.Var -> list GHC.Base.String.
+Definition eqTickish
+   : Core.RnEnv2 -> Core.Tickish Core.Id -> Core.Tickish Core.Id -> bool :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | env, Core.Breakpoint lid lids, Core.Breakpoint rid rids =>
+        andb (lid GHC.Base.== rid) (GHC.Base.map (Core.rnOccL env) lids GHC.Base.==
+              GHC.Base.map (Core.rnOccR env) rids)
+    | _, l, r => l GHC.Base.== r
+    end.
 
 Axiom diffExpr : bool ->
                  Core.RnEnv2 -> Core.CoreExpr -> Core.CoreExpr -> list GHC.Base.String.
@@ -639,26 +697,24 @@ Axiom diffBinds : bool ->
                   list (Core.Var * Core.CoreExpr)%type ->
                   (list GHC.Base.String * Core.RnEnv2)%type.
 
-Axiom dataConRepInstPat : list Unique.Unique ->
-                          Core.DataCon ->
-                          list AxiomatizedTypes.Type_ -> (list Core.TyVar * list Core.Id)%type.
+Axiom diffIdInfo : Core.RnEnv2 -> Core.Var -> Core.Var -> list GHC.Base.String.
 
-Axiom dataConRepFSInstPat : list FastString.FastString ->
-                            list Unique.Unique ->
-                            Core.DataCon ->
-                            list AxiomatizedTypes.Type_ -> (list Core.TyVar * list Core.Id)%type.
+Axiom diffUnfold : Core.RnEnv2 ->
+                   Core.Unfolding -> Core.Unfolding -> list GHC.Base.String.
 
-Axiom dataConInstPat : list FastString.FastString ->
-                       list Unique.Unique ->
-                       Core.DataCon ->
-                       list AxiomatizedTypes.Type_ -> (list Core.TyVar * list Core.Id)%type.
+Definition locBind
+   : GHC.Base.String ->
+     Core.Var -> Core.Var -> list GHC.Base.String -> list GHC.Base.String :=
+  fun loc b1 b2 diffs =>
+    let bindLoc :=
+      if b1 GHC.Base.== b2 : bool then Panic.someSDoc else
+      GHC.Base.mappend (GHC.Base.mappend Panic.someSDoc Panic.someSDoc)
+                       Panic.someSDoc in
+    let addLoc := fun d => d in GHC.Base.map addLoc diffs.
 
-Axiom coreAltsType : list Core.CoreAlt -> AxiomatizedTypes.Type_.
+Axiom tryEtaReduce : list Core.Var -> Core.CoreExpr -> option Core.CoreExpr.
 
-Axiom coreAltType : Core.CoreAlt -> AxiomatizedTypes.Type_.
-
-Axiom combineIdenticalAlts : list Core.AltCon ->
-                             list Core.CoreAlt -> (bool * list Core.AltCon * list Core.CoreAlt)%type.
+(* Skipping definition `CoreUtils.rhsIsStatic' *)
 
 Definition collectMakeStaticArgs
    : Core.CoreExpr ->
@@ -674,69 +730,13 @@ Definition collectMakeStaticArgs
     | _ => None
     end.
 
-Axiom cheapEqExpr' : forall {b},
-                     (Core.Tickish Core.Id -> bool) -> Core.Expr b -> Core.Expr b -> bool.
-
-Definition cheapEqExpr {b} : Core.Expr b -> Core.Expr b -> bool :=
-  cheapEqExpr' (GHC.Base.const false).
-
-Axiom bindNonRec : Core.Id -> Core.CoreExpr -> Core.CoreExpr -> Core.CoreExpr.
-
-Axiom applyTypeToArgs : Core.CoreExpr ->
-                        AxiomatizedTypes.Type_ -> list Core.CoreExpr -> AxiomatizedTypes.Type_.
-
-Axiom app_ok : (AxiomatizedTypes.PrimOp -> bool) ->
-               Core.Id -> list Core.CoreExpr -> bool.
-
-Definition altsAreExhaustive {b} : list (Core.Alt b) -> bool :=
+Definition isJoinBind : Core.CoreBind -> bool :=
   fun arg_0__ =>
     match arg_0__ with
-    | nil => false
-    | cons (pair (pair con1 _) _) alts =>
-        match con1 with
-        | Core.DEFAULT => true
-        | Core.LitAlt _ => false
-        | Core.DataAlt c =>
-            Util.lengthIs alts (Core.tyConFamilySize (Core.dataConTyCon c) GHC.Num.- #1)
-        end
+    | Core.NonRec b _ => Id.isJoinId b
+    | Core.Rec (cons (pair b _) _) => Id.isJoinId b
+    | _ => false
     end.
-
-Definition addDefault {a} {b}
-   : list (Core.AltCon * list a * b)%type ->
-     option b -> list (Core.AltCon * list a * b)%type :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | alts, None => alts
-    | alts, Some rhs => cons (pair (pair Core.DEFAULT nil) rhs) alts
-    end.
-
-Definition filterAlts {a}
-   : Core.TyCon ->
-     list AxiomatizedTypes.Type_ ->
-     list Core.AltCon ->
-     list (Core.AltCon * list Core.Var * a)%type ->
-     (list Core.AltCon * list (Core.AltCon * list Core.Var * a)%type)%type :=
-  fun _tycon inst_tys imposs_cons alts =>
-    let impossible_alt {a} {b}
-     : list AxiomatizedTypes.Type_ -> (Core.AltCon * a * b)%type -> bool :=
-      fun arg_0__ arg_1__ =>
-        match arg_0__, arg_1__ with
-        | _, pair (pair con _) _ =>
-            if Data.Foldable.elem con imposs_cons : bool then true else
-            match arg_0__, arg_1__ with
-            | inst_tys, pair (pair (Core.DataAlt con) _) _ =>
-                Core.dataConCannotMatch inst_tys con
-            | _, _ => false
-            end
-        end in
-    let 'pair alts_wo_default maybe_deflt := findDefault alts in
-    let alt_cons :=
-      let cont_7__ arg_8__ := let 'pair (pair con _) _ := arg_8__ in cons con nil in
-      Coq.Lists.List.flat_map cont_7__ alts_wo_default in
-    let imposs_deflt_cons :=
-      Data.OldList.nub (Coq.Init.Datatypes.app imposs_cons alt_cons) in
-    let trimmed_alts := Util.filterOut (impossible_alt inst_tys) alts_wo_default in
-    pair imposs_deflt_cons (addDefault trimmed_alts maybe_deflt).
 
 (* External variables:
      Eq Gt Lt None Some andb bool cons false id list nat negb nil op_zt__ option orb

--- a/examples/ghc/lib/Digraph.v
+++ b/examples/ghc/lib/Digraph.v
@@ -53,97 +53,97 @@ Definition node_payload {key} {payload} (arg_0__ : Node key payload) :=
 
 (* Converted value declarations: *)
 
-Axiom verticesG : forall {node}, Graph node -> list node.
-
-(* Skipping definition `Digraph.vertexReady' *)
-
-(* Skipping definition `Digraph.vertexGroupsS' *)
-
-(* Skipping definition `Digraph.vertexGroupsG' *)
-
-(* Skipping definition `Digraph.vertexGroups' *)
-
-Axiom transposeG : forall {node}, Graph node -> Graph node.
-
-Axiom topologicalSortG : forall {node}, Graph node -> list node.
-
-(* Skipping definition `Digraph.stronglyConnCompG' *)
-
-(* Skipping definition `Digraph.stronglyConnCompFromEdgedVerticesUniqR' *)
-
-(* Skipping definition `Digraph.stronglyConnCompFromEdgedVerticesUniq' *)
-
-(* Skipping definition `Digraph.stronglyConnCompFromEdgedVerticesOrdR' *)
-
-(* Skipping definition `Digraph.stronglyConnCompFromEdgedVerticesOrd' *)
-
-Axiom reduceNodesIntoVerticesUniq : forall {key} {payload},
-                                    forall `{Unique.Uniquable key}, ReduceFn key payload.
-
-Axiom reduceNodesIntoVerticesOrd : forall {key} {payload},
-                                   forall `{GHC.Base.Ord key}, ReduceFn key payload.
-
-(* Skipping definition `Digraph.reduceNodesIntoVertices' *)
-
-Axiom reachablesG : forall {node}, Graph node -> list node -> list node.
-
-Axiom reachableG : forall {node}, Graph node -> node -> list node.
-
-(* Skipping definition `Digraph.reachable' *)
-
-(* Skipping definition `Digraph.preorderF' *)
-
-Axiom outdegreeG : forall {node}, Graph node -> node -> option nat.
-
-(* Skipping definition `Digraph.noOutEdges' *)
-
-(* Skipping definition `Digraph.mkEmpty' *)
-
-Axiom indegreeG : forall {node}, Graph node -> node -> option nat.
-
-(* Skipping definition `Digraph.include' *)
-
-Axiom hasVertexG : forall {node}, Graph node -> node -> bool.
-
-Axiom graphFromEdgedVerticesUniq : forall {key} {payload},
-                                   forall `{Unique.Uniquable key},
-                                   list (Node key payload) -> Graph (Node key payload).
-
-Axiom graphFromEdgedVerticesOrd : forall {key} {payload},
-                                  forall `{GHC.Base.Ord key}, list (Node key payload) -> Graph (Node key payload).
-
-Axiom graphFromEdgedVertices : forall {key} {payload},
-                               ReduceFn key payload -> list (Node key payload) -> Graph (Node key payload).
-
-(* Skipping definition `Digraph.graphEmpty' *)
-
-Axiom findCycle : forall {payload} {key},
-                  forall `{GHC.Base.Ord key}, list (Node key payload) -> option (list payload).
-
-Axiom emptyGraph : forall {a}, Graph a.
-
-Axiom emptyG : forall {node}, Graph node -> bool.
-
-Axiom edgesG : forall {node}, Graph node -> list (Edge node).
-
-Axiom dfsTopSortG : forall {node}, Graph node -> list (list node).
-
-(* Skipping definition `Digraph.degreeG' *)
-
-(* Skipping definition `Digraph.decodeSccs' *)
-
-(* Skipping definition `Digraph.contains' *)
-
-Axiom componentsG : forall {node}, Graph node -> list (list node).
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Digraph.Outputable__Edge' *)
-
 (* Skipping all instances of class `Outputable.Outputable', including
    `Digraph.Outputable__Node' *)
 
 (* Skipping all instances of class `Outputable.Outputable', including
    `Digraph.Outputable__Graph' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Digraph.Outputable__Edge' *)
+
+Axiom emptyGraph : forall {a}, Graph a.
+
+Axiom graphFromEdgedVertices : forall {key} {payload},
+                               ReduceFn key payload -> list (Node key payload) -> Graph (Node key payload).
+
+Axiom graphFromEdgedVerticesOrd : forall {key} {payload},
+                                  forall `{GHC.Base.Ord key}, list (Node key payload) -> Graph (Node key payload).
+
+Axiom graphFromEdgedVerticesUniq : forall {key} {payload},
+                                   forall `{Unique.Uniquable key},
+                                   list (Node key payload) -> Graph (Node key payload).
+
+(* Skipping definition `Digraph.reduceNodesIntoVertices' *)
+
+Axiom reduceNodesIntoVerticesOrd : forall {key} {payload},
+                                   forall `{GHC.Base.Ord key}, ReduceFn key payload.
+
+Axiom reduceNodesIntoVerticesUniq : forall {key} {payload},
+                                    forall `{Unique.Uniquable key}, ReduceFn key payload.
+
+Axiom findCycle : forall {payload} {key},
+                  forall `{GHC.Base.Ord key}, list (Node key payload) -> option (list payload).
+
+(* Skipping definition `Digraph.stronglyConnCompG' *)
+
+(* Skipping definition `Digraph.decodeSccs' *)
+
+(* Skipping definition `Digraph.stronglyConnCompFromEdgedVerticesOrd' *)
+
+(* Skipping definition `Digraph.stronglyConnCompFromEdgedVerticesUniq' *)
+
+(* Skipping definition `Digraph.stronglyConnCompFromEdgedVerticesOrdR' *)
+
+(* Skipping definition `Digraph.stronglyConnCompFromEdgedVerticesUniqR' *)
+
+Axiom topologicalSortG : forall {node}, Graph node -> list node.
+
+Axiom dfsTopSortG : forall {node}, Graph node -> list (list node).
+
+Axiom reachableG : forall {node}, Graph node -> node -> list node.
+
+Axiom reachablesG : forall {node}, Graph node -> list node -> list node.
+
+Axiom hasVertexG : forall {node}, Graph node -> node -> bool.
+
+Axiom verticesG : forall {node}, Graph node -> list node.
+
+Axiom edgesG : forall {node}, Graph node -> list (Edge node).
+
+Axiom transposeG : forall {node}, Graph node -> Graph node.
+
+Axiom outdegreeG : forall {node}, Graph node -> node -> option nat.
+
+Axiom indegreeG : forall {node}, Graph node -> node -> option nat.
+
+(* Skipping definition `Digraph.degreeG' *)
+
+(* Skipping definition `Digraph.vertexGroupsG' *)
+
+Axiom emptyG : forall {node}, Graph node -> bool.
+
+Axiom componentsG : forall {node}, Graph node -> list (list node).
+
+(* Skipping definition `Digraph.graphEmpty' *)
+
+(* Skipping definition `Digraph.preorderF' *)
+
+(* Skipping definition `Digraph.reachable' *)
+
+(* Skipping definition `Digraph.mkEmpty' *)
+
+(* Skipping definition `Digraph.contains' *)
+
+(* Skipping definition `Digraph.include' *)
+
+(* Skipping definition `Digraph.vertexGroups' *)
+
+(* Skipping definition `Digraph.noOutEdges' *)
+
+(* Skipping definition `Digraph.vertexGroupsS' *)
+
+(* Skipping definition `Digraph.vertexReady' *)
 
 (* External variables:
      Type bool list nat op_zt__ option GHC.Base.Ord Unique.Uniquable

--- a/examples/ghc/lib/DynFlags.v
+++ b/examples/ghc/lib/DynFlags.v
@@ -590,965 +590,6 @@ Admitted.
 
 (* Converted value declarations: *)
 
-(* Skipping definition `DynFlags.xopt_unset' *)
-
-(* Skipping definition `DynFlags.xopt_set' *)
-
-(* Skipping definition `DynFlags.xopt' *)
-
-(* Skipping definition `DynFlags.xFlagsDeps' *)
-
-(* Skipping definition `DynFlags.xFlags' *)
-
-Axiom wopt_unset_fatal : DynFlags -> WarningFlag -> DynFlags.
-
-(* Skipping definition `DynFlags.wopt_unset' *)
-
-Axiom wopt_set_fatal : DynFlags -> WarningFlag -> DynFlags.
-
-(* Skipping definition `DynFlags.wopt_set' *)
-
-Axiom wopt_fatal : WarningFlag -> DynFlags -> bool.
-
-(* Skipping definition `DynFlags.wopt' *)
-
-(* Skipping definition `DynFlags.whenGeneratingDynamicToo' *)
-
-(* Skipping definition `DynFlags.whenCannotGenerateDynamicToo' *)
-
-(* Skipping definition `DynFlags.wayUnsetGeneralFlags' *)
-
-Axiom wayTag : Way -> GHC.Base.String.
-
-Axiom wayRTSOnly : Way -> bool.
-
-(* Skipping definition `DynFlags.wayOptl' *)
-
-(* Skipping definition `DynFlags.wayOptc' *)
-
-(* Skipping definition `DynFlags.wayOptP' *)
-
-(* Skipping definition `DynFlags.wayGeneralFlags' *)
-
-Axiom wayDesc : Way -> GHC.Base.String.
-
-Axiom warningHierarchies : list (list GHC.Base.String).
-
-Axiom warningGroups : list (GHC.Base.String * list WarningFlag)%type.
-
-Axiom wWarningFlagsDeps : list (Deprecation * FlagSpec WarningFlag)%type.
-
-Axiom wWarningFlags : list (FlagSpec WarningFlag).
-
-Axiom wORD_SIZE_IN_BITS : DynFlags -> BinNums.N.
-
-Axiom wORD_SIZE : DynFlags -> BinNums.N.
-
-Axiom wORDS_BIGENDIAN : DynFlags -> bool.
-
-Axiom versionedFilePath : DynFlags -> GHC.Base.String.
-
-(* Skipping definition `DynFlags.versionedAppDir' *)
-
-(* Skipping definition `DynFlags.v_unsafeGlobalDynFlags' *)
-
-Axiom useUnicodeSyntax : DynFlags -> bool.
-
-(* Skipping definition `DynFlags.useInstead' *)
-
-Axiom updateWays : DynFlags -> DynFlags.
-
-(* Skipping definition `DynFlags.updOptLevel' *)
-
-(* Skipping definition `DynFlags.updM' *)
-
-(* Skipping definition `DynFlags.upd' *)
-
-(* Skipping definition `DynFlags.unusedBindsFlags' *)
-
-Axiom unsafeGlobalDynFlags : DynFlags.
-
-Axiom unsafeFlagsForInfer : list (GHC.Base.String * (DynFlags -> SrcLoc.SrcSpan)
-                                  *
-                                  (DynFlags -> bool) *
-                                  (DynFlags -> DynFlags))%type.
-
-Axiom unsafeFlags : list (GHC.Base.String * (DynFlags -> SrcLoc.SrcSpan) *
-                          (DynFlags -> bool) *
-                          (DynFlags -> DynFlags))%type.
-
-(* Skipping definition `DynFlags.unrecognisedWarning' *)
-
-(* Skipping definition `DynFlags.unSetWarningFlag' *)
-
-(* Skipping definition `DynFlags.unSetGeneralFlag'' *)
-
-(* Skipping definition `DynFlags.unSetGeneralFlag' *)
-
-(* Skipping definition `DynFlags.unSetFatalWarningFlag' *)
-
-(* Skipping definition `DynFlags.unSetExtensionFlag'' *)
-
-(* Skipping definition `DynFlags.unSetExtensionFlag' *)
-
-Axiom turnOn : TurnOnFlag.
-
-Axiom turnOff : TurnOnFlag.
-
-(* Skipping definition `DynFlags.trustPackage' *)
-
-Axiom topDir : DynFlags -> GHC.Base.String.
-
-Axiom tmpDir : DynFlags -> GHC.Base.String.
-
-Axiom thisUnitIdInsts : DynFlags ->
-                        list (Module.ModuleName * Module.Module)%type.
-
-Axiom thisPackage : DynFlags -> Module.UnitId.
-
-Axiom thisComponentId : DynFlags -> Module.ComponentId.
-
-Axiom targetRetainsAllBindings : HscTarget -> bool.
-
-(* Skipping definition `DynFlags.targetPlatform' *)
-
-Axiom tablesNextToCode : DynFlags -> bool.
-
-Axiom tICKY_BIN_COUNT : DynFlags -> BinNums.N.
-
-Axiom tARGET_MIN_INT : DynFlags -> GHC.Num.Integer.
-
-Axiom tARGET_MAX_WORD : DynFlags -> GHC.Num.Integer.
-
-Axiom tARGET_MAX_INT : DynFlags -> GHC.Num.Integer.
-
-Axiom tAG_MASK : DynFlags -> BinNums.N.
-
-Axiom tAG_BITS : DynFlags -> BinNums.N.
-
-Axiom systemPackageConfig : DynFlags -> GHC.Base.String.
-
-Axiom supportedLanguagesAndExtensions : list GHC.Base.String.
-
-Axiom supportedLanguages : list GHC.Base.String.
-
-(* Skipping definition `DynFlags.supportedLanguageOverlays' *)
-
-(* Skipping definition `DynFlags.supportedExtensions' *)
-
-Axiom standardWarnings : list WarningFlag.
-
-Axiom split_marker : GHC.Char.Char.
-
-Axiom splitPathList : GHC.Base.String -> list GHC.Base.String.
-
-Axiom smallestGroups : WarningFlag -> list GHC.Base.String.
-
-Axiom showOpt : Option -> GHC.Base.String.
-
-Axiom shouldUseColor : DynFlags -> bool.
-
-(* Skipping definition `DynFlags.setWarningFlag' *)
-
-(* Skipping definition `DynFlags.setWarnUnsafe' *)
-
-(* Skipping definition `DynFlags.setWarnSafe' *)
-
-(* Skipping definition `DynFlags.setVerbosity' *)
-
-(* Skipping definition `DynFlags.setVerboseCore2Core' *)
-
-(* Skipping definition `DynFlags.setUnsafeGlobalDynFlags' *)
-
-Axiom setUnitIdInsts : GHC.Base.String -> DynFlags -> DynFlags.
-
-(* Skipping definition `DynFlags.setUnitId' *)
-
-(* Skipping definition `DynFlags.setTmpDir' *)
-
-(* Skipping definition `DynFlags.setTargetWithPlatform' *)
-
-(* Skipping definition `DynFlags.setTarget' *)
-
-Axiom setStubDir : GHC.Base.String -> DynFlags -> DynFlags.
-
-(* Skipping definition `DynFlags.setSafeHaskell' *)
-
-(* Skipping definition `DynFlags.setRtsOptsEnabled' *)
-
-(* Skipping definition `DynFlags.setRtsOpts' *)
-
-Axiom setPgmP : GHC.Base.String -> DynFlags -> DynFlags.
-
-(* Skipping definition `DynFlags.setPackageTrust' *)
-
-(* Skipping definition `DynFlags.setOverlappingInsts' *)
-
-Axiom setOutputHi : option GHC.Base.String -> DynFlags -> DynFlags.
-
-Axiom setOutputFile : option GHC.Base.String -> DynFlags -> DynFlags.
-
-Axiom setOutputDir : GHC.Base.String -> DynFlags -> DynFlags.
-
-(* Skipping definition `DynFlags.setOptLevel' *)
-
-(* Skipping definition `DynFlags.setOptHpcDir' *)
-
-Axiom setObjectSuf : GHC.Base.String -> DynFlags -> DynFlags.
-
-Axiom setObjectDir : GHC.Base.String -> DynFlags -> DynFlags.
-
-(* Skipping definition `DynFlags.setObjTarget' *)
-
-(* Skipping definition `DynFlags.setMainIs' *)
-
-(* Skipping definition `DynFlags.setLogAction' *)
-
-(* Skipping definition `DynFlags.setLanguage' *)
-
-Axiom setJsonLogAction : DynFlags -> DynFlags.
-
-Axiom setInteractivePrint : GHC.Base.String -> DynFlags -> DynFlags.
-
-(* Skipping definition `DynFlags.setIncoherentInsts' *)
-
-Axiom setHiSuf : GHC.Base.String -> DynFlags -> DynFlags.
-
-Axiom setHiDir : GHC.Base.String -> DynFlags -> DynFlags.
-
-Axiom setHcSuf : GHC.Base.String -> DynFlags -> DynFlags.
-
-(* Skipping definition `DynFlags.setGeneralFlag'' *)
-
-(* Skipping definition `DynFlags.setGeneralFlag' *)
-
-(* Skipping definition `DynFlags.setGenDeriving' *)
-
-(* Skipping definition `DynFlags.setFatalWarningFlag' *)
-
-(* Skipping definition `DynFlags.setExtensionFlag'' *)
-
-(* Skipping definition `DynFlags.setExtensionFlag' *)
-
-Axiom setDynOutputFile : option GHC.Base.String -> DynFlags -> DynFlags.
-
-Axiom setDynObjectSuf : GHC.Base.String -> DynFlags -> DynFlags.
-
-Axiom setDynHiSuf : GHC.Base.String -> DynFlags -> DynFlags.
-
-Axiom setDylibInstallName : GHC.Base.String -> DynFlags -> DynFlags.
-
-Axiom setDumpPrefixForce : option GHC.Base.String -> DynFlags -> DynFlags.
-
-(* Skipping definition `DynFlags.setDumpFlag'' *)
-
-(* Skipping definition `DynFlags.setDumpFlag' *)
-
-Axiom setDumpDir : GHC.Base.String -> DynFlags -> DynFlags.
-
-Axiom setDepMakefile : GHC.Base.String -> DynFlags -> DynFlags.
-
-Axiom setDepIncludePkgDeps : bool -> DynFlags -> DynFlags.
-
-(* Skipping definition `DynFlags.setDebugLevel' *)
-
-(* Skipping definition `DynFlags.setDPHOpt' *)
-
-Axiom setComponentId : GHC.Base.String -> DynFlags -> DynFlags.
-
-(* Skipping definition `DynFlags.sepArg' *)
-
-Axiom safeLanguageOn : DynFlags -> bool.
-
-Axiom safeInferOn : DynFlags -> bool.
-
-(* Skipping definition `DynFlags.safeImportsOn' *)
-
-Axiom safeImplicitImpsReq : DynFlags -> bool.
-
-Axiom safeHaskellOn : DynFlags -> bool.
-
-Axiom safeHaskellFlagsDeps : list (Deprecation * FlagSpec SafeHaskellMode)%type.
-
-Axiom safeFlagCheck : bool ->
-                      DynFlags -> (DynFlags * list (SrcLoc.Located GHC.Base.String))%type.
-
-Axiom safeDirectImpsReq : DynFlags -> bool.
-
-Axiom sTD_HDR_SIZE : DynFlags -> BinNums.N.
-
-Axiom sIZEOF_StgUpdateFrame_NoHdr : DynFlags -> BinNums.N.
-
-Axiom sIZEOF_StgSmallMutArrPtrs_NoHdr : DynFlags -> BinNums.N.
-
-Axiom sIZEOF_StgSMPThunkHeader : DynFlags -> BinNums.N.
-
-Axiom sIZEOF_StgMutArrPtrs_NoHdr : DynFlags -> BinNums.N.
-
-Axiom sIZEOF_StgFunInfoExtraRev : DynFlags -> BinNums.N.
-
-Axiom sIZEOF_StgArrBytes_NoHdr : DynFlags -> BinNums.N.
-
-Axiom sIZEOF_CostCentreStack : DynFlags -> BinNums.N.
-
-(* Skipping definition `DynFlags.rtsIsProfiled' *)
-
-(* Skipping definition `DynFlags.removeWayDyn' *)
-
-(* Skipping definition `DynFlags.removeUserPkgConf' *)
-
-(* Skipping definition `DynFlags.removeGlobalPkgConf' *)
-
-Axiom rawSettings : DynFlags -> list (GHC.Base.String * GHC.Base.String)%type.
-
-Axiom rESERVED_STACK_WORDS : DynFlags -> BinNums.N.
-
-Axiom rESERVED_C_STACK_BYTES : DynFlags -> BinNums.N.
-
-(* Skipping definition `DynFlags.putLogMsg' *)
-
-Axiom projectVersion : DynFlags -> GHC.Base.String.
-
-Axiom programName : DynFlags -> GHC.Base.String.
-
-Axiom positionIndependent : DynFlags -> bool.
-
-Axiom picPOpts : DynFlags -> list GHC.Base.String.
-
-Axiom picCCOpts : DynFlags -> list GHC.Base.String.
-
-Axiom pgm_windres : DynFlags -> GHC.Base.String.
-
-Axiom pgm_s : DynFlags -> (GHC.Base.String * list Option)%type.
-
-Axiom pgm_ranlib : DynFlags -> GHC.Base.String.
-
-Axiom pgm_lo : DynFlags -> (GHC.Base.String * list Option)%type.
-
-Axiom pgm_libtool : DynFlags -> GHC.Base.String.
-
-Axiom pgm_lcc : DynFlags -> (GHC.Base.String * list Option)%type.
-
-Axiom pgm_lc : DynFlags -> (GHC.Base.String * list Option)%type.
-
-Axiom pgm_l : DynFlags -> (GHC.Base.String * list Option)%type.
-
-Axiom pgm_i : DynFlags -> GHC.Base.String.
-
-Axiom pgm_dll : DynFlags -> (GHC.Base.String * list Option)%type.
-
-Axiom pgm_c : DynFlags -> (GHC.Base.String * list Option)%type.
-
-Axiom pgm_ar : DynFlags -> GHC.Base.String.
-
-Axiom pgm_a : DynFlags -> (GHC.Base.String * list Option)%type.
-
-Axiom pgm_T : DynFlags -> GHC.Base.String.
-
-Axiom pgm_P : DynFlags -> (GHC.Base.String * list Option)%type.
-
-Axiom pgm_L : DynFlags -> GHC.Base.String.
-
-Axiom pgm_F : DynFlags -> GHC.Base.String.
-
-Axiom parseUnitIdInsts : GHC.Base.String ->
-                         list (Module.ModuleName * Module.Module)%type.
-
-(* Skipping definition `DynFlags.parseUnitIdArg' *)
-
-(* Skipping definition `DynFlags.parsePackageFlag' *)
-
-(* Skipping definition `DynFlags.parsePackageArg' *)
-
-(* Skipping definition `DynFlags.parseDynamicFlagsFull' *)
-
-(* Skipping definition `DynFlags.parseDynamicFlagsCmdLine' *)
-
-(* Skipping definition `DynFlags.parseDynamicFilePragma' *)
-
-Axiom parseDynLibLoaderMode : GHC.Base.String -> DynFlags -> DynFlags.
-
-(* Skipping definition `DynFlags.package_flags_deps' *)
-
-Axiom packageTrustOn : DynFlags -> bool.
-
-Axiom packageFlagsChanged : DynFlags -> DynFlags -> bool.
-
-Axiom pROF_HDR_SIZE : DynFlags -> BinNums.N.
-
-Axiom optimisationFlags : EnumSet.EnumSet GeneralFlag.
-
-Axiom opt_windres : DynFlags -> list GHC.Base.String.
-
-Axiom opt_lo : DynFlags -> list GHC.Base.String.
-
-Axiom opt_lcc : DynFlags -> list GHC.Base.String.
-
-Axiom opt_lc : DynFlags -> list GHC.Base.String.
-
-Axiom opt_l : DynFlags -> list GHC.Base.String.
-
-Axiom opt_i : DynFlags -> list GHC.Base.String.
-
-Axiom opt_c : DynFlags -> list GHC.Base.String.
-
-Axiom opt_a : DynFlags -> list GHC.Base.String.
-
-Axiom opt_P : DynFlags -> list GHC.Base.String.
-
-Axiom opt_L : DynFlags -> list GHC.Base.String.
-
-Axiom opt_F : DynFlags -> list GHC.Base.String.
-
-Axiom optLevelFlags : list (list BinNums.N * GeneralFlag)%type.
-
-(* Skipping definition `DynFlags.optIntSuffixM' *)
-
-Axiom oFFSET_stgGCFun : DynFlags -> BinNums.N.
-
-Axiom oFFSET_stgGCEnter1 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_stgEagerBlackholeInfo : DynFlags -> BinNums.N.
-
-Axiom oFFSET_bdescr_start : DynFlags -> BinNums.N.
-
-Axiom oFFSET_bdescr_free : DynFlags -> BinNums.N.
-
-Axiom oFFSET_bdescr_flags : DynFlags -> BinNums.N.
-
-Axiom oFFSET_bdescr_blocks : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgUpdateFrame_updatee : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgTSO_stackobj : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgTSO_cccs : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgTSO_alloc_limit : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgStack_stack : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgStack_sp : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgSmallMutArrPtrs_ptrs : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rZMM6 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rZMM5 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rZMM4 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rZMM3 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rZMM2 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rZMM1 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rYMM6 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rYMM5 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rYMM4 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rYMM3 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rYMM2 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rYMM1 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rXMM6 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rXMM5 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rXMM4 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rXMM3 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rXMM2 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rXMM1 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rSpLim : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rSp : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rR9 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rR8 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rR7 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rR6 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rR5 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rR4 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rR3 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rR2 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rR10 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rR1 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rL1 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rHpLim : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rHpAlloc : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rHp : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rF6 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rF5 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rF4 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rF3 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rF2 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rF1 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rD6 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rD5 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rD4 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rD3 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rD2 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rD1 : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rCurrentTSO : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rCurrentNursery : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgRegTable_rCCCS : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgMutArrPtrs_size : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgMutArrPtrs_ptrs : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgHeader_ldvw : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgHeader_ccs : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgFunInfoExtraRev_arity : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgFunInfoExtraFwd_arity : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgEntCounter_registeredp : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgEntCounter_link : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgEntCounter_entry_count : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgEntCounter_allocs : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgEntCounter_allocd : DynFlags -> BinNums.N.
-
-Axiom oFFSET_StgArrBytes_bytes : DynFlags -> BinNums.N.
-
-Axiom oFFSET_CostCentreStack_scc_count : DynFlags -> BinNums.N.
-
-Axiom oFFSET_CostCentreStack_mem_alloc : DynFlags -> BinNums.N.
-
-Axiom oFFSET_Capability_r : DynFlags -> BinNums.N.
-
-(* Skipping definition `DynFlags.nop' *)
-
-(* Skipping definition `DynFlags.noArgM' *)
-
-(* Skipping definition `DynFlags.noArg' *)
-
-Axiom negatableFlagsDeps : list (Deprecation * FlagSpec GeneralFlag)%type.
-
-Axiom mkTablesNextToCode : bool -> bool.
-
-(* Skipping definition `DynFlags.mkFlag' *)
-
-Axiom mkBuildTag : list Way -> GHC.Base.String.
-
-Axiom minusWeverythingOpts : list WarningFlag.
-
-Axiom minusWcompatOpts : list WarningFlag.
-
-Axiom minusWallOpts : list WarningFlag.
-
-Axiom minusWOpts : list WarningFlag.
-
-(* Skipping definition `DynFlags.make_ord_flag' *)
-
-(* Skipping definition `DynFlags.make_dep_flag' *)
-
-Axiom makeDynFlagsConsistent : DynFlags ->
-                               (DynFlags * list (SrcLoc.Located GHC.Base.String))%type.
-
-Axiom mUT_ARR_PTRS_CARD_BITS : DynFlags -> BinNums.N.
-
-Axiom mIN_PAYLOAD_SIZE : DynFlags -> BinNums.N.
-
-Axiom mIN_INTLIKE : DynFlags -> BinNums.N.
-
-Axiom mIN_CHARLIKE : DynFlags -> BinNums.N.
-
-Axiom mAX_XMM_REG : DynFlags -> BinNums.N.
-
-Axiom mAX_Vanilla_REG : DynFlags -> BinNums.N.
-
-Axiom mAX_SPEC_SELECTEE_SIZE : DynFlags -> BinNums.N.
-
-Axiom mAX_SPEC_AP_SIZE : DynFlags -> BinNums.N.
-
-Axiom mAX_Real_XMM_REG : DynFlags -> BinNums.N.
-
-Axiom mAX_Real_Vanilla_REG : DynFlags -> BinNums.N.
-
-Axiom mAX_Real_Long_REG : DynFlags -> BinNums.N.
-
-Axiom mAX_Real_Float_REG : DynFlags -> BinNums.N.
-
-Axiom mAX_Real_Double_REG : DynFlags -> BinNums.N.
-
-Axiom mAX_PTR_TAG : DynFlags -> BinNums.N.
-
-Axiom mAX_Long_REG : DynFlags -> BinNums.N.
-
-Axiom mAX_INTLIKE : DynFlags -> BinNums.N.
-
-Axiom mAX_Float_REG : DynFlags -> BinNums.N.
-
-Axiom mAX_Double_REG : DynFlags -> BinNums.N.
-
-Axiom mAX_CHARLIKE : DynFlags -> BinNums.N.
-
-Axiom languageFlagsDeps : list (Deprecation * FlagSpec Language)%type.
-
-(* Skipping definition `DynFlags.languageExtensions' *)
-
-(* Skipping definition `DynFlags.lang_set' *)
-
-Axiom lDV_SHIFT : DynFlags -> BinNums.N.
-
-(* Skipping definition `DynFlags.jsonLogOutput' *)
-
-(* Skipping definition `DynFlags.jsonLogFinaliser' *)
-
-(* Skipping definition `DynFlags.jsonLogAction' *)
-
-Axiom isSseEnabled : DynFlags -> bool.
-
-Axiom isSse4_2Enabled : DynFlags -> bool.
-
-Axiom isSse2Enabled : DynFlags -> bool.
-
-Axiom isOneShot : GhcMode -> bool.
-
-Axiom isObjectTarget : HscTarget -> bool.
-
-Axiom isNoLink : GhcLink -> bool.
-
-Axiom isBmiEnabled : DynFlags -> bool.
-
-Axiom isBmi2Enabled : DynFlags -> bool.
-
-Axiom isAvxEnabled : DynFlags -> bool.
-
-Axiom isAvx512pfEnabled : DynFlags -> bool.
-
-Axiom isAvx512fEnabled : DynFlags -> bool.
-
-Axiom isAvx512erEnabled : DynFlags -> bool.
-
-Axiom isAvx512cdEnabled : DynFlags -> bool.
-
-Axiom isAvx2Enabled : DynFlags -> bool.
-
-Axiom interpreterProfiled : DynFlags -> bool.
-
-(* Skipping definition `DynFlags.interpreterDynamic' *)
-
-(* Skipping definition `DynFlags.interpretPackageEnv' *)
-
-Axiom interpWays : list Way.
-
-(* Skipping definition `DynFlags.intSuffixM' *)
-
-(* Skipping definition `DynFlags.intSuffix' *)
-
-(* Skipping definition `DynFlags.initDynFlags' *)
-
-(* Skipping definition `DynFlags.impliedXFlags' *)
-
-Axiom impliedOffGFlags : list (GeneralFlag * TurnOnFlag * GeneralFlag)%type.
-
-(* Skipping definition `DynFlags.impliedGFlags' *)
-
-(* Skipping definition `DynFlags.ignorePackage' *)
-
-(* Skipping definition `DynFlags.ifGeneratingDynamicToo' *)
-
-(* Skipping definition `DynFlags.ifCannotGenerateDynamicToo' *)
-
-Axiom iLDV_STATE_USE : DynFlags -> GHC.Num.Integer.
-
-Axiom iLDV_STATE_CREATE : DynFlags -> GHC.Num.Integer.
-
-Axiom iLDV_CREATE_MASK : DynFlags -> GHC.Num.Integer.
-
-(* Skipping definition `DynFlags.hidePackage' *)
-
-Axiom hideFlag : forall {a},
-                 (Deprecation * FlagSpec a)%type -> (Deprecation * FlagSpec a)%type.
-
-Axiom hasPprDebug : DynFlags -> bool.
-
-Axiom hasNoStateHack : DynFlags -> bool.
-
-Axiom hasNoOptCoercion : DynFlags -> bool.
-
-Axiom hasNoDebugOutput : DynFlags -> bool.
-
-(* Skipping definition `DynFlags.hasArg' *)
-
-(* Skipping definition `DynFlags.gopt_unset' *)
-
-Axiom gopt_set : DynFlags -> GeneralFlag -> DynFlags.
-
-Axiom gopt : GeneralFlag -> DynFlags -> bool.
-
-(* Skipping definition `DynFlags.glasgowExtsFlags' *)
-
-Axiom ghciUsagePath : DynFlags -> GHC.Base.String.
-
-Axiom ghcUsagePath : DynFlags -> GHC.Base.String.
-
-Axiom getVerbFlags : DynFlags -> list GHC.Base.String.
-
-Axiom getOpts : forall {a}, DynFlags -> (DynFlags -> list a) -> list a.
-
-(* Skipping definition `DynFlags.generateDynamicTooConditional' *)
-
-(* Skipping definition `DynFlags.forceRecompile' *)
-
-(* Skipping definition `DynFlags.floatSuffix' *)
-
-(* Skipping definition `DynFlags.flattenExtensionFlags' *)
-
-(* Skipping definition `DynFlags.flagsPackage' *)
-
-Axiom flagsForCompletion : bool -> list GHC.Base.String.
-
-(* Skipping definition `DynFlags.flagsDynamic' *)
-
-(* Skipping definition `DynFlags.flagsAllDeps' *)
-
-(* Skipping definition `DynFlags.flagsAll' *)
-
-Axiom flagSpecOf : WarningFlag -> option (FlagSpec WarningFlag).
-
-(* Skipping definition `DynFlags.flagSpec'' *)
-
-Axiom flagSpec : forall {flag},
-                 GHC.Base.String -> flag -> (Deprecation * FlagSpec flag)%type.
-
-(* Skipping definition `DynFlags.flagHiddenSpec'' *)
-
-Axiom flagHiddenSpec : forall {flag},
-                       GHC.Base.String -> flag -> (Deprecation * FlagSpec flag)%type.
-
-(* Skipping definition `DynFlags.flagGhciSpec'' *)
-
-Axiom flagGhciSpec : forall {flag},
-                     GHC.Base.String -> flag -> (Deprecation * FlagSpec flag)%type.
-
-(* Skipping definition `DynFlags.fLangFlagsDeps' *)
-
-(* Skipping definition `DynFlags.fLangFlags' *)
-
-Axiom fFlagsDeps : list (Deprecation * FlagSpec GeneralFlag)%type.
-
-Axiom fFlags : list (FlagSpec GeneralFlag).
-
-Axiom extraGccViaCFlags : DynFlags -> list GHC.Base.String.
-
-(* Skipping definition `DynFlags.exposePluginPackageId' *)
-
-(* Skipping definition `DynFlags.exposePluginPackage' *)
-
-(* Skipping definition `DynFlags.exposePackageId' *)
-
-Axiom exposePackage' : GHC.Base.String -> DynFlags -> DynFlags.
-
-(* Skipping definition `DynFlags.exposePackage' *)
-
-(* Skipping definition `DynFlags.enableUnusedBinds' *)
-
-(* Skipping definition `DynFlags.enableGlasgowExts' *)
-
-Axiom emptyFilesToClean : FilesToClean.
-
-(* Skipping definition `DynFlags.dynamic_flags_deps' *)
-
-Axiom dynamicTooMkDynamicDynFlags : DynFlags -> DynFlags.
-
-(* Skipping definition `DynFlags.dynamicGhc' *)
-
-(* Skipping definition `DynFlags.dynFlagDependencies' *)
-
-Axiom dopt_unset : DynFlags -> DumpFlag -> DynFlags.
-
-Axiom dopt_set : DynFlags -> DumpFlag -> DynFlags.
-
-(* Skipping definition `DynFlags.dopt' *)
-
-(* Skipping definition `DynFlags.distrustPackage' *)
-
-(* Skipping definition `DynFlags.disableUnusedBinds' *)
-
-(* Skipping definition `DynFlags.disableGlasgowExts' *)
-
-Axiom deprecatedForExtension : GHC.Base.String -> TurnOnFlag -> GHC.Base.String.
-
-(* Skipping definition `DynFlags.depFlagSpecOp'' *)
-
-(* Skipping definition `DynFlags.depFlagSpecOp' *)
-
-Axiom depFlagSpecCond : forall {flag},
-                        GHC.Base.String ->
-                        flag ->
-                        (TurnOnFlag -> bool) -> GHC.Base.String -> (Deprecation * FlagSpec flag)%type.
-
-(* Skipping definition `DynFlags.depFlagSpec'' *)
-
-Axiom depFlagSpec : forall {flag},
-                    GHC.Base.String ->
-                    flag -> GHC.Base.String -> (Deprecation * FlagSpec flag)%type.
-
-(* Skipping definition `DynFlags.default_PIC' *)
-
-Axiom defaultWays : Settings -> list Way.
-
-(* Skipping definition `DynFlags.defaultObjectTarget' *)
-
-(* Skipping definition `DynFlags.defaultLogOutput' *)
-
-(* Skipping definition `DynFlags.defaultLogActionHPutStrDoc' *)
-
-(* Skipping definition `DynFlags.defaultLogActionHPrintDoc' *)
-
-(* Skipping definition `DynFlags.defaultLogAction' *)
-
-(* Skipping definition `DynFlags.defaultHscTarget' *)
-
-Axiom defaultGlobalDynFlags : DynFlags.
-
-Axiom defaultFlushOut : FlushOut.
-
-(* Skipping definition `DynFlags.defaultFlushErr' *)
-
-Axiom defaultFlags : Settings -> list GeneralFlag.
-
-(* Skipping definition `DynFlags.defaultFatalMessager' *)
-
-Axiom defaultDynFlags : Settings -> LlvmTargets -> DynFlags.
-
-Axiom decodeSize : GHC.Base.String -> GHC.Num.Integer.
-
-Axiom dYNAMIC_BY_DEFAULT : DynFlags -> bool.
-
-Axiom dOUBLE_SIZE : DynFlags -> BinNums.N.
-
-Axiom dFlagsDeps : list (Deprecation * FlagSpec GeneralFlag)%type.
-
-Axiom compilerInfo : DynFlags -> list (GHC.Base.String * GHC.Base.String)%type.
-
-(* Skipping definition `DynFlags.combineSafeFlags' *)
-
-(* Skipping definition `DynFlags.clearPkgConf' *)
-
-(* Skipping definition `DynFlags.checkTemplateHaskellOk' *)
-
-Axiom checkOptLevel : BinNums.N ->
-                      DynFlags -> Data.Either.Either GHC.Base.String DynFlags.
-
-Axiom canonicalizeHomeModule : DynFlags -> Module.ModuleName -> Module.Module.
-
-Axiom can_split : bool.
-
-Axiom cONTROL_GROUP_CONST_291 : DynFlags -> BinNums.N.
-
-Axiom cLONG_SIZE : DynFlags -> BinNums.N.
-
-Axiom cLONG_LONG_SIZE : DynFlags -> BinNums.N.
-
-Axiom cINT_SIZE : DynFlags -> BinNums.N.
-
-Axiom bLOCK_SIZE_W : DynFlags -> BinNums.N.
-
-Axiom bLOCK_SIZE : DynFlags -> BinNums.N.
-
-Axiom bLOCKS_PER_MBLOCK : DynFlags -> BinNums.N.
-
-Axiom bITMAP_BITS_SHIFT : DynFlags -> BinNums.N.
-
-Axiom alterSettings : (Settings -> Settings) -> DynFlags -> DynFlags.
-
-Axiom allowed_combination : list Way -> bool.
-
-Axiom allNonDeprecatedFlags : list GHC.Base.String.
-
-(* Skipping definition `DynFlags.allFlagsDeps' *)
-
-(* Skipping definition `DynFlags.add_dep_message' *)
-
-Axiom addWay' : Way -> DynFlags -> DynFlags.
-
-(* Skipping definition `DynFlags.addWay' *)
-
-Axiom addPluginModuleNameOption : GHC.Base.String -> DynFlags -> DynFlags.
-
-Axiom addPluginModuleName : GHC.Base.String -> DynFlags -> DynFlags.
-
-(* Skipping definition `DynFlags.addPkgConfRef' *)
-
-Axiom addOptl : GHC.Base.String -> DynFlags -> DynFlags.
-
-Axiom addOptc : GHC.Base.String -> DynFlags -> DynFlags.
-
-Axiom addOptP : GHC.Base.String -> DynFlags -> DynFlags.
-
-(* Skipping definition `DynFlags.addLibraryPath' *)
-
-Axiom addLdInputs : Option -> DynFlags -> DynFlags.
-
-(* Skipping definition `DynFlags.addIncludePath' *)
-
-(* Skipping definition `DynFlags.addImportPath' *)
-
-Axiom addHaddockOpts : GHC.Base.String -> DynFlags -> DynFlags.
-
-Axiom addGhciScript : GHC.Base.String -> DynFlags -> DynFlags.
-
-Axiom addGhcVersionFile : GHC.Base.String -> DynFlags -> DynFlags.
-
-Axiom addFrontendPluginOption : GHC.Base.String -> DynFlags -> DynFlags.
-
-(* Skipping definition `DynFlags.addFrameworkPath' *)
-
-Axiom addDepSuffix : GHC.Base.String -> DynFlags -> DynFlags.
-
-Axiom addDepExcludeMod : GHC.Base.String -> DynFlags -> DynFlags.
-
-Axiom addCmdlineFramework : GHC.Base.String -> DynFlags -> DynFlags.
-
-Axiom aP_STACK_SPLIM : DynFlags -> BinNums.N.
-
 (* Skipping instance `DynFlags.Eq___DumpFlag' of class `GHC.Base.Eq_' *)
 
 (* Skipping all instances of class `GHC.Show.Show', including
@@ -1704,20 +745,32 @@ Instance Eq___CompilerInfo : GHC.Base.Eq_ CompilerInfo.
 Proof.
 Admitted.
 
+(* Skipping all instances of class `Outputable.Outputable', including
+   `DynFlags.Outputable__WarnReason' *)
+
 (* Skipping all instances of class `Json.ToJson', including
    `DynFlags.ToJson__WarnReason' *)
 
 (* Skipping all instances of class `Outputable.Outputable', including
-   `DynFlags.Outputable__WarnReason' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
    `DynFlags.Outputable__Language' *)
+
+(* Skipping all instances of class `GHC.Show.Show', including
+   `DynFlags.Show__SafeHaskellMode' *)
 
 (* Skipping all instances of class `Outputable.Outputable', including
    `DynFlags.Outputable__SafeHaskellMode' *)
 
-(* Skipping all instances of class `GHC.Show.Show', including
-   `DynFlags.Show__SafeHaskellMode' *)
+(* Skipping instance `DynFlags.HasDynFlags__WriterT' of class
+   `DynFlags.HasDynFlags' *)
+
+(* Skipping instance `DynFlags.HasDynFlags__ReaderT' of class
+   `DynFlags.HasDynFlags' *)
+
+(* Skipping instance `DynFlags.HasDynFlags__MaybeT' of class
+   `DynFlags.HasDynFlags' *)
+
+(* Skipping instance `DynFlags.HasDynFlags__ExceptT' of class
+   `DynFlags.HasDynFlags' *)
 
 (* Skipping all instances of class `Outputable.Outputable', including
    `DynFlags.Outputable__GhcMode' *)
@@ -1734,17 +787,964 @@ Admitted.
 (* Skipping all instances of class `Outputable.Outputable', including
    `DynFlags.Outputable__OnOff' *)
 
-(* Skipping instance `DynFlags.HasDynFlags__ExceptT' of class
-   `DynFlags.HasDynFlags' *)
+Axiom cONTROL_GROUP_CONST_291 : DynFlags -> BinNums.N.
 
-(* Skipping instance `DynFlags.HasDynFlags__MaybeT' of class
-   `DynFlags.HasDynFlags' *)
+Axiom sTD_HDR_SIZE : DynFlags -> BinNums.N.
 
-(* Skipping instance `DynFlags.HasDynFlags__ReaderT' of class
-   `DynFlags.HasDynFlags' *)
+Axiom pROF_HDR_SIZE : DynFlags -> BinNums.N.
 
-(* Skipping instance `DynFlags.HasDynFlags__WriterT' of class
-   `DynFlags.HasDynFlags' *)
+Axiom bLOCK_SIZE : DynFlags -> BinNums.N.
+
+Axiom bLOCKS_PER_MBLOCK : DynFlags -> BinNums.N.
+
+Axiom tICKY_BIN_COUNT : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rR1 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rR2 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rR3 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rR4 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rR5 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rR6 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rR7 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rR8 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rR9 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rR10 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rF1 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rF2 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rF3 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rF4 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rF5 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rF6 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rD1 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rD2 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rD3 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rD4 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rD5 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rD6 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rXMM1 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rXMM2 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rXMM3 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rXMM4 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rXMM5 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rXMM6 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rYMM1 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rYMM2 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rYMM3 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rYMM4 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rYMM5 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rYMM6 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rZMM1 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rZMM2 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rZMM3 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rZMM4 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rZMM5 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rZMM6 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rL1 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rSp : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rSpLim : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rHp : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rHpLim : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rCCCS : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rCurrentTSO : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rCurrentNursery : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgRegTable_rHpAlloc : DynFlags -> BinNums.N.
+
+Axiom oFFSET_stgEagerBlackholeInfo : DynFlags -> BinNums.N.
+
+Axiom oFFSET_stgGCEnter1 : DynFlags -> BinNums.N.
+
+Axiom oFFSET_stgGCFun : DynFlags -> BinNums.N.
+
+Axiom oFFSET_Capability_r : DynFlags -> BinNums.N.
+
+Axiom oFFSET_bdescr_start : DynFlags -> BinNums.N.
+
+Axiom oFFSET_bdescr_free : DynFlags -> BinNums.N.
+
+Axiom oFFSET_bdescr_blocks : DynFlags -> BinNums.N.
+
+Axiom oFFSET_bdescr_flags : DynFlags -> BinNums.N.
+
+Axiom sIZEOF_CostCentreStack : DynFlags -> BinNums.N.
+
+Axiom oFFSET_CostCentreStack_mem_alloc : DynFlags -> BinNums.N.
+
+Axiom oFFSET_CostCentreStack_scc_count : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgHeader_ccs : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgHeader_ldvw : DynFlags -> BinNums.N.
+
+Axiom sIZEOF_StgSMPThunkHeader : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgEntCounter_allocs : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgEntCounter_allocd : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgEntCounter_registeredp : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgEntCounter_link : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgEntCounter_entry_count : DynFlags -> BinNums.N.
+
+Axiom sIZEOF_StgUpdateFrame_NoHdr : DynFlags -> BinNums.N.
+
+Axiom sIZEOF_StgMutArrPtrs_NoHdr : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgMutArrPtrs_ptrs : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgMutArrPtrs_size : DynFlags -> BinNums.N.
+
+Axiom sIZEOF_StgSmallMutArrPtrs_NoHdr : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgSmallMutArrPtrs_ptrs : DynFlags -> BinNums.N.
+
+Axiom sIZEOF_StgArrBytes_NoHdr : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgArrBytes_bytes : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgTSO_alloc_limit : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgTSO_cccs : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgTSO_stackobj : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgStack_sp : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgStack_stack : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgUpdateFrame_updatee : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgFunInfoExtraFwd_arity : DynFlags -> BinNums.N.
+
+Axiom sIZEOF_StgFunInfoExtraRev : DynFlags -> BinNums.N.
+
+Axiom oFFSET_StgFunInfoExtraRev_arity : DynFlags -> BinNums.N.
+
+Axiom mAX_SPEC_SELECTEE_SIZE : DynFlags -> BinNums.N.
+
+Axiom mAX_SPEC_AP_SIZE : DynFlags -> BinNums.N.
+
+Axiom mIN_PAYLOAD_SIZE : DynFlags -> BinNums.N.
+
+Axiom mIN_INTLIKE : DynFlags -> BinNums.N.
+
+Axiom mAX_INTLIKE : DynFlags -> BinNums.N.
+
+Axiom mIN_CHARLIKE : DynFlags -> BinNums.N.
+
+Axiom mAX_CHARLIKE : DynFlags -> BinNums.N.
+
+Axiom mUT_ARR_PTRS_CARD_BITS : DynFlags -> BinNums.N.
+
+Axiom mAX_Vanilla_REG : DynFlags -> BinNums.N.
+
+Axiom mAX_Float_REG : DynFlags -> BinNums.N.
+
+Axiom mAX_Double_REG : DynFlags -> BinNums.N.
+
+Axiom mAX_Long_REG : DynFlags -> BinNums.N.
+
+Axiom mAX_XMM_REG : DynFlags -> BinNums.N.
+
+Axiom mAX_Real_Vanilla_REG : DynFlags -> BinNums.N.
+
+Axiom mAX_Real_Float_REG : DynFlags -> BinNums.N.
+
+Axiom mAX_Real_Double_REG : DynFlags -> BinNums.N.
+
+Axiom mAX_Real_XMM_REG : DynFlags -> BinNums.N.
+
+Axiom mAX_Real_Long_REG : DynFlags -> BinNums.N.
+
+Axiom rESERVED_C_STACK_BYTES : DynFlags -> BinNums.N.
+
+Axiom rESERVED_STACK_WORDS : DynFlags -> BinNums.N.
+
+Axiom aP_STACK_SPLIM : DynFlags -> BinNums.N.
+
+Axiom wORD_SIZE : DynFlags -> BinNums.N.
+
+Axiom dOUBLE_SIZE : DynFlags -> BinNums.N.
+
+Axiom cINT_SIZE : DynFlags -> BinNums.N.
+
+Axiom cLONG_SIZE : DynFlags -> BinNums.N.
+
+Axiom cLONG_LONG_SIZE : DynFlags -> BinNums.N.
+
+Axiom bITMAP_BITS_SHIFT : DynFlags -> BinNums.N.
+
+Axiom tAG_BITS : DynFlags -> BinNums.N.
+
+Axiom wORDS_BIGENDIAN : DynFlags -> bool.
+
+Axiom dYNAMIC_BY_DEFAULT : DynFlags -> bool.
+
+Axiom lDV_SHIFT : DynFlags -> BinNums.N.
+
+Axiom iLDV_CREATE_MASK : DynFlags -> GHC.Num.Integer.
+
+Axiom iLDV_STATE_CREATE : DynFlags -> GHC.Num.Integer.
+
+Axiom iLDV_STATE_USE : DynFlags -> GHC.Num.Integer.
+
+Axiom optimisationFlags : EnumSet.EnumSet GeneralFlag.
+
+(* Skipping definition `DynFlags.targetPlatform' *)
+
+Axiom programName : DynFlags -> GHC.Base.String.
+
+Axiom projectVersion : DynFlags -> GHC.Base.String.
+
+Axiom ghcUsagePath : DynFlags -> GHC.Base.String.
+
+Axiom ghciUsagePath : DynFlags -> GHC.Base.String.
+
+Axiom topDir : DynFlags -> GHC.Base.String.
+
+Axiom tmpDir : DynFlags -> GHC.Base.String.
+
+Axiom rawSettings : DynFlags -> list (GHC.Base.String * GHC.Base.String)%type.
+
+Axiom extraGccViaCFlags : DynFlags -> list GHC.Base.String.
+
+Axiom systemPackageConfig : DynFlags -> GHC.Base.String.
+
+Axiom pgm_L : DynFlags -> GHC.Base.String.
+
+Axiom pgm_P : DynFlags -> (GHC.Base.String * list Option)%type.
+
+Axiom pgm_F : DynFlags -> GHC.Base.String.
+
+Axiom pgm_c : DynFlags -> (GHC.Base.String * list Option)%type.
+
+Axiom pgm_s : DynFlags -> (GHC.Base.String * list Option)%type.
+
+Axiom pgm_a : DynFlags -> (GHC.Base.String * list Option)%type.
+
+Axiom pgm_l : DynFlags -> (GHC.Base.String * list Option)%type.
+
+Axiom pgm_dll : DynFlags -> (GHC.Base.String * list Option)%type.
+
+Axiom pgm_T : DynFlags -> GHC.Base.String.
+
+Axiom pgm_windres : DynFlags -> GHC.Base.String.
+
+Axiom pgm_libtool : DynFlags -> GHC.Base.String.
+
+Axiom pgm_lcc : DynFlags -> (GHC.Base.String * list Option)%type.
+
+Axiom pgm_ar : DynFlags -> GHC.Base.String.
+
+Axiom pgm_ranlib : DynFlags -> GHC.Base.String.
+
+Axiom pgm_lo : DynFlags -> (GHC.Base.String * list Option)%type.
+
+Axiom pgm_lc : DynFlags -> (GHC.Base.String * list Option)%type.
+
+Axiom pgm_i : DynFlags -> GHC.Base.String.
+
+Axiom opt_L : DynFlags -> list GHC.Base.String.
+
+Axiom opt_P : DynFlags -> list GHC.Base.String.
+
+Axiom opt_F : DynFlags -> list GHC.Base.String.
+
+Axiom opt_c : DynFlags -> list GHC.Base.String.
+
+Axiom opt_a : DynFlags -> list GHC.Base.String.
+
+Axiom opt_l : DynFlags -> list GHC.Base.String.
+
+Axiom opt_windres : DynFlags -> list GHC.Base.String.
+
+Axiom opt_lcc : DynFlags -> list GHC.Base.String.
+
+Axiom opt_lo : DynFlags -> list GHC.Base.String.
+
+Axiom opt_lc : DynFlags -> list GHC.Base.String.
+
+Axiom opt_i : DynFlags -> list GHC.Base.String.
+
+(* Skipping definition `DynFlags.versionedAppDir' *)
+
+Axiom versionedFilePath : DynFlags -> GHC.Base.String.
+
+Axiom isObjectTarget : HscTarget -> bool.
+
+Axiom targetRetainsAllBindings : HscTarget -> bool.
+
+Axiom isOneShot : GhcMode -> bool.
+
+Axiom isNoLink : GhcLink -> bool.
+
+Axiom packageFlagsChanged : DynFlags -> DynFlags -> bool.
+
+(* Skipping definition `DynFlags.defaultHscTarget' *)
+
+(* Skipping definition `DynFlags.defaultObjectTarget' *)
+
+Axiom tablesNextToCode : DynFlags -> bool.
+
+Axiom mkTablesNextToCode : bool -> bool.
+
+Axiom shouldUseColor : DynFlags -> bool.
+
+Axiom positionIndependent : DynFlags -> bool.
+
+Axiom allowed_combination : list Way -> bool.
+
+Axiom mkBuildTag : list Way -> GHC.Base.String.
+
+Axiom wayTag : Way -> GHC.Base.String.
+
+Axiom wayRTSOnly : Way -> bool.
+
+Axiom wayDesc : Way -> GHC.Base.String.
+
+(* Skipping definition `DynFlags.wayGeneralFlags' *)
+
+(* Skipping definition `DynFlags.wayUnsetGeneralFlags' *)
+
+(* Skipping definition `DynFlags.wayOptc' *)
+
+(* Skipping definition `DynFlags.wayOptl' *)
+
+(* Skipping definition `DynFlags.wayOptP' *)
+
+(* Skipping definition `DynFlags.whenGeneratingDynamicToo' *)
+
+(* Skipping definition `DynFlags.ifGeneratingDynamicToo' *)
+
+(* Skipping definition `DynFlags.whenCannotGenerateDynamicToo' *)
+
+(* Skipping definition `DynFlags.ifCannotGenerateDynamicToo' *)
+
+(* Skipping definition `DynFlags.generateDynamicTooConditional' *)
+
+Axiom dynamicTooMkDynamicDynFlags : DynFlags -> DynFlags.
+
+(* Skipping definition `DynFlags.initDynFlags' *)
+
+Axiom defaultDynFlags : Settings -> LlvmTargets -> DynFlags.
+
+Axiom defaultWays : Settings -> list Way.
+
+Axiom interpWays : list Way.
+
+Axiom interpreterProfiled : DynFlags -> bool.
+
+(* Skipping definition `DynFlags.interpreterDynamic' *)
+
+(* Skipping definition `DynFlags.defaultLogOutput' *)
+
+(* Skipping definition `DynFlags.defaultFatalMessager' *)
+
+(* Skipping definition `DynFlags.jsonLogOutput' *)
+
+(* Skipping definition `DynFlags.jsonLogAction' *)
+
+(* Skipping definition `DynFlags.jsonLogFinaliser' *)
+
+(* Skipping definition `DynFlags.defaultLogAction' *)
+
+(* Skipping definition `DynFlags.defaultLogActionHPrintDoc' *)
+
+(* Skipping definition `DynFlags.defaultLogActionHPutStrDoc' *)
+
+Axiom defaultFlushOut : FlushOut.
+
+(* Skipping definition `DynFlags.defaultFlushErr' *)
+
+(* Skipping definition `DynFlags.flattenExtensionFlags' *)
+
+(* Skipping definition `DynFlags.languageExtensions' *)
+
+Axiom hasPprDebug : DynFlags -> bool.
+
+Axiom hasNoDebugOutput : DynFlags -> bool.
+
+Axiom hasNoStateHack : DynFlags -> bool.
+
+Axiom hasNoOptCoercion : DynFlags -> bool.
+
+(* Skipping definition `DynFlags.dopt' *)
+
+Axiom dopt_set : DynFlags -> DumpFlag -> DynFlags.
+
+Axiom dopt_unset : DynFlags -> DumpFlag -> DynFlags.
+
+Axiom gopt : GeneralFlag -> DynFlags -> bool.
+
+Axiom gopt_set : DynFlags -> GeneralFlag -> DynFlags.
+
+(* Skipping definition `DynFlags.gopt_unset' *)
+
+(* Skipping definition `DynFlags.wopt' *)
+
+(* Skipping definition `DynFlags.wopt_set' *)
+
+(* Skipping definition `DynFlags.wopt_unset' *)
+
+Axiom wopt_fatal : WarningFlag -> DynFlags -> bool.
+
+Axiom wopt_set_fatal : DynFlags -> WarningFlag -> DynFlags.
+
+Axiom wopt_unset_fatal : DynFlags -> WarningFlag -> DynFlags.
+
+(* Skipping definition `DynFlags.xopt' *)
+
+(* Skipping definition `DynFlags.xopt_set' *)
+
+(* Skipping definition `DynFlags.xopt_unset' *)
+
+(* Skipping definition `DynFlags.lang_set' *)
+
+Axiom useUnicodeSyntax : DynFlags -> bool.
+
+(* Skipping definition `DynFlags.setLanguage' *)
+
+(* Skipping definition `DynFlags.dynFlagDependencies' *)
+
+Axiom packageTrustOn : DynFlags -> bool.
+
+Axiom safeHaskellOn : DynFlags -> bool.
+
+Axiom safeLanguageOn : DynFlags -> bool.
+
+Axiom safeInferOn : DynFlags -> bool.
+
+(* Skipping definition `DynFlags.safeImportsOn' *)
+
+(* Skipping definition `DynFlags.setSafeHaskell' *)
+
+Axiom safeDirectImpsReq : DynFlags -> bool.
+
+Axiom safeImplicitImpsReq : DynFlags -> bool.
+
+(* Skipping definition `DynFlags.combineSafeFlags' *)
+
+Axiom unsafeFlags : list (GHC.Base.String * (DynFlags -> SrcLoc.SrcSpan) *
+                          (DynFlags -> bool) *
+                          (DynFlags -> DynFlags))%type.
+
+Axiom unsafeFlagsForInfer : list (GHC.Base.String * (DynFlags -> SrcLoc.SrcSpan)
+                                  *
+                                  (DynFlags -> bool) *
+                                  (DynFlags -> DynFlags))%type.
+
+Axiom getOpts : forall {a}, DynFlags -> (DynFlags -> list a) -> list a.
+
+Axiom getVerbFlags : DynFlags -> list GHC.Base.String.
+
+Axiom setObjectDir : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom setHiDir : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom setStubDir : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom setDumpDir : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom setOutputDir : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom setDylibInstallName : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom setObjectSuf : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom setDynObjectSuf : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom setHiSuf : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom setDynHiSuf : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom setHcSuf : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom setOutputFile : option GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom setDynOutputFile : option GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom setOutputHi : option GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom setJsonLogAction : DynFlags -> DynFlags.
+
+Axiom thisComponentId : DynFlags -> Module.ComponentId.
+
+Axiom thisUnitIdInsts : DynFlags ->
+                        list (Module.ModuleName * Module.Module)%type.
+
+Axiom thisPackage : DynFlags -> Module.UnitId.
+
+Axiom parseUnitIdInsts : GHC.Base.String ->
+                         list (Module.ModuleName * Module.Module)%type.
+
+Axiom setUnitIdInsts : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom setComponentId : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom addPluginModuleName : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom addPluginModuleNameOption : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom addFrontendPluginOption : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom parseDynLibLoaderMode : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom setDumpPrefixForce : option GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom setPgmP : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom addOptl : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom addOptc : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom addOptP : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom setDepMakefile : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom setDepIncludePkgDeps : bool -> DynFlags -> DynFlags.
+
+Axiom addDepExcludeMod : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom addDepSuffix : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom addCmdlineFramework : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom addGhcVersionFile : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom addHaddockOpts : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom addGhciScript : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom setInteractivePrint : GHC.Base.String -> DynFlags -> DynFlags.
+
+Axiom showOpt : Option -> GHC.Base.String.
+
+(* Skipping definition `DynFlags.updOptLevel' *)
+
+(* Skipping definition `DynFlags.parseDynamicFlagsCmdLine' *)
+
+(* Skipping definition `DynFlags.parseDynamicFilePragma' *)
+
+(* Skipping definition `DynFlags.parseDynamicFlagsFull' *)
+
+(* Skipping definition `DynFlags.setLogAction' *)
+
+(* Skipping definition `DynFlags.putLogMsg' *)
+
+Axiom updateWays : DynFlags -> DynFlags.
+
+Axiom safeFlagCheck : bool ->
+                      DynFlags -> (DynFlags * list (SrcLoc.Located GHC.Base.String))%type.
+
+Axiom allNonDeprecatedFlags : list GHC.Base.String.
+
+(* Skipping definition `DynFlags.allFlagsDeps' *)
+
+(* Skipping definition `DynFlags.flagsAll' *)
+
+(* Skipping definition `DynFlags.flagsAllDeps' *)
+
+(* Skipping definition `DynFlags.flagsDynamic' *)
+
+(* Skipping definition `DynFlags.flagsPackage' *)
+
+(* Skipping definition `DynFlags.make_ord_flag' *)
+
+(* Skipping definition `DynFlags.make_dep_flag' *)
+
+(* Skipping definition `DynFlags.add_dep_message' *)
+
+(* Skipping definition `DynFlags.dynamic_flags_deps' *)
+
+(* Skipping definition `DynFlags.unrecognisedWarning' *)
+
+(* Skipping definition `DynFlags.package_flags_deps' *)
+
+Axiom flagsForCompletion : bool -> list GHC.Base.String.
+
+Axiom turnOn : TurnOnFlag.
+
+Axiom turnOff : TurnOnFlag.
+
+Axiom flagSpec : forall {flag},
+                 GHC.Base.String -> flag -> (Deprecation * FlagSpec flag)%type.
+
+(* Skipping definition `DynFlags.flagSpec'' *)
+
+(* Skipping definition `DynFlags.depFlagSpecOp' *)
+
+Axiom depFlagSpec : forall {flag},
+                    GHC.Base.String ->
+                    flag -> GHC.Base.String -> (Deprecation * FlagSpec flag)%type.
+
+(* Skipping definition `DynFlags.depFlagSpecOp'' *)
+
+(* Skipping definition `DynFlags.depFlagSpec'' *)
+
+Axiom depFlagSpecCond : forall {flag},
+                        GHC.Base.String ->
+                        flag ->
+                        (TurnOnFlag -> bool) -> GHC.Base.String -> (Deprecation * FlagSpec flag)%type.
+
+Axiom flagGhciSpec : forall {flag},
+                     GHC.Base.String -> flag -> (Deprecation * FlagSpec flag)%type.
+
+(* Skipping definition `DynFlags.flagGhciSpec'' *)
+
+Axiom flagHiddenSpec : forall {flag},
+                       GHC.Base.String -> flag -> (Deprecation * FlagSpec flag)%type.
+
+(* Skipping definition `DynFlags.flagHiddenSpec'' *)
+
+Axiom hideFlag : forall {a},
+                 (Deprecation * FlagSpec a)%type -> (Deprecation * FlagSpec a)%type.
+
+(* Skipping definition `DynFlags.mkFlag' *)
+
+Axiom deprecatedForExtension : GHC.Base.String -> TurnOnFlag -> GHC.Base.String.
+
+(* Skipping definition `DynFlags.useInstead' *)
+
+(* Skipping definition `DynFlags.nop' *)
+
+Axiom flagSpecOf : WarningFlag -> option (FlagSpec WarningFlag).
+
+Axiom wWarningFlags : list (FlagSpec WarningFlag).
+
+Axiom wWarningFlagsDeps : list (Deprecation * FlagSpec WarningFlag)%type.
+
+Axiom negatableFlagsDeps : list (Deprecation * FlagSpec GeneralFlag)%type.
+
+Axiom dFlagsDeps : list (Deprecation * FlagSpec GeneralFlag)%type.
+
+Axiom fFlags : list (FlagSpec GeneralFlag).
+
+Axiom fFlagsDeps : list (Deprecation * FlagSpec GeneralFlag)%type.
+
+(* Skipping definition `DynFlags.fLangFlags' *)
+
+(* Skipping definition `DynFlags.fLangFlagsDeps' *)
+
+Axiom supportedLanguages : list GHC.Base.String.
+
+(* Skipping definition `DynFlags.supportedLanguageOverlays' *)
+
+(* Skipping definition `DynFlags.supportedExtensions' *)
+
+Axiom supportedLanguagesAndExtensions : list GHC.Base.String.
+
+Axiom languageFlagsDeps : list (Deprecation * FlagSpec Language)%type.
+
+Axiom safeHaskellFlagsDeps : list (Deprecation * FlagSpec SafeHaskellMode)%type.
+
+(* Skipping definition `DynFlags.xFlags' *)
+
+(* Skipping definition `DynFlags.xFlagsDeps' *)
+
+Axiom defaultFlags : Settings -> list GeneralFlag.
+
+(* Skipping definition `DynFlags.default_PIC' *)
+
+(* Skipping definition `DynFlags.impliedGFlags' *)
+
+Axiom impliedOffGFlags : list (GeneralFlag * TurnOnFlag * GeneralFlag)%type.
+
+(* Skipping definition `DynFlags.impliedXFlags' *)
+
+Axiom optLevelFlags : list (list BinNums.N * GeneralFlag)%type.
+
+Axiom warningGroups : list (GHC.Base.String * list WarningFlag)%type.
+
+Axiom warningHierarchies : list (list GHC.Base.String).
+
+Axiom smallestGroups : WarningFlag -> list GHC.Base.String.
+
+Axiom standardWarnings : list WarningFlag.
+
+Axiom minusWOpts : list WarningFlag.
+
+Axiom minusWallOpts : list WarningFlag.
+
+Axiom minusWeverythingOpts : list WarningFlag.
+
+Axiom minusWcompatOpts : list WarningFlag.
+
+(* Skipping definition `DynFlags.enableUnusedBinds' *)
+
+(* Skipping definition `DynFlags.disableUnusedBinds' *)
+
+(* Skipping definition `DynFlags.unusedBindsFlags' *)
+
+(* Skipping definition `DynFlags.enableGlasgowExts' *)
+
+(* Skipping definition `DynFlags.disableGlasgowExts' *)
+
+(* Skipping definition `DynFlags.glasgowExtsFlags' *)
+
+(* Skipping definition `DynFlags.rtsIsProfiled' *)
+
+(* Skipping definition `DynFlags.dynamicGhc' *)
+
+(* Skipping definition `DynFlags.setWarnSafe' *)
+
+(* Skipping definition `DynFlags.setWarnUnsafe' *)
+
+(* Skipping definition `DynFlags.setPackageTrust' *)
+
+(* Skipping definition `DynFlags.setGenDeriving' *)
+
+(* Skipping definition `DynFlags.setOverlappingInsts' *)
+
+(* Skipping definition `DynFlags.setIncoherentInsts' *)
+
+(* Skipping definition `DynFlags.checkTemplateHaskellOk' *)
+
+(* Skipping definition `DynFlags.upd' *)
+
+(* Skipping definition `DynFlags.updM' *)
+
+(* Skipping definition `DynFlags.noArg' *)
+
+(* Skipping definition `DynFlags.noArgM' *)
+
+(* Skipping definition `DynFlags.hasArg' *)
+
+(* Skipping definition `DynFlags.sepArg' *)
+
+(* Skipping definition `DynFlags.intSuffix' *)
+
+(* Skipping definition `DynFlags.intSuffixM' *)
+
+(* Skipping definition `DynFlags.floatSuffix' *)
+
+(* Skipping definition `DynFlags.optIntSuffixM' *)
+
+(* Skipping definition `DynFlags.setDumpFlag' *)
+
+(* Skipping definition `DynFlags.addWay' *)
+
+Axiom addWay' : Way -> DynFlags -> DynFlags.
+
+(* Skipping definition `DynFlags.removeWayDyn' *)
+
+(* Skipping definition `DynFlags.setGeneralFlag' *)
+
+(* Skipping definition `DynFlags.unSetGeneralFlag' *)
+
+(* Skipping definition `DynFlags.setGeneralFlag'' *)
+
+(* Skipping definition `DynFlags.unSetGeneralFlag'' *)
+
+(* Skipping definition `DynFlags.setWarningFlag' *)
+
+(* Skipping definition `DynFlags.unSetWarningFlag' *)
+
+(* Skipping definition `DynFlags.setFatalWarningFlag' *)
+
+(* Skipping definition `DynFlags.unSetFatalWarningFlag' *)
+
+(* Skipping definition `DynFlags.setExtensionFlag' *)
+
+(* Skipping definition `DynFlags.unSetExtensionFlag' *)
+
+(* Skipping definition `DynFlags.setExtensionFlag'' *)
+
+(* Skipping definition `DynFlags.unSetExtensionFlag'' *)
+
+Axiom alterSettings : (Settings -> Settings) -> DynFlags -> DynFlags.
+
+(* Skipping definition `DynFlags.setDumpFlag'' *)
+
+(* Skipping definition `DynFlags.forceRecompile' *)
+
+(* Skipping definition `DynFlags.setVerboseCore2Core' *)
+
+(* Skipping definition `DynFlags.setVerbosity' *)
+
+(* Skipping definition `DynFlags.setDebugLevel' *)
+
+(* Skipping definition `DynFlags.addPkgConfRef' *)
+
+(* Skipping definition `DynFlags.removeUserPkgConf' *)
+
+(* Skipping definition `DynFlags.removeGlobalPkgConf' *)
+
+(* Skipping definition `DynFlags.clearPkgConf' *)
+
+(* Skipping definition `DynFlags.parsePackageFlag' *)
+
+(* Skipping definition `DynFlags.exposePackage' *)
+
+(* Skipping definition `DynFlags.exposePackageId' *)
+
+(* Skipping definition `DynFlags.exposePluginPackage' *)
+
+(* Skipping definition `DynFlags.exposePluginPackageId' *)
+
+(* Skipping definition `DynFlags.hidePackage' *)
+
+(* Skipping definition `DynFlags.ignorePackage' *)
+
+(* Skipping definition `DynFlags.trustPackage' *)
+
+(* Skipping definition `DynFlags.distrustPackage' *)
+
+Axiom exposePackage' : GHC.Base.String -> DynFlags -> DynFlags.
+
+(* Skipping definition `DynFlags.parsePackageArg' *)
+
+(* Skipping definition `DynFlags.parseUnitIdArg' *)
+
+(* Skipping definition `DynFlags.setUnitId' *)
+
+Axiom canonicalizeHomeModule : DynFlags -> Module.ModuleName -> Module.Module.
+
+(* Skipping definition `DynFlags.interpretPackageEnv' *)
+
+(* Skipping definition `DynFlags.setTarget' *)
+
+(* Skipping definition `DynFlags.setTargetWithPlatform' *)
+
+(* Skipping definition `DynFlags.setObjTarget' *)
+
+(* Skipping definition `DynFlags.setOptLevel' *)
+
+Axiom checkOptLevel : BinNums.N ->
+                      DynFlags -> Data.Either.Either GHC.Base.String DynFlags.
+
+(* Skipping definition `DynFlags.setDPHOpt' *)
+
+(* Skipping definition `DynFlags.setMainIs' *)
+
+Axiom addLdInputs : Option -> DynFlags -> DynFlags.
+
+(* Skipping definition `DynFlags.addImportPath' *)
+
+(* Skipping definition `DynFlags.addLibraryPath' *)
+
+(* Skipping definition `DynFlags.addIncludePath' *)
+
+(* Skipping definition `DynFlags.addFrameworkPath' *)
+
+Axiom split_marker : GHC.Char.Char.
+
+Axiom splitPathList : GHC.Base.String -> list GHC.Base.String.
+
+(* Skipping definition `DynFlags.setTmpDir' *)
+
+(* Skipping definition `DynFlags.setRtsOpts' *)
+
+(* Skipping definition `DynFlags.setRtsOptsEnabled' *)
+
+(* Skipping definition `DynFlags.setOptHpcDir' *)
+
+Axiom picCCOpts : DynFlags -> list GHC.Base.String.
+
+Axiom picPOpts : DynFlags -> list GHC.Base.String.
+
+Axiom can_split : bool.
+
+Axiom compilerInfo : DynFlags -> list (GHC.Base.String * GHC.Base.String)%type.
+
+Axiom bLOCK_SIZE_W : DynFlags -> BinNums.N.
+
+Axiom wORD_SIZE_IN_BITS : DynFlags -> BinNums.N.
+
+Axiom tAG_MASK : DynFlags -> BinNums.N.
+
+Axiom mAX_PTR_TAG : DynFlags -> BinNums.N.
+
+Axiom tARGET_MIN_INT : DynFlags -> GHC.Num.Integer.
+
+Axiom tARGET_MAX_INT : DynFlags -> GHC.Num.Integer.
+
+Axiom tARGET_MAX_WORD : DynFlags -> GHC.Num.Integer.
+
+Axiom makeDynFlagsConsistent : DynFlags ->
+                               (DynFlags * list (SrcLoc.Located GHC.Base.String))%type.
+
+Axiom defaultGlobalDynFlags : DynFlags.
+
+(* Skipping definition `DynFlags.v_unsafeGlobalDynFlags' *)
+
+Axiom unsafeGlobalDynFlags : DynFlags.
+
+(* Skipping definition `DynFlags.setUnsafeGlobalDynFlags' *)
+
+Axiom isSseEnabled : DynFlags -> bool.
+
+Axiom isSse2Enabled : DynFlags -> bool.
+
+Axiom isSse4_2Enabled : DynFlags -> bool.
+
+Axiom isAvxEnabled : DynFlags -> bool.
+
+Axiom isAvx2Enabled : DynFlags -> bool.
+
+Axiom isAvx512cdEnabled : DynFlags -> bool.
+
+Axiom isAvx512erEnabled : DynFlags -> bool.
+
+Axiom isAvx512fEnabled : DynFlags -> bool.
+
+Axiom isAvx512pfEnabled : DynFlags -> bool.
+
+Axiom isBmiEnabled : DynFlags -> bool.
+
+Axiom isBmi2Enabled : DynFlags -> bool.
+
+Axiom decodeSize : GHC.Base.String -> GHC.Num.Integer.
+
+Axiom emptyFilesToClean : FilesToClean.
 
 (* External variables:
      Type bool list op_zt__ option BinNums.N Data.Either.Either

--- a/examples/ghc/lib/EnumSet.v
+++ b/examples/ghc/lib/EnumSet.v
@@ -25,19 +25,19 @@ Arguments Mk_EnumSet {_} _.
 
 (* Converted value declarations: *)
 
-Axiom toList : forall {a}, forall `{GHC.Enum.Enum a}, EnumSet a -> list a.
-
 Axiom member : forall {a}, forall `{GHC.Enum.Enum a}, a -> EnumSet a -> bool.
 
 Axiom insert : forall {a},
                forall `{GHC.Enum.Enum a}, a -> EnumSet a -> EnumSet a.
 
+Axiom delete : forall {a},
+               forall `{GHC.Enum.Enum a}, a -> EnumSet a -> EnumSet a.
+
+Axiom toList : forall {a}, forall `{GHC.Enum.Enum a}, EnumSet a -> list a.
+
 Axiom fromList : forall {a}, forall `{GHC.Enum.Enum a}, list a -> EnumSet a.
 
 Axiom empty : forall {a}, EnumSet a.
-
-Axiom delete : forall {a},
-               forall `{GHC.Enum.Enum a}, a -> EnumSet a -> EnumSet a.
 
 Definition fromEnumN {a} `{GHC.Enum.Enum a} (e : a) :=
   Coq.ZArith.BinInt.Z.to_N (GHC.Enum.fromEnum e).

--- a/examples/ghc/lib/FastStringEnv.v
+++ b/examples/ghc/lib/FastStringEnv.v
@@ -25,38 +25,40 @@ Definition DFastStringEnv :=
 
 (* Converted value declarations: *)
 
+Axiom emptyFsEnv : forall {a}, FastStringEnv a.
+
 Axiom unitFsEnv : forall {a}, FastString.FastString -> a -> FastStringEnv a.
 
-Axiom plusFsEnv_C : forall {a},
-                    (a -> a -> a) -> FastStringEnv a -> FastStringEnv a -> FastStringEnv a.
+Axiom extendFsEnv : forall {a},
+                    FastStringEnv a -> FastString.FastString -> a -> FastStringEnv a.
 
-Axiom plusFsEnv : forall {a},
-                  FastStringEnv a -> FastStringEnv a -> FastStringEnv a.
-
-Axiom mkFsEnv : forall {a},
-                list (FastString.FastString * a)%type -> FastStringEnv a.
-
-Axiom mkDFsEnv : forall {a},
-                 list (FastString.FastString * a)%type -> DFastStringEnv a.
-
-Axiom mapFsEnv : forall {elt1} {elt2},
-                 (elt1 -> elt2) -> FastStringEnv elt1 -> FastStringEnv elt2.
-
-Axiom lookupFsEnv_NF : forall {a},
-                       FastStringEnv a -> FastString.FastString -> a.
+Axiom extendFsEnvList : forall {a},
+                        FastStringEnv a -> list (FastString.FastString * a)%type -> FastStringEnv a.
 
 Axiom lookupFsEnv : forall {a},
                     FastStringEnv a -> FastString.FastString -> option a.
 
-Axiom lookupDFsEnv : forall {a},
-                     DFastStringEnv a -> FastString.FastString -> option a.
+Axiom alterFsEnv : forall {a},
+                   (option a -> option a) ->
+                   FastStringEnv a -> FastString.FastString -> FastStringEnv a.
 
-Axiom filterFsEnv : forall {elt},
-                    (elt -> bool) -> FastStringEnv elt -> FastStringEnv elt.
+Axiom mkFsEnv : forall {a},
+                list (FastString.FastString * a)%type -> FastStringEnv a.
+
+Axiom elemFsEnv : forall {a}, FastString.FastString -> FastStringEnv a -> bool.
+
+Axiom plusFsEnv : forall {a},
+                  FastStringEnv a -> FastStringEnv a -> FastStringEnv a.
+
+Axiom plusFsEnv_C : forall {a},
+                    (a -> a -> a) -> FastStringEnv a -> FastStringEnv a -> FastStringEnv a.
 
 Axiom extendFsEnv_C : forall {a},
                       (a -> a -> a) ->
                       FastStringEnv a -> FastString.FastString -> a -> FastStringEnv a.
+
+Axiom mapFsEnv : forall {elt1} {elt2},
+                 (elt1 -> elt2) -> FastStringEnv elt1 -> FastStringEnv elt2.
 
 Axiom extendFsEnv_Acc : forall {a} {b},
                         (a -> b -> b) ->
@@ -66,29 +68,27 @@ Axiom extendFsEnvList_C : forall {a},
                           (a -> a -> a) ->
                           FastStringEnv a -> list (FastString.FastString * a)%type -> FastStringEnv a.
 
-Axiom extendFsEnvList : forall {a},
-                        FastStringEnv a -> list (FastString.FastString * a)%type -> FastStringEnv a.
-
-Axiom extendFsEnv : forall {a},
-                    FastStringEnv a -> FastString.FastString -> a -> FastStringEnv a.
-
-Axiom emptyFsEnv : forall {a}, FastStringEnv a.
-
-Axiom emptyDFsEnv : forall {a}, DFastStringEnv a.
-
-Axiom elemFsEnv : forall {a}, FastString.FastString -> FastStringEnv a -> bool.
+Axiom delFromFsEnv : forall {a},
+                     FastStringEnv a -> FastString.FastString -> FastStringEnv a.
 
 Axiom delListFromFsEnv : forall {a},
                          FastStringEnv a -> list FastString.FastString -> FastStringEnv a.
 
-Axiom delFromFsEnv : forall {a},
-                     FastStringEnv a -> FastString.FastString -> FastStringEnv a.
+Axiom filterFsEnv : forall {elt},
+                    (elt -> bool) -> FastStringEnv elt -> FastStringEnv elt.
+
+Axiom lookupFsEnv_NF : forall {a},
+                       FastStringEnv a -> FastString.FastString -> a.
+
+Axiom emptyDFsEnv : forall {a}, DFastStringEnv a.
 
 Axiom dFsEnvElts : forall {a}, DFastStringEnv a -> list a.
 
-Axiom alterFsEnv : forall {a},
-                   (option a -> option a) ->
-                   FastStringEnv a -> FastString.FastString -> FastStringEnv a.
+Axiom mkDFsEnv : forall {a},
+                 list (FastString.FastString * a)%type -> DFastStringEnv a.
+
+Axiom lookupDFsEnv : forall {a},
+                     DFastStringEnv a -> FastString.FastString -> option a.
 
 (* External variables:
      bool list op_zt__ option FastString.FastString UniqFM.UniqFM

--- a/examples/ghc/lib/FieldLabel.v
+++ b/examples/ghc/lib/FieldLabel.v
@@ -52,9 +52,6 @@ Definition flSelector {a} (arg_0__ : FieldLbl a) :=
 
 (* Converted value declarations: *)
 
-Axiom mkFieldLabelOccs : FieldLabelString ->
-                         OccName.OccName -> bool -> FieldLbl OccName.OccName.
-
 (* Skipping all instances of class `Data.Data.Data', including
    `FieldLabel.Data__FieldLbl' *)
 
@@ -75,11 +72,14 @@ Instance Traversable__FieldLbl : Data.Traversable.Traversable FieldLbl.
 Proof.
 Admitted.
 
+(* Skipping all instances of class `Outputable.Outputable', including
+   `FieldLabel.Outputable__FieldLbl' *)
+
 (* Skipping all instances of class `Binary.Binary', including
    `FieldLabel.Binary__FieldLbl' *)
 
-(* Skipping all instances of class `Outputable.Outputable', including
-   `FieldLabel.Outputable__FieldLbl' *)
+Axiom mkFieldLabelOccs : FieldLabelString ->
+                         OccName.OccName -> bool -> FieldLbl OccName.OccName.
 
 (* External variables:
      bool Data.Foldable.Foldable Data.Traversable.Traversable FastString.FastString

--- a/examples/ghc/lib/FiniteMap.v
+++ b/examples/ghc/lib/FiniteMap.v
@@ -20,6 +20,15 @@ Require GHC.Base.
 
 (* Converted value declarations: *)
 
+Definition insertList {key} {elt} `{GHC.Base.Ord key}
+   : list (key * elt)%type ->
+     Data.Map.Internal.Map key elt -> Data.Map.Internal.Map key elt :=
+  fun xs m =>
+    Data.Foldable.foldl (fun arg_0__ arg_1__ =>
+                           match arg_0__, arg_1__ with
+                           | m, pair k v => Data.Map.Internal.insert k v m
+                           end) m xs.
+
 Definition insertListWith {key} {elt} `{GHC.Base.Ord key}
    : (elt -> elt -> elt) ->
      list (key * elt)%type ->
@@ -30,26 +39,17 @@ Definition insertListWith {key} {elt} `{GHC.Base.Ord key}
                            | m, pair k v => Data.Map.Internal.insertWith f k v m
                            end) m0 xs.
 
-Definition insertList {key} {elt} `{GHC.Base.Ord key}
-   : list (key * elt)%type ->
-     Data.Map.Internal.Map key elt -> Data.Map.Internal.Map key elt :=
-  fun xs m =>
-    Data.Foldable.foldl (fun arg_0__ arg_1__ =>
-                           match arg_0__, arg_1__ with
-                           | m, pair k v => Data.Map.Internal.insert k v m
-                           end) m xs.
-
-Definition foldRightWithKey {key} {elt} {a}
-   : (key -> elt -> a -> a) -> a -> Data.Map.Internal.Map key elt -> a :=
-  Data.Map.Internal.foldrWithKey.
+Definition deleteList {key} {elt} `{GHC.Base.Ord key}
+   : list key -> Data.Map.Internal.Map key elt -> Data.Map.Internal.Map key elt :=
+  fun ks m => Data.Foldable.foldl (GHC.Base.flip Data.Map.Internal.delete) m ks.
 
 Definition foldRight {elt} {a} {key}
    : (elt -> a -> a) -> a -> Data.Map.Internal.Map key elt -> a :=
   Data.Map.Internal.foldr.
 
-Definition deleteList {key} {elt} `{GHC.Base.Ord key}
-   : list key -> Data.Map.Internal.Map key elt -> Data.Map.Internal.Map key elt :=
-  fun ks m => Data.Foldable.foldl (GHC.Base.flip Data.Map.Internal.delete) m ks.
+Definition foldRightWithKey {key} {elt} {a}
+   : (key -> elt -> a -> a) -> a -> Data.Map.Internal.Map key elt -> a :=
+  Data.Map.Internal.foldrWithKey.
 
 (* External variables:
      list op_zt__ pair Data.Foldable.foldl Data.Map.Internal.Map

--- a/examples/ghc/lib/Id.v
+++ b/examples/ghc/lib/Id.v
@@ -37,8 +37,17 @@ Import GHC.Num.Notations.
 
 (* Converted value declarations: *)
 
-Definition stateHackOneShot : BasicTypes.OneShotInfo :=
-  BasicTypes.OneShotLam.
+Definition idName : Core.Id -> Name.Name :=
+  Core.varName.
+
+Definition idUnique : Core.Id -> Unique.Unique :=
+  Core.varUnique.
+
+Definition idType : Core.Id -> AxiomatizedTypes.Kind :=
+  Core.varType.
+
+Definition setIdName : Core.Id -> Name.Name -> Core.Id :=
+  Core.setVarName.
 
 Definition setIdUnique : Core.Id -> Unique.Unique -> Core.Id :=
   Core.setVarUnique.
@@ -46,93 +55,36 @@ Definition setIdUnique : Core.Id -> Unique.Unique -> Core.Id :=
 Definition setIdType : Core.Id -> AxiomatizedTypes.Type_ -> Core.Id :=
   fun id ty => Core.setVarType id ty.
 
-(* Skipping definition `Id.setIdNotExported' *)
-
-Definition setIdName : Core.Id -> Name.Name -> Core.Id :=
-  Core.setVarName.
-
 (* Skipping definition `Id.setIdExported' *)
 
-(* Skipping definition `Id.setCaseBndrEvald' *)
+(* Skipping definition `Id.setIdNotExported' *)
 
-Definition recordSelectorTyCon : Core.Id -> Core.RecSelParent :=
+Definition localiseId : Core.Id -> Core.Id :=
   fun id =>
-    match Core.idDetails id with
-    | Core.RecSelId parent _ => parent
-    | _ => Panic.panic (GHC.Base.hs_string__ "recordSelectorTyCon")
+    let name := idName id in
+    if (if andb Util.debugIsOn (negb (Core.isId id)) : bool
+        then (Panic.assertPanic (GHC.Base.hs_string__ "ghc/compiler/basicTypes/Id.hs")
+              #209)
+        else andb (Core.isLocalId id) (Name.isInternalName name)) : bool
+    then id else
+    Core.mkLocalVar (Core.idDetails id) (Name.localiseName name) (idType id)
+    (Core.idInfo id).
+
+Definition lazySetIdInfo : Core.Id -> Core.IdInfo -> Core.Id :=
+  Core.lazySetIdInfo.
+
+Definition setIdInfo : Core.Id -> Core.IdInfo -> Core.Id :=
+  fun id info => GHC.Prim.seq info (lazySetIdInfo id info).
+
+Definition modifyIdInfo : (Core.IdInfo -> Core.IdInfo) -> Core.Id -> Core.Id :=
+  fun fn id => setIdInfo id (fn (Core.idInfo id)).
+
+Definition maybeModifyIdInfo : option Core.IdInfo -> Core.Id -> Core.Id :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Some new_info, id => lazySetIdInfo id new_info
+    | None, id => id
     end.
-
-Definition realIdUnfolding : Core.Id -> Core.Unfolding :=
-  fun id => Core.unfoldingInfo (Core.idInfo id).
-
-Axiom mkTemplateLocalsNum : nat -> list AxiomatizedTypes.Type_ -> list Core.Id.
-
-Axiom mkTemplateLocals : list AxiomatizedTypes.Type_ -> list Core.Id.
-
-Axiom mkTemplateLocal : nat -> AxiomatizedTypes.Type_ -> Core.Id.
-
-Definition mkLocalIdWithInfo
-   : Name.Name -> AxiomatizedTypes.Type_ -> Core.IdInfo -> Core.Id :=
-  fun name ty info => Core.mkLocalVar Core.VanillaId name ty info.
-
-Definition mkLocalIdOrCoVarWithInfo
-   : Name.Name -> AxiomatizedTypes.Type_ -> Core.IdInfo -> Core.Id :=
-  fun name ty info =>
-    let details := Core.VanillaId in Core.mkLocalVar details name ty info.
-
-Definition mkLocalId : Name.Name -> AxiomatizedTypes.Type_ -> Core.Id :=
-  fun name ty => mkLocalIdWithInfo name ty Core.vanillaIdInfo.
-
-Definition mkLocalIdOrCoVar : Name.Name -> AxiomatizedTypes.Type_ -> Core.Id :=
-  fun name ty => mkLocalId name ty.
-
-Definition mkSysLocalOrCoVar
-   : FastString.FastString ->
-     Unique.Unique -> AxiomatizedTypes.Type_ -> Core.Id :=
-  fun fs uniq ty => mkLocalIdOrCoVar (Name.mkSystemVarName uniq fs) ty.
-
-Definition mkSysLocalOrCoVarM {m} `{UniqSupply.MonadUnique m}
-   : FastString.FastString -> AxiomatizedTypes.Type_ -> m Core.Id :=
-  fun fs ty =>
-    UniqSupply.getUniqueM GHC.Base.>>=
-    (fun uniq => GHC.Base.return_ (mkSysLocalOrCoVar fs uniq ty)).
-
-Definition mkUserLocalOrCoVar
-   : OccName.OccName ->
-     Unique.Unique -> AxiomatizedTypes.Type_ -> SrcLoc.SrcSpan -> Core.Id :=
-  fun occ uniq ty loc => mkLocalIdOrCoVar (Name.mkInternalName uniq occ loc) ty.
-
-Definition mkWorkerId
-   : Unique.Unique -> Core.Id -> AxiomatizedTypes.Type_ -> Core.Id :=
-  fun uniq unwrkr ty =>
-    mkLocalIdOrCoVar (Name.mkDerivedInternalName OccName.mkWorkerOcc uniq
-                      (Name.getName unwrkr)) ty.
-
-Definition mkSysLocal
-   : FastString.FastString ->
-     Unique.Unique -> AxiomatizedTypes.Type_ -> Core.Id :=
-  fun fs uniq ty =>
-    if andb Util.debugIsOn (negb (negb (false))) : bool
-    then (Panic.assertPanic (GHC.Base.hs_string__ "ghc/compiler/basicTypes/Id.hs")
-          #313)
-    else mkLocalId (Name.mkSystemVarName uniq fs) ty.
-
-Definition mkSysLocalM {m} `{UniqSupply.MonadUnique m}
-   : FastString.FastString -> AxiomatizedTypes.Type_ -> m Core.Id :=
-  fun fs ty =>
-    UniqSupply.getUniqueM GHC.Base.>>=
-    (fun uniq => GHC.Base.return_ (mkSysLocal fs uniq ty)).
-
-Definition mkUserLocal
-   : OccName.OccName ->
-     Unique.Unique -> AxiomatizedTypes.Type_ -> SrcLoc.SrcSpan -> Core.Id :=
-  fun occ uniq ty loc =>
-    if andb Util.debugIsOn (negb (negb (false))) : bool
-    then (Panic.assertPanic (GHC.Base.hs_string__ "ghc/compiler/basicTypes/Id.hs")
-          #330)
-    else mkLocalId (Name.mkInternalName uniq occ loc) ty.
-
-(* Skipping definition `Id.mkLocalCoVar' *)
 
 Definition mkGlobalId
    : Core.IdDetails ->
@@ -146,151 +98,91 @@ Definition mkVanillaGlobalWithInfo
 Definition mkVanillaGlobal : Name.Name -> AxiomatizedTypes.Type_ -> Core.Id :=
   fun name ty => mkVanillaGlobalWithInfo name ty Core.vanillaIdInfo.
 
-Definition mkExportedVanillaId
-   : Name.Name -> AxiomatizedTypes.Type_ -> Core.Id :=
-  fun name ty =>
-    Core.mkExportedLocalVar Core.VanillaId name ty Core.vanillaIdInfo.
+Definition mkLocalIdWithInfo
+   : Name.Name -> AxiomatizedTypes.Type_ -> Core.IdInfo -> Core.Id :=
+  fun name ty info => Core.mkLocalVar Core.VanillaId name ty info.
+
+Definition mkLocalId : Name.Name -> AxiomatizedTypes.Type_ -> Core.Id :=
+  fun name ty => mkLocalIdWithInfo name ty Core.vanillaIdInfo.
+
+(* Skipping definition `Id.mkLocalCoVar' *)
+
+Definition mkLocalIdOrCoVar : Name.Name -> AxiomatizedTypes.Type_ -> Core.Id :=
+  fun name ty => mkLocalId name ty.
+
+Definition mkLocalIdOrCoVarWithInfo
+   : Name.Name -> AxiomatizedTypes.Type_ -> Core.IdInfo -> Core.Id :=
+  fun name ty info =>
+    let details := Core.VanillaId in Core.mkLocalVar details name ty info.
 
 Definition mkExportedLocalId
    : Core.IdDetails -> Name.Name -> AxiomatizedTypes.Type_ -> Core.Id :=
   fun details name ty =>
     Core.mkExportedLocalVar details name ty Core.vanillaIdInfo.
 
-Definition lazySetIdInfo : Core.Id -> Core.IdInfo -> Core.Id :=
-  Core.lazySetIdInfo.
+Definition mkExportedVanillaId
+   : Name.Name -> AxiomatizedTypes.Type_ -> Core.Id :=
+  fun name ty =>
+    Core.mkExportedLocalVar Core.VanillaId name ty Core.vanillaIdInfo.
 
-Definition maybeModifyIdInfo : option Core.IdInfo -> Core.Id -> Core.Id :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Some new_info, id => lazySetIdInfo id new_info
-    | None, id => id
+Definition mkSysLocal
+   : FastString.FastString ->
+     Unique.Unique -> AxiomatizedTypes.Type_ -> Core.Id :=
+  fun fs uniq ty =>
+    if andb Util.debugIsOn (negb (negb (false))) : bool
+    then (Panic.assertPanic (GHC.Base.hs_string__ "ghc/compiler/basicTypes/Id.hs")
+          #313)
+    else mkLocalId (Name.mkSystemVarName uniq fs) ty.
+
+Definition mkSysLocalOrCoVar
+   : FastString.FastString ->
+     Unique.Unique -> AxiomatizedTypes.Type_ -> Core.Id :=
+  fun fs uniq ty => mkLocalIdOrCoVar (Name.mkSystemVarName uniq fs) ty.
+
+Definition mkSysLocalM {m} `{UniqSupply.MonadUnique m}
+   : FastString.FastString -> AxiomatizedTypes.Type_ -> m Core.Id :=
+  fun fs ty =>
+    UniqSupply.getUniqueM GHC.Base.>>=
+    (fun uniq => GHC.Base.return_ (mkSysLocal fs uniq ty)).
+
+Definition mkSysLocalOrCoVarM {m} `{UniqSupply.MonadUnique m}
+   : FastString.FastString -> AxiomatizedTypes.Type_ -> m Core.Id :=
+  fun fs ty =>
+    UniqSupply.getUniqueM GHC.Base.>>=
+    (fun uniq => GHC.Base.return_ (mkSysLocalOrCoVar fs uniq ty)).
+
+Definition mkUserLocal
+   : OccName.OccName ->
+     Unique.Unique -> AxiomatizedTypes.Type_ -> SrcLoc.SrcSpan -> Core.Id :=
+  fun occ uniq ty loc =>
+    if andb Util.debugIsOn (negb (negb (false))) : bool
+    then (Panic.assertPanic (GHC.Base.hs_string__ "ghc/compiler/basicTypes/Id.hs")
+          #330)
+    else mkLocalId (Name.mkInternalName uniq occ loc) ty.
+
+Definition mkUserLocalOrCoVar
+   : OccName.OccName ->
+     Unique.Unique -> AxiomatizedTypes.Type_ -> SrcLoc.SrcSpan -> Core.Id :=
+  fun occ uniq ty loc => mkLocalIdOrCoVar (Name.mkInternalName uniq occ loc) ty.
+
+Definition mkWorkerId
+   : Unique.Unique -> Core.Id -> AxiomatizedTypes.Type_ -> Core.Id :=
+  fun uniq unwrkr ty =>
+    mkLocalIdOrCoVar (Name.mkDerivedInternalName OccName.mkWorkerOcc uniq
+                      (Name.getName unwrkr)) ty.
+
+Axiom mkTemplateLocal : nat -> AxiomatizedTypes.Type_ -> Core.Id.
+
+Axiom mkTemplateLocals : list AxiomatizedTypes.Type_ -> list Core.Id.
+
+Axiom mkTemplateLocalsNum : nat -> list AxiomatizedTypes.Type_ -> list Core.Id.
+
+Definition recordSelectorTyCon : Core.Id -> Core.RecSelParent :=
+  fun id =>
+    match Core.idDetails id with
+    | Core.RecSelId parent _ => parent
+    | _ => Panic.panic (GHC.Base.hs_string__ "recordSelectorTyCon")
     end.
-
-Definition zapInfo
-   : (Core.IdInfo -> option Core.IdInfo) -> Core.Id -> Core.Id :=
-  fun zapper id => maybeModifyIdInfo (zapper (Core.idInfo id)) id.
-
-Definition zapFragileIdInfo : Core.Id -> Core.Id :=
-  zapInfo Core.zapFragileInfo.
-
-Definition zapIdDemandInfo : Core.Id -> Core.Id :=
-  zapInfo Core.zapDemandInfo.
-
-Definition zapIdTailCallInfo : Core.Id -> Core.Id :=
-  zapInfo Core.zapTailCallInfo.
-
-Definition zapIdUsageEnvInfo : Core.Id -> Core.Id :=
-  zapInfo Core.zapUsageEnvInfo.
-
-Definition zapIdUsageInfo : Core.Id -> Core.Id :=
-  zapInfo Core.zapUsageInfo.
-
-Definition zapIdUsedOnceInfo : Core.Id -> Core.Id :=
-  zapInfo Core.zapUsedOnceInfo.
-
-Definition zapLamIdInfo : Core.Id -> Core.Id :=
-  zapInfo Core.zapLamInfo.
-
-Definition setIdInfo : Core.Id -> Core.IdInfo -> Core.Id :=
-  fun id info => GHC.Prim.seq info (lazySetIdInfo id info).
-
-Definition modifyIdInfo : (Core.IdInfo -> Core.IdInfo) -> Core.Id -> Core.Id :=
-  fun fn id => setIdInfo id (fn (Core.idInfo id)).
-
-Definition modifyInlinePragma
-   : Core.Id -> (BasicTypes.InlinePragma -> BasicTypes.InlinePragma) -> Core.Id :=
-  fun id fn =>
-    modifyIdInfo (fun info =>
-                    Core.setInlinePragInfo info (fn (Core.inlinePragInfo info))) id.
-
-Definition setInlineActivation : Core.Id -> BasicTypes.Activation -> Core.Id :=
-  fun id act =>
-    modifyInlinePragma id (fun prag =>
-                             BasicTypes.setInlinePragmaActivation prag act).
-
-Definition setIdArity : Core.Id -> BasicTypes.Arity -> Core.Id :=
-  fun id arity =>
-    modifyIdInfo (fun arg_0__ => Core.setArityInfo arg_0__ arity) id.
-
-Definition setIdCafInfo : Core.Id -> Core.CafInfo -> Core.Id :=
-  fun id caf_info =>
-    modifyIdInfo (fun arg_0__ => Core.setCafInfo arg_0__ caf_info) id.
-
-Definition setIdCallArity : Core.Id -> BasicTypes.Arity -> Core.Id :=
-  fun id arity =>
-    modifyIdInfo (fun arg_0__ => Core.setCallArityInfo arg_0__ arity) id.
-
-Definition setIdDemandInfo : Core.Id -> Core.Demand -> Core.Id :=
-  fun id dmd => modifyIdInfo (fun arg_0__ => Core.setDemandInfo arg_0__ dmd) id.
-
-Definition setIdOccInfo : Core.Id -> BasicTypes.OccInfo -> Core.Id :=
-  fun id occ_info =>
-    modifyIdInfo (fun arg_0__ => Core.setOccInfo arg_0__ occ_info) id.
-
-Definition zapIdOccInfo : Core.Id -> Core.Id :=
-  fun b => setIdOccInfo b BasicTypes.noOccInfo.
-
-Definition setIdOneShotInfo : Core.Id -> BasicTypes.OneShotInfo -> Core.Id :=
-  fun id one_shot =>
-    modifyIdInfo (fun arg_0__ => Core.setOneShotInfo arg_0__ one_shot) id.
-
-Definition setIdSpecialisation : Core.Id -> Core.RuleInfo -> Core.Id :=
-  fun id spec_info =>
-    modifyIdInfo (fun arg_0__ => Core.setRuleInfo arg_0__ spec_info) id.
-
-Definition setIdStrictness : Core.Id -> Core.StrictSig -> Core.Id :=
-  fun id sig =>
-    modifyIdInfo (fun arg_0__ => Core.setStrictnessInfo arg_0__ sig) id.
-
-Definition setIdUnfolding : Core.Id -> Core.Unfolding -> Core.Id :=
-  fun id unfolding =>
-    modifyIdInfo (fun arg_0__ => Core.setUnfoldingInfo arg_0__ unfolding) id.
-
-Definition zapStableUnfolding : Core.Id -> Core.Id :=
-  fun id =>
-    if Core.isStableUnfolding (realIdUnfolding id) : bool
-    then setIdUnfolding id Core.NoUnfolding else
-    id.
-
-Definition setInlinePragma : Core.Id -> BasicTypes.InlinePragma -> Core.Id :=
-  fun id prag =>
-    modifyIdInfo (fun arg_0__ => Core.setInlinePragInfo arg_0__ prag) id.
-
-Definition setOneShotLambda : Core.Id -> Core.Id :=
-  fun id =>
-    modifyIdInfo (fun arg_0__ => Core.setOneShotInfo arg_0__ BasicTypes.OneShotLam)
-    id.
-
-Definition transferPolyIdInfo
-   : Core.Id -> list Core.Var -> Core.Id -> Core.Id :=
-  fun old_id abstract_wrt new_id =>
-    let old_info := Core.idInfo old_id in
-    let old_arity := Core.arityInfo old_info in
-    let old_inline_prag := Core.inlinePragInfo old_info in
-    let old_occ_info := Core.occInfo old_info in
-    let new_occ_info := BasicTypes.zapOccTailCallInfo old_occ_info in
-    let old_strictness := Core.strictnessInfo old_info in
-    let arity_increase := Util.count Core.isId abstract_wrt in
-    let new_arity := old_arity GHC.Num.+ arity_increase in
-    let new_strictness :=
-      Core.increaseStrictSigArity arity_increase old_strictness in
-    let transfer :=
-      fun new_info =>
-        Core.setStrictnessInfo (Core.setOccInfo (Core.setInlinePragInfo
-                                                 (Core.setArityInfo new_info new_arity) old_inline_prag) new_occ_info)
-                               new_strictness in
-    modifyIdInfo transfer new_id.
-
-Definition zapIdStrictness : Core.Id -> Core.Id :=
-  fun id =>
-    modifyIdInfo (fun arg_0__ => Core.setStrictnessInfo arg_0__ Core.nopSig) id.
-
-Axiom isStateHackType : AxiomatizedTypes.Type_ -> bool.
-
-Definition typeOneShot : AxiomatizedTypes.Type_ -> BasicTypes.OneShotInfo :=
-  fun ty =>
-    if isStateHackType ty : bool then stateHackOneShot else
-    BasicTypes.NoOneShotInfo.
 
 Definition isRecordSelector : Core.Id -> bool :=
   fun id =>
@@ -299,17 +191,10 @@ Definition isRecordSelector : Core.Id -> bool :=
     | _ => false
     end.
 
-Definition isPrimOpId_maybe : Core.Id -> option AxiomatizedTypes.PrimOp :=
+Definition isDataConRecordSelector : Core.Id -> bool :=
   fun id =>
     match Core.idDetails id with
-    | Core.PrimOpId op => Some op
-    | _ => None
-    end.
-
-Definition isPrimOpId : Core.Id -> bool :=
-  fun id =>
-    match Core.idDetails id with
-    | Core.PrimOpId _ => true
+    | Core.RecSelId (Core.RecSelData _) _ => true
     | _ => false
     end.
 
@@ -320,15 +205,85 @@ Definition isPatSynRecordSelector : Core.Id -> bool :=
     | _ => false
     end.
 
-Definition isNeverLevPolyId : Core.Id -> bool :=
-  Core.isNeverLevPolyIdInfo GHC.Base.∘ Core.idInfo.
-
 Definition isNaughtyRecordSelector : Core.Id -> bool :=
   fun id =>
     match Core.idDetails id with
     | Core.RecSelId _ n => n
     | _ => false
     end.
+
+Definition isClassOpId_maybe : Core.Id -> option Core.Class :=
+  fun id =>
+    match Core.idDetails id with
+    | Core.ClassOpId cls => Some cls
+    | _other => None
+    end.
+
+Definition isPrimOpId : Core.Id -> bool :=
+  fun id =>
+    match Core.idDetails id with
+    | Core.PrimOpId _ => true
+    | _ => false
+    end.
+
+Definition isDFunId : Core.Id -> bool :=
+  fun id =>
+    match Core.idDetails id with
+    | Core.Mk_DFunId _ => true
+    | _ => false
+    end.
+
+Definition isPrimOpId_maybe : Core.Id -> option AxiomatizedTypes.PrimOp :=
+  fun id =>
+    match Core.idDetails id with
+    | Core.PrimOpId op => Some op
+    | _ => None
+    end.
+
+Definition isFCallId : Core.Id -> bool :=
+  fun id =>
+    match Core.idDetails id with
+    | Core.FCallId _ => true
+    | _ => false
+    end.
+
+Definition isFCallId_maybe : Core.Id -> option AxiomatizedTypes.ForeignCall :=
+  fun id =>
+    match Core.idDetails id with
+    | Core.FCallId call => Some call
+    | _ => None
+    end.
+
+Definition isDataConWorkId : Core.Id -> bool :=
+  fun id =>
+    match Core.idDetails id with
+    | Core.DataConWorkId _ => true
+    | _ => false
+    end.
+
+Definition isDataConWorkId_maybe : Core.Id -> option Core.DataCon :=
+  fun id =>
+    match Core.idDetails id with
+    | Core.DataConWorkId con => Some con
+    | _ => None
+    end.
+
+Definition isDataConId_maybe : Core.Id -> option Core.DataCon :=
+  fun id =>
+    match Core.idDetails id with
+    | Core.DataConWorkId con => Some con
+    | Core.DataConWrapId con => Some con
+    | _ => None
+    end.
+
+Definition isJoinId : Core.Var -> bool :=
+  fun id =>
+    if Core.isId id : bool
+    then match Core.idDetails id with
+         | Core.Mk_JoinId _ => true
+         | _ => false
+         end else
+    false.
 
 Definition isJoinId_maybe : Core.Var -> option BasicTypes.JoinArity :=
   fun id =>
@@ -341,20 +296,28 @@ Definition isJoinId_maybe : Core.Var -> option BasicTypes.JoinArity :=
               end else
     None.
 
-Definition isJoinId : Core.Var -> bool :=
-  fun id =>
-    if Core.isId id : bool
-    then match Core.idDetails id with
-         | Core.Mk_JoinId _ => true
-         | _ => false
-         end else
-    false.
+Definition idOccInfo : Core.Id -> BasicTypes.OccInfo :=
+  fun id => Core.occInfo (Core.idInfo id).
 
-Definition zapJoinId : Core.Id -> Core.Id :=
-  fun jid =>
-    if isJoinId jid : bool
-    then zapIdTailCallInfo (Core.setIdDetails jid Core.VanillaId) else
-    jid.
+Definition isExitJoinId : Core.Var -> bool :=
+  fun id =>
+    andb (isJoinId id) (andb (BasicTypes.isOneOcc (idOccInfo id))
+                             (BasicTypes.occ_in_lam (idOccInfo id))).
+
+Definition idDataCon : Core.Id -> Core.DataCon :=
+  fun id =>
+    Maybes.orElse (isDataConId_maybe id) (Panic.panicStr (GHC.Base.hs_string__
+                                                          "idDataCon") (Panic.someSDoc)).
+
+Definition hasNoBinding : Core.Id -> bool :=
+  fun id =>
+    match Core.idDetails id with
+    | Core.PrimOpId _ => true
+    | Core.FCallId _ => true
+    | Core.DataConWorkId dc =>
+        orb (Core.isUnboxedTupleCon dc) (Core.isUnboxedSumCon dc)
+    | _ => false
+    end.
 
 Definition isImplicitId : Core.Id -> bool :=
   fun id =>
@@ -367,220 +330,24 @@ Definition isImplicitId : Core.Id -> bool :=
     | _ => false
     end.
 
-Definition isFCallId_maybe : Core.Id -> option AxiomatizedTypes.ForeignCall :=
-  fun id =>
-    match Core.idDetails id with
-    | Core.FCallId call => Some call
-    | _ => None
-    end.
-
-Definition isFCallId : Core.Id -> bool :=
-  fun id =>
-    match Core.idDetails id with
-    | Core.FCallId _ => true
-    | _ => false
-    end.
-
-Definition isEvVar : Core.Var -> bool :=
-  fun var => Core.isPredTy (Core.varType var).
-
-Definition isDataConWorkId_maybe : Core.Id -> option Core.DataCon :=
-  fun id =>
-    match Core.idDetails id with
-    | Core.DataConWorkId con => Some con
-    | _ => None
-    end.
-
-Definition isDataConWorkId : Core.Id -> bool :=
-  fun id =>
-    match Core.idDetails id with
-    | Core.DataConWorkId _ => true
-    | _ => false
-    end.
-
-Definition isDataConRecordSelector : Core.Id -> bool :=
-  fun id =>
-    match Core.idDetails id with
-    | Core.RecSelId (Core.RecSelData _) _ => true
-    | _ => false
-    end.
-
-Definition isDataConId_maybe : Core.Id -> option Core.DataCon :=
-  fun id =>
-    match Core.idDetails id with
-    | Core.DataConWorkId con => Some con
-    | Core.DataConWrapId con => Some con
-    | _ => None
-    end.
-
-Definition isDFunId : Core.Id -> bool :=
-  fun id =>
-    match Core.idDetails id with
-    | Core.Mk_DFunId _ => true
-    | _ => false
-    end.
-
-Definition isClassOpId_maybe : Core.Id -> option Core.Class :=
-  fun id =>
-    match Core.idDetails id with
-    | Core.ClassOpId cls => Some cls
-    | _other => None
-    end.
-
-Definition idUnique : Core.Id -> Unique.Unique :=
-  Core.varUnique.
-
-Definition idUnfolding : Core.Id -> Core.Unfolding :=
-  fun id =>
-    let info := Core.idInfo id in
-    if BasicTypes.isStrongLoopBreaker (Core.occInfo info) : bool
-    then Core.NoUnfolding else
-    Core.unfoldingInfo info.
-
-Definition idType : Core.Id -> AxiomatizedTypes.Kind :=
-  Core.varType.
-
-Definition isDictId : Core.Id -> bool :=
-  fun id => Core.isDictTy (idType id).
-
-Definition idStrictness : Core.Id -> Core.StrictSig :=
-  fun id => Core.strictnessInfo (Core.idInfo id).
-
-Definition isBottomingId : Core.Var -> bool :=
-  fun v =>
-    if Core.isId v : bool then Core.isBottomingSig (idStrictness v) else
-    false.
-
-Definition idSpecialisation : Core.Id -> Core.RuleInfo :=
-  fun id => Core.ruleInfo (Core.idInfo id).
-
-Definition idOneShotInfo : Core.Id -> BasicTypes.OneShotInfo :=
-  fun id => Core.oneShotInfo (Core.idInfo id).
-
-Definition idStateHackOneShotInfo : Core.Id -> BasicTypes.OneShotInfo :=
-  fun id =>
-    if isStateHackType (idType id) : bool then stateHackOneShot else
-    idOneShotInfo id.
-
-Definition isOneShotBndr : Core.Var -> bool :=
-  fun var =>
-    if Core.isTyVar var : bool then true else
-    match idStateHackOneShotInfo var with
-    | BasicTypes.OneShotLam => true
-    | _ => false
-    end.
-
-Definition isProbablyOneShotLambda : Core.Id -> bool :=
-  fun id =>
-    match idStateHackOneShotInfo id with
-    | BasicTypes.OneShotLam => true
-    | BasicTypes.NoOneShotInfo => false
-    end.
-
-Definition updOneShotInfo : Core.Id -> BasicTypes.OneShotInfo -> Core.Id :=
-  fun id one_shot =>
-    let do_upd :=
-      match pair (idOneShotInfo id) one_shot with
-      | pair BasicTypes.NoOneShotInfo _ => true
-      | pair BasicTypes.OneShotLam _ => false
-      end in
-    if do_upd : bool then setIdOneShotInfo id one_shot else
-    id.
-
-Definition idOccInfo : Core.Id -> BasicTypes.OccInfo :=
-  fun id => Core.occInfo (Core.idInfo id).
+Definition idIsFrom : Module.Module -> Core.Id -> bool :=
+  fun mod_ id => Name.nameIsLocalOrFrom mod_ (idName id).
 
 Definition isDeadBinder : Core.Id -> bool :=
   fun bndr =>
     if Core.isId bndr : bool then BasicTypes.isDeadOcc (idOccInfo bndr) else
     false.
 
-Definition isExitJoinId : Core.Var -> bool :=
-  fun id =>
-    andb (isJoinId id) (andb (BasicTypes.isOneOcc (idOccInfo id))
-                             (BasicTypes.occ_in_lam (idOccInfo id))).
+Definition isEvVar : Core.Var -> bool :=
+  fun var => Core.isPredTy (Core.varType var).
 
-Definition idName : Core.Id -> Name.Name :=
-  Core.varName.
-
-Definition localiseId : Core.Id -> Core.Id :=
-  fun id =>
-    let name := idName id in
-    if (if andb Util.debugIsOn (negb (Core.isId id)) : bool
-        then (Panic.assertPanic (GHC.Base.hs_string__ "ghc/compiler/basicTypes/Id.hs")
-              #209)
-        else andb (Core.isLocalId id) (Name.isInternalName name)) : bool
-    then id else
-    Core.mkLocalVar (Core.idDetails id) (Name.localiseName name) (idType id)
-    (Core.idInfo id).
+Definition isDictId : Core.Id -> bool :=
+  fun id => Core.isDictTy (idType id).
 
 Definition idJoinArity : Core.JoinId -> BasicTypes.JoinArity :=
   fun id =>
     Maybes.orElse (isJoinId_maybe id) (Panic.panicStr (GHC.Base.hs_string__
                                                        "idJoinArity") (Panic.someSDoc)).
-
-Definition idIsFrom : Module.Module -> Core.Id -> bool :=
-  fun mod_ id => Name.nameIsLocalOrFrom mod_ (idName id).
-
-Definition idInlinePragma : Core.Id -> BasicTypes.InlinePragma :=
-  fun id => Core.inlinePragInfo (Core.idInfo id).
-
-Definition idRuleMatchInfo : Core.Id -> BasicTypes.RuleMatchInfo :=
-  fun id => BasicTypes.inlinePragmaRuleMatchInfo (idInlinePragma id).
-
-Definition isConLikeId : Core.Id -> bool :=
-  fun id => orb (isDataConWorkId id) (BasicTypes.isConLike (idRuleMatchInfo id)).
-
-Definition idInlineActivation : Core.Id -> BasicTypes.Activation :=
-  fun id => BasicTypes.inlinePragmaActivation (idInlinePragma id).
-
-Definition idHasRules : Core.Id -> bool :=
-  fun id => negb (Core.isEmptyRuleInfo (idSpecialisation id)).
-
-(* Skipping definition `Id.idFunRepArity' *)
-
-Definition idDemandInfo : Core.Id -> Core.Demand :=
-  fun id => Core.demandInfo (Core.idInfo id).
-
-Definition isStrictId : Core.Id -> bool :=
-  fun id =>
-    if andb Util.debugIsOn (negb (Core.isId id)) : bool
-    then (GHC.Err.error (GHC.Base.mappend (Datatypes.id (GHC.Base.hs_string__
-                                                         "isStrictId: not an id: ")) Panic.someSDoc))
-    else andb (negb (isJoinId id)) (orb (Core.isStrictType (idType id))
-                                        (Core.isStrictDmd (idDemandInfo id))).
-
-Definition idDataCon : Core.Id -> Core.DataCon :=
-  fun id =>
-    Maybes.orElse (isDataConId_maybe id) (Panic.panicStr (GHC.Base.hs_string__
-                                                          "idDataCon") (Panic.someSDoc)).
-
-Definition idCoreRules : Core.Id -> list Core.CoreRule :=
-  fun x => nil.
-
-Definition idCallArity : Core.Id -> BasicTypes.Arity :=
-  fun id => Core.callArityInfo (Core.idInfo id).
-
-Definition idCafInfo : Core.Id -> Core.CafInfo :=
-  fun id => Core.cafInfo (Core.idInfo id).
-
-Definition idArity : Core.Id -> BasicTypes.Arity :=
-  fun id => Core.arityInfo (Core.idInfo id).
-
-Definition hasNoBinding : Core.Id -> bool :=
-  fun id =>
-    match Core.idDetails id with
-    | Core.PrimOpId _ => true
-    | Core.FCallId _ => true
-    | Core.DataConWorkId dc =>
-        orb (Core.isUnboxedTupleCon dc) (Core.isUnboxedSumCon dc)
-    | _ => false
-    end.
-
-Definition clearOneShotLambda : Core.Id -> Core.Id :=
-  fun id =>
-    modifyIdInfo (fun arg_0__ =>
-                    Core.setOneShotInfo arg_0__ BasicTypes.NoOneShotInfo) id.
 
 Definition asJoinId : Core.Id -> BasicTypes.JoinArity -> Core.JoinId :=
   fun id arity =>
@@ -608,12 +375,245 @@ Definition asJoinId : Core.Id -> BasicTypes.JoinArity -> Core.JoinId :=
                                                                                                                     (Core.Mk_JoinId
                                                                                                                      arity))).
 
+Definition zapInfo
+   : (Core.IdInfo -> option Core.IdInfo) -> Core.Id -> Core.Id :=
+  fun zapper id => maybeModifyIdInfo (zapper (Core.idInfo id)) id.
+
+Definition zapIdTailCallInfo : Core.Id -> Core.Id :=
+  zapInfo Core.zapTailCallInfo.
+
+Definition zapJoinId : Core.Id -> Core.Id :=
+  fun jid =>
+    if isJoinId jid : bool
+    then zapIdTailCallInfo (Core.setIdDetails jid Core.VanillaId) else
+    jid.
+
 Definition asJoinId_maybe : Core.Id -> option BasicTypes.JoinArity -> Core.Id :=
   fun arg_0__ arg_1__ =>
     match arg_0__, arg_1__ with
     | id, Some arity => asJoinId id arity
     | id, None => zapJoinId id
     end.
+
+Definition idArity : Core.Id -> BasicTypes.Arity :=
+  fun id => Core.arityInfo (Core.idInfo id).
+
+Definition setIdArity : Core.Id -> BasicTypes.Arity -> Core.Id :=
+  fun id arity =>
+    modifyIdInfo (fun arg_0__ => Core.setArityInfo arg_0__ arity) id.
+
+Definition idCallArity : Core.Id -> BasicTypes.Arity :=
+  fun id => Core.callArityInfo (Core.idInfo id).
+
+Definition setIdCallArity : Core.Id -> BasicTypes.Arity -> Core.Id :=
+  fun id arity =>
+    modifyIdInfo (fun arg_0__ => Core.setCallArityInfo arg_0__ arity) id.
+
+(* Skipping definition `Id.idFunRepArity' *)
+
+Definition idStrictness : Core.Id -> Core.StrictSig :=
+  fun id => Core.strictnessInfo (Core.idInfo id).
+
+Definition isBottomingId : Core.Var -> bool :=
+  fun v =>
+    if Core.isId v : bool then Core.isBottomingSig (idStrictness v) else
+    false.
+
+Definition setIdStrictness : Core.Id -> Core.StrictSig -> Core.Id :=
+  fun id sig =>
+    modifyIdInfo (fun arg_0__ => Core.setStrictnessInfo arg_0__ sig) id.
+
+Definition zapIdStrictness : Core.Id -> Core.Id :=
+  fun id =>
+    modifyIdInfo (fun arg_0__ => Core.setStrictnessInfo arg_0__ Core.nopSig) id.
+
+Definition idDemandInfo : Core.Id -> Core.Demand :=
+  fun id => Core.demandInfo (Core.idInfo id).
+
+Definition isStrictId : Core.Id -> bool :=
+  fun id =>
+    if andb Util.debugIsOn (negb (Core.isId id)) : bool
+    then (GHC.Err.error (GHC.Base.mappend (Datatypes.id (GHC.Base.hs_string__
+                                                         "isStrictId: not an id: ")) Panic.someSDoc))
+    else andb (negb (isJoinId id)) (orb (Core.isStrictType (idType id))
+                                        (Core.isStrictDmd (idDemandInfo id))).
+
+Definition idUnfolding : Core.Id -> Core.Unfolding :=
+  fun id =>
+    let info := Core.idInfo id in
+    if BasicTypes.isStrongLoopBreaker (Core.occInfo info) : bool
+    then Core.NoUnfolding else
+    Core.unfoldingInfo info.
+
+Definition realIdUnfolding : Core.Id -> Core.Unfolding :=
+  fun id => Core.unfoldingInfo (Core.idInfo id).
+
+Definition setIdUnfolding : Core.Id -> Core.Unfolding -> Core.Id :=
+  fun id unfolding =>
+    modifyIdInfo (fun arg_0__ => Core.setUnfoldingInfo arg_0__ unfolding) id.
+
+Definition setIdDemandInfo : Core.Id -> Core.Demand -> Core.Id :=
+  fun id dmd => modifyIdInfo (fun arg_0__ => Core.setDemandInfo arg_0__ dmd) id.
+
+(* Skipping definition `Id.setCaseBndrEvald' *)
+
+Definition idSpecialisation : Core.Id -> Core.RuleInfo :=
+  fun id => Core.ruleInfo (Core.idInfo id).
+
+Definition idCoreRules : Core.Id -> list Core.CoreRule :=
+  fun x => nil.
+
+Definition idHasRules : Core.Id -> bool :=
+  fun id => negb (Core.isEmptyRuleInfo (idSpecialisation id)).
+
+Definition setIdSpecialisation : Core.Id -> Core.RuleInfo -> Core.Id :=
+  fun id spec_info =>
+    modifyIdInfo (fun arg_0__ => Core.setRuleInfo arg_0__ spec_info) id.
+
+Definition idCafInfo : Core.Id -> Core.CafInfo :=
+  fun id => Core.cafInfo (Core.idInfo id).
+
+Definition setIdCafInfo : Core.Id -> Core.CafInfo -> Core.Id :=
+  fun id caf_info =>
+    modifyIdInfo (fun arg_0__ => Core.setCafInfo arg_0__ caf_info) id.
+
+Definition setIdOccInfo : Core.Id -> BasicTypes.OccInfo -> Core.Id :=
+  fun id occ_info =>
+    modifyIdInfo (fun arg_0__ => Core.setOccInfo arg_0__ occ_info) id.
+
+Definition zapIdOccInfo : Core.Id -> Core.Id :=
+  fun b => setIdOccInfo b BasicTypes.noOccInfo.
+
+Definition idInlinePragma : Core.Id -> BasicTypes.InlinePragma :=
+  fun id => Core.inlinePragInfo (Core.idInfo id).
+
+Definition setInlinePragma : Core.Id -> BasicTypes.InlinePragma -> Core.Id :=
+  fun id prag =>
+    modifyIdInfo (fun arg_0__ => Core.setInlinePragInfo arg_0__ prag) id.
+
+Definition modifyInlinePragma
+   : Core.Id -> (BasicTypes.InlinePragma -> BasicTypes.InlinePragma) -> Core.Id :=
+  fun id fn =>
+    modifyIdInfo (fun info =>
+                    Core.setInlinePragInfo info (fn (Core.inlinePragInfo info))) id.
+
+Definition idInlineActivation : Core.Id -> BasicTypes.Activation :=
+  fun id => BasicTypes.inlinePragmaActivation (idInlinePragma id).
+
+Definition setInlineActivation : Core.Id -> BasicTypes.Activation -> Core.Id :=
+  fun id act =>
+    modifyInlinePragma id (fun prag =>
+                             BasicTypes.setInlinePragmaActivation prag act).
+
+Definition idRuleMatchInfo : Core.Id -> BasicTypes.RuleMatchInfo :=
+  fun id => BasicTypes.inlinePragmaRuleMatchInfo (idInlinePragma id).
+
+Definition isConLikeId : Core.Id -> bool :=
+  fun id => orb (isDataConWorkId id) (BasicTypes.isConLike (idRuleMatchInfo id)).
+
+Definition idOneShotInfo : Core.Id -> BasicTypes.OneShotInfo :=
+  fun id => Core.oneShotInfo (Core.idInfo id).
+
+Axiom isStateHackType : AxiomatizedTypes.Type_ -> bool.
+
+Definition stateHackOneShot : BasicTypes.OneShotInfo :=
+  BasicTypes.OneShotLam.
+
+Definition idStateHackOneShotInfo : Core.Id -> BasicTypes.OneShotInfo :=
+  fun id =>
+    if isStateHackType (idType id) : bool then stateHackOneShot else
+    idOneShotInfo id.
+
+Definition isOneShotBndr : Core.Var -> bool :=
+  fun var =>
+    if Core.isTyVar var : bool then true else
+    match idStateHackOneShotInfo var with
+    | BasicTypes.OneShotLam => true
+    | _ => false
+    end.
+
+Definition typeOneShot : AxiomatizedTypes.Type_ -> BasicTypes.OneShotInfo :=
+  fun ty =>
+    if isStateHackType ty : bool then stateHackOneShot else
+    BasicTypes.NoOneShotInfo.
+
+Definition isProbablyOneShotLambda : Core.Id -> bool :=
+  fun id =>
+    match idStateHackOneShotInfo id with
+    | BasicTypes.OneShotLam => true
+    | BasicTypes.NoOneShotInfo => false
+    end.
+
+Definition setOneShotLambda : Core.Id -> Core.Id :=
+  fun id =>
+    modifyIdInfo (fun arg_0__ => Core.setOneShotInfo arg_0__ BasicTypes.OneShotLam)
+    id.
+
+Definition clearOneShotLambda : Core.Id -> Core.Id :=
+  fun id =>
+    modifyIdInfo (fun arg_0__ =>
+                    Core.setOneShotInfo arg_0__ BasicTypes.NoOneShotInfo) id.
+
+Definition setIdOneShotInfo : Core.Id -> BasicTypes.OneShotInfo -> Core.Id :=
+  fun id one_shot =>
+    modifyIdInfo (fun arg_0__ => Core.setOneShotInfo arg_0__ one_shot) id.
+
+Definition updOneShotInfo : Core.Id -> BasicTypes.OneShotInfo -> Core.Id :=
+  fun id one_shot =>
+    let do_upd :=
+      match pair (idOneShotInfo id) one_shot with
+      | pair BasicTypes.NoOneShotInfo _ => true
+      | pair BasicTypes.OneShotLam _ => false
+      end in
+    if do_upd : bool then setIdOneShotInfo id one_shot else
+    id.
+
+Definition zapLamIdInfo : Core.Id -> Core.Id :=
+  zapInfo Core.zapLamInfo.
+
+Definition zapFragileIdInfo : Core.Id -> Core.Id :=
+  zapInfo Core.zapFragileInfo.
+
+Definition zapIdDemandInfo : Core.Id -> Core.Id :=
+  zapInfo Core.zapDemandInfo.
+
+Definition zapIdUsageInfo : Core.Id -> Core.Id :=
+  zapInfo Core.zapUsageInfo.
+
+Definition zapIdUsageEnvInfo : Core.Id -> Core.Id :=
+  zapInfo Core.zapUsageEnvInfo.
+
+Definition zapIdUsedOnceInfo : Core.Id -> Core.Id :=
+  zapInfo Core.zapUsedOnceInfo.
+
+Definition zapStableUnfolding : Core.Id -> Core.Id :=
+  fun id =>
+    if Core.isStableUnfolding (realIdUnfolding id) : bool
+    then setIdUnfolding id Core.NoUnfolding else
+    id.
+
+Definition transferPolyIdInfo
+   : Core.Id -> list Core.Var -> Core.Id -> Core.Id :=
+  fun old_id abstract_wrt new_id =>
+    let old_info := Core.idInfo old_id in
+    let old_arity := Core.arityInfo old_info in
+    let old_inline_prag := Core.inlinePragInfo old_info in
+    let old_occ_info := Core.occInfo old_info in
+    let new_occ_info := BasicTypes.zapOccTailCallInfo old_occ_info in
+    let old_strictness := Core.strictnessInfo old_info in
+    let arity_increase := Util.count Core.isId abstract_wrt in
+    let new_arity := old_arity GHC.Num.+ arity_increase in
+    let new_strictness :=
+      Core.increaseStrictSigArity arity_increase old_strictness in
+    let transfer :=
+      fun new_info =>
+        Core.setStrictnessInfo (Core.setOccInfo (Core.setInlinePragInfo
+                                                 (Core.setArityInfo new_info new_arity) old_inline_prag) new_occ_info)
+                               new_strictness in
+    modifyIdInfo transfer new_id.
+
+Definition isNeverLevPolyId : Core.Id -> bool :=
+  Core.isNeverLevPolyIdInfo GHC.Base.∘ Core.idInfo.
 
 (* External variables:
      None Some andb bool false list nat negb nil option orb pair true

--- a/examples/ghc/lib/ListSetOps.v
+++ b/examples/ghc/lib/ListSetOps.v
@@ -33,6 +33,8 @@ Definition Assoc a b :=
 
 (* Converted value declarations: *)
 
+(* Skipping definition `ListSetOps.getNth' *)
+
 Definition unionLists {a} `{GHC.Base.Eq_ a} : list a -> list a -> list a :=
   fun xs ys =>
     Panic.warnPprTrace (orb (Util.lengthExceeds xs #100) (Util.lengthExceeds ys
@@ -60,6 +62,44 @@ Definition minusList {a} `{GHC.Base.Ord a} : list a -> list a -> list a :=
         end
     end.
 
+Fixpoint assocDefaultUsing {a} {b} (arg_0__ : (a -> a -> bool)) (arg_1__ : b)
+                           (arg_2__ : Assoc a b) (arg_3__ : a) : b
+           := match arg_0__, arg_1__, arg_2__, arg_3__ with
+              | _, deflt, nil, _ => deflt
+              | eq, deflt, cons (pair k v) rest, key =>
+                  if eq k key : bool then v else
+                  assocDefaultUsing eq deflt rest key
+              end.
+
+Definition assoc {a} {b} `{GHC.Base.Eq_ a} `{GHC.Err.Default b}
+   : GHC.Base.String -> Assoc a b -> a -> b :=
+  fun crash_msg list key =>
+    assocDefaultUsing _GHC.Base.==_ (Panic.panic (Coq.Init.Datatypes.app
+                                                  (GHC.Base.hs_string__ "Failed in assoc: ") crash_msg)) list key.
+
+Definition assocDefault {a} {b} `{(GHC.Base.Eq_ a)}
+   : b -> Assoc a b -> a -> b :=
+  fun deflt list key => assocDefaultUsing _GHC.Base.==_ deflt list key.
+
+Definition assocUsing {a} {b} `{GHC.Err.Default b}
+   : (a -> a -> bool) -> GHC.Base.String -> Assoc a b -> a -> b :=
+  fun eq crash_msg list key =>
+    assocDefaultUsing eq (Panic.panic (Coq.Init.Datatypes.app (GHC.Base.hs_string__
+                                                               "Failed in assoc: ") crash_msg)) list key.
+
+Definition assocMaybe {a} {b} `{(GHC.Base.Eq_ a)}
+   : Assoc a b -> a -> option b :=
+  fun alist key =>
+    let fix lookup arg_0__
+              := match arg_0__ with
+                 | nil => None
+                 | cons (pair tv ty) rest =>
+                     if key GHC.Base.== tv : bool
+                     then Some ty
+                     else lookup rest
+                 end in
+    lookup alist.
+
 Definition hasNoDups {a} `{(GHC.Base.Eq_ a)} : list a -> bool :=
   fun xs =>
     let is_elem := Util.isIn (GHC.Base.hs_string__ "hasNoDups") in
@@ -72,10 +112,6 @@ Definition hasNoDups {a} `{(GHC.Base.Eq_ a)} : list a -> bool :=
                      else f (cons x seen_so_far) xs
                  end in
     f nil xs.
-
-(* Skipping definition `ListSetOps.getNth' *)
-
-(* Skipping definition `ListSetOps.findDupsEq' *)
 
 Axiom equivClasses : forall {a},
                      (a -> a -> comparison) -> list a -> list (GHC.Base.NonEmpty a).
@@ -101,43 +137,7 @@ Definition removeDups {a}
         pair xs' dups
     end.
 
-Definition assocMaybe {a} {b} `{(GHC.Base.Eq_ a)}
-   : Assoc a b -> a -> option b :=
-  fun alist key =>
-    let fix lookup arg_0__
-              := match arg_0__ with
-                 | nil => None
-                 | cons (pair tv ty) rest =>
-                     if key GHC.Base.== tv : bool
-                     then Some ty
-                     else lookup rest
-                 end in
-    lookup alist.
-
-Fixpoint assocDefaultUsing {a} {b} (arg_0__ : (a -> a -> bool)) (arg_1__ : b)
-                           (arg_2__ : Assoc a b) (arg_3__ : a) : b
-           := match arg_0__, arg_1__, arg_2__, arg_3__ with
-              | _, deflt, nil, _ => deflt
-              | eq, deflt, cons (pair k v) rest, key =>
-                  if eq k key : bool then v else
-                  assocDefaultUsing eq deflt rest key
-              end.
-
-Definition assocUsing {a} {b} `{GHC.Err.Default b}
-   : (a -> a -> bool) -> GHC.Base.String -> Assoc a b -> a -> b :=
-  fun eq crash_msg list key =>
-    assocDefaultUsing eq (Panic.panic (Coq.Init.Datatypes.app (GHC.Base.hs_string__
-                                                               "Failed in assoc: ") crash_msg)) list key.
-
-Definition assocDefault {a} {b} `{(GHC.Base.Eq_ a)}
-   : b -> Assoc a b -> a -> b :=
-  fun deflt list key => assocDefaultUsing _GHC.Base.==_ deflt list key.
-
-Definition assoc {a} {b} `{GHC.Base.Eq_ a} `{GHC.Err.Default b}
-   : GHC.Base.String -> Assoc a b -> a -> b :=
-  fun crash_msg list key =>
-    assocDefaultUsing _GHC.Base.==_ (Panic.panic (Coq.Init.Datatypes.app
-                                                  (GHC.Base.hs_string__ "Failed in assoc: ") crash_msg)) list key.
+(* Skipping definition `ListSetOps.findDupsEq' *)
 
 (* External variables:
      None Some bool comparison cons false list nil op_zt__ option orb pair true

--- a/examples/ghc/lib/Literal.v
+++ b/examples/ghc/lib/Literal.v
@@ -48,110 +48,14 @@ Instance Default__Literal : GHC.Err.Default Literal :=
 
 (* Converted value declarations: *)
 
-Axiom word2IntLit : DynFlags.DynFlags -> Literal -> Literal.
-
-(* Skipping definition `Literal.pprLiteral' *)
-
-(* Skipping definition `Literal.pprIntegerVal' *)
-
-Axiom nullAddrLit : Literal.
-
-(* Skipping definition `Literal.narrow8WordLit' *)
-
-(* Skipping definition `Literal.narrow8IntLit' *)
-
-(* Skipping definition `Literal.narrow32WordLit' *)
-
-(* Skipping definition `Literal.narrow32IntLit' *)
-
-(* Skipping definition `Literal.narrow16WordLit' *)
-
-(* Skipping definition `Literal.narrow16IntLit' *)
-
-(* Skipping definition `Literal.mkMachWordWrap' *)
-
-(* Skipping definition `Literal.mkMachWord64Wrap' *)
-
-(* Skipping definition `Literal.mkMachWord64' *)
-
-(* Skipping definition `Literal.mkMachWord' *)
-
-Axiom mkMachString : GHC.Base.String -> Literal.
-
-(* Skipping definition `Literal.mkMachIntWrap' *)
-
-(* Skipping definition `Literal.mkMachInt64Wrap' *)
-
-(* Skipping definition `Literal.mkMachInt64' *)
-
-(* Skipping definition `Literal.mkMachInt' *)
-
-Axiom mkMachFloat : GHC.Real.Rational -> Literal.
-
-Axiom mkMachDouble : GHC.Real.Rational -> Literal.
-
-Axiom mkMachChar : GHC.Char.Char -> Literal.
-
-Axiom mkLitInteger : GHC.Num.Integer -> AxiomatizedTypes.Type_ -> Literal.
-
-(* Skipping definition `Literal.mapLitValue' *)
-
-Axiom literalType : Literal -> AxiomatizedTypes.Type_.
-
-Axiom litValue : Literal -> GHC.Num.Integer.
-
-Axiom litTag : Literal -> nat.
-
-Axiom litIsTrivial : Literal -> bool.
-
-Axiom litIsLifted : Literal -> bool.
-
-Axiom litIsDupable : DynFlags.DynFlags -> Literal -> bool.
-
-Axiom litFitsInChar : Literal -> bool.
-
-Axiom isZeroLit : Literal -> bool.
-
-Axiom isLitValue_maybe : Literal -> option GHC.Num.Integer.
-
-Axiom isLitValue : Literal -> bool.
-
-Axiom int2WordLit : DynFlags.DynFlags -> Literal -> Literal.
-
-Axiom int2FloatLit : Literal -> Literal.
-
-Axiom int2DoubleLit : Literal -> Literal.
-
-Axiom int2CharLit : Literal -> Literal.
-
-Axiom inWordRange : DynFlags.DynFlags -> GHC.Num.Integer -> bool.
-
-(* Skipping definition `Literal.inWord64Range' *)
-
-Axiom inIntRange : DynFlags.DynFlags -> GHC.Num.Integer -> bool.
-
-(* Skipping definition `Literal.inInt64Range' *)
-
-Axiom inCharRange : GHC.Char.Char -> bool.
-
-(* Skipping definition `Literal.float2IntLit' *)
-
-Axiom float2DoubleLit : Literal -> Literal.
-
-(* Skipping definition `Literal.double2IntLit' *)
-
-Axiom double2FloatLit : Literal -> Literal.
-
-Axiom cmpLit : Literal -> Literal -> comparison.
-
-Axiom char2IntLit : Literal -> Literal.
-
-Axiom absent_lits : UniqFM.UniqFM Literal.
-
-(* Skipping definition `Literal.absentLiteralOf' *)
-
 (* Skipping all instances of class `Data.Data.Data', including
    `Literal.Data__Literal' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `Literal.Binary__Literal' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Literal.Outputable__Literal' *)
 
 Instance Eq___Literal : GHC.Base.Eq_ Literal.
 Proof.
@@ -161,11 +65,107 @@ Instance Ord__Literal : GHC.Base.Ord Literal.
 Proof.
 Admitted.
 
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Literal.Outputable__Literal' *)
+(* Skipping definition `Literal.mkMachInt' *)
 
-(* Skipping all instances of class `Binary.Binary', including
-   `Literal.Binary__Literal' *)
+(* Skipping definition `Literal.mkMachIntWrap' *)
+
+(* Skipping definition `Literal.mkMachWord' *)
+
+(* Skipping definition `Literal.mkMachWordWrap' *)
+
+(* Skipping definition `Literal.mkMachInt64' *)
+
+(* Skipping definition `Literal.mkMachInt64Wrap' *)
+
+(* Skipping definition `Literal.mkMachWord64' *)
+
+(* Skipping definition `Literal.mkMachWord64Wrap' *)
+
+Axiom mkMachFloat : GHC.Real.Rational -> Literal.
+
+Axiom mkMachDouble : GHC.Real.Rational -> Literal.
+
+Axiom mkMachChar : GHC.Char.Char -> Literal.
+
+Axiom mkMachString : GHC.Base.String -> Literal.
+
+Axiom mkLitInteger : GHC.Num.Integer -> AxiomatizedTypes.Type_ -> Literal.
+
+Axiom inIntRange : DynFlags.DynFlags -> GHC.Num.Integer -> bool.
+
+Axiom inWordRange : DynFlags.DynFlags -> GHC.Num.Integer -> bool.
+
+(* Skipping definition `Literal.inInt64Range' *)
+
+(* Skipping definition `Literal.inWord64Range' *)
+
+Axiom inCharRange : GHC.Char.Char -> bool.
+
+Axiom isZeroLit : Literal -> bool.
+
+Axiom litValue : Literal -> GHC.Num.Integer.
+
+Axiom isLitValue_maybe : Literal -> option GHC.Num.Integer.
+
+(* Skipping definition `Literal.mapLitValue' *)
+
+Axiom isLitValue : Literal -> bool.
+
+Axiom word2IntLit : DynFlags.DynFlags -> Literal -> Literal.
+
+Axiom int2WordLit : DynFlags.DynFlags -> Literal -> Literal.
+
+(* Skipping definition `Literal.narrow8IntLit' *)
+
+(* Skipping definition `Literal.narrow16IntLit' *)
+
+(* Skipping definition `Literal.narrow32IntLit' *)
+
+(* Skipping definition `Literal.narrow8WordLit' *)
+
+(* Skipping definition `Literal.narrow16WordLit' *)
+
+(* Skipping definition `Literal.narrow32WordLit' *)
+
+Axiom char2IntLit : Literal -> Literal.
+
+Axiom int2CharLit : Literal -> Literal.
+
+(* Skipping definition `Literal.float2IntLit' *)
+
+Axiom int2FloatLit : Literal -> Literal.
+
+(* Skipping definition `Literal.double2IntLit' *)
+
+Axiom int2DoubleLit : Literal -> Literal.
+
+Axiom float2DoubleLit : Literal -> Literal.
+
+Axiom double2FloatLit : Literal -> Literal.
+
+Axiom nullAddrLit : Literal.
+
+Axiom litIsTrivial : Literal -> bool.
+
+Axiom litIsDupable : DynFlags.DynFlags -> Literal -> bool.
+
+Axiom litFitsInChar : Literal -> bool.
+
+Axiom litIsLifted : Literal -> bool.
+
+Axiom literalType : Literal -> AxiomatizedTypes.Type_.
+
+(* Skipping definition `Literal.absentLiteralOf' *)
+
+Axiom absent_lits : UniqFM.UniqFM Literal.
+
+Axiom cmpLit : Literal -> Literal -> comparison.
+
+Axiom litTag : Literal -> nat.
+
+(* Skipping definition `Literal.pprLiteral' *)
+
+(* Skipping definition `Literal.pprIntegerVal' *)
 
 (* External variables:
      bool comparison nat option AxiomatizedTypes.Type_ BasicTypes.FunctionOrData

--- a/examples/ghc/lib/Maybes.v
+++ b/examples/ghc/lib/Maybes.v
@@ -31,58 +31,6 @@ Arguments Failed {_} {_} _.
 
 (* Converted value declarations: *)
 
-Definition whenIsJust {m} {a} `{GHC.Base.Monad m}
-   : option a -> (a -> m unit) -> m unit :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Some x, f => f x
-    | None, _ => GHC.Base.return_ tt
-    end.
-
-(* Skipping definition `Maybes.tryMaybeT' *)
-
-Definition orElse {a} : option a -> a -> a :=
-  GHC.Base.flip Data.Maybe.fromMaybe.
-
-Definition liftMaybeT {m} {a} `{GHC.Base.Monad m}
-   : m a -> Control.Monad.Trans.Maybe.MaybeT m a :=
-  fun act => Control.Monad.Trans.Maybe.Mk_MaybeT (GHC.Base.liftM Some act).
-
-Definition isSuccess {err} {val} : MaybeErr err val -> bool :=
-  fun arg_0__ => match arg_0__ with | Succeeded _ => true | Failed _ => false end.
-
-(* Skipping definition `Maybes.firstJusts' *)
-
-(* Skipping definition `Maybes.firstJust' *)
-
-Definition failME {err} {val} : err -> MaybeErr err val :=
-  fun e => Failed e.
-
-Definition expectJust {a} `{GHC.Err.Default a}
-   : GHC.Base.String -> option a -> a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | _, Some x => x
-    | err, None =>
-        GHC.Err.error (Coq.Init.Datatypes.app (GHC.Base.hs_string__ "expectJust ") err)
-    end.
-
-Local Definition Monad__MaybeErr_op_zgzgze__ {inst_err}
-   : forall {a} {b},
-     (MaybeErr inst_err) a ->
-     (a -> (MaybeErr inst_err) b) -> (MaybeErr inst_err) b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | Succeeded v, k => k v
-      | Failed e, _ => Failed e
-      end.
-
-Local Definition Monad__MaybeErr_op_zgzg__ {inst_err}
-   : forall {a} {b},
-     (MaybeErr inst_err) a -> (MaybeErr inst_err) b -> (MaybeErr inst_err) b :=
-  fun {a} {b} => fun m k => Monad__MaybeErr_op_zgzgze__ m (fun arg_0__ => k).
-
 Local Definition Functor__MaybeErr_fmap {inst_err}
    : forall {a} {b}, (a -> b) -> MaybeErr inst_err a -> MaybeErr inst_err b :=
   fun {a} {b} =>
@@ -140,6 +88,22 @@ Program Instance Applicative__MaybeErr {err}
            GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__MaybeErr_op_ztzg__ ;
            GHC.Base.pure__ := fun {a} => Applicative__MaybeErr_pure |}.
 
+Local Definition Monad__MaybeErr_op_zgzgze__ {inst_err}
+   : forall {a} {b},
+     (MaybeErr inst_err) a ->
+     (a -> (MaybeErr inst_err) b) -> (MaybeErr inst_err) b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | Succeeded v, k => k v
+      | Failed e, _ => Failed e
+      end.
+
+Local Definition Monad__MaybeErr_op_zgzg__ {inst_err}
+   : forall {a} {b},
+     (MaybeErr inst_err) a -> (MaybeErr inst_err) b -> (MaybeErr inst_err) b :=
+  fun {a} {b} => fun m k => Monad__MaybeErr_op_zgzgze__ m (fun arg_0__ => k).
+
 Local Definition Monad__MaybeErr_return_ {inst_err}
    : forall {a}, a -> (MaybeErr inst_err) a :=
   fun {a} => GHC.Base.pure.
@@ -149,6 +113,42 @@ Program Instance Monad__MaybeErr {err} : GHC.Base.Monad (MaybeErr err) :=
     k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__MaybeErr_op_zgzg__ ;
            GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__MaybeErr_op_zgzgze__ ;
            GHC.Base.return___ := fun {a} => Monad__MaybeErr_return_ |}.
+
+(* Skipping definition `Maybes.firstJust' *)
+
+(* Skipping definition `Maybes.firstJusts' *)
+
+Definition expectJust {a} `{GHC.Err.Default a}
+   : GHC.Base.String -> option a -> a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | _, Some x => x
+    | err, None =>
+        GHC.Err.error (Coq.Init.Datatypes.app (GHC.Base.hs_string__ "expectJust ") err)
+    end.
+
+Definition whenIsJust {m} {a} `{GHC.Base.Monad m}
+   : option a -> (a -> m unit) -> m unit :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Some x, f => f x
+    | None, _ => GHC.Base.return_ tt
+    end.
+
+Definition orElse {a} : option a -> a -> a :=
+  GHC.Base.flip Data.Maybe.fromMaybe.
+
+Definition liftMaybeT {m} {a} `{GHC.Base.Monad m}
+   : m a -> Control.Monad.Trans.Maybe.MaybeT m a :=
+  fun act => Control.Monad.Trans.Maybe.Mk_MaybeT (GHC.Base.liftM Some act).
+
+(* Skipping definition `Maybes.tryMaybeT' *)
+
+Definition isSuccess {err} {val} : MaybeErr err val -> bool :=
+  fun arg_0__ => match arg_0__ with | Succeeded _ => true | Failed _ => false end.
+
+Definition failME {err} {val} : err -> MaybeErr err val :=
+  fun e => Failed e.
 
 (* External variables:
      None Some bool false option true tt unit Control.Monad.Trans.Maybe.MaybeT

--- a/examples/ghc/lib/Module.v
+++ b/examples/ghc/lib/Module.v
@@ -201,764 +201,6 @@ Instance Unpeel_NDModule : Prim.Unpeel NDModule Module :=
 
 (* Converted value declarations: *)
 
-(* Skipping definition `Module.wiredInUnitIds' *)
-
-Definition unitModuleSet : Module -> ModuleSet :=
-  GHC.Prim.coerce Data.Set.Internal.singleton.
-
-Definition unitModuleEnv {a} : Module -> a -> ModuleEnv a :=
-  fun m x => Mk_ModuleEnv (Data.Map.Internal.singleton (Mk_NDModule m) x).
-
-Definition unitIdFreeHoles : UnitId -> UniqSet.UniqSet ModuleName :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | IndefiniteUnitId x => indefUnitIdFreeHoles x
-    | DefiniteUnitId _ => UniqSet.emptyUniqSet
-    end.
-
-Definition unitIdIsDefinite : UnitId -> bool :=
-  UniqSet.isEmptyUniqSet GHC.Base.∘ unitIdFreeHoles.
-
-Definition unitIdFS : UnitId -> FastString.FastString :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | IndefiniteUnitId x => indefUnitIdFS x
-    | DefiniteUnitId (Mk_DefUnitId x) => installedUnitIdFS x
-    end.
-
-Definition unitIdString : UnitId -> GHC.Base.String :=
-  FastString.unpackFS GHC.Base.∘ unitIdFS.
-
-Local Definition Uniquable__ModuleName_getUnique
-   : ModuleName -> Unique.Unique :=
-  fun '(Mk_ModuleName nm) => Unique.getUnique nm.
-
-Program Instance Uniquable__ModuleName : Unique.Uniquable ModuleName :=
-  fun _ k__ => k__ {| Unique.getUnique__ := Uniquable__ModuleName_getUnique |}.
-
-Definition installedUnitIdKey : InstalledUnitId -> Unique.Unique :=
-  Unique.getUnique GHC.Base.∘ installedUnitIdFS.
-
-Definition unitIdKey : UnitId -> Unique.Unique :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | IndefiniteUnitId x => indefUnitIdKey x
-    | DefiniteUnitId (Mk_DefUnitId x) => installedUnitIdKey x
-    end.
-
-Local Definition Uniquable__UnitId_getUnique : UnitId -> Unique.Unique :=
-  unitIdKey.
-
-Program Instance Uniquable__UnitId : Unique.Uniquable UnitId :=
-  fun _ k__ => k__ {| Unique.getUnique__ := Uniquable__UnitId_getUnique |}.
-
-Local Definition Ord__NDModule_compare : NDModule -> NDModule -> comparison :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_NDModule (Mk_Module p1 n1), Mk_NDModule (Mk_Module p2 n2) =>
-        Util.thenCmp (Unique.nonDetCmpUnique (Unique.getUnique p1) (Unique.getUnique
-                                              p2)) (Unique.nonDetCmpUnique (Unique.getUnique n1) (Unique.getUnique n2))
-    end.
-
-Local Definition Ord__NDModule_op_zlze__ : NDModule -> NDModule -> bool :=
-  fun x y => Ord__NDModule_compare x y GHC.Base./= Gt.
-
-Local Definition Ord__NDModule_max : NDModule -> NDModule -> NDModule :=
-  fun x y => if Ord__NDModule_op_zlze__ x y : bool then y else x.
-
-Local Definition Ord__NDModule_min : NDModule -> NDModule -> NDModule :=
-  fun x y => if Ord__NDModule_op_zlze__ x y : bool then x else y.
-
-Local Definition Ord__NDModule_op_zg__ : NDModule -> NDModule -> bool :=
-  fun x y => Ord__NDModule_compare x y GHC.Base.== Gt.
-
-Local Definition Ord__NDModule_op_zgze__ : NDModule -> NDModule -> bool :=
-  fun x y => Ord__NDModule_compare x y GHC.Base./= Lt.
-
-Local Definition Ord__NDModule_op_zl__ : NDModule -> NDModule -> bool :=
-  fun x y => Ord__NDModule_compare x y GHC.Base.== Lt.
-
-Local Definition Eq___ModuleName_op_zeze__ : ModuleName -> ModuleName -> bool :=
-  fun nm1 nm2 => Unique.getUnique nm1 GHC.Base.== Unique.getUnique nm2.
-
-Local Definition Eq___ModuleName_op_zsze__ : ModuleName -> ModuleName -> bool :=
-  fun x y => negb (Eq___ModuleName_op_zeze__ x y).
-
-Program Instance Eq___ModuleName : GHC.Base.Eq_ ModuleName :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___ModuleName_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___ModuleName_op_zsze__ |}.
-
-Local Definition Eq___UnitId_op_zeze__ : UnitId -> UnitId -> bool :=
-  fun uid1 uid2 => unitIdKey uid1 GHC.Base.== unitIdKey uid2.
-
-Local Definition Eq___UnitId_op_zsze__ : UnitId -> UnitId -> bool :=
-  fun x y => negb (Eq___UnitId_op_zeze__ x y).
-
-Program Instance Eq___UnitId : GHC.Base.Eq_ UnitId :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___UnitId_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___UnitId_op_zsze__ |}.
-
-Local Definition Eq___Module_op_zeze__ : Module -> Module -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_Module a1 a2, Mk_Module b1 b2 =>
-        (andb ((a1 GHC.Base.== b1)) ((a2 GHC.Base.== b2)))
-    end.
-
-Local Definition Eq___Module_op_zsze__ : Module -> Module -> bool :=
-  fun x y => negb (Eq___Module_op_zeze__ x y).
-
-Program Instance Eq___Module : GHC.Base.Eq_ Module :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___Module_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___Module_op_zsze__ |}.
-
-Local Definition Eq___NDModule_op_zeze__ : NDModule -> NDModule -> bool :=
-  GHC.Prim.coerce _GHC.Base.==_.
-
-Local Definition Eq___NDModule_op_zsze__ : NDModule -> NDModule -> bool :=
-  GHC.Prim.coerce _GHC.Base./=_.
-
-Program Instance Eq___NDModule : GHC.Base.Eq_ NDModule :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___NDModule_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___NDModule_op_zsze__ |}.
-
-Program Instance Ord__NDModule : GHC.Base.Ord NDModule :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zl____ := Ord__NDModule_op_zl__ ;
-           GHC.Base.op_zlze____ := Ord__NDModule_op_zlze__ ;
-           GHC.Base.op_zg____ := Ord__NDModule_op_zg__ ;
-           GHC.Base.op_zgze____ := Ord__NDModule_op_zgze__ ;
-           GHC.Base.compare__ := Ord__NDModule_compare ;
-           GHC.Base.max__ := Ord__NDModule_max ;
-           GHC.Base.min__ := Ord__NDModule_min |}.
-
-Definition unionModuleSet : ModuleSet -> ModuleSet -> ModuleSet :=
-  GHC.Prim.coerce Data.Set.Internal.union.
-
-Definition stableUnitIdCmp : UnitId -> UnitId -> comparison :=
-  fun p1 p2 => GHC.Base.compare (unitIdFS p1) (unitIdFS p2).
-
-(* Skipping definition `Module.renameHoleUnitId'' *)
-
-(* Skipping definition `Module.renameHoleUnitId' *)
-
-(* Skipping definition `Module.renameHoleModule'' *)
-
-(* Skipping definition `Module.renameHoleModule' *)
-
-(* Skipping definition `Module.rawHashUnitId' *)
-
-Definition pprUnitId : UnitId -> GHC.Base.String :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | DefiniteUnitId uid => Panic.someSDoc
-    | IndefiniteUnitId uid => Panic.someSDoc
-    end.
-
-(* Skipping definition `Module.pprModuleName' *)
-
-(* Skipping definition `Module.pprModule' *)
-
-Definition plusModuleEnv_C {a}
-   : (a -> a -> a) -> ModuleEnv a -> ModuleEnv a -> ModuleEnv a :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | f, Mk_ModuleEnv e1, Mk_ModuleEnv e2 =>
-        Mk_ModuleEnv (Data.Map.Internal.unionWith f e1 e2)
-    end.
-
-Definition plusModuleEnv {a} : ModuleEnv a -> ModuleEnv a -> ModuleEnv a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_ModuleEnv e1, Mk_ModuleEnv e2 =>
-        Mk_ModuleEnv (Data.Map.Internal.union e1 e2)
-    end.
-
-(* Skipping definition `Module.parseUnitId' *)
-
-(* Skipping definition `Module.parseModuleName' *)
-
-(* Skipping definition `Module.parseModuleId' *)
-
-(* Skipping definition `Module.parseModSubst' *)
-
-(* Skipping definition `Module.parseComponentId' *)
-
-(* Skipping definition `Module.newUnitId' *)
-
-(* Skipping definition `Module.newIndefUnitId' *)
-
-Local Definition Ord__ModuleName_compare
-   : ModuleName -> ModuleName -> comparison :=
-  fun nm1 nm2 => Eq.
-
-Local Definition Ord__ModuleName_op_zlze__ : ModuleName -> ModuleName -> bool :=
-  fun x y => Ord__ModuleName_compare x y GHC.Base./= Gt.
-
-Local Definition Ord__ModuleName_max : ModuleName -> ModuleName -> ModuleName :=
-  fun x y => if Ord__ModuleName_op_zlze__ x y : bool then y else x.
-
-Local Definition Ord__ModuleName_min : ModuleName -> ModuleName -> ModuleName :=
-  fun x y => if Ord__ModuleName_op_zlze__ x y : bool then x else y.
-
-Local Definition Ord__ModuleName_op_zg__ : ModuleName -> ModuleName -> bool :=
-  fun x y => Ord__ModuleName_compare x y GHC.Base.== Gt.
-
-Local Definition Ord__ModuleName_op_zgze__ : ModuleName -> ModuleName -> bool :=
-  fun x y => Ord__ModuleName_compare x y GHC.Base./= Lt.
-
-Local Definition Ord__ModuleName_op_zl__ : ModuleName -> ModuleName -> bool :=
-  fun x y => Ord__ModuleName_compare x y GHC.Base.== Lt.
-
-Program Instance Ord__ModuleName : GHC.Base.Ord ModuleName :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zl____ := Ord__ModuleName_op_zl__ ;
-           GHC.Base.op_zlze____ := Ord__ModuleName_op_zlze__ ;
-           GHC.Base.op_zg____ := Ord__ModuleName_op_zg__ ;
-           GHC.Base.op_zgze____ := Ord__ModuleName_op_zgze__ ;
-           GHC.Base.compare__ := Ord__ModuleName_compare ;
-           GHC.Base.max__ := Ord__ModuleName_max ;
-           GHC.Base.min__ := Ord__ModuleName_min |}.
-
-Local Definition Ord__UnitId_compare : UnitId -> UnitId -> comparison :=
-  fun nm1 nm2 => Eq.
-
-Local Definition Ord__UnitId_op_zlze__ : UnitId -> UnitId -> bool :=
-  fun x y => Ord__UnitId_compare x y GHC.Base./= Gt.
-
-Local Definition Ord__UnitId_max : UnitId -> UnitId -> UnitId :=
-  fun x y => if Ord__UnitId_op_zlze__ x y : bool then y else x.
-
-Local Definition Ord__UnitId_min : UnitId -> UnitId -> UnitId :=
-  fun x y => if Ord__UnitId_op_zlze__ x y : bool then x else y.
-
-Local Definition Ord__UnitId_op_zg__ : UnitId -> UnitId -> bool :=
-  fun x y => Ord__UnitId_compare x y GHC.Base.== Gt.
-
-Local Definition Ord__UnitId_op_zgze__ : UnitId -> UnitId -> bool :=
-  fun x y => Ord__UnitId_compare x y GHC.Base./= Lt.
-
-Local Definition Ord__UnitId_op_zl__ : UnitId -> UnitId -> bool :=
-  fun x y => Ord__UnitId_compare x y GHC.Base.== Lt.
-
-Program Instance Ord__UnitId : GHC.Base.Ord UnitId :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zl____ := Ord__UnitId_op_zl__ ;
-           GHC.Base.op_zlze____ := Ord__UnitId_op_zlze__ ;
-           GHC.Base.op_zg____ := Ord__UnitId_op_zg__ ;
-           GHC.Base.op_zgze____ := Ord__UnitId_op_zgze__ ;
-           GHC.Base.compare__ := Ord__UnitId_compare ;
-           GHC.Base.max__ := Ord__UnitId_max ;
-           GHC.Base.min__ := Ord__UnitId_min |}.
-
-Local Definition Ord__Module_compare : Module -> Module -> comparison :=
-  fun a b =>
-    let 'Mk_Module a1 a2 := a in
-    let 'Mk_Module b1 b2 := b in
-    match (GHC.Base.compare a1 b1) with
-    | Lt => Lt
-    | Eq => (GHC.Base.compare a2 b2)
-    | Gt => Gt
-    end.
-
-Local Definition Ord__Module_op_zl__ : Module -> Module -> bool :=
-  fun a b =>
-    let 'Mk_Module a1 a2 := a in
-    let 'Mk_Module b1 b2 := b in
-    match (GHC.Base.compare a1 b1) with
-    | Lt => true
-    | Eq => (a2 GHC.Base.< b2)
-    | Gt => false
-    end.
-
-Local Definition Ord__Module_op_zlze__ : Module -> Module -> bool :=
-  fun a b => negb (Ord__Module_op_zl__ b a).
-
-Local Definition Ord__Module_max : Module -> Module -> Module :=
-  fun x y => if Ord__Module_op_zlze__ x y : bool then y else x.
-
-Local Definition Ord__Module_min : Module -> Module -> Module :=
-  fun x y => if Ord__Module_op_zlze__ x y : bool then x else y.
-
-Local Definition Ord__Module_op_zg__ : Module -> Module -> bool :=
-  fun a b => Ord__Module_op_zl__ b a.
-
-Local Definition Ord__Module_op_zgze__ : Module -> Module -> bool :=
-  fun a b => negb (Ord__Module_op_zl__ a b).
-
-Program Instance Ord__Module : GHC.Base.Ord Module :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zl____ := Ord__Module_op_zl__ ;
-           GHC.Base.op_zlze____ := Ord__Module_op_zlze__ ;
-           GHC.Base.op_zg____ := Ord__Module_op_zg__ ;
-           GHC.Base.op_zgze____ := Ord__Module_op_zgze__ ;
-           GHC.Base.compare__ := Ord__Module_compare ;
-           GHC.Base.max__ := Ord__Module_max ;
-           GHC.Base.min__ := Ord__Module_min |}.
-
-Definition moduleSetElts : ModuleSet -> list Module :=
-  Data.OldList.sort GHC.Base.∘
-  (GHC.Prim.coerce GHC.Base.∘ Data.Set.Internal.toList).
-
-Definition moduleNameString : ModuleName -> GHC.Base.String :=
-  fun '(Mk_ModuleName mod_) => FastString.unpackFS mod_.
-
-Definition moduleStableString : Module -> GHC.Base.String :=
-  fun '(Mk_Module moduleUnitId moduleName) =>
-    Coq.Init.Datatypes.app (GHC.Base.hs_string__ "$") (Coq.Init.Datatypes.app
-                            (unitIdString moduleUnitId) (Coq.Init.Datatypes.app (GHC.Base.hs_string__ "$")
-                                                                                (moduleNameString moduleName))).
-
-(* Skipping definition `Module.moduleNameSlashes' *)
-
-Definition moduleNameFS : ModuleName -> FastString.FastString :=
-  fun '(Mk_ModuleName mod_) => mod_.
-
-Definition stableModuleNameCmp : ModuleName -> ModuleName -> comparison :=
-  fun n1 n2 => GHC.Base.compare (moduleNameFS n1) (moduleNameFS n2).
-
-Definition stableModuleCmp : Module -> Module -> comparison :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_Module p1 n1, Mk_Module p2 n2 =>
-        Util.thenCmp (stableUnitIdCmp p1 p2) (stableModuleNameCmp n1 n2)
-    end.
-
-Definition moduleNameColons : ModuleName -> GHC.Base.String :=
-  let dots_to_colons :=
-    GHC.Base.map (fun c =>
-                    if c GHC.Base.== GHC.Char.hs_char__ "." : bool
-                    then GHC.Char.hs_char__ ":"
-                    else c) in
-  dots_to_colons GHC.Base.∘ moduleNameString.
-
-Definition moduleEnvToList {a} : ModuleEnv a -> list (Module * a)%type :=
-  fun '(Mk_ModuleEnv e) =>
-    Data.OldList.sortBy (Data.Ord.comparing Data.Tuple.fst) (let cont_1__ arg_2__ :=
-                                                               let 'pair (Mk_NDModule m) v := arg_2__ in
-                                                               cons (pair m v) nil in
-                                                             Coq.Lists.List.flat_map cont_1__ (Data.Map.Internal.toList
-                                                                                      e)).
-
-Definition moduleEnvKeys {a} : ModuleEnv a -> list Module :=
-  fun '(Mk_ModuleEnv e) =>
-    Data.OldList.sort (GHC.Base.map unNDModule (Data.Map.Internal.keys e)).
-
-Definition moduleEnvElts {a} : ModuleEnv a -> list a :=
-  fun e => GHC.Base.map Data.Tuple.snd (moduleEnvToList e).
-
-Definition mkModuleSet : list Module -> ModuleSet :=
-  Data.Set.Internal.fromList GHC.Base.∘ GHC.Prim.coerce.
-
-Definition mkModuleNameFS : FastString.FastString -> ModuleName :=
-  fun s => Mk_ModuleName s.
-
-(* Skipping definition `Module.mkModuleName' *)
-
-Definition mkModuleEnv {a} : list (Module * a)%type -> ModuleEnv a :=
-  fun xs =>
-    Mk_ModuleEnv (Data.Map.Internal.fromList (let cont_0__ arg_1__ :=
-                                                let 'pair k v := arg_1__ in
-                                                cons (pair (Mk_NDModule k) v) nil in
-                                              Coq.Lists.List.flat_map cont_0__ xs)).
-
-Definition mkModule : UnitId -> ModuleName -> Module :=
-  Mk_Module.
-
-Definition minusModuleSet : ModuleSet -> ModuleSet -> ModuleSet :=
-  GHC.Prim.coerce Data.Set.Internal.difference.
-
-Definition mapModuleEnv {a} {b} : (a -> b) -> ModuleEnv a -> ModuleEnv b :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, Mk_ModuleEnv e =>
-        Mk_ModuleEnv (Data.Map.Internal.mapWithKey (fun arg_2__ arg_3__ =>
-                                                      match arg_2__, arg_3__ with
-                                                      | _, v => f v
-                                                      end) e)
-    end.
-
-Definition lookupWithDefaultModuleEnv {a} : ModuleEnv a -> a -> Module -> a :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | Mk_ModuleEnv e, x, m => Data.Map.Internal.findWithDefault x (Mk_NDModule m) e
-    end.
-
-Definition lookupModuleEnv {a} : ModuleEnv a -> Module -> option a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_ModuleEnv e, m => Data.Map.Internal.lookup (Mk_NDModule m) e
-    end.
-
-Local Definition Ord__InstalledUnitId_compare
-   : InstalledUnitId -> InstalledUnitId -> comparison :=
-  fun u1 u2 => GHC.Base.compare (installedUnitIdFS u1) (installedUnitIdFS u2).
-
-Local Definition Ord__InstalledUnitId_op_zlze__
-   : InstalledUnitId -> InstalledUnitId -> bool :=
-  fun x y => Ord__InstalledUnitId_compare x y GHC.Base./= Gt.
-
-Local Definition Ord__InstalledUnitId_max
-   : InstalledUnitId -> InstalledUnitId -> InstalledUnitId :=
-  fun x y => if Ord__InstalledUnitId_op_zlze__ x y : bool then y else x.
-
-Local Definition Ord__InstalledUnitId_min
-   : InstalledUnitId -> InstalledUnitId -> InstalledUnitId :=
-  fun x y => if Ord__InstalledUnitId_op_zlze__ x y : bool then x else y.
-
-Local Definition Ord__InstalledUnitId_op_zg__
-   : InstalledUnitId -> InstalledUnitId -> bool :=
-  fun x y => Ord__InstalledUnitId_compare x y GHC.Base.== Gt.
-
-Local Definition Ord__InstalledUnitId_op_zgze__
-   : InstalledUnitId -> InstalledUnitId -> bool :=
-  fun x y => Ord__InstalledUnitId_compare x y GHC.Base./= Lt.
-
-Local Definition Ord__InstalledUnitId_op_zl__
-   : InstalledUnitId -> InstalledUnitId -> bool :=
-  fun x y => Ord__InstalledUnitId_compare x y GHC.Base.== Lt.
-
-Local Definition Eq___InstalledUnitId_op_zeze__
-   : InstalledUnitId -> InstalledUnitId -> bool :=
-  fun uid1 uid2 => installedUnitIdKey uid1 GHC.Base.== installedUnitIdKey uid2.
-
-Local Definition Eq___InstalledUnitId_op_zsze__
-   : InstalledUnitId -> InstalledUnitId -> bool :=
-  fun x y => negb (Eq___InstalledUnitId_op_zeze__ x y).
-
-Program Instance Eq___InstalledUnitId : GHC.Base.Eq_ InstalledUnitId :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___InstalledUnitId_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___InstalledUnitId_op_zsze__ |}.
-
-Program Instance Ord__InstalledUnitId : GHC.Base.Ord InstalledUnitId :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zl____ := Ord__InstalledUnitId_op_zl__ ;
-           GHC.Base.op_zlze____ := Ord__InstalledUnitId_op_zlze__ ;
-           GHC.Base.op_zg____ := Ord__InstalledUnitId_op_zg__ ;
-           GHC.Base.op_zgze____ := Ord__InstalledUnitId_op_zgze__ ;
-           GHC.Base.compare__ := Ord__InstalledUnitId_compare ;
-           GHC.Base.max__ := Ord__InstalledUnitId_max ;
-           GHC.Base.min__ := Ord__InstalledUnitId_min |}.
-
-Local Definition Ord__InstalledModule_compare
-   : InstalledModule -> InstalledModule -> comparison :=
-  fun a b =>
-    let 'Mk_InstalledModule a1 a2 := a in
-    let 'Mk_InstalledModule b1 b2 := b in
-    match (GHC.Base.compare a1 b1) with
-    | Lt => Lt
-    | Eq => (GHC.Base.compare a2 b2)
-    | Gt => Gt
-    end.
-
-Local Definition Ord__InstalledModule_op_zl__
-   : InstalledModule -> InstalledModule -> bool :=
-  fun a b =>
-    let 'Mk_InstalledModule a1 a2 := a in
-    let 'Mk_InstalledModule b1 b2 := b in
-    match (GHC.Base.compare a1 b1) with
-    | Lt => true
-    | Eq => (a2 GHC.Base.< b2)
-    | Gt => false
-    end.
-
-Local Definition Ord__InstalledModule_op_zlze__
-   : InstalledModule -> InstalledModule -> bool :=
-  fun a b => negb (Ord__InstalledModule_op_zl__ b a).
-
-Local Definition Ord__InstalledModule_max
-   : InstalledModule -> InstalledModule -> InstalledModule :=
-  fun x y => if Ord__InstalledModule_op_zlze__ x y : bool then y else x.
-
-Local Definition Ord__InstalledModule_min
-   : InstalledModule -> InstalledModule -> InstalledModule :=
-  fun x y => if Ord__InstalledModule_op_zlze__ x y : bool then x else y.
-
-Local Definition Ord__InstalledModule_op_zg__
-   : InstalledModule -> InstalledModule -> bool :=
-  fun a b => Ord__InstalledModule_op_zl__ b a.
-
-Local Definition Ord__InstalledModule_op_zgze__
-   : InstalledModule -> InstalledModule -> bool :=
-  fun a b => negb (Ord__InstalledModule_op_zl__ a b).
-
-Local Definition Eq___InstalledModule_op_zeze__
-   : InstalledModule -> InstalledModule -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_InstalledModule a1 a2, Mk_InstalledModule b1 b2 =>
-        (andb ((a1 GHC.Base.== b1)) ((a2 GHC.Base.== b2)))
-    end.
-
-Local Definition Eq___InstalledModule_op_zsze__
-   : InstalledModule -> InstalledModule -> bool :=
-  fun x y => negb (Eq___InstalledModule_op_zeze__ x y).
-
-Program Instance Eq___InstalledModule : GHC.Base.Eq_ InstalledModule :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___InstalledModule_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___InstalledModule_op_zsze__ |}.
-
-Program Instance Ord__InstalledModule : GHC.Base.Ord InstalledModule :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zl____ := Ord__InstalledModule_op_zl__ ;
-           GHC.Base.op_zlze____ := Ord__InstalledModule_op_zlze__ ;
-           GHC.Base.op_zg____ := Ord__InstalledModule_op_zg__ ;
-           GHC.Base.op_zgze____ := Ord__InstalledModule_op_zgze__ ;
-           GHC.Base.compare__ := Ord__InstalledModule_compare ;
-           GHC.Base.max__ := Ord__InstalledModule_max ;
-           GHC.Base.min__ := Ord__InstalledModule_min |}.
-
-Definition lookupInstalledModuleEnv {a}
-   : InstalledModuleEnv a -> InstalledModule -> option a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_InstalledModuleEnv e, m => Data.Map.Internal.lookup m e
-    end.
-
-Definition isEmptyModuleEnv {a} : ModuleEnv a -> bool :=
-  fun '(Mk_ModuleEnv e) => Data.Map.Internal.null e.
-
-Definition intersectModuleSet : ModuleSet -> ModuleSet -> ModuleSet :=
-  GHC.Prim.coerce Data.Set.Internal.intersection.
-
-(* Skipping definition `Module.integerUnitId' *)
-
-Definition installedUnitIdString : InstalledUnitId -> GHC.Base.String :=
-  FastString.unpackFS GHC.Base.∘ installedUnitIdFS.
-
-(* Skipping definition `Module.indefUnitIdToUnitId' *)
-
-(* Skipping definition `Module.indefModuleToModule' *)
-
-(* Skipping definition `Module.hashUnitId' *)
-
-(* Skipping definition `Module.generalizeIndefUnitId' *)
-
-(* Skipping definition `Module.generalizeIndefModule' *)
-
-Definition fsToUnitId : FastString.FastString -> UnitId :=
-  DefiniteUnitId GHC.Base.∘ (Mk_DefUnitId GHC.Base.∘ Mk_InstalledUnitId).
-
-Definition holeUnitId : UnitId :=
-  fsToUnitId (FastString.fsLit (GHC.Base.hs_string__ "hole")).
-
-Definition isHoleModule : Module -> bool :=
-  fun mod_ => moduleUnitId mod_ GHC.Base.== holeUnitId.
-
-Definition moduleFreeHoles : Module -> UniqSet.UniqSet ModuleName :=
-  fun m =>
-    if isHoleModule m : bool then UniqSet.unitUniqSet (moduleName m) else
-    unitIdFreeHoles (moduleUnitId m).
-
-Definition moduleIsDefinite : Module -> bool :=
-  UniqSet.isEmptyUniqSet GHC.Base.∘ moduleFreeHoles.
-
-Definition mkHoleModule : ModuleName -> Module :=
-  mkModule holeUnitId.
-
-Definition interactiveUnitId : UnitId :=
-  fsToUnitId (FastString.fsLit (GHC.Base.hs_string__ "interactive")).
-
-Definition isInteractiveModule : Module -> bool :=
-  fun mod_ => moduleUnitId mod_ GHC.Base.== interactiveUnitId.
-
-Definition mainUnitId : UnitId :=
-  fsToUnitId (FastString.fsLit (GHC.Base.hs_string__ "main")).
-
-Definition newSimpleUnitId : ComponentId -> UnitId :=
-  fun '(Mk_ComponentId fs) => fsToUnitId fs.
-
-Definition primUnitId : UnitId :=
-  fsToUnitId (FastString.fsLit (GHC.Base.hs_string__ "ghc-prim")).
-
-Definition rtsUnitId : UnitId :=
-  fsToUnitId (FastString.fsLit (GHC.Base.hs_string__ "rts")).
-
-Definition stringToUnitId : GHC.Base.String -> UnitId :=
-  fsToUnitId GHC.Base.∘ FastString.mkFastString.
-
-Definition thUnitId : UnitId :=
-  fsToUnitId (FastString.fsLit (GHC.Base.hs_string__ "template-haskell")).
-
-Definition thisGhcUnitId : UnitId :=
-  fsToUnitId (FastString.fsLit (GHC.Base.hs_string__ "ghc")).
-
-Definition fsToInstalledUnitId : FastString.FastString -> InstalledUnitId :=
-  fun fs => Mk_InstalledUnitId fs.
-
-Definition stringToInstalledUnitId : GHC.Base.String -> InstalledUnitId :=
-  fsToInstalledUnitId GHC.Base.∘ FastString.mkFastString.
-
-(* Skipping definition `Module.fingerprintUnitId' *)
-
-(* Skipping definition `Module.fingerprintByteString' *)
-
-Definition filterModuleEnv {a}
-   : (Module -> a -> bool) -> ModuleEnv a -> ModuleEnv a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, Mk_ModuleEnv e =>
-        Mk_ModuleEnv (Data.Map.Internal.filterWithKey (f GHC.Base.∘ unNDModule) e)
-    end.
-
-Definition filterInstalledModuleEnv {a}
-   : (InstalledModule -> a -> bool) ->
-     InstalledModuleEnv a -> InstalledModuleEnv a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, Mk_InstalledModuleEnv e =>
-        Mk_InstalledModuleEnv (Data.Map.Internal.filterWithKey f e)
-    end.
-
-Definition extendModuleSetList : ModuleSet -> list Module -> ModuleSet :=
-  fun s ms =>
-    Data.Foldable.foldl' (GHC.Prim.coerce GHC.Base.∘
-                          GHC.Base.flip Data.Set.Internal.insert) s ms.
-
-Definition extendModuleSet : ModuleSet -> Module -> ModuleSet :=
-  fun s m => Data.Set.Internal.insert (Mk_NDModule m) s.
-
-Definition extendModuleEnvWith {a}
-   : (a -> a -> a) -> ModuleEnv a -> Module -> a -> ModuleEnv a :=
-  fun arg_0__ arg_1__ arg_2__ arg_3__ =>
-    match arg_0__, arg_1__, arg_2__, arg_3__ with
-    | f, Mk_ModuleEnv e, m, x =>
-        Mk_ModuleEnv (Data.Map.Internal.insertWith f (Mk_NDModule m) x e)
-    end.
-
-Definition extendModuleEnvList_C {a}
-   : (a -> a -> a) -> ModuleEnv a -> list (Module * a)%type -> ModuleEnv a :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | f, Mk_ModuleEnv e, xs =>
-        Mk_ModuleEnv (FiniteMap.insertListWith f (let cont_3__ arg_4__ :=
-                                                    let 'pair k v := arg_4__ in
-                                                    cons (pair (Mk_NDModule k) v) nil in
-                                                  Coq.Lists.List.flat_map cont_3__ xs) e)
-    end.
-
-Definition extendModuleEnvList {a}
-   : ModuleEnv a -> list (Module * a)%type -> ModuleEnv a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_ModuleEnv e, xs =>
-        Mk_ModuleEnv (FiniteMap.insertList (let cont_2__ arg_3__ :=
-                                              let 'pair k v := arg_3__ in
-                                              cons (pair (Mk_NDModule k) v) nil in
-                                            Coq.Lists.List.flat_map cont_2__ xs) e)
-    end.
-
-Definition extendModuleEnv {a} : ModuleEnv a -> Module -> a -> ModuleEnv a :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | Mk_ModuleEnv e, m, x =>
-        Mk_ModuleEnv (Data.Map.Internal.insert (Mk_NDModule m) x e)
-    end.
-
-Definition extendInstalledModuleEnv {a}
-   : InstalledModuleEnv a -> InstalledModule -> a -> InstalledModuleEnv a :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | Mk_InstalledModuleEnv e, m, x =>
-        Mk_InstalledModuleEnv (Data.Map.Internal.insert m x e)
-    end.
-
-Definition emptyModuleSet : ModuleSet :=
-  Data.Set.Internal.empty.
-
-Definition emptyModuleEnv {a} : ModuleEnv a :=
-  Mk_ModuleEnv Data.Map.Internal.empty.
-
-Definition emptyInstalledModuleEnv {a} : InstalledModuleEnv a :=
-  Mk_InstalledModuleEnv Data.Map.Internal.empty.
-
-Definition elemModuleSet : Module -> ModuleSet -> bool :=
-  Data.Set.Internal.member GHC.Base.∘ GHC.Prim.coerce.
-
-Definition elemModuleEnv {a} : Module -> ModuleEnv a -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | m, Mk_ModuleEnv e => Data.Map.Internal.member (Mk_NDModule m) e
-    end.
-
-Definition dphSeqUnitId : UnitId :=
-  fsToUnitId (FastString.fsLit (GHC.Base.hs_string__ "dph-seq")).
-
-Definition dphParUnitId : UnitId :=
-  fsToUnitId (FastString.fsLit (GHC.Base.hs_string__ "dph-par")).
-
-Definition delModuleSet : ModuleSet -> Module -> ModuleSet :=
-  GHC.Prim.coerce (GHC.Base.flip Data.Set.Internal.delete).
-
-Definition delModuleEnvList {a} : ModuleEnv a -> list Module -> ModuleEnv a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_ModuleEnv e, ms =>
-        Mk_ModuleEnv (FiniteMap.deleteList (GHC.Base.map Mk_NDModule ms) e)
-    end.
-
-Definition delModuleEnv {a} : ModuleEnv a -> Module -> ModuleEnv a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_ModuleEnv e, m => Mk_ModuleEnv (Data.Map.Internal.delete (Mk_NDModule m) e)
-    end.
-
-Definition delInstalledModuleEnv {a}
-   : InstalledModuleEnv a -> InstalledModule -> InstalledModuleEnv a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_InstalledModuleEnv e, m =>
-        Mk_InstalledModuleEnv (Data.Map.Internal.delete m e)
-    end.
-
-Definition componentIdToInstalledUnitId : ComponentId -> InstalledUnitId :=
-  fun '(Mk_ComponentId fs) => fsToInstalledUnitId fs.
-
-Definition splitUnitIdInsts
-   : UnitId -> (InstalledUnitId * option IndefUnitId)%type :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | IndefiniteUnitId iuid =>
-        pair (componentIdToInstalledUnitId (indefUnitIdComponentId iuid)) (Some iuid)
-    | DefiniteUnitId (Mk_DefUnitId uid) => pair uid None
-    end.
-
-Definition installedUnitIdEq : InstalledUnitId -> UnitId -> bool :=
-  fun iuid uid => Data.Tuple.fst (splitUnitIdInsts uid) GHC.Base.== iuid.
-
-Definition splitModuleInsts
-   : Module -> (InstalledModule * option IndefModule)%type :=
-  fun m =>
-    let 'pair uid mb_iuid := splitUnitIdInsts (moduleUnitId m) in
-    pair (Mk_InstalledModule uid (moduleName m)) (GHC.Base.fmap (fun iuid =>
-                                                                   Mk_IndefModule iuid (moduleName m)) mb_iuid).
-
-Definition installedModuleEq : InstalledModule -> Module -> bool :=
-  fun imod mod_ => Data.Tuple.fst (splitModuleInsts mod_) GHC.Base.== imod.
-
-Definition toInstalledUnitId : UnitId -> InstalledUnitId :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | DefiniteUnitId (Mk_DefUnitId iuid) => iuid
-    | IndefiniteUnitId indef =>
-        componentIdToInstalledUnitId (indefUnitIdComponentId indef)
-    end.
-
-Definition baseUnitId : UnitId :=
-  fsToUnitId (FastString.fsLit (GHC.Base.hs_string__ "base")).
-
-(* Skipping definition `Module.addBootSuffix_maybe' *)
-
-(* Skipping definition `Module.addBootSuffixLocn' *)
-
-(* Skipping definition `Module.addBootSuffix' *)
-
 (* Skipping all instances of class `GHC.Show.Show', including
    `Module.Show__ModLocation' *)
 
@@ -1017,6 +259,179 @@ Program Instance Ord__ComponentId : GHC.Base.Ord ComponentId :=
            GHC.Base.max__ := Ord__ComponentId_max ;
            GHC.Base.min__ := Ord__ComponentId_min |}.
 
+Definition installedUnitIdKey : InstalledUnitId -> Unique.Unique :=
+  Unique.getUnique GHC.Base.∘ installedUnitIdFS.
+
+Local Definition Eq___InstalledUnitId_op_zeze__
+   : InstalledUnitId -> InstalledUnitId -> bool :=
+  fun uid1 uid2 => installedUnitIdKey uid1 GHC.Base.== installedUnitIdKey uid2.
+
+Local Definition Eq___InstalledUnitId_op_zsze__
+   : InstalledUnitId -> InstalledUnitId -> bool :=
+  fun x y => negb (Eq___InstalledUnitId_op_zeze__ x y).
+
+Program Instance Eq___InstalledUnitId : GHC.Base.Eq_ InstalledUnitId :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___InstalledUnitId_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___InstalledUnitId_op_zsze__ |}.
+
+Local Definition Uniquable__ModuleName_getUnique
+   : ModuleName -> Unique.Unique :=
+  fun '(Mk_ModuleName nm) => Unique.getUnique nm.
+
+Program Instance Uniquable__ModuleName : Unique.Uniquable ModuleName :=
+  fun _ k__ => k__ {| Unique.getUnique__ := Uniquable__ModuleName_getUnique |}.
+
+Local Definition Eq___ModuleName_op_zeze__ : ModuleName -> ModuleName -> bool :=
+  fun nm1 nm2 => Unique.getUnique nm1 GHC.Base.== Unique.getUnique nm2.
+
+Local Definition Eq___ModuleName_op_zsze__ : ModuleName -> ModuleName -> bool :=
+  fun x y => negb (Eq___ModuleName_op_zeze__ x y).
+
+Program Instance Eq___ModuleName : GHC.Base.Eq_ ModuleName :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___ModuleName_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___ModuleName_op_zsze__ |}.
+
+Local Definition Eq___InstalledModule_op_zeze__
+   : InstalledModule -> InstalledModule -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_InstalledModule a1 a2, Mk_InstalledModule b1 b2 =>
+        (andb ((a1 GHC.Base.== b1)) ((a2 GHC.Base.== b2)))
+    end.
+
+Local Definition Eq___InstalledModule_op_zsze__
+   : InstalledModule -> InstalledModule -> bool :=
+  fun x y => negb (Eq___InstalledModule_op_zeze__ x y).
+
+Program Instance Eq___InstalledModule : GHC.Base.Eq_ InstalledModule :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___InstalledModule_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___InstalledModule_op_zsze__ |}.
+
+Local Definition Ord__InstalledUnitId_compare
+   : InstalledUnitId -> InstalledUnitId -> comparison :=
+  fun u1 u2 => GHC.Base.compare (installedUnitIdFS u1) (installedUnitIdFS u2).
+
+Local Definition Ord__InstalledUnitId_op_zlze__
+   : InstalledUnitId -> InstalledUnitId -> bool :=
+  fun x y => Ord__InstalledUnitId_compare x y GHC.Base./= Gt.
+
+Local Definition Ord__InstalledUnitId_max
+   : InstalledUnitId -> InstalledUnitId -> InstalledUnitId :=
+  fun x y => if Ord__InstalledUnitId_op_zlze__ x y : bool then y else x.
+
+Local Definition Ord__InstalledUnitId_min
+   : InstalledUnitId -> InstalledUnitId -> InstalledUnitId :=
+  fun x y => if Ord__InstalledUnitId_op_zlze__ x y : bool then x else y.
+
+Local Definition Ord__InstalledUnitId_op_zg__
+   : InstalledUnitId -> InstalledUnitId -> bool :=
+  fun x y => Ord__InstalledUnitId_compare x y GHC.Base.== Gt.
+
+Local Definition Ord__InstalledUnitId_op_zgze__
+   : InstalledUnitId -> InstalledUnitId -> bool :=
+  fun x y => Ord__InstalledUnitId_compare x y GHC.Base./= Lt.
+
+Local Definition Ord__InstalledUnitId_op_zl__
+   : InstalledUnitId -> InstalledUnitId -> bool :=
+  fun x y => Ord__InstalledUnitId_compare x y GHC.Base.== Lt.
+
+Program Instance Ord__InstalledUnitId : GHC.Base.Ord InstalledUnitId :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zl____ := Ord__InstalledUnitId_op_zl__ ;
+           GHC.Base.op_zlze____ := Ord__InstalledUnitId_op_zlze__ ;
+           GHC.Base.op_zg____ := Ord__InstalledUnitId_op_zg__ ;
+           GHC.Base.op_zgze____ := Ord__InstalledUnitId_op_zgze__ ;
+           GHC.Base.compare__ := Ord__InstalledUnitId_compare ;
+           GHC.Base.max__ := Ord__InstalledUnitId_max ;
+           GHC.Base.min__ := Ord__InstalledUnitId_min |}.
+
+Local Definition Ord__ModuleName_compare
+   : ModuleName -> ModuleName -> comparison :=
+  fun nm1 nm2 => Eq.
+
+Local Definition Ord__ModuleName_op_zlze__ : ModuleName -> ModuleName -> bool :=
+  fun x y => Ord__ModuleName_compare x y GHC.Base./= Gt.
+
+Local Definition Ord__ModuleName_max : ModuleName -> ModuleName -> ModuleName :=
+  fun x y => if Ord__ModuleName_op_zlze__ x y : bool then y else x.
+
+Local Definition Ord__ModuleName_min : ModuleName -> ModuleName -> ModuleName :=
+  fun x y => if Ord__ModuleName_op_zlze__ x y : bool then x else y.
+
+Local Definition Ord__ModuleName_op_zg__ : ModuleName -> ModuleName -> bool :=
+  fun x y => Ord__ModuleName_compare x y GHC.Base.== Gt.
+
+Local Definition Ord__ModuleName_op_zgze__ : ModuleName -> ModuleName -> bool :=
+  fun x y => Ord__ModuleName_compare x y GHC.Base./= Lt.
+
+Local Definition Ord__ModuleName_op_zl__ : ModuleName -> ModuleName -> bool :=
+  fun x y => Ord__ModuleName_compare x y GHC.Base.== Lt.
+
+Program Instance Ord__ModuleName : GHC.Base.Ord ModuleName :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zl____ := Ord__ModuleName_op_zl__ ;
+           GHC.Base.op_zlze____ := Ord__ModuleName_op_zlze__ ;
+           GHC.Base.op_zg____ := Ord__ModuleName_op_zg__ ;
+           GHC.Base.op_zgze____ := Ord__ModuleName_op_zgze__ ;
+           GHC.Base.compare__ := Ord__ModuleName_compare ;
+           GHC.Base.max__ := Ord__ModuleName_max ;
+           GHC.Base.min__ := Ord__ModuleName_min |}.
+
+Local Definition Ord__InstalledModule_op_zl__
+   : InstalledModule -> InstalledModule -> bool :=
+  fun a b =>
+    let 'Mk_InstalledModule a1 a2 := a in
+    let 'Mk_InstalledModule b1 b2 := b in
+    match (GHC.Base.compare a1 b1) with
+    | Lt => true
+    | Eq => (a2 GHC.Base.< b2)
+    | Gt => false
+    end.
+
+Local Definition Ord__InstalledModule_op_zlze__
+   : InstalledModule -> InstalledModule -> bool :=
+  fun a b => negb (Ord__InstalledModule_op_zl__ b a).
+
+Local Definition Ord__InstalledModule_op_zg__
+   : InstalledModule -> InstalledModule -> bool :=
+  fun a b => Ord__InstalledModule_op_zl__ b a.
+
+Local Definition Ord__InstalledModule_op_zgze__
+   : InstalledModule -> InstalledModule -> bool :=
+  fun a b => negb (Ord__InstalledModule_op_zl__ a b).
+
+Local Definition Ord__InstalledModule_compare
+   : InstalledModule -> InstalledModule -> comparison :=
+  fun a b =>
+    let 'Mk_InstalledModule a1 a2 := a in
+    let 'Mk_InstalledModule b1 b2 := b in
+    match (GHC.Base.compare a1 b1) with
+    | Lt => Lt
+    | Eq => (GHC.Base.compare a2 b2)
+    | Gt => Gt
+    end.
+
+Local Definition Ord__InstalledModule_max
+   : InstalledModule -> InstalledModule -> InstalledModule :=
+  fun x y => if Ord__InstalledModule_op_zlze__ x y : bool then y else x.
+
+Local Definition Ord__InstalledModule_min
+   : InstalledModule -> InstalledModule -> InstalledModule :=
+  fun x y => if Ord__InstalledModule_op_zlze__ x y : bool then x else y.
+
+Program Instance Ord__InstalledModule : GHC.Base.Ord InstalledModule :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zl____ := Ord__InstalledModule_op_zl__ ;
+           GHC.Base.op_zlze____ := Ord__InstalledModule_op_zlze__ ;
+           GHC.Base.op_zg____ := Ord__InstalledModule_op_zg__ ;
+           GHC.Base.op_zgze____ := Ord__InstalledModule_op_zgze__ ;
+           GHC.Base.compare__ := Ord__InstalledModule_compare ;
+           GHC.Base.max__ := Ord__InstalledModule_max ;
+           GHC.Base.min__ := Ord__InstalledModule_min |}.
+
 Local Definition Eq___DefUnitId_op_zeze__ : DefUnitId -> DefUnitId -> bool :=
   GHC.Prim.coerce _GHC.Base.==_.
 
@@ -1059,6 +474,115 @@ Program Instance Ord__DefUnitId : GHC.Base.Ord DefUnitId :=
            GHC.Base.compare__ := Ord__DefUnitId_compare ;
            GHC.Base.max__ := Ord__DefUnitId_max ;
            GHC.Base.min__ := Ord__DefUnitId_min |}.
+
+Definition unitIdKey : UnitId -> Unique.Unique :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | IndefiniteUnitId x => indefUnitIdKey x
+    | DefiniteUnitId (Mk_DefUnitId x) => installedUnitIdKey x
+    end.
+
+Local Definition Eq___UnitId_op_zeze__ : UnitId -> UnitId -> bool :=
+  fun uid1 uid2 => unitIdKey uid1 GHC.Base.== unitIdKey uid2.
+
+Local Definition Eq___UnitId_op_zsze__ : UnitId -> UnitId -> bool :=
+  fun x y => negb (Eq___UnitId_op_zeze__ x y).
+
+Program Instance Eq___UnitId : GHC.Base.Eq_ UnitId :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___UnitId_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___UnitId_op_zsze__ |}.
+
+Local Definition Eq___Module_op_zeze__ : Module -> Module -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_Module a1 a2, Mk_Module b1 b2 =>
+        (andb ((a1 GHC.Base.== b1)) ((a2 GHC.Base.== b2)))
+    end.
+
+Local Definition Eq___Module_op_zsze__ : Module -> Module -> bool :=
+  fun x y => negb (Eq___Module_op_zeze__ x y).
+
+Program Instance Eq___Module : GHC.Base.Eq_ Module :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___Module_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___Module_op_zsze__ |}.
+
+Local Definition Ord__UnitId_compare : UnitId -> UnitId -> comparison :=
+  fun nm1 nm2 => Eq.
+
+Local Definition Ord__UnitId_op_zlze__ : UnitId -> UnitId -> bool :=
+  fun x y => Ord__UnitId_compare x y GHC.Base./= Gt.
+
+Local Definition Ord__UnitId_max : UnitId -> UnitId -> UnitId :=
+  fun x y => if Ord__UnitId_op_zlze__ x y : bool then y else x.
+
+Local Definition Ord__UnitId_min : UnitId -> UnitId -> UnitId :=
+  fun x y => if Ord__UnitId_op_zlze__ x y : bool then x else y.
+
+Local Definition Ord__UnitId_op_zg__ : UnitId -> UnitId -> bool :=
+  fun x y => Ord__UnitId_compare x y GHC.Base.== Gt.
+
+Local Definition Ord__UnitId_op_zgze__ : UnitId -> UnitId -> bool :=
+  fun x y => Ord__UnitId_compare x y GHC.Base./= Lt.
+
+Local Definition Ord__UnitId_op_zl__ : UnitId -> UnitId -> bool :=
+  fun x y => Ord__UnitId_compare x y GHC.Base.== Lt.
+
+Program Instance Ord__UnitId : GHC.Base.Ord UnitId :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zl____ := Ord__UnitId_op_zl__ ;
+           GHC.Base.op_zlze____ := Ord__UnitId_op_zlze__ ;
+           GHC.Base.op_zg____ := Ord__UnitId_op_zg__ ;
+           GHC.Base.op_zgze____ := Ord__UnitId_op_zgze__ ;
+           GHC.Base.compare__ := Ord__UnitId_compare ;
+           GHC.Base.max__ := Ord__UnitId_max ;
+           GHC.Base.min__ := Ord__UnitId_min |}.
+
+Local Definition Ord__Module_op_zl__ : Module -> Module -> bool :=
+  fun a b =>
+    let 'Mk_Module a1 a2 := a in
+    let 'Mk_Module b1 b2 := b in
+    match (GHC.Base.compare a1 b1) with
+    | Lt => true
+    | Eq => (a2 GHC.Base.< b2)
+    | Gt => false
+    end.
+
+Local Definition Ord__Module_op_zlze__ : Module -> Module -> bool :=
+  fun a b => negb (Ord__Module_op_zl__ b a).
+
+Local Definition Ord__Module_op_zg__ : Module -> Module -> bool :=
+  fun a b => Ord__Module_op_zl__ b a.
+
+Local Definition Ord__Module_op_zgze__ : Module -> Module -> bool :=
+  fun a b => negb (Ord__Module_op_zl__ a b).
+
+Local Definition Ord__Module_compare : Module -> Module -> comparison :=
+  fun a b =>
+    let 'Mk_Module a1 a2 := a in
+    let 'Mk_Module b1 b2 := b in
+    match (GHC.Base.compare a1 b1) with
+    | Lt => Lt
+    | Eq => (GHC.Base.compare a2 b2)
+    | Gt => Gt
+    end.
+
+Local Definition Ord__Module_max : Module -> Module -> Module :=
+  fun x y => if Ord__Module_op_zlze__ x y : bool then y else x.
+
+Local Definition Ord__Module_min : Module -> Module -> Module :=
+  fun x y => if Ord__Module_op_zlze__ x y : bool then x else y.
+
+Program Instance Ord__Module : GHC.Base.Ord Module :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zl____ := Ord__Module_op_zl__ ;
+           GHC.Base.op_zlze____ := Ord__Module_op_zlze__ ;
+           GHC.Base.op_zg____ := Ord__Module_op_zg__ ;
+           GHC.Base.op_zgze____ := Ord__Module_op_zgze__ ;
+           GHC.Base.compare__ := Ord__Module_compare ;
+           GHC.Base.max__ := Ord__Module_max ;
+           GHC.Base.min__ := Ord__Module_min |}.
 
 Local Definition Eq___IndefUnitId_op_zeze__
    : IndefUnitId -> IndefUnitId -> bool :=
@@ -1180,29 +704,69 @@ Program Instance Ord__IndefModule : GHC.Base.Ord IndefModule :=
            GHC.Base.max__ := Ord__IndefModule_max ;
            GHC.Base.min__ := Ord__IndefModule_min |}.
 
+Local Definition Eq___NDModule_op_zeze__ : NDModule -> NDModule -> bool :=
+  GHC.Prim.coerce _GHC.Base.==_.
+
+Local Definition Eq___NDModule_op_zsze__ : NDModule -> NDModule -> bool :=
+  GHC.Prim.coerce _GHC.Base./=_.
+
+Program Instance Eq___NDModule : GHC.Base.Eq_ NDModule :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___NDModule_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___NDModule_op_zsze__ |}.
+
 (* Skipping all instances of class `Outputable.Outputable', including
    `Module.Outputable__ModLocation' *)
-
-(* Skipping all instances of class `Control.DeepSeq.NFData', including
-   `Module.NFData__ModuleName' *)
-
-(* Skipping all instances of class `Data.Data.Data', including
-   `Module.Data__ModuleName' *)
-
-(* Skipping all instances of class `GHC.PackageDb.BinaryStringRep', including
-   `Module.BinaryStringRep__ModuleName' *)
-
-(* Skipping all instances of class `Binary.Binary', including
-   `Module.Binary__ModuleName' *)
 
 (* Skipping all instances of class `Outputable.Outputable', including
    `Module.Outputable__ModuleName' *)
 
 (* Skipping all instances of class `Binary.Binary', including
-   `Module.Binary__ComponentId' *)
+   `Module.Binary__ModuleName' *)
+
+(* Skipping all instances of class `GHC.PackageDb.BinaryStringRep', including
+   `Module.BinaryStringRep__ModuleName' *)
+
+(* Skipping all instances of class `Data.Data.Data', including
+   `Module.Data__ModuleName' *)
+
+(* Skipping all instances of class `Control.DeepSeq.NFData', including
+   `Module.NFData__ModuleName' *)
+
+Definition moduleNameFS : ModuleName -> FastString.FastString :=
+  fun '(Mk_ModuleName mod_) => mod_.
+
+Definition unitIdFS : UnitId -> FastString.FastString :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | IndefiniteUnitId x => indefUnitIdFS x
+    | DefiniteUnitId (Mk_DefUnitId x) => installedUnitIdFS x
+    end.
+
+Local Definition Uniquable__Module_getUnique : Module -> Unique.Unique :=
+  fun '(Mk_Module p n) =>
+    Unique.getUnique (FastString.appendFS (unitIdFS p) (moduleNameFS n)).
+
+Program Instance Uniquable__Module : Unique.Uniquable Module :=
+  fun _ k__ => k__ {| Unique.getUnique__ := Uniquable__Module_getUnique |}.
 
 (* Skipping all instances of class `Outputable.Outputable', including
-   `Module.Outputable__ComponentId' *)
+   `Module.Outputable__Module' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `Module.Binary__Module' *)
+
+(* Skipping all instances of class `Data.Data.Data', including
+   `Module.Data__Module' *)
+
+(* Skipping all instances of class `Control.DeepSeq.NFData', including
+   `Module.NFData__Module' *)
+
+(* Skipping all instances of class `GHC.PackageDb.DbUnitIdModuleRep', including
+   `Module.DbUnitIdModuleRep__InstalledUnitId__ComponentId__UnitId__ModuleName__Module' *)
+
+(* Skipping all instances of class `GHC.PackageDb.BinaryStringRep', including
+   `Module.BinaryStringRep__ComponentId' *)
 
 Local Definition Uniquable__ComponentId_getUnique
    : ComponentId -> Unique.Unique :=
@@ -1211,11 +775,20 @@ Local Definition Uniquable__ComponentId_getUnique
 Program Instance Uniquable__ComponentId : Unique.Uniquable ComponentId :=
   fun _ k__ => k__ {| Unique.getUnique__ := Uniquable__ComponentId_getUnique |}.
 
-(* Skipping all instances of class `GHC.PackageDb.BinaryStringRep', including
-   `Module.BinaryStringRep__ComponentId' *)
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Module.Outputable__ComponentId' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `Module.Binary__IndefUnitId' *)
 
 (* Skipping all instances of class `Outputable.Outputable', including
-   `Module.Outputable__InstalledUnitId' *)
+   `Module.Outputable__IndefModule' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `Module.Binary__InstalledUnitId' *)
+
+(* Skipping all instances of class `GHC.PackageDb.BinaryStringRep', including
+   `Module.BinaryStringRep__InstalledUnitId' *)
 
 Local Definition Uniquable__InstalledUnitId_getUnique
    : InstalledUnitId -> Unique.Unique :=
@@ -1226,66 +799,493 @@ Program Instance Uniquable__InstalledUnitId
   fun _ k__ =>
     k__ {| Unique.getUnique__ := Uniquable__InstalledUnitId_getUnique |}.
 
-(* Skipping all instances of class `GHC.PackageDb.BinaryStringRep', including
-   `Module.BinaryStringRep__InstalledUnitId' *)
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Module.Outputable__InstalledUnitId' *)
 
-(* Skipping all instances of class `Binary.Binary', including
-   `Module.Binary__InstalledUnitId' *)
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Module.Outputable__IndefUnitId' *)
 
 (* Skipping all instances of class `Outputable.Outputable', including
    `Module.Outputable__InstalledModule' *)
-
-(* Skipping all instances of class `Binary.Binary', including
-   `Module.Binary__DefUnitId' *)
 
 (* Skipping all instances of class `Outputable.Outputable', including
    `Module.Outputable__DefUnitId' *)
 
 (* Skipping all instances of class `Binary.Binary', including
-   `Module.Binary__UnitId' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Module.Outputable__UnitId' *)
-
-(* Skipping all instances of class `Control.DeepSeq.NFData', including
-   `Module.NFData__UnitId' *)
-
-(* Skipping all instances of class `Data.Data.Data', including
-   `Module.Data__UnitId' *)
+   `Module.Binary__DefUnitId' *)
 
 (* Skipping all instances of class `GHC.Show.Show', including
    `Module.Show__UnitId' *)
 
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Module.Outputable__IndefUnitId' *)
+Local Definition Uniquable__UnitId_getUnique : UnitId -> Unique.Unique :=
+  unitIdKey.
 
-(* Skipping all instances of class `Binary.Binary', including
-   `Module.Binary__IndefUnitId' *)
-
-(* Skipping all instances of class `GHC.PackageDb.DbUnitIdModuleRep', including
-   `Module.DbUnitIdModuleRep__InstalledUnitId__ComponentId__UnitId__ModuleName__Module' *)
-
-(* Skipping all instances of class `Control.DeepSeq.NFData', including
-   `Module.NFData__Module' *)
+Program Instance Uniquable__UnitId : Unique.Uniquable UnitId :=
+  fun _ k__ => k__ {| Unique.getUnique__ := Uniquable__UnitId_getUnique |}.
 
 (* Skipping all instances of class `Data.Data.Data', including
-   `Module.Data__Module' *)
+   `Module.Data__UnitId' *)
+
+(* Skipping all instances of class `Control.DeepSeq.NFData', including
+   `Module.NFData__UnitId' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Module.Outputable__UnitId' *)
 
 (* Skipping all instances of class `Binary.Binary', including
-   `Module.Binary__Module' *)
+   `Module.Binary__UnitId' *)
 
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Module.Outputable__Module' *)
+(* Skipping all instances of class `Binary.Binary', including
+   `Module.Binary__ComponentId' *)
 
-Local Definition Uniquable__Module_getUnique : Module -> Unique.Unique :=
-  fun '(Mk_Module p n) =>
-    Unique.getUnique (FastString.appendFS (unitIdFS p) (moduleNameFS n)).
+Local Definition Ord__NDModule_compare : NDModule -> NDModule -> comparison :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_NDModule (Mk_Module p1 n1), Mk_NDModule (Mk_Module p2 n2) =>
+        Util.thenCmp (Unique.nonDetCmpUnique (Unique.getUnique p1) (Unique.getUnique
+                                              p2)) (Unique.nonDetCmpUnique (Unique.getUnique n1) (Unique.getUnique n2))
+    end.
 
-Program Instance Uniquable__Module : Unique.Uniquable Module :=
-  fun _ k__ => k__ {| Unique.getUnique__ := Uniquable__Module_getUnique |}.
+Local Definition Ord__NDModule_op_zl__ : NDModule -> NDModule -> bool :=
+  fun x y => Ord__NDModule_compare x y GHC.Base.== Lt.
 
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Module.Outputable__IndefModule' *)
+Local Definition Ord__NDModule_op_zlze__ : NDModule -> NDModule -> bool :=
+  fun x y => Ord__NDModule_compare x y GHC.Base./= Gt.
+
+Local Definition Ord__NDModule_op_zg__ : NDModule -> NDModule -> bool :=
+  fun x y => Ord__NDModule_compare x y GHC.Base.== Gt.
+
+Local Definition Ord__NDModule_op_zgze__ : NDModule -> NDModule -> bool :=
+  fun x y => Ord__NDModule_compare x y GHC.Base./= Lt.
+
+Local Definition Ord__NDModule_max : NDModule -> NDModule -> NDModule :=
+  fun x y => if Ord__NDModule_op_zlze__ x y : bool then y else x.
+
+Local Definition Ord__NDModule_min : NDModule -> NDModule -> NDModule :=
+  fun x y => if Ord__NDModule_op_zlze__ x y : bool then x else y.
+
+Program Instance Ord__NDModule : GHC.Base.Ord NDModule :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zl____ := Ord__NDModule_op_zl__ ;
+           GHC.Base.op_zlze____ := Ord__NDModule_op_zlze__ ;
+           GHC.Base.op_zg____ := Ord__NDModule_op_zg__ ;
+           GHC.Base.op_zgze____ := Ord__NDModule_op_zgze__ ;
+           GHC.Base.compare__ := Ord__NDModule_compare ;
+           GHC.Base.max__ := Ord__NDModule_max ;
+           GHC.Base.min__ := Ord__NDModule_min |}.
+
+(* Skipping definition `Module.addBootSuffix' *)
+
+(* Skipping definition `Module.addBootSuffix_maybe' *)
+
+(* Skipping definition `Module.addBootSuffixLocn' *)
+
+Definition stableModuleNameCmp : ModuleName -> ModuleName -> comparison :=
+  fun n1 n2 => GHC.Base.compare (moduleNameFS n1) (moduleNameFS n2).
+
+(* Skipping definition `Module.pprModuleName' *)
+
+Definition moduleNameString : ModuleName -> GHC.Base.String :=
+  fun '(Mk_ModuleName mod_) => FastString.unpackFS mod_.
+
+Definition unitIdString : UnitId -> GHC.Base.String :=
+  FastString.unpackFS GHC.Base.∘ unitIdFS.
+
+Definition moduleStableString : Module -> GHC.Base.String :=
+  fun '(Mk_Module moduleUnitId moduleName) =>
+    Coq.Init.Datatypes.app (GHC.Base.hs_string__ "$") (Coq.Init.Datatypes.app
+                            (unitIdString moduleUnitId) (Coq.Init.Datatypes.app (GHC.Base.hs_string__ "$")
+                                                                                (moduleNameString moduleName))).
+
+(* Skipping definition `Module.mkModuleName' *)
+
+Definition mkModuleNameFS : FastString.FastString -> ModuleName :=
+  fun s => Mk_ModuleName s.
+
+(* Skipping definition `Module.moduleNameSlashes' *)
+
+Definition moduleNameColons : ModuleName -> GHC.Base.String :=
+  let dots_to_colons :=
+    GHC.Base.map (fun c =>
+                    if c GHC.Base.== GHC.Char.hs_char__ "." : bool
+                    then GHC.Char.hs_char__ ":"
+                    else c) in
+  dots_to_colons GHC.Base.∘ moduleNameString.
+
+Definition fsToUnitId : FastString.FastString -> UnitId :=
+  DefiniteUnitId GHC.Base.∘ (Mk_DefUnitId GHC.Base.∘ Mk_InstalledUnitId).
+
+Definition holeUnitId : UnitId :=
+  fsToUnitId (FastString.fsLit (GHC.Base.hs_string__ "hole")).
+
+Definition isHoleModule : Module -> bool :=
+  fun mod_ => moduleUnitId mod_ GHC.Base.== holeUnitId.
+
+Definition unitIdFreeHoles : UnitId -> UniqSet.UniqSet ModuleName :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | IndefiniteUnitId x => indefUnitIdFreeHoles x
+    | DefiniteUnitId _ => UniqSet.emptyUniqSet
+    end.
+
+Definition moduleFreeHoles : Module -> UniqSet.UniqSet ModuleName :=
+  fun m =>
+    if isHoleModule m : bool then UniqSet.unitUniqSet (moduleName m) else
+    unitIdFreeHoles (moduleUnitId m).
+
+Definition moduleIsDefinite : Module -> bool :=
+  UniqSet.isEmptyUniqSet GHC.Base.∘ moduleFreeHoles.
+
+Definition mkModule : UnitId -> ModuleName -> Module :=
+  Mk_Module.
+
+Definition mkHoleModule : ModuleName -> Module :=
+  mkModule holeUnitId.
+
+Definition stableUnitIdCmp : UnitId -> UnitId -> comparison :=
+  fun p1 p2 => GHC.Base.compare (unitIdFS p1) (unitIdFS p2).
+
+Definition stableModuleCmp : Module -> Module -> comparison :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_Module p1 n1, Mk_Module p2 n2 =>
+        Util.thenCmp (stableUnitIdCmp p1 p2) (stableModuleNameCmp n1 n2)
+    end.
+
+(* Skipping definition `Module.pprModule' *)
+
+(* Skipping definition `Module.newIndefUnitId' *)
+
+(* Skipping definition `Module.indefUnitIdToUnitId' *)
+
+(* Skipping definition `Module.indefModuleToModule' *)
+
+Definition fsToInstalledUnitId : FastString.FastString -> InstalledUnitId :=
+  fun fs => Mk_InstalledUnitId fs.
+
+Definition componentIdToInstalledUnitId : ComponentId -> InstalledUnitId :=
+  fun '(Mk_ComponentId fs) => fsToInstalledUnitId fs.
+
+Definition toInstalledUnitId : UnitId -> InstalledUnitId :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | DefiniteUnitId (Mk_DefUnitId iuid) => iuid
+    | IndefiniteUnitId indef =>
+        componentIdToInstalledUnitId (indefUnitIdComponentId indef)
+    end.
+
+Definition installedUnitIdString : InstalledUnitId -> GHC.Base.String :=
+  FastString.unpackFS GHC.Base.∘ installedUnitIdFS.
+
+Definition stringToInstalledUnitId : GHC.Base.String -> InstalledUnitId :=
+  fsToInstalledUnitId GHC.Base.∘ FastString.mkFastString.
+
+Definition splitUnitIdInsts
+   : UnitId -> (InstalledUnitId * option IndefUnitId)%type :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | IndefiniteUnitId iuid =>
+        pair (componentIdToInstalledUnitId (indefUnitIdComponentId iuid)) (Some iuid)
+    | DefiniteUnitId (Mk_DefUnitId uid) => pair uid None
+    end.
+
+Definition splitModuleInsts
+   : Module -> (InstalledModule * option IndefModule)%type :=
+  fun m =>
+    let 'pair uid mb_iuid := splitUnitIdInsts (moduleUnitId m) in
+    pair (Mk_InstalledModule uid (moduleName m)) (GHC.Base.fmap (fun iuid =>
+                                                                   Mk_IndefModule iuid (moduleName m)) mb_iuid).
+
+Definition installedModuleEq : InstalledModule -> Module -> bool :=
+  fun imod mod_ => Data.Tuple.fst (splitModuleInsts mod_) GHC.Base.== imod.
+
+Definition installedUnitIdEq : InstalledUnitId -> UnitId -> bool :=
+  fun iuid uid => Data.Tuple.fst (splitUnitIdInsts uid) GHC.Base.== iuid.
+
+Definition emptyInstalledModuleEnv {a} : InstalledModuleEnv a :=
+  Mk_InstalledModuleEnv Data.Map.Internal.empty.
+
+Definition lookupInstalledModuleEnv {a}
+   : InstalledModuleEnv a -> InstalledModule -> option a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_InstalledModuleEnv e, m => Data.Map.Internal.lookup m e
+    end.
+
+Definition extendInstalledModuleEnv {a}
+   : InstalledModuleEnv a -> InstalledModule -> a -> InstalledModuleEnv a :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | Mk_InstalledModuleEnv e, m, x =>
+        Mk_InstalledModuleEnv (Data.Map.Internal.insert m x e)
+    end.
+
+Definition filterInstalledModuleEnv {a}
+   : (InstalledModule -> a -> bool) ->
+     InstalledModuleEnv a -> InstalledModuleEnv a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, Mk_InstalledModuleEnv e =>
+        Mk_InstalledModuleEnv (Data.Map.Internal.filterWithKey f e)
+    end.
+
+Definition delInstalledModuleEnv {a}
+   : InstalledModuleEnv a -> InstalledModule -> InstalledModuleEnv a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_InstalledModuleEnv e, m =>
+        Mk_InstalledModuleEnv (Data.Map.Internal.delete m e)
+    end.
+
+Definition unitIdIsDefinite : UnitId -> bool :=
+  UniqSet.isEmptyUniqSet GHC.Base.∘ unitIdFreeHoles.
+
+(* Skipping definition `Module.hashUnitId' *)
+
+(* Skipping definition `Module.rawHashUnitId' *)
+
+(* Skipping definition `Module.fingerprintByteString' *)
+
+(* Skipping definition `Module.fingerprintUnitId' *)
+
+(* Skipping definition `Module.newUnitId' *)
+
+Definition pprUnitId : UnitId -> GHC.Base.String :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | DefiniteUnitId uid => Panic.someSDoc
+    | IndefiniteUnitId uid => Panic.someSDoc
+    end.
+
+Definition newSimpleUnitId : ComponentId -> UnitId :=
+  fun '(Mk_ComponentId fs) => fsToUnitId fs.
+
+Definition stringToUnitId : GHC.Base.String -> UnitId :=
+  fsToUnitId GHC.Base.∘ FastString.mkFastString.
+
+(* Skipping definition `Module.renameHoleModule' *)
+
+(* Skipping definition `Module.renameHoleUnitId' *)
+
+(* Skipping definition `Module.renameHoleModule'' *)
+
+(* Skipping definition `Module.renameHoleUnitId'' *)
+
+(* Skipping definition `Module.generalizeIndefUnitId' *)
+
+(* Skipping definition `Module.generalizeIndefModule' *)
+
+(* Skipping definition `Module.parseModuleName' *)
+
+(* Skipping definition `Module.parseUnitId' *)
+
+(* Skipping definition `Module.parseComponentId' *)
+
+(* Skipping definition `Module.parseModuleId' *)
+
+(* Skipping definition `Module.parseModSubst' *)
+
+Definition primUnitId : UnitId :=
+  fsToUnitId (FastString.fsLit (GHC.Base.hs_string__ "ghc-prim")).
+
+(* Skipping definition `Module.integerUnitId' *)
+
+Definition baseUnitId : UnitId :=
+  fsToUnitId (FastString.fsLit (GHC.Base.hs_string__ "base")).
+
+Definition rtsUnitId : UnitId :=
+  fsToUnitId (FastString.fsLit (GHC.Base.hs_string__ "rts")).
+
+Definition thUnitId : UnitId :=
+  fsToUnitId (FastString.fsLit (GHC.Base.hs_string__ "template-haskell")).
+
+Definition dphSeqUnitId : UnitId :=
+  fsToUnitId (FastString.fsLit (GHC.Base.hs_string__ "dph-seq")).
+
+Definition dphParUnitId : UnitId :=
+  fsToUnitId (FastString.fsLit (GHC.Base.hs_string__ "dph-par")).
+
+Definition thisGhcUnitId : UnitId :=
+  fsToUnitId (FastString.fsLit (GHC.Base.hs_string__ "ghc")).
+
+Definition interactiveUnitId : UnitId :=
+  fsToUnitId (FastString.fsLit (GHC.Base.hs_string__ "interactive")).
+
+Definition mainUnitId : UnitId :=
+  fsToUnitId (FastString.fsLit (GHC.Base.hs_string__ "main")).
+
+Definition isInteractiveModule : Module -> bool :=
+  fun mod_ => moduleUnitId mod_ GHC.Base.== interactiveUnitId.
+
+(* Skipping definition `Module.wiredInUnitIds' *)
+
+Definition filterModuleEnv {a}
+   : (Module -> a -> bool) -> ModuleEnv a -> ModuleEnv a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, Mk_ModuleEnv e =>
+        Mk_ModuleEnv (Data.Map.Internal.filterWithKey (f GHC.Base.∘ unNDModule) e)
+    end.
+
+Definition elemModuleEnv {a} : Module -> ModuleEnv a -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | m, Mk_ModuleEnv e => Data.Map.Internal.member (Mk_NDModule m) e
+    end.
+
+Definition extendModuleEnv {a} : ModuleEnv a -> Module -> a -> ModuleEnv a :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | Mk_ModuleEnv e, m, x =>
+        Mk_ModuleEnv (Data.Map.Internal.insert (Mk_NDModule m) x e)
+    end.
+
+Definition extendModuleEnvWith {a}
+   : (a -> a -> a) -> ModuleEnv a -> Module -> a -> ModuleEnv a :=
+  fun arg_0__ arg_1__ arg_2__ arg_3__ =>
+    match arg_0__, arg_1__, arg_2__, arg_3__ with
+    | f, Mk_ModuleEnv e, m, x =>
+        Mk_ModuleEnv (Data.Map.Internal.insertWith f (Mk_NDModule m) x e)
+    end.
+
+Definition extendModuleEnvList {a}
+   : ModuleEnv a -> list (Module * a)%type -> ModuleEnv a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_ModuleEnv e, xs =>
+        Mk_ModuleEnv (FiniteMap.insertList (let cont_2__ arg_3__ :=
+                                              let 'pair k v := arg_3__ in
+                                              cons (pair (Mk_NDModule k) v) nil in
+                                            Coq.Lists.List.flat_map cont_2__ xs) e)
+    end.
+
+Definition extendModuleEnvList_C {a}
+   : (a -> a -> a) -> ModuleEnv a -> list (Module * a)%type -> ModuleEnv a :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | f, Mk_ModuleEnv e, xs =>
+        Mk_ModuleEnv (FiniteMap.insertListWith f (let cont_3__ arg_4__ :=
+                                                    let 'pair k v := arg_4__ in
+                                                    cons (pair (Mk_NDModule k) v) nil in
+                                                  Coq.Lists.List.flat_map cont_3__ xs) e)
+    end.
+
+Definition plusModuleEnv_C {a}
+   : (a -> a -> a) -> ModuleEnv a -> ModuleEnv a -> ModuleEnv a :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | f, Mk_ModuleEnv e1, Mk_ModuleEnv e2 =>
+        Mk_ModuleEnv (Data.Map.Internal.unionWith f e1 e2)
+    end.
+
+Definition delModuleEnvList {a} : ModuleEnv a -> list Module -> ModuleEnv a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_ModuleEnv e, ms =>
+        Mk_ModuleEnv (FiniteMap.deleteList (GHC.Base.map Mk_NDModule ms) e)
+    end.
+
+Definition delModuleEnv {a} : ModuleEnv a -> Module -> ModuleEnv a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_ModuleEnv e, m => Mk_ModuleEnv (Data.Map.Internal.delete (Mk_NDModule m) e)
+    end.
+
+Definition plusModuleEnv {a} : ModuleEnv a -> ModuleEnv a -> ModuleEnv a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_ModuleEnv e1, Mk_ModuleEnv e2 =>
+        Mk_ModuleEnv (Data.Map.Internal.union e1 e2)
+    end.
+
+Definition lookupModuleEnv {a} : ModuleEnv a -> Module -> option a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_ModuleEnv e, m => Data.Map.Internal.lookup (Mk_NDModule m) e
+    end.
+
+Definition lookupWithDefaultModuleEnv {a} : ModuleEnv a -> a -> Module -> a :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | Mk_ModuleEnv e, x, m => Data.Map.Internal.findWithDefault x (Mk_NDModule m) e
+    end.
+
+Definition mapModuleEnv {a} {b} : (a -> b) -> ModuleEnv a -> ModuleEnv b :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, Mk_ModuleEnv e =>
+        Mk_ModuleEnv (Data.Map.Internal.mapWithKey (fun arg_2__ arg_3__ =>
+                                                      match arg_2__, arg_3__ with
+                                                      | _, v => f v
+                                                      end) e)
+    end.
+
+Definition mkModuleEnv {a} : list (Module * a)%type -> ModuleEnv a :=
+  fun xs =>
+    Mk_ModuleEnv (Data.Map.Internal.fromList (let cont_0__ arg_1__ :=
+                                                let 'pair k v := arg_1__ in
+                                                cons (pair (Mk_NDModule k) v) nil in
+                                              Coq.Lists.List.flat_map cont_0__ xs)).
+
+Definition emptyModuleEnv {a} : ModuleEnv a :=
+  Mk_ModuleEnv Data.Map.Internal.empty.
+
+Definition moduleEnvKeys {a} : ModuleEnv a -> list Module :=
+  fun '(Mk_ModuleEnv e) =>
+    Data.OldList.sort (GHC.Base.map unNDModule (Data.Map.Internal.keys e)).
+
+Definition moduleEnvToList {a} : ModuleEnv a -> list (Module * a)%type :=
+  fun '(Mk_ModuleEnv e) =>
+    Data.OldList.sortBy (Data.Ord.comparing Data.Tuple.fst) (let cont_1__ arg_2__ :=
+                                                               let 'pair (Mk_NDModule m) v := arg_2__ in
+                                                               cons (pair m v) nil in
+                                                             Coq.Lists.List.flat_map cont_1__ (Data.Map.Internal.toList
+                                                                                      e)).
+
+Definition moduleEnvElts {a} : ModuleEnv a -> list a :=
+  fun e => GHC.Base.map Data.Tuple.snd (moduleEnvToList e).
+
+Definition unitModuleEnv {a} : Module -> a -> ModuleEnv a :=
+  fun m x => Mk_ModuleEnv (Data.Map.Internal.singleton (Mk_NDModule m) x).
+
+Definition isEmptyModuleEnv {a} : ModuleEnv a -> bool :=
+  fun '(Mk_ModuleEnv e) => Data.Map.Internal.null e.
+
+Definition mkModuleSet : list Module -> ModuleSet :=
+  Data.Set.Internal.fromList GHC.Base.∘ GHC.Prim.coerce.
+
+Definition extendModuleSet : ModuleSet -> Module -> ModuleSet :=
+  fun s m => Data.Set.Internal.insert (Mk_NDModule m) s.
+
+Definition extendModuleSetList : ModuleSet -> list Module -> ModuleSet :=
+  fun s ms =>
+    Data.Foldable.foldl' (GHC.Prim.coerce GHC.Base.∘
+                          GHC.Base.flip Data.Set.Internal.insert) s ms.
+
+Definition emptyModuleSet : ModuleSet :=
+  Data.Set.Internal.empty.
+
+Definition moduleSetElts : ModuleSet -> list Module :=
+  Data.OldList.sort GHC.Base.∘
+  (GHC.Prim.coerce GHC.Base.∘ Data.Set.Internal.toList).
+
+Definition elemModuleSet : Module -> ModuleSet -> bool :=
+  Data.Set.Internal.member GHC.Base.∘ GHC.Prim.coerce.
+
+Definition intersectModuleSet : ModuleSet -> ModuleSet -> ModuleSet :=
+  GHC.Prim.coerce Data.Set.Internal.intersection.
+
+Definition minusModuleSet : ModuleSet -> ModuleSet -> ModuleSet :=
+  GHC.Prim.coerce Data.Set.Internal.difference.
+
+Definition delModuleSet : ModuleSet -> Module -> ModuleSet :=
+  GHC.Prim.coerce (GHC.Base.flip Data.Set.Internal.delete).
+
+Definition unionModuleSet : ModuleSet -> ModuleSet -> ModuleSet :=
+  GHC.Prim.coerce Data.Set.Internal.union.
+
+Definition unitModuleSet : Module -> ModuleSet :=
+  GHC.Prim.coerce Data.Set.Internal.singleton.
 
 (* External variables:
      Eq Gt Lt None Some andb bool comparison cons false list negb nil op_zt__ option

--- a/examples/ghc/lib/MonadUtils.v
+++ b/examples/ghc/lib/MonadUtils.v
@@ -19,73 +19,57 @@ Require GHC.Base.
 
 (* Converted value declarations: *)
 
-Axiom zipWithAndUnzipM : forall {m} {a} {b} {c} {d},
-                         forall `{GHC.Base.Monad m},
-                         (a -> b -> m (c * d)%type) -> list a -> list b -> m (list c * list d)%type.
+(* Skipping definition `MonadUtils.liftIO1' *)
 
-Axiom zipWith4M : forall {m} {a} {b} {c} {d} {e},
-                  forall `{GHC.Base.Monad m},
-                  (a -> b -> c -> d -> m e) -> list a -> list b -> list c -> list d -> m (list e).
+(* Skipping definition `MonadUtils.liftIO2' *)
 
-Axiom zipWith3M_ : forall {m} {a} {b} {c} {d},
-                   forall `{GHC.Base.Monad m},
-                   (a -> b -> c -> m d) -> list a -> list b -> list c -> m unit.
+(* Skipping definition `MonadUtils.liftIO3' *)
+
+(* Skipping definition `MonadUtils.liftIO4' *)
 
 Axiom zipWith3M : forall {m} {a} {b} {c} {d},
                   forall `{GHC.Base.Monad m},
                   (a -> b -> c -> m d) -> list a -> list b -> list c -> m (list d).
 
-Axiom whenM : forall {m},
-              forall `{GHC.Base.Monad m}, m bool -> m unit -> m unit.
+Axiom zipWith3M_ : forall {m} {a} {b} {c} {d},
+                   forall `{GHC.Base.Monad m},
+                   (a -> b -> c -> m d) -> list a -> list b -> list c -> m unit.
 
-(* Skipping definition `MonadUtils.unlessM' *)
+Axiom zipWith4M : forall {m} {a} {b} {c} {d} {e},
+                  forall `{GHC.Base.Monad m},
+                  (a -> b -> c -> d -> m e) -> list a -> list b -> list c -> list d -> m (list e).
 
-Axiom orM : forall {m}, forall `{GHC.Base.Monad m}, m bool -> m bool -> m bool.
+Axiom zipWithAndUnzipM : forall {m} {a} {b} {c} {d},
+                         forall `{GHC.Base.Monad m},
+                         (a -> b -> m (c * d)%type) -> list a -> list b -> m (list c * list d)%type.
 
-Axiom maybeMapM : forall {m} {a} {b},
-                  forall `{GHC.Base.Monad m}, (a -> m b) -> (option a -> m (option b)).
-
-Axiom mapSndM : forall {m} {b} {c} {a},
-                forall `{GHC.Base.Monad m},
-                (b -> m c) -> list (a * b)%type -> m (list (a * c)%type).
-
-Axiom mapMaybeM : forall {m} {a} {b},
-                  forall `{(GHC.Base.Monad m)}, (a -> m (option b)) -> list a -> m (list b).
-
-Axiom mapAndUnzip5M : forall {m} {a} {b} {c} {d} {e} {f},
+Axiom mapAndUnzip3M : forall {m} {a} {b} {c} {d},
                       forall `{GHC.Base.Monad m},
-                      (a -> m (b * c * d * e * f)%type) ->
-                      list a -> m (list b * list c * list d * list e * list f)%type.
+                      (a -> m (b * c * d)%type) -> list a -> m (list b * list c * list d)%type.
 
 Axiom mapAndUnzip4M : forall {m} {a} {b} {c} {d} {e},
                       forall `{GHC.Base.Monad m},
                       (a -> m (b * c * d * e)%type) ->
                       list a -> m (list b * list c * list d * list e)%type.
 
-Axiom mapAndUnzip3M : forall {m} {a} {b} {c} {d},
+Axiom mapAndUnzip5M : forall {m} {a} {b} {c} {d} {e} {f},
                       forall `{GHC.Base.Monad m},
-                      (a -> m (b * c * d)%type) -> list a -> m (list b * list c * list d)%type.
+                      (a -> m (b * c * d * e * f)%type) ->
+                      list a -> m (list b * list c * list d * list e * list f)%type.
 
 Axiom mapAccumLM : forall {m} {acc} {x} {y},
                    forall `{GHC.Base.Monad m},
                    (acc -> x -> m (acc * y)%type) -> acc -> list x -> m (acc * list y)%type.
 
-(* Skipping definition `MonadUtils.liftIO4' *)
+Axiom mapSndM : forall {m} {b} {c} {a},
+                forall `{GHC.Base.Monad m},
+                (b -> m c) -> list (a * b)%type -> m (list (a * c)%type).
 
-(* Skipping definition `MonadUtils.liftIO3' *)
+Axiom concatMapM : forall {m} {a} {b},
+                   forall `{GHC.Base.Monad m}, (a -> m (list b)) -> list a -> m (list b).
 
-(* Skipping definition `MonadUtils.liftIO2' *)
-
-(* Skipping definition `MonadUtils.liftIO1' *)
-
-Axiom foldrM : forall {m} {b} {a},
-               forall `{(GHC.Base.Monad m)}, (b -> a -> m a) -> a -> list b -> m a.
-
-Axiom foldlM_ : forall {m} {a} {b},
-                forall `{(GHC.Base.Monad m)}, (a -> b -> m a) -> a -> list b -> m unit.
-
-Axiom foldlM : forall {m} {a} {b},
-               forall `{(GHC.Base.Monad m)}, (a -> b -> m a) -> a -> list b -> m a.
+Axiom mapMaybeM : forall {m} {a} {b},
+                  forall `{(GHC.Base.Monad m)}, (a -> m (option b)) -> list a -> m (list b).
 
 Axiom fmapMaybeM : forall {m} {a} {b},
                    forall `{(GHC.Base.Monad m)}, (a -> m b) -> option a -> m (option b).
@@ -95,14 +79,30 @@ Axiom fmapEitherM : forall {m} {a} {b} {c} {d},
                     (a -> m b) ->
                     (c -> m d) -> Data.Either.Either a c -> m (Data.Either.Either b d).
 
-Axiom concatMapM : forall {m} {a} {b},
-                   forall `{GHC.Base.Monad m}, (a -> m (list b)) -> list a -> m (list b).
-
 Axiom anyM : forall {m} {a},
              forall `{GHC.Base.Monad m}, (a -> m bool) -> list a -> m bool.
 
 Axiom allM : forall {m} {a},
              forall `{GHC.Base.Monad m}, (a -> m bool) -> list a -> m bool.
+
+Axiom orM : forall {m}, forall `{GHC.Base.Monad m}, m bool -> m bool -> m bool.
+
+Axiom foldlM : forall {m} {a} {b},
+               forall `{(GHC.Base.Monad m)}, (a -> b -> m a) -> a -> list b -> m a.
+
+Axiom foldlM_ : forall {m} {a} {b},
+                forall `{(GHC.Base.Monad m)}, (a -> b -> m a) -> a -> list b -> m unit.
+
+Axiom foldrM : forall {m} {b} {a},
+               forall `{(GHC.Base.Monad m)}, (b -> a -> m a) -> a -> list b -> m a.
+
+Axiom maybeMapM : forall {m} {a} {b},
+                  forall `{GHC.Base.Monad m}, (a -> m b) -> (option a -> m (option b)).
+
+Axiom whenM : forall {m},
+              forall `{GHC.Base.Monad m}, m bool -> m unit -> m unit.
+
+(* Skipping definition `MonadUtils.unlessM' *)
 
 (* External variables:
      bool list op_zt__ option unit Data.Either.Either GHC.Base.Monad

--- a/examples/ghc/lib/Name.v
+++ b/examples/ghc/lib/Name.v
@@ -90,297 +90,37 @@ Instance Default__Name : Default Name := Build_Default _ (Mk_Name default defaul
 
 (* Converted value declarations: *)
 
-(* Skipping definition `Name.wiredInNameTyThing_maybe' *)
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Name.Outputable__NameSort' *)
 
-Definition tidyNameOcc : Name -> OccName.OccName -> Name :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | (Mk_Name System _ _ _ as name), occ =>
-        let 'Mk_Name n_sort_2__ n_occ_3__ n_uniq_4__ n_loc_5__ := name in
-        Mk_Name Internal occ n_uniq_4__ n_loc_5__
-    | name, occ =>
-        let 'Mk_Name n_sort_9__ n_occ_10__ n_uniq_11__ n_loc_12__ := name in
-        Mk_Name n_sort_9__ occ n_uniq_11__ n_loc_12__
-    end.
-
-Definition stableNameCmp : Name -> Name -> comparison :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_Name s1 occ1 _ _, Mk_Name s2 occ2 _ _ =>
-        let sort_cmp :=
-          fun arg_2__ arg_3__ =>
-            match arg_2__, arg_3__ with
-            | External m1, External m2 => Module.stableModuleCmp m1 m2
-            | External _, _ => Lt
-            | WiredIn _ _ _, External _ => Gt
-            | WiredIn m1 _ _, WiredIn m2 _ _ => Module.stableModuleCmp m1 m2
-            | WiredIn _ _ _, _ => Lt
-            | Internal, External _ => Gt
-            | Internal, WiredIn _ _ _ => Gt
-            | Internal, Internal => Eq
-            | Internal, System => Lt
-            | System, System => Eq
-            | System, _ => Gt
-            end in
-        Util.thenCmp (sort_cmp s1 s2) (GHC.Base.compare occ1 occ2)
-    end.
-
-Definition setNameUnique : Name -> Unique.Unique -> Name :=
-  fun name uniq =>
-    let 'Mk_Name n_sort_0__ n_occ_1__ n_uniq_2__ n_loc_3__ := name in
-    Mk_Name n_sort_0__ n_occ_1__ uniq n_loc_3__.
-
-Definition setNameLoc : Name -> SrcLoc.SrcSpan -> Name :=
-  fun name loc =>
-    let 'Mk_Name n_sort_0__ n_occ_1__ n_uniq_2__ n_loc_3__ := name in
-    Mk_Name n_sort_0__ n_occ_1__ n_uniq_2__ loc.
-
-(* Skipping definition `Name.ppr_z_occ_name' *)
-
-(* Skipping definition `Name.ppr_underscore_unique' *)
-
-(* Skipping definition `Name.ppr_occ_name' *)
-
-(* Skipping definition `Name.pprUnique' *)
-
-(* Skipping definition `Name.pprSystem' *)
-
-(* Skipping definition `Name.pprPrefixName' *)
-
-(* Skipping definition `Name.pprNameDefnLoc' *)
-
-(* Skipping definition `Name.pprName' *)
-
-(* Skipping definition `Name.pprModulePrefix' *)
-
-(* Skipping definition `Name.pprInternal' *)
-
-(* Skipping definition `Name.pprInfixName' *)
-
-(* Skipping definition `Name.pprExternal' *)
-
-(* Skipping definition `Name.pprDefinedAt' *)
-
-Definition nameUnique : Name -> Unique.Unique :=
-  fun name => n_uniq name.
-
-Definition nameSrcSpan : Name -> SrcLoc.SrcSpan :=
-  fun name => n_loc name.
-
-Definition nameSrcLoc : Name -> SrcLoc.SrcLoc :=
-  fun name => SrcLoc.srcSpanStart (n_loc name).
-
-Definition nameSortStableString : NameSort -> GHC.Base.String :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | System => GHC.Base.hs_string__ "$_sys"
-    | Internal => GHC.Base.hs_string__ "$_in"
-    | External mod_ => Module.moduleStableString mod_
-    | WiredIn mod_ _ _ => Module.moduleStableString mod_
-    end.
-
-Definition nameStableString : Name -> GHC.Base.String :=
-  fun '(Mk_Name n_sort n_occ n_uniq n_loc) =>
-    Coq.Init.Datatypes.app (nameSortStableString n_sort) (Coq.Init.Datatypes.app
-                            (GHC.Base.hs_string__ "$") (OccName.occNameString n_occ)).
-
-Definition nameOccName : Name -> OccName.OccName :=
-  fun name => n_occ name.
-
-Definition nameModule_maybe : Name -> option Module.Module :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Mk_Name (External mod_) _ _ _ => Some mod_
-    | Mk_Name (WiredIn mod_ _ _) _ _ _ => Some mod_
-    | _ => None
-    end.
-
-Definition nameModule : Name -> Module.Module :=
-  fun nm => Maybes.orElse (nameModule_maybe nm) (Panic.panic default).
-
-Definition nameIsLocalOrFrom : Module.Module -> Name -> bool :=
-  fun from name =>
-    match nameModule_maybe name with
-    | Some mod_ => orb (from GHC.Base.== mod_) (Module.isInteractiveModule mod_)
-    | _ => true
-    end.
-
-Definition nameIsHomePackageImport : Module.Module -> Name -> bool :=
-  fun this_mod =>
-    let this_pkg := Module.moduleUnitId this_mod in
-    fun nm =>
-      match nameModule_maybe nm with
-      | None => false
-      | Some nm_mod =>
-          andb (nm_mod GHC.Base./= this_mod) (Module.moduleUnitId nm_mod GHC.Base.==
-                this_pkg)
-      end.
-
-Definition nameIsHomePackage : Module.Module -> Name -> bool :=
-  fun this_mod =>
-    let this_pkg := Module.moduleUnitId this_mod in
-    fun nm =>
-      match n_sort nm with
-      | External nm_mod => Module.moduleUnitId nm_mod GHC.Base.== this_pkg
-      | WiredIn nm_mod _ _ => Module.moduleUnitId nm_mod GHC.Base.== this_pkg
-      | Internal => true
-      | System => false
-      end.
-
-Definition nameIsFromExternalPackage : Module.UnitId -> Name -> bool :=
-  fun this_pkg name =>
-    match nameModule_maybe name with
-    | Some mod_ =>
-        if andb (Module.moduleUnitId mod_ GHC.Base./= this_pkg) (negb
-                 (Module.isInteractiveModule mod_)) : bool
-        then true else
-        false
-    | _ => false
-    end.
-
-(* Skipping definition `Name.mkWiredInName' *)
-
-Definition mkSystemNameAt
-   : Unique.Unique -> OccName.OccName -> SrcLoc.SrcSpan -> Name :=
-  fun uniq occ loc => Mk_Name System occ uniq loc.
-
-Definition mkSystemName : Unique.Unique -> OccName.OccName -> Name :=
-  fun uniq occ => mkSystemNameAt uniq occ SrcLoc.noSrcSpan.
-
-Definition mkSystemVarName : Unique.Unique -> FastString.FastString -> Name :=
-  fun uniq fs => mkSystemName uniq (OccName.mkVarOccFS fs).
-
-Definition mkSysTvName : Unique.Unique -> FastString.FastString -> Name :=
-  fun uniq fs => mkSystemName uniq (OccName.mkTyVarOccFS fs).
-
-Definition mkLocalisedOccName
-   : Module.Module ->
-     (option GHC.Base.String -> OccName.OccName -> OccName.OccName) ->
-     Name -> OccName.OccName :=
-  fun this_mod mk_occ name =>
-    let origin :=
-      if nameIsLocalOrFrom this_mod name : bool then None else
-      Some ((Module.moduleNameColons GHC.Base.∘
-             (Module.moduleName GHC.Base.∘ nameModule)) name) in
-    mk_occ origin (nameOccName name).
-
-Definition mkInternalName
-   : Unique.Unique -> OccName.OccName -> SrcLoc.SrcSpan -> Name :=
-  fun uniq occ loc => Mk_Name Internal occ uniq loc.
-
-Definition mkFCallName : Unique.Unique -> GHC.Base.String -> Name :=
-  fun uniq str => mkInternalName uniq (OccName.mkVarOcc str) SrcLoc.noSrcSpan.
-
-Definition mkExternalName
-   : Unique.Unique ->
-     Module.Module -> OccName.OccName -> SrcLoc.SrcSpan -> Name :=
-  fun uniq mod_ occ loc => Mk_Name (External mod_) occ uniq loc.
-
-Definition mkDerivedInternalName
-   : (OccName.OccName -> OccName.OccName) -> Unique.Unique -> Name -> Name :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | derive_occ, uniq, Mk_Name _ occ _ loc =>
-        Mk_Name Internal (derive_occ occ) uniq loc
-    end.
-
-Definition mkClonedInternalName : Unique.Unique -> Name -> Name :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | uniq, Mk_Name _ occ _ loc => Mk_Name Internal occ uniq loc
-    end.
-
-Definition localiseName : Name -> Name :=
-  fun '(Mk_Name n_sort_0__ n_occ_1__ n_uniq_2__ n_loc_3__) =>
-    Mk_Name Internal n_occ_1__ n_uniq_2__ n_loc_3__.
-
-Definition isWiredInName : Name -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Mk_Name (WiredIn _ _ _) _ _ _ => true
-    | _ => false
-    end.
-
-Definition isVarName : Name -> bool :=
-  OccName.isVarOcc GHC.Base.∘ nameOccName.
-
-Definition isValName : Name -> bool :=
-  fun name => OccName.isValOcc (nameOccName name).
-
-Definition isTyVarName : Name -> bool :=
-  fun name => OccName.isTvOcc (nameOccName name).
-
-Definition isTyConName : Name -> bool :=
-  fun name => OccName.isTcOcc (nameOccName name).
-
-Definition isSystemName : Name -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Mk_Name System _ _ _ => true
-    | _ => false
-    end.
-
-(* Skipping definition `Name.isHoleName' *)
-
-Definition isExternalName : Name -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Mk_Name (External _) _ _ _ => true
-    | Mk_Name (WiredIn _ _ _) _ _ _ => true
-    | _ => false
-    end.
-
-Definition isInternalName : Name -> bool :=
-  fun name => negb (isExternalName name).
-
-Definition isDataConName : Name -> bool :=
-  fun name => OccName.isDataOcc (nameOccName name).
-
-Definition isBuiltInSyntax : Name -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Mk_Name (WiredIn _ _ Mk_BuiltInSyntax) _ _ _ => true
-    | _ => false
-    end.
-
-Definition getSrcSpan {a} `{NamedThing a} : a -> SrcLoc.SrcSpan :=
-  nameSrcSpan GHC.Base.∘ getName.
-
-Definition getSrcLoc {a} `{NamedThing a} : a -> SrcLoc.SrcLoc :=
-  nameSrcLoc GHC.Base.∘ getName.
-
-Definition getOccString {a} `{NamedThing a} : a -> GHC.Base.String :=
-  OccName.occNameString GHC.Base.∘ getOccName.
-
-Definition getOccFS {a} `{NamedThing a} : a -> FastString.FastString :=
-  OccName.occNameFS GHC.Base.∘ getOccName.
-
-Definition cmpName : Name -> Name -> comparison :=
-  fun n1 n2 => Unique.nonDetCmpUnique (n_uniq n1) (n_uniq n2).
+(* Skipping all instances of class `Control.DeepSeq.NFData', including
+   `Name.NFData__Name' *)
 
 (* Skipping all instances of class `Control.DeepSeq.NFData', including
    `Name.NFData__NameSort' *)
 
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Name.Outputable__NameSort' *)
+Definition nameOccName : Name -> OccName.OccName :=
+  fun name => n_occ name.
 
-(* Skipping all instances of class `Outputable.OutputableBndr', including
-   `Name.OutputableBndr__Name' *)
+Local Definition HasOccName__Name_occName : Name -> OccName.OccName :=
+  nameOccName.
 
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Name.Outputable__Name' *)
+Program Instance HasOccName__Name : OccName.HasOccName Name :=
+  fun _ k__ => k__ {| OccName.occName__ := HasOccName__Name_occName |}.
 
-(* Skipping all instances of class `Binary.Binary', including
-   `Name.Binary__Name' *)
+Definition cmpName : Name -> Name -> comparison :=
+  fun n1 n2 => Unique.nonDetCmpUnique (n_uniq n1) (n_uniq n2).
 
-(* Skipping all instances of class `Data.Data.Data', including
-   `Name.Data__Name' *)
+Local Definition Eq___Name_op_zeze__ : Name -> Name -> bool :=
+  fun a b => match cmpName a b with | Eq => true | _ => false end.
 
-Local Definition Uniquable__Name_getUnique : Name -> Unique.Unique :=
-  nameUnique.
+Local Definition Eq___Name_op_zsze__ : Name -> Name -> bool :=
+  fun a b => match cmpName a b with | Eq => false | _ => true end.
 
-Program Instance Uniquable__Name : Unique.Uniquable Name :=
-  fun _ k__ => k__ {| Unique.getUnique__ := Uniquable__Name_getUnique |}.
+Program Instance Eq___Name : GHC.Base.Eq_ Name :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___Name_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___Name_op_zsze__ |}.
 
 Local Definition Ord__Name_compare : Name -> Name -> comparison :=
   fun a b => cmpName a b.
@@ -423,17 +163,6 @@ Local Definition Ord__Name_max : Name -> Name -> Name :=
 Local Definition Ord__Name_min : Name -> Name -> Name :=
   fun x y => if Ord__Name_op_zlze__ x y : bool then x else y.
 
-Local Definition Eq___Name_op_zeze__ : Name -> Name -> bool :=
-  fun a b => match cmpName a b with | Eq => true | _ => false end.
-
-Local Definition Eq___Name_op_zsze__ : Name -> Name -> bool :=
-  fun a b => match cmpName a b with | Eq => false | _ => true end.
-
-Program Instance Eq___Name : GHC.Base.Eq_ Name :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___Name_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___Name_op_zsze__ |}.
-
 Program Instance Ord__Name : GHC.Base.Ord Name :=
   fun _ k__ =>
     k__ {| GHC.Base.op_zl____ := Ord__Name_op_zl__ ;
@@ -444,14 +173,37 @@ Program Instance Ord__Name : GHC.Base.Ord Name :=
            GHC.Base.max__ := Ord__Name_max ;
            GHC.Base.min__ := Ord__Name_min |}.
 
-Local Definition HasOccName__Name_occName : Name -> OccName.OccName :=
-  nameOccName.
+Definition nameUnique : Name -> Unique.Unique :=
+  fun name => n_uniq name.
 
-Program Instance HasOccName__Name : OccName.HasOccName Name :=
-  fun _ k__ => k__ {| OccName.occName__ := HasOccName__Name_occName |}.
+Local Definition Uniquable__Name_getUnique : Name -> Unique.Unique :=
+  nameUnique.
 
-(* Skipping all instances of class `Control.DeepSeq.NFData', including
-   `Name.NFData__Name' *)
+Program Instance Uniquable__Name : Unique.Uniquable Name :=
+  fun _ k__ => k__ {| Unique.getUnique__ := Uniquable__Name_getUnique |}.
+
+Local Definition NamedThing__Name_getName : Name -> Name :=
+  fun n => n.
+
+Local Definition NamedThing__Name_getOccName : Name -> OccName.OccName :=
+  fun n => nameOccName (NamedThing__Name_getName n).
+
+Program Instance NamedThing__Name : NamedThing Name :=
+  fun _ k__ =>
+    k__ {| getName__ := NamedThing__Name_getName ;
+           getOccName__ := NamedThing__Name_getOccName |}.
+
+(* Skipping all instances of class `Data.Data.Data', including
+   `Name.Data__Name' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `Name.Binary__Name' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Name.Outputable__Name' *)
+
+(* Skipping all instances of class `Outputable.OutputableBndr', including
+   `Name.OutputableBndr__Name' *)
 
 Local Definition NamedThing__GenLocated_getName {inst_e} {inst_l} `{NamedThing
   inst_e}
@@ -469,16 +221,264 @@ Program Instance NamedThing__GenLocated {e} {l} `{NamedThing e}
     k__ {| getName__ := NamedThing__GenLocated_getName ;
            getOccName__ := NamedThing__GenLocated_getOccName |}.
 
-Local Definition NamedThing__Name_getName : Name -> Name :=
-  fun n => n.
+Definition nameSrcLoc : Name -> SrcLoc.SrcLoc :=
+  fun name => SrcLoc.srcSpanStart (n_loc name).
 
-Local Definition NamedThing__Name_getOccName : Name -> OccName.OccName :=
-  fun n => nameOccName (NamedThing__Name_getName n).
+Definition nameSrcSpan : Name -> SrcLoc.SrcSpan :=
+  fun name => n_loc name.
 
-Program Instance NamedThing__Name : NamedThing Name :=
-  fun _ k__ =>
-    k__ {| getName__ := NamedThing__Name_getName ;
-           getOccName__ := NamedThing__Name_getOccName |}.
+Definition isWiredInName : Name -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Mk_Name (WiredIn _ _ _) _ _ _ => true
+    | _ => false
+    end.
+
+(* Skipping definition `Name.wiredInNameTyThing_maybe' *)
+
+Definition isBuiltInSyntax : Name -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Mk_Name (WiredIn _ _ Mk_BuiltInSyntax) _ _ _ => true
+    | _ => false
+    end.
+
+Definition isExternalName : Name -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Mk_Name (External _) _ _ _ => true
+    | Mk_Name (WiredIn _ _ _) _ _ _ => true
+    | _ => false
+    end.
+
+Definition isInternalName : Name -> bool :=
+  fun name => negb (isExternalName name).
+
+(* Skipping definition `Name.isHoleName' *)
+
+Definition nameModule_maybe : Name -> option Module.Module :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Mk_Name (External mod_) _ _ _ => Some mod_
+    | Mk_Name (WiredIn mod_ _ _) _ _ _ => Some mod_
+    | _ => None
+    end.
+
+Definition nameModule : Name -> Module.Module :=
+  fun nm => Maybes.orElse (nameModule_maybe nm) (Panic.panic default).
+
+Definition nameIsLocalOrFrom : Module.Module -> Name -> bool :=
+  fun from name =>
+    match nameModule_maybe name with
+    | Some mod_ => orb (from GHC.Base.== mod_) (Module.isInteractiveModule mod_)
+    | _ => true
+    end.
+
+Definition nameIsHomePackage : Module.Module -> Name -> bool :=
+  fun this_mod =>
+    let this_pkg := Module.moduleUnitId this_mod in
+    fun nm =>
+      match n_sort nm with
+      | External nm_mod => Module.moduleUnitId nm_mod GHC.Base.== this_pkg
+      | WiredIn nm_mod _ _ => Module.moduleUnitId nm_mod GHC.Base.== this_pkg
+      | Internal => true
+      | System => false
+      end.
+
+Definition nameIsHomePackageImport : Module.Module -> Name -> bool :=
+  fun this_mod =>
+    let this_pkg := Module.moduleUnitId this_mod in
+    fun nm =>
+      match nameModule_maybe nm with
+      | None => false
+      | Some nm_mod =>
+          andb (nm_mod GHC.Base./= this_mod) (Module.moduleUnitId nm_mod GHC.Base.==
+                this_pkg)
+      end.
+
+Definition nameIsFromExternalPackage : Module.UnitId -> Name -> bool :=
+  fun this_pkg name =>
+    match nameModule_maybe name with
+    | Some mod_ =>
+        if andb (Module.moduleUnitId mod_ GHC.Base./= this_pkg) (negb
+                 (Module.isInteractiveModule mod_)) : bool
+        then true else
+        false
+    | _ => false
+    end.
+
+Definition isTyVarName : Name -> bool :=
+  fun name => OccName.isTvOcc (nameOccName name).
+
+Definition isTyConName : Name -> bool :=
+  fun name => OccName.isTcOcc (nameOccName name).
+
+Definition isDataConName : Name -> bool :=
+  fun name => OccName.isDataOcc (nameOccName name).
+
+Definition isValName : Name -> bool :=
+  fun name => OccName.isValOcc (nameOccName name).
+
+Definition isVarName : Name -> bool :=
+  OccName.isVarOcc GHC.Base.∘ nameOccName.
+
+Definition isSystemName : Name -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Mk_Name System _ _ _ => true
+    | _ => false
+    end.
+
+Definition mkInternalName
+   : Unique.Unique -> OccName.OccName -> SrcLoc.SrcSpan -> Name :=
+  fun uniq occ loc => Mk_Name Internal occ uniq loc.
+
+Definition mkClonedInternalName : Unique.Unique -> Name -> Name :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | uniq, Mk_Name _ occ _ loc => Mk_Name Internal occ uniq loc
+    end.
+
+Definition mkDerivedInternalName
+   : (OccName.OccName -> OccName.OccName) -> Unique.Unique -> Name -> Name :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | derive_occ, uniq, Mk_Name _ occ _ loc =>
+        Mk_Name Internal (derive_occ occ) uniq loc
+    end.
+
+Definition mkExternalName
+   : Unique.Unique ->
+     Module.Module -> OccName.OccName -> SrcLoc.SrcSpan -> Name :=
+  fun uniq mod_ occ loc => Mk_Name (External mod_) occ uniq loc.
+
+(* Skipping definition `Name.mkWiredInName' *)
+
+Definition mkSystemNameAt
+   : Unique.Unique -> OccName.OccName -> SrcLoc.SrcSpan -> Name :=
+  fun uniq occ loc => Mk_Name System occ uniq loc.
+
+Definition mkSystemName : Unique.Unique -> OccName.OccName -> Name :=
+  fun uniq occ => mkSystemNameAt uniq occ SrcLoc.noSrcSpan.
+
+Definition mkSystemVarName : Unique.Unique -> FastString.FastString -> Name :=
+  fun uniq fs => mkSystemName uniq (OccName.mkVarOccFS fs).
+
+Definition mkSysTvName : Unique.Unique -> FastString.FastString -> Name :=
+  fun uniq fs => mkSystemName uniq (OccName.mkTyVarOccFS fs).
+
+Definition mkFCallName : Unique.Unique -> GHC.Base.String -> Name :=
+  fun uniq str => mkInternalName uniq (OccName.mkVarOcc str) SrcLoc.noSrcSpan.
+
+Definition setNameUnique : Name -> Unique.Unique -> Name :=
+  fun name uniq =>
+    let 'Mk_Name n_sort_0__ n_occ_1__ n_uniq_2__ n_loc_3__ := name in
+    Mk_Name n_sort_0__ n_occ_1__ uniq n_loc_3__.
+
+Definition setNameLoc : Name -> SrcLoc.SrcSpan -> Name :=
+  fun name loc =>
+    let 'Mk_Name n_sort_0__ n_occ_1__ n_uniq_2__ n_loc_3__ := name in
+    Mk_Name n_sort_0__ n_occ_1__ n_uniq_2__ loc.
+
+Definition tidyNameOcc : Name -> OccName.OccName -> Name :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | (Mk_Name System _ _ _ as name), occ =>
+        let 'Mk_Name n_sort_2__ n_occ_3__ n_uniq_4__ n_loc_5__ := name in
+        Mk_Name Internal occ n_uniq_4__ n_loc_5__
+    | name, occ =>
+        let 'Mk_Name n_sort_9__ n_occ_10__ n_uniq_11__ n_loc_12__ := name in
+        Mk_Name n_sort_9__ occ n_uniq_11__ n_loc_12__
+    end.
+
+Definition localiseName : Name -> Name :=
+  fun '(Mk_Name n_sort_0__ n_occ_1__ n_uniq_2__ n_loc_3__) =>
+    Mk_Name Internal n_occ_1__ n_uniq_2__ n_loc_3__.
+
+Definition mkLocalisedOccName
+   : Module.Module ->
+     (option GHC.Base.String -> OccName.OccName -> OccName.OccName) ->
+     Name -> OccName.OccName :=
+  fun this_mod mk_occ name =>
+    let origin :=
+      if nameIsLocalOrFrom this_mod name : bool then None else
+      Some ((Module.moduleNameColons GHC.Base.∘
+             (Module.moduleName GHC.Base.∘ nameModule)) name) in
+    mk_occ origin (nameOccName name).
+
+Definition stableNameCmp : Name -> Name -> comparison :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_Name s1 occ1 _ _, Mk_Name s2 occ2 _ _ =>
+        let sort_cmp :=
+          fun arg_2__ arg_3__ =>
+            match arg_2__, arg_3__ with
+            | External m1, External m2 => Module.stableModuleCmp m1 m2
+            | External _, _ => Lt
+            | WiredIn _ _ _, External _ => Gt
+            | WiredIn m1 _ _, WiredIn m2 _ _ => Module.stableModuleCmp m1 m2
+            | WiredIn _ _ _, _ => Lt
+            | Internal, External _ => Gt
+            | Internal, WiredIn _ _ _ => Gt
+            | Internal, Internal => Eq
+            | Internal, System => Lt
+            | System, System => Eq
+            | System, _ => Gt
+            end in
+        Util.thenCmp (sort_cmp s1 s2) (GHC.Base.compare occ1 occ2)
+    end.
+
+(* Skipping definition `Name.pprName' *)
+
+(* Skipping definition `Name.pprExternal' *)
+
+(* Skipping definition `Name.pprInternal' *)
+
+(* Skipping definition `Name.pprSystem' *)
+
+(* Skipping definition `Name.pprModulePrefix' *)
+
+(* Skipping definition `Name.pprUnique' *)
+
+(* Skipping definition `Name.ppr_underscore_unique' *)
+
+(* Skipping definition `Name.ppr_occ_name' *)
+
+(* Skipping definition `Name.ppr_z_occ_name' *)
+
+(* Skipping definition `Name.pprDefinedAt' *)
+
+(* Skipping definition `Name.pprNameDefnLoc' *)
+
+Definition nameSortStableString : NameSort -> GHC.Base.String :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | System => GHC.Base.hs_string__ "$_sys"
+    | Internal => GHC.Base.hs_string__ "$_in"
+    | External mod_ => Module.moduleStableString mod_
+    | WiredIn mod_ _ _ => Module.moduleStableString mod_
+    end.
+
+Definition nameStableString : Name -> GHC.Base.String :=
+  fun '(Mk_Name n_sort n_occ n_uniq n_loc) =>
+    Coq.Init.Datatypes.app (nameSortStableString n_sort) (Coq.Init.Datatypes.app
+                            (GHC.Base.hs_string__ "$") (OccName.occNameString n_occ)).
+
+Definition getSrcLoc {a} `{NamedThing a} : a -> SrcLoc.SrcLoc :=
+  nameSrcLoc GHC.Base.∘ getName.
+
+Definition getSrcSpan {a} `{NamedThing a} : a -> SrcLoc.SrcSpan :=
+  nameSrcSpan GHC.Base.∘ getName.
+
+Definition getOccString {a} `{NamedThing a} : a -> GHC.Base.String :=
+  OccName.occNameString GHC.Base.∘ getOccName.
+
+Definition getOccFS {a} `{NamedThing a} : a -> FastString.FastString :=
+  OccName.occNameFS GHC.Base.∘ getOccName.
+
+(* Skipping definition `Name.pprInfixName' *)
+
+(* Skipping definition `Name.pprPrefixName' *)
 
 (* External variables:
      Eq Gt Lt None Some andb bool comparison default false negb option orb true

--- a/examples/ghc/lib/NameEnv.v
+++ b/examples/ghc/lib/NameEnv.v
@@ -27,46 +27,54 @@ Definition DNameEnv :=
 
 (* Converted value declarations: *)
 
+(* Skipping definition `NameEnv.depAnal' *)
+
+Definition nameEnvElts {a} : NameEnv a -> list a :=
+  fun x => UniqFM.eltsUFM x.
+
+Definition emptyNameEnv {a} : NameEnv a :=
+  UniqFM.emptyUFM.
+
+Definition isEmptyNameEnv {a} : NameEnv a -> bool :=
+  UniqFM.isNullUFM.
+
 Definition unitNameEnv {a} : Name.Name -> a -> NameEnv a :=
   fun x y => UniqFM.unitUFM x y.
+
+Definition extendNameEnv {a} : NameEnv a -> Name.Name -> a -> NameEnv a :=
+  fun x y z => UniqFM.addToUFM x y z.
+
+Definition extendNameEnvList {a}
+   : NameEnv a -> list (Name.Name * a)%type -> NameEnv a :=
+  fun x l => UniqFM.addListToUFM x l.
+
+Definition lookupNameEnv {a} : NameEnv a -> Name.Name -> option a :=
+  fun x y => UniqFM.lookupUFM x y.
+
+Definition alterNameEnv {a}
+   : (option a -> option a) -> NameEnv a -> Name.Name -> NameEnv a :=
+  UniqFM.alterUFM.
+
+Definition mkNameEnv {a} : list (Name.Name * a)%type -> NameEnv a :=
+  fun l => UniqFM.listToUFM l.
+
+Definition elemNameEnv {a} : Name.Name -> NameEnv a -> bool :=
+  fun x y => UniqFM.elemUFM x y.
+
+Definition plusNameEnv {a} : NameEnv a -> NameEnv a -> NameEnv a :=
+  fun x y => UniqFM.plusUFM x y.
 
 Definition plusNameEnv_C {a}
    : (a -> a -> a) -> NameEnv a -> NameEnv a -> NameEnv a :=
   fun f x y => UniqFM.plusUFM_C f x y.
 
-Definition plusNameEnv {a} : NameEnv a -> NameEnv a -> NameEnv a :=
-  fun x y => UniqFM.plusUFM x y.
-
-Definition nameEnvElts {a} : NameEnv a -> list a :=
-  fun x => UniqFM.eltsUFM x.
-
-Definition mkNameEnv {a} : list (Name.Name * a)%type -> NameEnv a :=
-  fun l => UniqFM.listToUFM l.
+Definition extendNameEnv_C {a}
+   : (a -> a -> a) -> NameEnv a -> Name.Name -> a -> NameEnv a :=
+  fun f x y z => UniqFM.addToUFM_C f x y z.
 
 Definition mapNameEnv {elt1} {elt2}
    : (elt1 -> elt2) -> NameEnv elt1 -> NameEnv elt2 :=
   fun f x => UniqFM.mapUFM f x.
-
-Definition mapDNameEnv {a} {b} : (a -> b) -> DNameEnv a -> DNameEnv b :=
-  UniqFM.mapUFM.
-
-(* Skipping definition `NameEnv.lookupNameEnv_NF' *)
-
-Definition lookupNameEnv {a} : NameEnv a -> Name.Name -> option a :=
-  fun x y => UniqFM.lookupUFM x y.
-
-Definition lookupDNameEnv {a} : DNameEnv a -> Name.Name -> option a :=
-  UniqFM.lookupUFM.
-
-Definition isEmptyNameEnv {a} : NameEnv a -> bool :=
-  UniqFM.isNullUFM.
-
-Definition filterNameEnv {elt} : (elt -> bool) -> NameEnv elt -> NameEnv elt :=
-  fun x y => UniqFM.filterUFM x y.
-
-Definition extendNameEnv_C {a}
-   : (a -> a -> a) -> NameEnv a -> Name.Name -> a -> NameEnv a :=
-  fun f x y z => UniqFM.addToUFM_C f x y z.
 
 Definition extendNameEnv_Acc {a} {b}
    : (a -> b -> b) -> (a -> b) -> NameEnv b -> Name.Name -> a -> NameEnv b :=
@@ -76,39 +84,31 @@ Definition extendNameEnvList_C {a}
    : (a -> a -> a) -> NameEnv a -> list (Name.Name * a)%type -> NameEnv a :=
   fun x y z => UniqFM.addListToUFM_C x y z.
 
-Definition extendNameEnvList {a}
-   : NameEnv a -> list (Name.Name * a)%type -> NameEnv a :=
-  fun x l => UniqFM.addListToUFM x l.
-
-Definition extendNameEnv {a} : NameEnv a -> Name.Name -> a -> NameEnv a :=
-  fun x y z => UniqFM.addToUFM x y z.
-
-Definition emptyNameEnv {a} : NameEnv a :=
-  UniqFM.emptyUFM.
-
-Definition emptyDNameEnv {a} : DNameEnv a :=
-  UniqFM.emptyUFM.
-
-Definition elemNameEnv {a} : Name.Name -> NameEnv a -> bool :=
-  fun x y => UniqFM.elemUFM x y.
-
-Definition disjointNameEnv {a} : NameEnv a -> NameEnv a -> bool :=
-  fun x y => UniqFM.isNullUFM (UniqFM.intersectUFM x y).
-
-(* Skipping definition `NameEnv.depAnal' *)
+Definition delFromNameEnv {a} : NameEnv a -> Name.Name -> NameEnv a :=
+  fun x y => UniqFM.delFromUFM x y.
 
 Definition delListFromNameEnv {a} : NameEnv a -> list Name.Name -> NameEnv a :=
   fun x y => UniqFM.delListFromUFM x y.
 
-Definition delFromNameEnv {a} : NameEnv a -> Name.Name -> NameEnv a :=
-  fun x y => UniqFM.delFromUFM x y.
+Definition filterNameEnv {elt} : (elt -> bool) -> NameEnv elt -> NameEnv elt :=
+  fun x y => UniqFM.filterUFM x y.
 
 Definition anyNameEnv {elt} : (elt -> bool) -> NameEnv elt -> bool :=
   fun f x => UniqFM.foldUFM (orb GHC.Base.∘ f) false x.
 
-Definition alterNameEnv {a}
-   : (option a -> option a) -> NameEnv a -> Name.Name -> NameEnv a :=
-  UniqFM.alterUFM.
+Definition disjointNameEnv {a} : NameEnv a -> NameEnv a -> bool :=
+  fun x y => UniqFM.isNullUFM (UniqFM.intersectUFM x y).
+
+(* Skipping definition `NameEnv.lookupNameEnv_NF' *)
+
+Definition emptyDNameEnv {a} : DNameEnv a :=
+  UniqFM.emptyUFM.
+
+Definition lookupDNameEnv {a} : DNameEnv a -> Name.Name -> option a :=
+  UniqFM.lookupUFM.
+
+Definition mapDNameEnv {a} {b} : (a -> b) -> DNameEnv a -> DNameEnv b :=
+  UniqFM.mapUFM.
 
 Definition alterDNameEnv {a}
    : (option a -> option a) -> DNameEnv a -> Name.Name -> DNameEnv a :=

--- a/examples/ghc/lib/OccName.v
+++ b/examples/ghc/lib/OccName.v
@@ -77,95 +77,6 @@ Instance Default__OccName : Default OccName :=
 
 (* Converted value declarations: *)
 
-Definition varName : NameSpace :=
-  VarName.
-
-Local Definition Uniquable__OccName_getUnique : OccName -> Unique.Unique :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Mk_OccName VarName fs => Unique.mkVarOccUnique fs
-    | Mk_OccName DataName fs => Unique.mkDataOccUnique fs
-    | Mk_OccName TvName fs => Unique.mkTvOccUnique fs
-    | Mk_OccName TcClsName fs => Unique.mkTcOccUnique fs
-    end.
-
-Program Instance Uniquable__OccName : Unique.Uniquable OccName :=
-  fun _ k__ => k__ {| Unique.getUnique__ := Uniquable__OccName_getUnique |}.
-
-Definition unitOccSet : OccName -> OccSet :=
-  UniqSet.unitUniqSet.
-
-Definition unitOccEnv {a} : OccName -> a -> OccEnv a :=
-  fun x y => A (UniqFM.unitUFM x y).
-
-Definition unionOccSets : OccSet -> OccSet -> OccSet :=
-  UniqSet.unionUniqSets.
-
-Definition unionManyOccSets : list OccSet -> OccSet :=
-  UniqSet.unionManyUniqSets.
-
-Definition tvName : NameSpace :=
-  TvName.
-
-Axiom tidyOccName : TidyOccEnv -> OccName -> (TidyOccEnv * OccName)%type.
-
-Definition tcName : NameSpace :=
-  TcClsName.
-
-Definition tcClsName : NameSpace :=
-  TcClsName.
-
-Axiom startsWithUnderscore : OccName -> bool.
-
-Definition srcDataName : NameSpace :=
-  DataName.
-
-Definition setOccNameSpace : NameSpace -> OccName -> OccName :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | sp, Mk_OccName _ occ => Mk_OccName sp occ
-    end.
-
-(* Skipping definition `OccName.pprOccName' *)
-
-(* Skipping definition `OccName.pprOccEnv' *)
-
-(* Skipping definition `OccName.pprNonVarNameSpace' *)
-
-(* Skipping definition `OccName.pprNameSpaceBrief' *)
-
-(* Skipping definition `OccName.pprNameSpace' *)
-
-Definition plusOccEnv_C {a}
-   : (a -> a -> a) -> OccEnv a -> OccEnv a -> OccEnv a :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | f, A x, A y => A (UniqFM.plusUFM_C f x y)
-    end.
-
-Definition plusOccEnv {a} : OccEnv a -> OccEnv a -> OccEnv a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | A x, A y => A (UniqFM.plusUFM x y)
-    end.
-
-(* Skipping definition `OccName.parenSymOcc' *)
-
-Definition otherNameSpace : NameSpace -> NameSpace :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | VarName => DataName
-    | DataName => VarName
-    | TvName => TcClsName
-    | TcClsName => TvName
-    end.
-
-Definition occNameString : OccName -> GHC.Base.String :=
-  fun '(Mk_OccName _ s) => FastString.unpackFS s.
-
-Definition occEnvElts {a} : OccEnv a -> list a :=
-  fun '(A x) => UniqFM.eltsUFM x.
-
 Local Definition Eq___NameSpace_op_zeze__ : NameSpace -> NameSpace -> bool :=
   fun arg_0__ arg_1__ =>
     match arg_0__, arg_1__ with
@@ -183,438 +94,6 @@ Program Instance Eq___NameSpace : GHC.Base.Eq_ NameSpace :=
   fun _ k__ =>
     k__ {| GHC.Base.op_zeze____ := Eq___NameSpace_op_zeze__ ;
            GHC.Base.op_zsze____ := Eq___NameSpace_op_zsze__ |}.
-
-Definition nameSpacesRelated : NameSpace -> NameSpace -> bool :=
-  fun ns1 ns2 => orb (ns1 GHC.Base.== ns2) (otherNameSpace ns1 GHC.Base.== ns2).
-
-Axiom mkSuperDictSelOcc : GHC.Num.Int -> OccName -> OccName.
-
-Axiom mkSuperDictAuxOcc : GHC.Num.Int -> OccName -> OccName.
-
-Definition mkOccSet : list OccName -> OccSet :=
-  UniqSet.mkUniqSet.
-
-Definition mkOccNameFS : NameSpace -> FastString.FastString -> OccName :=
-  fun occ_sp fs => Mk_OccName occ_sp fs.
-
-Definition mkTcOccFS : FastString.FastString -> OccName :=
-  mkOccNameFS tcName.
-
-Definition mkTyVarOccFS : FastString.FastString -> OccName :=
-  fun fs => mkOccNameFS tvName fs.
-
-Definition mkVarOccFS : FastString.FastString -> OccName :=
-  fun fs => mkOccNameFS varName fs.
-
-Definition mk_deriv
-   : NameSpace ->
-     FastString.FastString -> list FastString.FastString -> OccName :=
-  fun occ_sp sys_prefix str =>
-    mkOccNameFS occ_sp (FastString.concatFS (cons sys_prefix str)).
-
-Definition mkRecFldSelOcc : GHC.Base.String -> OccName :=
-  fun s =>
-    mk_deriv varName (GHC.Base.hs_string__ "$sel") (cons (FastString.fsLit s) nil).
-
-Definition mk_simple_deriv
-   : NameSpace -> FastString.FastString -> OccName -> OccName :=
-  fun sp px occ => mk_deriv sp px (cons (occNameFS occ) nil).
-
-Definition mkRepEqOcc : OccName -> OccName :=
-  mk_simple_deriv tvName (GHC.Base.hs_string__ "$r").
-
-Definition mkSpecOcc : OccName -> OccName :=
-  mk_simple_deriv varName (GHC.Base.hs_string__ "$s").
-
-Definition mkTag2ConOcc : OccName -> OccName :=
-  mk_simple_deriv varName (GHC.Base.hs_string__ "$tag2con_").
-
-Definition mkWorkerOcc : OccName -> OccName :=
-  mk_simple_deriv varName (GHC.Base.hs_string__ "$w").
-
-Definition mk_simple_deriv_with
-   : NameSpace ->
-     FastString.FastString -> option GHC.Base.String -> OccName -> OccName :=
-  fun arg_0__ arg_1__ arg_2__ arg_3__ =>
-    match arg_0__, arg_1__, arg_2__, arg_3__ with
-    | sp, px, None, occ => mk_deriv sp px (cons (occNameFS occ) nil)
-    | sp, px, Some with_, occ =>
-        mk_deriv sp px (cons (FastString.fsLit with_) (cons (FastString.fsLit
-                                                             (GHC.Base.hs_string__ "_")) (cons (occNameFS occ) nil)))
-    end.
-
-Definition mkPADFunOcc : option GHC.Base.String -> OccName -> OccName :=
-  mk_simple_deriv_with varName (GHC.Base.hs_string__ "$pa").
-
-Definition mkPDataTyConOcc : option GHC.Base.String -> OccName -> OccName :=
-  mk_simple_deriv_with tcName (GHC.Base.hs_string__ "VP:").
-
-Definition mkPDatasTyConOcc : option GHC.Base.String -> OccName -> OccName :=
-  mk_simple_deriv_with tcName (GHC.Base.hs_string__ "VPs:").
-
-Definition mkPReprTyConOcc : option GHC.Base.String -> OccName -> OccName :=
-  mk_simple_deriv_with tcName (GHC.Base.hs_string__ "VR:").
-
-Definition mkVectIsoOcc : option GHC.Base.String -> OccName -> OccName :=
-  mk_simple_deriv_with varName (GHC.Base.hs_string__ "$vi").
-
-Definition mkVectOcc : option GHC.Base.String -> OccName -> OccName :=
-  mk_simple_deriv_with varName (GHC.Base.hs_string__ "$v").
-
-Definition mkVectTyConOcc : option GHC.Base.String -> OccName -> OccName :=
-  mk_simple_deriv_with tcName (GHC.Base.hs_string__ "V:").
-
-Definition mkOccName : NameSpace -> GHC.Base.String -> OccName :=
-  fun occ_sp str => Mk_OccName occ_sp (FastString.mkFastString str).
-
-Definition mkTcOcc : GHC.Base.String -> OccName :=
-  mkOccName tcName.
-
-Definition mkTyVarOcc : GHC.Base.String -> OccName :=
-  mkOccName tvName.
-
-Definition mkVarOcc : GHC.Base.String -> OccName :=
-  fun s => mkOccName varName s.
-
-Definition mkOccEnv_C {a}
-   : (a -> a -> a) -> list (OccName * a)%type -> OccEnv a :=
-  fun comb l => A (UniqFM.addListToUFM_C comb UniqFM.emptyUFM l).
-
-Definition mkOccEnv {a} : list (OccName * a)%type -> OccEnv a :=
-  fun l => A (UniqFM.listToUFM l).
-
-Definition mkNewTyCoOcc : OccName -> OccName :=
-  mk_simple_deriv tcName (GHC.Base.hs_string__ "N:").
-
-Definition mkMethodOcc : OccName -> OccName :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | (Mk_OccName VarName _ as occ) => occ
-    | occ => mk_simple_deriv varName (GHC.Base.hs_string__ "$m") occ
-    end.
-
-Definition mkMaxTagOcc : OccName -> OccName :=
-  mk_simple_deriv varName (GHC.Base.hs_string__ "$maxtag_").
-
-Definition mkMatcherOcc : OccName -> OccName :=
-  mk_simple_deriv varName (GHC.Base.hs_string__ "$m").
-
-Axiom mkLocalOcc : Unique.Unique -> OccName -> OccName.
-
-Definition mkInstTyCoOcc : OccName -> OccName :=
-  mk_simple_deriv tcName (GHC.Base.hs_string__ "D:").
-
-Definition mkIPOcc : OccName -> OccName :=
-  mk_simple_deriv varName (GHC.Base.hs_string__ "$i").
-
-Definition mkGenR : OccName -> OccName :=
-  mk_simple_deriv tcName (GHC.Base.hs_string__ "Rep_").
-
-Definition mkGen1R : OccName -> OccName :=
-  mk_simple_deriv tcName (GHC.Base.hs_string__ "Rep1_").
-
-Definition mkForeignExportOcc : OccName -> OccName :=
-  mk_simple_deriv varName (GHC.Base.hs_string__ "$f").
-
-Definition mkEqPredCoOcc : OccName -> OccName :=
-  mk_simple_deriv tcName (GHC.Base.hs_string__ "$co").
-
-Definition mkDictOcc : OccName -> OccName :=
-  mk_simple_deriv varName (GHC.Base.hs_string__ "$d").
-
-Definition mkDefaultMethodOcc : OccName -> OccName :=
-  mk_simple_deriv varName (GHC.Base.hs_string__ "$dm").
-
-Definition mkDataConWrapperOcc : OccName -> OccName :=
-  mk_simple_deriv varName (GHC.Base.hs_string__ "$W").
-
-Definition mkDataConWorkerOcc : OccName -> OccName :=
-  fun datacon_occ => setOccNameSpace varName datacon_occ.
-
-Definition mkCon2TagOcc : OccName -> OccName :=
-  mk_simple_deriv varName (GHC.Base.hs_string__ "$con2tag_").
-
-Definition mkClassOpAuxOcc : OccName -> OccName :=
-  mk_simple_deriv varName (GHC.Base.hs_string__ "$c").
-
-Definition mkBuilderOcc : OccName -> OccName :=
-  mk_simple_deriv varName (GHC.Base.hs_string__ "$b").
-
-Definition minusOccSet : OccSet -> OccSet -> OccSet :=
-  UniqSet.minusUniqSet.
-
-Definition mapOccEnv {a} {b} : (a -> b) -> OccEnv a -> OccEnv b :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, A x => A (UniqFM.mapUFM f x)
-    end.
-
-Definition lookupOccEnv {a} : OccEnv a -> OccName -> option a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | A x, y => UniqFM.lookupUFM x y
-    end.
-
-Definition isVarOcc : OccName -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Mk_OccName VarName _ => true
-    | _ => false
-    end.
-
-Definition isVarNameSpace : NameSpace -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | TvName => true
-    | VarName => true
-    | _ => false
-    end.
-
-Definition isValOcc : OccName -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Mk_OccName VarName _ => true
-    | Mk_OccName DataName _ => true
-    | _ => false
-    end.
-
-Definition isValNameSpace : NameSpace -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | DataName => true
-    | VarName => true
-    | _ => false
-    end.
-
-Axiom isTypeableBindOcc : OccName -> bool.
-
-Definition isTvOcc : OccName -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Mk_OccName TvName _ => true
-    | _ => false
-    end.
-
-Definition isTvNameSpace : NameSpace -> bool :=
-  fun arg_0__ => match arg_0__ with | TvName => true | _ => false end.
-
-Definition isTcOcc : OccName -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Mk_OccName TcClsName _ => true
-    | _ => false
-    end.
-
-Definition isTcClsNameSpace : NameSpace -> bool :=
-  fun arg_0__ => match arg_0__ with | TcClsName => true | _ => false end.
-
-Axiom isSymOcc : OccName -> bool.
-
-Definition isEmptyOccSet : OccSet -> bool :=
-  UniqSet.isEmptyUniqSet.
-
-Axiom isDerivedOccName : OccName -> bool.
-
-Axiom isDefaultMethodOcc : OccName -> bool.
-
-Axiom isDataSymOcc : OccName -> bool.
-
-Definition isDataOcc : OccName -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Mk_OccName DataName _ => true
-    | _ => false
-    end.
-
-Definition mkTyConRepOcc : OccName -> OccName :=
-  fun occ =>
-    let prefix :=
-      if isDataOcc occ : bool then GHC.Base.hs_string__ "$tc'" else
-      GHC.Base.hs_string__ "$tc" in
-    mk_simple_deriv varName prefix occ.
-
-Definition isDataConNameSpace : NameSpace -> bool :=
-  fun arg_0__ => match arg_0__ with | DataName => true | _ => false end.
-
-Definition intersectOccSet : OccSet -> OccSet -> OccSet :=
-  UniqSet.intersectUniqSets.
-
-Definition intersectsOccSet : OccSet -> OccSet -> bool :=
-  fun s1 s2 => negb (isEmptyOccSet (intersectOccSet s1 s2)).
-
-Definition initTidyOccEnv : list OccName -> TidyOccEnv :=
-  let add :=
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | env, Mk_OccName _ fs => UniqFM.addToUFM env fs #1
-      end in
-  Data.Foldable.foldl add UniqFM.emptyUFM.
-
-Definition foldOccEnv {a} {b} : (a -> b -> b) -> b -> OccEnv a -> b :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | a, b, A c => UniqFM.foldUFM a b c
-    end.
-
-Definition filterOccSet : (OccName -> bool) -> OccSet -> OccSet :=
-  UniqSet.filterUniqSet.
-
-Definition filterOccEnv {elt} : (elt -> bool) -> OccEnv elt -> OccEnv elt :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | x, A y => A (UniqFM.filterUFM x y)
-    end.
-
-Definition extendOccSetList : OccSet -> list OccName -> OccSet :=
-  UniqSet.addListToUniqSet.
-
-Definition extendOccSet : OccSet -> OccName -> OccSet :=
-  UniqSet.addOneToUniqSet.
-
-Definition extendOccEnv_C {a}
-   : (a -> a -> a) -> OccEnv a -> OccName -> a -> OccEnv a :=
-  fun arg_0__ arg_1__ arg_2__ arg_3__ =>
-    match arg_0__, arg_1__, arg_2__, arg_3__ with
-    | f, A x, y, z => A (UniqFM.addToUFM_C f x y z)
-    end.
-
-Definition extendOccEnv_Acc {a} {b}
-   : (a -> b -> b) -> (a -> b) -> OccEnv b -> OccName -> a -> OccEnv b :=
-  fun arg_0__ arg_1__ arg_2__ arg_3__ arg_4__ =>
-    match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__ with
-    | f, g, A x, y, z => A (UniqFM.addToUFM_Acc f g x y z)
-    end.
-
-Definition extendOccEnvList {a}
-   : OccEnv a -> list (OccName * a)%type -> OccEnv a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | A x, l => A (UniqFM.addListToUFM x l)
-    end.
-
-Definition extendOccEnv {a} : OccEnv a -> OccName -> a -> OccEnv a :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | A x, y, z => A (UniqFM.addToUFM x y z)
-    end.
-
-Definition emptyTidyOccEnv : TidyOccEnv :=
-  UniqFM.emptyUFM.
-
-Definition emptyOccSet : OccSet :=
-  UniqSet.emptyUniqSet.
-
-Definition emptyOccEnv {a} : OccEnv a :=
-  A UniqFM.emptyUFM.
-
-Definition elemOccSet : OccName -> OccSet -> bool :=
-  UniqSet.elementOfUniqSet.
-
-Definition elemOccEnv {a} : OccName -> OccEnv a -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | x, A y => UniqFM.elemUFM x y
-    end.
-
-Definition demoteNameSpace : NameSpace -> option NameSpace :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | VarName => None
-    | DataName => None
-    | TvName => None
-    | TcClsName => Some DataName
-    end.
-
-Definition demoteOccName : OccName -> option OccName :=
-  fun '(Mk_OccName space name) =>
-    demoteNameSpace space GHC.Base.>>=
-    (fun space' => GHC.Base.return_ (Mk_OccName space' name)).
-
-Definition delListFromOccEnv {a} : OccEnv a -> list OccName -> OccEnv a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | A x, y => A (UniqFM.delListFromUFM x y)
-    end.
-
-Definition delFromOccEnv {a} : OccEnv a -> OccName -> OccEnv a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | A x, y => A (UniqFM.delFromUFM x y)
-    end.
-
-Definition dataName : NameSpace :=
-  DataName.
-
-Definition mkClassDataConOcc : OccName -> OccName :=
-  mk_simple_deriv dataName (GHC.Base.hs_string__ "C:").
-
-Definition mkDataOcc : GHC.Base.String -> OccName :=
-  mkOccName dataName.
-
-Definition mkDataOccFS : FastString.FastString -> OccName :=
-  mkOccNameFS dataName.
-
-Definition mkPDataDataConOcc : option GHC.Base.String -> OccName -> OccName :=
-  mk_simple_deriv_with dataName (GHC.Base.hs_string__ "VPD:").
-
-Definition mkPDatasDataConOcc : option GHC.Base.String -> OccName -> OccName :=
-  mk_simple_deriv_with dataName (GHC.Base.hs_string__ "VPDs:").
-
-Definition mkVectDataConOcc : option GHC.Base.String -> OccName -> OccName :=
-  mk_simple_deriv_with dataName (GHC.Base.hs_string__ "VD:").
-
-Definition clsName : NameSpace :=
-  TcClsName.
-
-Definition mkClsOcc : GHC.Base.String -> OccName :=
-  mkOccName clsName.
-
-Definition mkClsOccFS : FastString.FastString -> OccName :=
-  mkOccNameFS clsName.
-
-Axiom chooseUniqueOcc : NameSpace -> GHC.Base.String -> OccSet -> OccName.
-
-Definition mkDFunOcc : GHC.Base.String -> bool -> OccSet -> OccName :=
-  fun info_str is_boot set =>
-    let prefix :=
-      if is_boot : bool then GHC.Base.hs_string__ "$fx" else
-      GHC.Base.hs_string__ "$f" in
-    chooseUniqueOcc VarName (Coq.Init.Datatypes.app prefix info_str) set.
-
-Definition mkDataCOcc : OccName -> OccSet -> OccName :=
-  fun occ =>
-    chooseUniqueOcc VarName (Coq.Init.Datatypes.app (GHC.Base.hs_string__ "$c")
-                                                    (occNameString occ)).
-
-Definition mkDataTOcc : OccName -> OccSet -> OccName :=
-  fun occ =>
-    chooseUniqueOcc VarName (Coq.Init.Datatypes.app (GHC.Base.hs_string__ "$t")
-                                                    (occNameString occ)).
-
-Definition mkInstTyTcOcc : GHC.Base.String -> OccSet -> OccName :=
-  fun str =>
-    chooseUniqueOcc tcName (cons (GHC.Char.hs_char__ "R") (cons (GHC.Char.hs_char__
-                                                                 ":") str)).
-
-Definition avoidClashesOccEnv : TidyOccEnv -> list OccName -> TidyOccEnv :=
-  fun env occs =>
-    let fix go arg_0__ arg_1__ arg_2__
-              := match arg_0__, arg_1__, arg_2__ with
-                 | env, _, nil => env
-                 | env, seenOnce, cons (Mk_OccName _ fs) occs =>
-                     if UniqFM.elemUFM fs env : bool then go env seenOnce occs else
-                     if UniqFM.elemUFM fs seenOnce : bool
-                     then go (UniqFM.addToUFM env fs #1) seenOnce occs else
-                     go env (UniqFM.addToUFM seenOnce fs tt) occs
-                 end in
-    go env UniqFM.emptyUFM occs.
-
-Definition alterOccEnv {elt}
-   : (option elt -> option elt) -> OccEnv elt -> OccName -> OccEnv elt :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | fn, A y, k => A (UniqFM.alterUFM fn y k)
-    end.
 
 Local Definition Ord__NameSpace_compare
    : NameSpace -> NameSpace -> comparison :=
@@ -673,24 +152,6 @@ Program Instance Ord__NameSpace : GHC.Base.Ord NameSpace :=
 (* Skipping all instances of class `Data.Data.Data', including
    `OccName.Data__OccEnv' *)
 
-(* Skipping all instances of class `Binary.Binary', including
-   `OccName.Binary__NameSpace' *)
-
-(* Skipping all instances of class `Binary.Binary', including
-   `OccName.Binary__OccName' *)
-
-(* Skipping all instances of class `Outputable.OutputableBndr', including
-   `OccName.OutputableBndr__OccName' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `OccName.Outputable__OccName' *)
-
-(* Skipping all instances of class `Control.DeepSeq.NFData', including
-   `OccName.NFData__OccName' *)
-
-(* Skipping all instances of class `Data.Data.Data', including
-   `OccName.Data__OccName' *)
-
 Local Definition Eq___OccName_op_zeze__ : OccName -> OccName -> bool :=
   fun arg_0__ arg_1__ =>
     match arg_0__, arg_1__ with
@@ -741,14 +202,553 @@ Program Instance Ord__OccName : GHC.Base.Ord OccName :=
            GHC.Base.max__ := Ord__OccName_max ;
            GHC.Base.min__ := Ord__OccName_min |}.
 
+(* Skipping all instances of class `Data.Data.Data', including
+   `OccName.Data__OccName' *)
+
 Local Definition HasOccName__OccName_occName : OccName -> OccName :=
   GHC.Base.id.
 
 Program Instance HasOccName__OccName : HasOccName OccName :=
   fun _ k__ => k__ {| occName__ := HasOccName__OccName_occName |}.
 
+(* Skipping all instances of class `Control.DeepSeq.NFData', including
+   `OccName.NFData__OccName' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `OccName.Outputable__OccName' *)
+
+(* Skipping all instances of class `Outputable.OutputableBndr', including
+   `OccName.OutputableBndr__OccName' *)
+
+Local Definition Uniquable__OccName_getUnique : OccName -> Unique.Unique :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Mk_OccName VarName fs => Unique.mkVarOccUnique fs
+    | Mk_OccName DataName fs => Unique.mkDataOccUnique fs
+    | Mk_OccName TvName fs => Unique.mkTvOccUnique fs
+    | Mk_OccName TcClsName fs => Unique.mkTcOccUnique fs
+    end.
+
+Program Instance Uniquable__OccName : Unique.Uniquable OccName :=
+  fun _ k__ => k__ {| Unique.getUnique__ := Uniquable__OccName_getUnique |}.
+
 (* Skipping all instances of class `Outputable.Outputable', including
    `OccName.Outputable__OccEnv' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `OccName.Binary__NameSpace' *)
+
+(* Skipping all instances of class `Binary.Binary', including
+   `OccName.Binary__OccName' *)
+
+Definition tcName : NameSpace :=
+  TcClsName.
+
+Definition clsName : NameSpace :=
+  TcClsName.
+
+Definition tcClsName : NameSpace :=
+  TcClsName.
+
+Definition dataName : NameSpace :=
+  DataName.
+
+Definition srcDataName : NameSpace :=
+  DataName.
+
+Definition tvName : NameSpace :=
+  TvName.
+
+Definition varName : NameSpace :=
+  VarName.
+
+Definition isDataConNameSpace : NameSpace -> bool :=
+  fun arg_0__ => match arg_0__ with | DataName => true | _ => false end.
+
+Definition isTcClsNameSpace : NameSpace -> bool :=
+  fun arg_0__ => match arg_0__ with | TcClsName => true | _ => false end.
+
+Definition isTvNameSpace : NameSpace -> bool :=
+  fun arg_0__ => match arg_0__ with | TvName => true | _ => false end.
+
+Definition isVarNameSpace : NameSpace -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | TvName => true
+    | VarName => true
+    | _ => false
+    end.
+
+Definition isValNameSpace : NameSpace -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | DataName => true
+    | VarName => true
+    | _ => false
+    end.
+
+(* Skipping definition `OccName.pprNameSpace' *)
+
+(* Skipping definition `OccName.pprNonVarNameSpace' *)
+
+(* Skipping definition `OccName.pprNameSpaceBrief' *)
+
+Definition demoteNameSpace : NameSpace -> option NameSpace :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | VarName => None
+    | DataName => None
+    | TvName => None
+    | TcClsName => Some DataName
+    end.
+
+(* Skipping definition `OccName.pprOccName' *)
+
+Definition mkOccName : NameSpace -> GHC.Base.String -> OccName :=
+  fun occ_sp str => Mk_OccName occ_sp (FastString.mkFastString str).
+
+Definition mkOccNameFS : NameSpace -> FastString.FastString -> OccName :=
+  fun occ_sp fs => Mk_OccName occ_sp fs.
+
+Definition mkVarOcc : GHC.Base.String -> OccName :=
+  fun s => mkOccName varName s.
+
+Definition mkVarOccFS : FastString.FastString -> OccName :=
+  fun fs => mkOccNameFS varName fs.
+
+Definition mkDataOcc : GHC.Base.String -> OccName :=
+  mkOccName dataName.
+
+Definition mkDataOccFS : FastString.FastString -> OccName :=
+  mkOccNameFS dataName.
+
+Definition mkTyVarOcc : GHC.Base.String -> OccName :=
+  mkOccName tvName.
+
+Definition mkTyVarOccFS : FastString.FastString -> OccName :=
+  fun fs => mkOccNameFS tvName fs.
+
+Definition mkTcOcc : GHC.Base.String -> OccName :=
+  mkOccName tcName.
+
+Definition mkTcOccFS : FastString.FastString -> OccName :=
+  mkOccNameFS tcName.
+
+Definition mkClsOcc : GHC.Base.String -> OccName :=
+  mkOccName clsName.
+
+Definition mkClsOccFS : FastString.FastString -> OccName :=
+  mkOccNameFS clsName.
+
+Definition demoteOccName : OccName -> option OccName :=
+  fun '(Mk_OccName space name) =>
+    demoteNameSpace space GHC.Base.>>=
+    (fun space' => GHC.Base.return_ (Mk_OccName space' name)).
+
+Definition otherNameSpace : NameSpace -> NameSpace :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | VarName => DataName
+    | DataName => VarName
+    | TvName => TcClsName
+    | TcClsName => TvName
+    end.
+
+Definition nameSpacesRelated : NameSpace -> NameSpace -> bool :=
+  fun ns1 ns2 => orb (ns1 GHC.Base.== ns2) (otherNameSpace ns1 GHC.Base.== ns2).
+
+Definition emptyOccEnv {a} : OccEnv a :=
+  A UniqFM.emptyUFM.
+
+Definition unitOccSet : OccName -> OccSet :=
+  UniqSet.unitUniqSet.
+
+Definition unitOccEnv {a} : OccName -> a -> OccEnv a :=
+  fun x y => A (UniqFM.unitUFM x y).
+
+Definition mkOccSet : list OccName -> OccSet :=
+  UniqSet.mkUniqSet.
+
+Definition mkOccEnv_C {a}
+   : (a -> a -> a) -> list (OccName * a)%type -> OccEnv a :=
+  fun comb l => A (UniqFM.addListToUFM_C comb UniqFM.emptyUFM l).
+
+Definition mkOccEnv {a} : list (OccName * a)%type -> OccEnv a :=
+  fun l => A (UniqFM.listToUFM l).
+
+Definition lookupOccEnv {a} : OccEnv a -> OccName -> option a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | A x, y => UniqFM.lookupUFM x y
+    end.
+
+Definition initTidyOccEnv : list OccName -> TidyOccEnv :=
+  let add :=
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | env, Mk_OccName _ fs => UniqFM.addToUFM env fs #1
+      end in
+  Data.Foldable.foldl add UniqFM.emptyUFM.
+
+Definition foldOccEnv {a} {b} : (a -> b -> b) -> b -> OccEnv a -> b :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | a, b, A c => UniqFM.foldUFM a b c
+    end.
+
+Definition filterOccSet : (OccName -> bool) -> OccSet -> OccSet :=
+  UniqSet.filterUniqSet.
+
+Definition extendOccSetList : OccSet -> list OccName -> OccSet :=
+  UniqSet.addListToUniqSet.
+
+Definition extendOccSet : OccSet -> OccName -> OccSet :=
+  UniqSet.addOneToUniqSet.
+
+Definition extendOccEnv_C {a}
+   : (a -> a -> a) -> OccEnv a -> OccName -> a -> OccEnv a :=
+  fun arg_0__ arg_1__ arg_2__ arg_3__ =>
+    match arg_0__, arg_1__, arg_2__, arg_3__ with
+    | f, A x, y, z => A (UniqFM.addToUFM_C f x y z)
+    end.
+
+Definition extendOccEnv_Acc {a} {b}
+   : (a -> b -> b) -> (a -> b) -> OccEnv b -> OccName -> a -> OccEnv b :=
+  fun arg_0__ arg_1__ arg_2__ arg_3__ arg_4__ =>
+    match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__ with
+    | f, g, A x, y, z => A (UniqFM.addToUFM_Acc f g x y z)
+    end.
+
+Definition extendOccEnvList {a}
+   : OccEnv a -> list (OccName * a)%type -> OccEnv a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | A x, l => A (UniqFM.addListToUFM x l)
+    end.
+
+Definition extendOccEnv {a} : OccEnv a -> OccName -> a -> OccEnv a :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | A x, y, z => A (UniqFM.addToUFM x y z)
+    end.
+
+Definition elemOccEnv {a} : OccName -> OccEnv a -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | x, A y => UniqFM.elemUFM x y
+    end.
+
+Definition occEnvElts {a} : OccEnv a -> list a :=
+  fun '(A x) => UniqFM.eltsUFM x.
+
+Definition plusOccEnv {a} : OccEnv a -> OccEnv a -> OccEnv a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | A x, A y => A (UniqFM.plusUFM x y)
+    end.
+
+Definition plusOccEnv_C {a}
+   : (a -> a -> a) -> OccEnv a -> OccEnv a -> OccEnv a :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | f, A x, A y => A (UniqFM.plusUFM_C f x y)
+    end.
+
+Definition mapOccEnv {a} {b} : (a -> b) -> OccEnv a -> OccEnv b :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, A x => A (UniqFM.mapUFM f x)
+    end.
+
+Definition delFromOccEnv {a} : OccEnv a -> OccName -> OccEnv a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | A x, y => A (UniqFM.delFromUFM x y)
+    end.
+
+Definition delListFromOccEnv {a} : OccEnv a -> list OccName -> OccEnv a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | A x, y => A (UniqFM.delListFromUFM x y)
+    end.
+
+Definition filterOccEnv {elt} : (elt -> bool) -> OccEnv elt -> OccEnv elt :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | x, A y => A (UniqFM.filterUFM x y)
+    end.
+
+Definition alterOccEnv {elt}
+   : (option elt -> option elt) -> OccEnv elt -> OccName -> OccEnv elt :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | fn, A y, k => A (UniqFM.alterUFM fn y k)
+    end.
+
+(* Skipping definition `OccName.pprOccEnv' *)
+
+Definition emptyOccSet : OccSet :=
+  UniqSet.emptyUniqSet.
+
+Definition unionOccSets : OccSet -> OccSet -> OccSet :=
+  UniqSet.unionUniqSets.
+
+Definition unionManyOccSets : list OccSet -> OccSet :=
+  UniqSet.unionManyUniqSets.
+
+Definition minusOccSet : OccSet -> OccSet -> OccSet :=
+  UniqSet.minusUniqSet.
+
+Definition elemOccSet : OccName -> OccSet -> bool :=
+  UniqSet.elementOfUniqSet.
+
+Definition isEmptyOccSet : OccSet -> bool :=
+  UniqSet.isEmptyUniqSet.
+
+Definition intersectOccSet : OccSet -> OccSet -> OccSet :=
+  UniqSet.intersectUniqSets.
+
+Definition intersectsOccSet : OccSet -> OccSet -> bool :=
+  fun s1 s2 => negb (isEmptyOccSet (intersectOccSet s1 s2)).
+
+Definition occNameString : OccName -> GHC.Base.String :=
+  fun '(Mk_OccName _ s) => FastString.unpackFS s.
+
+Definition setOccNameSpace : NameSpace -> OccName -> OccName :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | sp, Mk_OccName _ occ => Mk_OccName sp occ
+    end.
+
+Definition isVarOcc : OccName -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Mk_OccName VarName _ => true
+    | _ => false
+    end.
+
+Definition isTvOcc : OccName -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Mk_OccName TvName _ => true
+    | _ => false
+    end.
+
+Definition isTcOcc : OccName -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Mk_OccName TcClsName _ => true
+    | _ => false
+    end.
+
+Definition isValOcc : OccName -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Mk_OccName VarName _ => true
+    | Mk_OccName DataName _ => true
+    | _ => false
+    end.
+
+Definition isDataOcc : OccName -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Mk_OccName DataName _ => true
+    | _ => false
+    end.
+
+Axiom isDataSymOcc : OccName -> bool.
+
+Axiom isSymOcc : OccName -> bool.
+
+(* Skipping definition `OccName.parenSymOcc' *)
+
+Axiom startsWithUnderscore : OccName -> bool.
+
+Definition mk_deriv
+   : NameSpace ->
+     FastString.FastString -> list FastString.FastString -> OccName :=
+  fun occ_sp sys_prefix str =>
+    mkOccNameFS occ_sp (FastString.concatFS (cons sys_prefix str)).
+
+Axiom isDerivedOccName : OccName -> bool.
+
+Axiom isDefaultMethodOcc : OccName -> bool.
+
+Axiom isTypeableBindOcc : OccName -> bool.
+
+Definition mk_simple_deriv
+   : NameSpace -> FastString.FastString -> OccName -> OccName :=
+  fun sp px occ => mk_deriv sp px (cons (occNameFS occ) nil).
+
+Definition mkDataConWrapperOcc : OccName -> OccName :=
+  mk_simple_deriv varName (GHC.Base.hs_string__ "$W").
+
+Definition mkWorkerOcc : OccName -> OccName :=
+  mk_simple_deriv varName (GHC.Base.hs_string__ "$w").
+
+Definition mkMatcherOcc : OccName -> OccName :=
+  mk_simple_deriv varName (GHC.Base.hs_string__ "$m").
+
+Definition mkBuilderOcc : OccName -> OccName :=
+  mk_simple_deriv varName (GHC.Base.hs_string__ "$b").
+
+Definition mkDefaultMethodOcc : OccName -> OccName :=
+  mk_simple_deriv varName (GHC.Base.hs_string__ "$dm").
+
+Definition mkClassOpAuxOcc : OccName -> OccName :=
+  mk_simple_deriv varName (GHC.Base.hs_string__ "$c").
+
+Definition mkDictOcc : OccName -> OccName :=
+  mk_simple_deriv varName (GHC.Base.hs_string__ "$d").
+
+Definition mkIPOcc : OccName -> OccName :=
+  mk_simple_deriv varName (GHC.Base.hs_string__ "$i").
+
+Definition mkSpecOcc : OccName -> OccName :=
+  mk_simple_deriv varName (GHC.Base.hs_string__ "$s").
+
+Definition mkForeignExportOcc : OccName -> OccName :=
+  mk_simple_deriv varName (GHC.Base.hs_string__ "$f").
+
+Definition mkRepEqOcc : OccName -> OccName :=
+  mk_simple_deriv tvName (GHC.Base.hs_string__ "$r").
+
+Definition mkClassDataConOcc : OccName -> OccName :=
+  mk_simple_deriv dataName (GHC.Base.hs_string__ "C:").
+
+Definition mkNewTyCoOcc : OccName -> OccName :=
+  mk_simple_deriv tcName (GHC.Base.hs_string__ "N:").
+
+Definition mkInstTyCoOcc : OccName -> OccName :=
+  mk_simple_deriv tcName (GHC.Base.hs_string__ "D:").
+
+Definition mkEqPredCoOcc : OccName -> OccName :=
+  mk_simple_deriv tcName (GHC.Base.hs_string__ "$co").
+
+Definition mkCon2TagOcc : OccName -> OccName :=
+  mk_simple_deriv varName (GHC.Base.hs_string__ "$con2tag_").
+
+Definition mkTag2ConOcc : OccName -> OccName :=
+  mk_simple_deriv varName (GHC.Base.hs_string__ "$tag2con_").
+
+Definition mkMaxTagOcc : OccName -> OccName :=
+  mk_simple_deriv varName (GHC.Base.hs_string__ "$maxtag_").
+
+Definition mkTyConRepOcc : OccName -> OccName :=
+  fun occ =>
+    let prefix :=
+      if isDataOcc occ : bool then GHC.Base.hs_string__ "$tc'" else
+      GHC.Base.hs_string__ "$tc" in
+    mk_simple_deriv varName prefix occ.
+
+Definition mkGenR : OccName -> OccName :=
+  mk_simple_deriv tcName (GHC.Base.hs_string__ "Rep_").
+
+Definition mkGen1R : OccName -> OccName :=
+  mk_simple_deriv tcName (GHC.Base.hs_string__ "Rep1_").
+
+Definition mk_simple_deriv_with
+   : NameSpace ->
+     FastString.FastString -> option GHC.Base.String -> OccName -> OccName :=
+  fun arg_0__ arg_1__ arg_2__ arg_3__ =>
+    match arg_0__, arg_1__, arg_2__, arg_3__ with
+    | sp, px, None, occ => mk_deriv sp px (cons (occNameFS occ) nil)
+    | sp, px, Some with_, occ =>
+        mk_deriv sp px (cons (FastString.fsLit with_) (cons (FastString.fsLit
+                                                             (GHC.Base.hs_string__ "_")) (cons (occNameFS occ) nil)))
+    end.
+
+Definition mkVectOcc : option GHC.Base.String -> OccName -> OccName :=
+  mk_simple_deriv_with varName (GHC.Base.hs_string__ "$v").
+
+Definition mkVectTyConOcc : option GHC.Base.String -> OccName -> OccName :=
+  mk_simple_deriv_with tcName (GHC.Base.hs_string__ "V:").
+
+Definition mkVectDataConOcc : option GHC.Base.String -> OccName -> OccName :=
+  mk_simple_deriv_with dataName (GHC.Base.hs_string__ "VD:").
+
+Definition mkVectIsoOcc : option GHC.Base.String -> OccName -> OccName :=
+  mk_simple_deriv_with varName (GHC.Base.hs_string__ "$vi").
+
+Definition mkPADFunOcc : option GHC.Base.String -> OccName -> OccName :=
+  mk_simple_deriv_with varName (GHC.Base.hs_string__ "$pa").
+
+Definition mkPReprTyConOcc : option GHC.Base.String -> OccName -> OccName :=
+  mk_simple_deriv_with tcName (GHC.Base.hs_string__ "VR:").
+
+Definition mkPDataTyConOcc : option GHC.Base.String -> OccName -> OccName :=
+  mk_simple_deriv_with tcName (GHC.Base.hs_string__ "VP:").
+
+Definition mkPDatasTyConOcc : option GHC.Base.String -> OccName -> OccName :=
+  mk_simple_deriv_with tcName (GHC.Base.hs_string__ "VPs:").
+
+Definition mkPDataDataConOcc : option GHC.Base.String -> OccName -> OccName :=
+  mk_simple_deriv_with dataName (GHC.Base.hs_string__ "VPD:").
+
+Definition mkPDatasDataConOcc : option GHC.Base.String -> OccName -> OccName :=
+  mk_simple_deriv_with dataName (GHC.Base.hs_string__ "VPDs:").
+
+Definition mkRecFldSelOcc : GHC.Base.String -> OccName :=
+  fun s =>
+    mk_deriv varName (GHC.Base.hs_string__ "$sel") (cons (FastString.fsLit s) nil).
+
+Definition mkDataConWorkerOcc : OccName -> OccName :=
+  fun datacon_occ => setOccNameSpace varName datacon_occ.
+
+Axiom mkSuperDictAuxOcc : GHC.Num.Int -> OccName -> OccName.
+
+Axiom mkSuperDictSelOcc : GHC.Num.Int -> OccName -> OccName.
+
+Axiom mkLocalOcc : Unique.Unique -> OccName -> OccName.
+
+Axiom chooseUniqueOcc : NameSpace -> GHC.Base.String -> OccSet -> OccName.
+
+Definition mkInstTyTcOcc : GHC.Base.String -> OccSet -> OccName :=
+  fun str =>
+    chooseUniqueOcc tcName (cons (GHC.Char.hs_char__ "R") (cons (GHC.Char.hs_char__
+                                                                 ":") str)).
+
+Definition mkDFunOcc : GHC.Base.String -> bool -> OccSet -> OccName :=
+  fun info_str is_boot set =>
+    let prefix :=
+      if is_boot : bool then GHC.Base.hs_string__ "$fx" else
+      GHC.Base.hs_string__ "$f" in
+    chooseUniqueOcc VarName (Coq.Init.Datatypes.app prefix info_str) set.
+
+Definition mkDataTOcc : OccName -> OccSet -> OccName :=
+  fun occ =>
+    chooseUniqueOcc VarName (Coq.Init.Datatypes.app (GHC.Base.hs_string__ "$t")
+                                                    (occNameString occ)).
+
+Definition mkDataCOcc : OccName -> OccSet -> OccName :=
+  fun occ =>
+    chooseUniqueOcc VarName (Coq.Init.Datatypes.app (GHC.Base.hs_string__ "$c")
+                                                    (occNameString occ)).
+
+Definition mkMethodOcc : OccName -> OccName :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | (Mk_OccName VarName _ as occ) => occ
+    | occ => mk_simple_deriv varName (GHC.Base.hs_string__ "$m") occ
+    end.
+
+Definition emptyTidyOccEnv : TidyOccEnv :=
+  UniqFM.emptyUFM.
+
+Definition avoidClashesOccEnv : TidyOccEnv -> list OccName -> TidyOccEnv :=
+  fun env occs =>
+    let fix go arg_0__ arg_1__ arg_2__
+              := match arg_0__, arg_1__, arg_2__ with
+                 | env, _, nil => env
+                 | env, seenOnce, cons (Mk_OccName _ fs) occs =>
+                     if UniqFM.elemUFM fs env : bool then go env seenOnce occs else
+                     if UniqFM.elemUFM fs seenOnce : bool
+                     then go (UniqFM.addToUFM env fs #1) seenOnce occs else
+                     go env (UniqFM.addToUFM seenOnce fs tt) occs
+                 end in
+    go env UniqFM.emptyUFM occs.
+
+Axiom tidyOccName : TidyOccEnv -> OccName -> (TidyOccEnv * OccName)%type.
 
 (* External variables:
      Eq Gt Lt None Some andb bool comparison cons false list negb nil op_zt__ option

--- a/examples/ghc/lib/OccurAnal.v
+++ b/examples/ghc/lib/OccurAnal.v
@@ -174,102 +174,236 @@ Definition nd_weak (arg_0__ : Details) :=
 
 (* Converted value declarations: *)
 
-Definition willBeJoinId_maybe : Core.CoreBndr -> option BasicTypes.JoinArity :=
-  fun bndr =>
-    match BasicTypes.tailCallInfo (Id.idOccInfo bndr) with
-    | BasicTypes.AlwaysTailCalled arity => Some arity
-    | _ => Id.isJoinId_maybe bndr
-    end.
+(* Skipping all instances of class `Outputable.Outputable', including
+   `OccurAnal.Outputable__Details' *)
 
-Definition vanillaCtxt : OccEnv -> OccEnv :=
-  fun '(Mk_OccEnv occ_encl_0__ occ_one_shots_1__ occ_gbl_scrut_2__
-  occ_rule_act_3__ occ_binder_swap_4__) =>
-    Mk_OccEnv OccVanilla nil occ_gbl_scrut_2__ occ_rule_act_3__ occ_binder_swap_4__.
+(* Skipping all instances of class `Outputable.Outputable', including
+   `OccurAnal.Outputable__OccEncl' *)
 
-Definition usedIn : Core.Id -> UsageDetails -> bool :=
-  fun v ud => orb (Core.isExportedId v) (Core.elemVarEnv v (ud_env ud)).
-
-Definition udFreeVars : Core.VarSet -> UsageDetails -> Core.VarSet :=
-  fun bndrs ud => UniqSet.restrictUniqSetToUFM bndrs (ud_env ud).
-
-Axiom transClosureFV : UniqFM.UniqFM Core.VarSet -> UniqFM.UniqFM Core.VarSet.
-
-Definition setBinderOcc
-   : BasicTypes.OccInfo -> Core.CoreBndr -> Core.CoreBndr :=
-  fun occ_info bndr =>
-    if Core.isTyVar bndr : bool then bndr else
-    if Core.isExportedId bndr : bool
-    then if BasicTypes.isManyOccs (Id.idOccInfo bndr) : bool
-         then bndr
-         else Id.setIdOccInfo bndr BasicTypes.noOccInfo else
-    Id.setIdOccInfo bndr occ_info.
-
-Definition rhsCtxt : OccEnv -> OccEnv :=
-  fun '(Mk_OccEnv occ_encl_0__ occ_one_shots_1__ occ_gbl_scrut_2__
-  occ_rule_act_3__ occ_binder_swap_4__) =>
-    Mk_OccEnv OccRhs nil occ_gbl_scrut_2__ occ_rule_act_3__ occ_binder_swap_4__.
-
-Axiom reOrderNodes : nat ->
-                     Core.VarSet -> Core.VarSet -> list LetrecNode -> list Binding -> list Binding.
-
-Definition rank : NodeScore -> nat :=
-  fun '(pair (pair r _) _) => r.
-
-Definition oneShotGroup
-   : OccEnv -> list Core.CoreBndr -> (OccEnv * list Core.CoreBndr)%type :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | (Mk_OccEnv _ ctxt _ _ _ as env), bndrs =>
-        let fix go arg_2__ arg_3__ arg_4__
-                  := match arg_2__, arg_3__, arg_4__ with
-                     | ctxt, nil, rev_bndrs =>
-                         pair (let 'Mk_OccEnv occ_encl_5__ occ_one_shots_6__ occ_gbl_scrut_7__
-                                  occ_rule_act_8__ occ_binder_swap_9__ := env in
-                               Mk_OccEnv OccVanilla ctxt occ_gbl_scrut_7__ occ_rule_act_8__
-                                         occ_binder_swap_9__) (GHC.List.reverse rev_bndrs)
-                     | nil, bndrs, rev_bndrs =>
-                         pair (let 'Mk_OccEnv occ_encl_13__ occ_one_shots_14__ occ_gbl_scrut_15__
-                                  occ_rule_act_16__ occ_binder_swap_17__ := env in
-                               Mk_OccEnv OccVanilla nil occ_gbl_scrut_15__ occ_rule_act_16__
-                                         occ_binder_swap_17__) (Coq.Init.Datatypes.app (GHC.List.reverse rev_bndrs)
-                                                                                       bndrs)
-                     | (cons one_shot ctxt' as ctxt), cons bndr bndrs, rev_bndrs =>
-                         let bndr' := Id.updOneShotInfo bndr one_shot in
-                         if Core.isId bndr : bool then go ctxt' bndrs (cons bndr' rev_bndrs) else
-                         go ctxt bndrs (cons bndr rev_bndrs)
-                     end in
-        go ctxt bndrs nil
-    end.
+(* Skipping all instances of class `Outputable.Outputable', including
+   `OccurAnal.Outputable__UsageDetails' *)
 
 Axiom occurAnalysePgm : Module.Module ->
                         (BasicTypes.Activation -> bool) ->
                         list Core.CoreRule ->
                         list Core.CoreVect -> Core.VarSet -> Core.CoreProgram -> Core.CoreProgram.
 
-Definition occAnalUnfolding
-   : OccEnv -> BasicTypes.RecFlag -> Core.Id -> option UsageDetails :=
-  fun env rec_flag id => let scrut_0__ := Id.realIdUnfolding id in None.
+Definition initOccEnv : (BasicTypes.Activation -> bool) -> OccEnv :=
+  fun active_rule => Mk_OccEnv OccVanilla nil Core.emptyVarSet active_rule true.
 
-Axiom occAnalRules : OccEnv ->
-                     option BasicTypes.JoinArity ->
-                     BasicTypes.RecFlag ->
-                     Core.Id -> list (Core.CoreRule * UsageDetails * UsageDetails)%type.
+Axiom occAnal : OccEnv -> Core.CoreExpr -> (UsageDetails * Core.CoreExpr)%type.
 
-Axiom occAnalRecRhs : OccEnv ->
-                      list Core.CoreBndr ->
-                      Core.CoreExpr -> (UsageDetails * list Core.CoreBndr * Core.CoreExpr)%type.
+Definition occurAnalyseExpr' : bool -> Core.CoreExpr -> Core.CoreExpr :=
+  fun enable_binder_swap expr =>
+    let all_active_rules := fun arg_0__ => true in
+    let env :=
+      let 'Mk_OccEnv occ_encl_2__ occ_one_shots_3__ occ_gbl_scrut_4__ occ_rule_act_5__
+         occ_binder_swap_6__ := (initOccEnv all_active_rules) in
+      Mk_OccEnv occ_encl_2__ occ_one_shots_3__ occ_gbl_scrut_4__ occ_rule_act_5__
+                enable_binder_swap in
+    Data.Tuple.snd (occAnal env expr).
 
-Axiom occAnalRecBind : OccEnv ->
-                       BasicTypes.TopLevelFlag ->
-                       ImpRuleEdges ->
-                       list (Core.Var * Core.CoreExpr)%type ->
-                       UsageDetails -> (UsageDetails * list Core.CoreBind)%type.
+Definition occurAnalyseExpr : Core.CoreExpr -> Core.CoreExpr :=
+  occurAnalyseExpr' true.
 
-(* Skipping definition `OccurAnal.occAnalRec' *)
+Definition occurAnalyseExpr_NoBinderSwap : Core.CoreExpr -> Core.CoreExpr :=
+  occurAnalyseExpr' false.
+
+Axiom occAnalBind : OccEnv ->
+                    BasicTypes.TopLevelFlag ->
+                    ImpRuleEdges ->
+                    Core.CoreBind -> UsageDetails -> (UsageDetails * list Core.CoreBind)%type.
+
+Definition andTailCallInfo
+   : BasicTypes.TailCallInfo ->
+     BasicTypes.TailCallInfo -> BasicTypes.TailCallInfo :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | (BasicTypes.AlwaysTailCalled arity1 as info)
+    , BasicTypes.AlwaysTailCalled arity2 =>
+        if arity1 GHC.Base.== arity2 : bool then info else
+        BasicTypes.NoTailCallInfo
+    | _, _ => BasicTypes.NoTailCallInfo
+    end.
+
+Definition addOccInfo
+   : BasicTypes.OccInfo -> BasicTypes.OccInfo -> BasicTypes.OccInfo :=
+  fun a1 a2 =>
+    if andb Util.debugIsOn (negb (negb (orb (BasicTypes.isDeadOcc a1)
+                                            (BasicTypes.isDeadOcc a2)))) : bool
+    then (Panic.assertPanic (GHC.Base.hs_string__
+                             "ghc/compiler/simplCore/OccurAnal.hs") #2825)
+    else BasicTypes.ManyOccs (andTailCallInfo (BasicTypes.tailCallInfo a1)
+                                              (BasicTypes.tailCallInfo a2)).
+
+Definition alterZappedSets
+   : UsageDetails -> (ZappedSet -> ZappedSet) -> UsageDetails :=
+  fun ud f =>
+    let 'UD ud_env_0__ ud_z_many_1__ ud_z_in_lam_2__ ud_z_no_tail_3__ := ud in
+    UD ud_env_0__ (f (ud_z_many ud)) (f (ud_z_in_lam ud)) (f (ud_z_no_tail ud)).
+
+Definition markInsideLam : BasicTypes.OccInfo -> BasicTypes.OccInfo :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | (BasicTypes.OneOcc _ _ _ _ as occ) =>
+        match occ with
+        | BasicTypes.ManyOccs _ =>
+            GHC.Err.error (GHC.Base.hs_string__ "Partial record update")
+        | BasicTypes.IAmDead =>
+            GHC.Err.error (GHC.Base.hs_string__ "Partial record update")
+        | BasicTypes.OneOcc occ_in_lam_1__ occ_one_br_2__ occ_int_cxt_3__
+        occ_tail_4__ =>
+            BasicTypes.OneOcc true occ_one_br_2__ occ_int_cxt_3__ occ_tail_4__
+        | BasicTypes.IAmALoopBreaker _ _ =>
+            GHC.Err.error (GHC.Base.hs_string__ "Partial record update")
+        end
+    | occ => occ
+    end.
+
+Definition markMany : BasicTypes.OccInfo -> BasicTypes.OccInfo :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | BasicTypes.IAmDead => BasicTypes.IAmDead
+    | occ => BasicTypes.ManyOccs (BasicTypes.occ_tail occ)
+    end.
+
+Definition markNonTailCalled : BasicTypes.OccInfo -> BasicTypes.OccInfo :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | BasicTypes.IAmDead => BasicTypes.IAmDead
+    | occ =>
+        match occ with
+        | BasicTypes.ManyOccs occ_tail_1__ =>
+            BasicTypes.ManyOccs BasicTypes.NoTailCallInfo
+        | BasicTypes.IAmDead =>
+            GHC.Err.error (GHC.Base.hs_string__ "Partial record update")
+        | BasicTypes.OneOcc occ_in_lam_2__ occ_one_br_3__ occ_int_cxt_4__
+        occ_tail_5__ =>
+            BasicTypes.OneOcc occ_in_lam_2__ occ_one_br_3__ occ_int_cxt_4__
+                              BasicTypes.NoTailCallInfo
+        | BasicTypes.IAmALoopBreaker occ_rules_only_6__ occ_tail_7__ =>
+            BasicTypes.IAmALoopBreaker occ_rules_only_6__ BasicTypes.NoTailCallInfo
+        end
+    end.
+
+Definition doZappingByUnique
+   : UsageDetails -> Unique.Unique -> BasicTypes.OccInfo -> BasicTypes.OccInfo :=
+  fun ud uniq =>
+    let in_subset := fun field => Core.elemVarEnvByKey uniq (field ud) in
+    (if in_subset ud_z_many : bool then markMany else
+     if in_subset ud_z_in_lam : bool then markInsideLam else
+     GHC.Base.id) GHC.Base.∘
+    (if in_subset ud_z_no_tail : bool then markNonTailCalled else
+     GHC.Base.id).
+
+Definition doZapping
+   : UsageDetails -> Core.Var -> BasicTypes.OccInfo -> BasicTypes.OccInfo :=
+  fun ud var occ => doZappingByUnique ud (Core.varUnique var) occ.
+
+Definition addOneOcc
+   : UsageDetails -> Core.Id -> BasicTypes.OccInfo -> UsageDetails :=
+  fun ud id info =>
+    let plus_zapped := fun old new => addOccInfo (doZapping ud id old) new in
+    alterZappedSets (let 'UD ud_env_1__ ud_z_many_2__ ud_z_in_lam_3__
+                        ud_z_no_tail_4__ := ud in
+                     UD (Core.extendVarEnv_C plus_zapped (ud_env ud) id info) ud_z_many_2__
+                        ud_z_in_lam_3__ ud_z_no_tail_4__) (fun arg_7__ => Core.delVarEnv arg_7__ id).
+
+Definition addManyOccs : Core.Var -> UsageDetails -> UsageDetails :=
+  fun v u => if Core.isId v : bool then addOneOcc u v BasicTypes.noOccInfo else u.
+
+Definition addManyOccsSet : UsageDetails -> Core.VarSet -> UsageDetails :=
+  fun usage id_set => UniqSet.nonDetFoldUniqSet addManyOccs usage id_set.
+
+Definition markAllInsideLam : UsageDetails -> UsageDetails :=
+  fun ud =>
+    let 'UD ud_env_0__ ud_z_many_1__ ud_z_in_lam_2__ ud_z_no_tail_3__ := ud in
+    UD ud_env_0__ ud_z_many_1__ (ud_env ud) ud_z_no_tail_3__.
+
+Definition markAllNonTailCalled : UsageDetails -> UsageDetails :=
+  fun ud =>
+    let 'UD ud_env_0__ ud_z_many_1__ ud_z_in_lam_2__ ud_z_no_tail_3__ := ud in
+    UD ud_env_0__ ud_z_many_1__ ud_z_in_lam_2__ (ud_env ud).
+
+Definition adjustRhsUsage
+   : option BasicTypes.JoinArity ->
+     BasicTypes.RecFlag -> list Core.CoreBndr -> UsageDetails -> UsageDetails :=
+  fun mb_join_arity rec_flag bndrs usage =>
+    let exact_join :=
+      match mb_join_arity with
+      | Some join_arity => Util.lengthIs bndrs join_arity
+      | _ => false
+      end in
+    let one_shot :=
+      match mb_join_arity with
+      | Some join_arity =>
+          if BasicTypes.isRec rec_flag : bool then false else
+          Data.Foldable.all Id.isOneShotBndr (Coq.Lists.List.skipn join_arity bndrs)
+      | None => Data.Foldable.all Id.isOneShotBndr bndrs
+      end in
+    let maybe_drop_tails :=
+      fun ud => if exact_join : bool then ud else markAllNonTailCalled ud in
+    let maybe_mark_lam :=
+      fun ud => if one_shot : bool then ud else markAllInsideLam ud in
+    maybe_mark_lam (maybe_drop_tails usage).
+
+Definition emptyDetails : UsageDetails :=
+  UD Core.emptyVarEnv Core.emptyVarEnv Core.emptyVarEnv Core.emptyVarEnv.
+
+Definition isEmptyDetails : UsageDetails -> bool :=
+  Core.isEmptyVarEnv GHC.Base.∘ ud_env.
+
+Definition combineUsageDetailsWith
+   : (BasicTypes.OccInfo -> BasicTypes.OccInfo -> BasicTypes.OccInfo) ->
+     UsageDetails -> UsageDetails -> UsageDetails :=
+  fun plus_occ_info ud1 ud2 =>
+    if isEmptyDetails ud1 : bool then ud2 else
+    if isEmptyDetails ud2 : bool then ud1 else
+    UD (Core.plusVarEnv_C plus_occ_info (ud_env ud1) (ud_env ud2)) (Core.plusVarEnv
+        (ud_z_many ud1) (ud_z_many ud2)) (Core.plusVarEnv (ud_z_in_lam ud1) (ud_z_in_lam
+                                                                             ud2)) (Core.plusVarEnv (ud_z_no_tail ud1)
+        (ud_z_no_tail ud2)).
+
+Definition op_zpzpzp__ : UsageDetails -> UsageDetails -> UsageDetails :=
+  combineUsageDetailsWith addOccInfo.
+
+Notation "'_+++_'" := (op_zpzpzp__).
+
+Infix "+++" := (_+++_) (at level 99).
+
+Definition combineUsageDetailsList : list UsageDetails -> UsageDetails :=
+  Data.Foldable.foldl _+++_ emptyDetails.
+
+Definition markJoinOneShots
+   : option BasicTypes.JoinArity -> list Core.Var -> list Core.Var :=
+  fun mb_join_arity bndrs =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | num_2__, bndrs =>
+                     if num_2__ GHC.Base.== #0 : bool then bndrs else
+                     match arg_0__, arg_1__ with
+                     | _, nil =>
+                         Panic.warnPprTrace (true) (GHC.Base.hs_string__
+                                             "ghc/compiler/simplCore/OccurAnal.hs") #2194 (GHC.Base.mappend
+                                             Panic.someSDoc Panic.someSDoc) nil
+                     | n, cons b bs =>
+                         let b' := if Core.isId b : bool then Id.setOneShotLambda b else b in
+                         cons b' (go (n GHC.Num.- #1) bs)
+                     end
+                 end in
+    match mb_join_arity with
+    | None => bndrs
+    | Some n => go n bndrs
+    end.
 
 Axiom occAnalLamOrRhs : OccEnv ->
                         list Core.CoreBndr ->
                         Core.CoreExpr -> (UsageDetails * list Core.CoreBndr * Core.CoreExpr)%type.
+
+Definition rhsCtxt : OccEnv -> OccEnv :=
+  fun '(Mk_OccEnv occ_encl_0__ occ_one_shots_1__ occ_gbl_scrut_2__
+  occ_rule_act_3__ occ_binder_swap_4__) =>
+    Mk_OccEnv OccRhs nil occ_gbl_scrut_2__ occ_rule_act_3__ occ_binder_swap_4__.
 
 Definition occAnalNonRecRhs
    : OccEnv ->
@@ -299,240 +433,14 @@ Definition occAnalNonRecRhs
                 occ_rule_act_14__ occ_binder_swap_15__ in
     occAnalLamOrRhs rhs_env bndrs body.
 
-Definition occAnalRhs
-   : OccEnv ->
-     BasicTypes.RecFlag ->
-     Core.Id ->
-     list Core.CoreBndr ->
-     Core.CoreExpr -> (UsageDetails * list Core.CoreBndr * Core.CoreExpr)%type :=
-  fun arg_0__ arg_1__ arg_2__ arg_3__ arg_4__ =>
-    match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__ with
-    | env, BasicTypes.Recursive, _, bndrs, body => occAnalRecRhs env bndrs body
-    | env, BasicTypes.NonRecursive, id, bndrs, body =>
-        occAnalNonRecRhs env id bndrs body
-    end.
+Axiom occAnalRules : OccEnv ->
+                     option BasicTypes.JoinArity ->
+                     BasicTypes.RecFlag ->
+                     Core.Id -> list (Core.CoreRule * UsageDetails * UsageDetails)%type.
 
-Axiom occAnalBind : OccEnv ->
-                    BasicTypes.TopLevelFlag ->
-                    ImpRuleEdges ->
-                    Core.CoreBind -> UsageDetails -> (UsageDetails * list Core.CoreBind)%type.
-
-Axiom occAnalArgs : OccEnv ->
-                    list Core.CoreExpr -> list OneShots -> (UsageDetails * list Core.CoreExpr)%type.
-
-Axiom occAnal : OccEnv -> Core.CoreExpr -> (UsageDetails * Core.CoreExpr)%type.
-
-Definition noImpRuleEdges : ImpRuleEdges :=
-  Core.emptyVarEnv.
-
-Axiom mk_non_loop_breaker : Core.VarSet -> LetrecNode -> Binding.
-
-Axiom mk_loop_breaker : LetrecNode -> Binding.
-
-Definition mkAltEnv
-   : OccEnv ->
-     Core.CoreExpr ->
-     Core.Id -> (OccEnv * option (Core.Id * Core.CoreExpr)%type)%type :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | (Mk_OccEnv _ _ pe _ _ as env), scrut, case_bndr =>
-        let localise :=
-          fun scrut_var =>
-            Id.mkLocalIdOrCoVar (Name.localiseName (Id.idName scrut_var)) (Id.idType
-                                                                           scrut_var) in
-        let case_bndr' := Core.Mk_Var (Id.zapIdOccInfo case_bndr) in
-        let add_scrut :=
-          fun v rhs =>
-            pair (let 'Mk_OccEnv occ_encl_5__ occ_one_shots_6__ occ_gbl_scrut_7__
-                     occ_rule_act_8__ occ_binder_swap_9__ := env in
-                  Mk_OccEnv OccVanilla occ_one_shots_6__ (Core.extendVarSet pe v) occ_rule_act_8__
-                            occ_binder_swap_9__) (Some (pair (localise v) rhs)) in
-        match CoreUtils.stripTicksTopE (GHC.Base.const true) scrut with
-        | Core.Mk_Var v => add_scrut v case_bndr'
-        | Core.Cast (Core.Mk_Var v) co =>
-            add_scrut v (Core.Cast case_bndr' (Core.mkSymCo co))
-        | _ =>
-            pair (let 'Mk_OccEnv occ_encl_16__ occ_one_shots_17__ occ_gbl_scrut_18__
-                     occ_rule_act_19__ occ_binder_swap_20__ := env in
-                  Mk_OccEnv OccVanilla occ_one_shots_17__ occ_gbl_scrut_18__ occ_rule_act_19__
-                            occ_binder_swap_20__) None
-        end
-    end.
-
-Definition maxExprSize : nat :=
-  #20.
-
-Definition markNonTailCalled : BasicTypes.OccInfo -> BasicTypes.OccInfo :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | BasicTypes.IAmDead => BasicTypes.IAmDead
-    | occ =>
-        match occ with
-        | BasicTypes.ManyOccs occ_tail_1__ =>
-            BasicTypes.ManyOccs BasicTypes.NoTailCallInfo
-        | BasicTypes.IAmDead =>
-            GHC.Err.error (GHC.Base.hs_string__ "Partial record update")
-        | BasicTypes.OneOcc occ_in_lam_2__ occ_one_br_3__ occ_int_cxt_4__
-        occ_tail_5__ =>
-            BasicTypes.OneOcc occ_in_lam_2__ occ_one_br_3__ occ_int_cxt_4__
-                              BasicTypes.NoTailCallInfo
-        | BasicTypes.IAmALoopBreaker occ_rules_only_6__ occ_tail_7__ =>
-            BasicTypes.IAmALoopBreaker occ_rules_only_6__ BasicTypes.NoTailCallInfo
-        end
-    end.
-
-Definition markMany : BasicTypes.OccInfo -> BasicTypes.OccInfo :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | BasicTypes.IAmDead => BasicTypes.IAmDead
-    | occ => BasicTypes.ManyOccs (BasicTypes.occ_tail occ)
-    end.
-
-Definition markJoinOneShots
-   : option BasicTypes.JoinArity -> list Core.Var -> list Core.Var :=
-  fun mb_join_arity bndrs =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | num_2__, bndrs =>
-                     if num_2__ GHC.Base.== #0 : bool then bndrs else
-                     match arg_0__, arg_1__ with
-                     | _, nil =>
-                         Panic.warnPprTrace (true) (GHC.Base.hs_string__
-                                             "ghc/compiler/simplCore/OccurAnal.hs") #2194 (GHC.Base.mappend
-                                             Panic.someSDoc Panic.someSDoc) nil
-                     | n, cons b bs =>
-                         let b' := if Core.isId b : bool then Id.setOneShotLambda b else b in
-                         cons b' (go (n GHC.Num.- #1) bs)
-                     end
-                 end in
-    match mb_join_arity with
-    | None => bndrs
-    | Some n => go n bndrs
-    end.
-
-Definition markInsideLam : BasicTypes.OccInfo -> BasicTypes.OccInfo :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | (BasicTypes.OneOcc _ _ _ _ as occ) =>
-        match occ with
-        | BasicTypes.ManyOccs _ =>
-            GHC.Err.error (GHC.Base.hs_string__ "Partial record update")
-        | BasicTypes.IAmDead =>
-            GHC.Err.error (GHC.Base.hs_string__ "Partial record update")
-        | BasicTypes.OneOcc occ_in_lam_1__ occ_one_br_2__ occ_int_cxt_3__
-        occ_tail_4__ =>
-            BasicTypes.OneOcc true occ_one_br_2__ occ_int_cxt_3__ occ_tail_4__
-        | BasicTypes.IAmALoopBreaker _ _ =>
-            GHC.Err.error (GHC.Base.hs_string__ "Partial record update")
-        end
-    | occ => occ
-    end.
-
-Definition markAllNonTailCalled : UsageDetails -> UsageDetails :=
-  fun ud =>
-    let 'UD ud_env_0__ ud_z_many_1__ ud_z_in_lam_2__ ud_z_no_tail_3__ := ud in
-    UD ud_env_0__ ud_z_many_1__ ud_z_in_lam_2__ (ud_env ud).
-
-Definition markAllMany : UsageDetails -> UsageDetails :=
-  fun ud =>
-    let 'UD ud_env_0__ ud_z_many_1__ ud_z_in_lam_2__ ud_z_no_tail_3__ := ud in
-    UD ud_env_0__ (ud_env ud) ud_z_in_lam_2__ ud_z_no_tail_3__.
-
-Definition zapDetails : UsageDetails -> UsageDetails :=
-  markAllMany GHC.Base.∘ markAllNonTailCalled.
-
-Definition zapDetailsIf : bool -> UsageDetails -> UsageDetails :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | true, uds => zapDetails uds
-    | false, uds => uds
-    end.
-
-Definition markAllInsideLam : UsageDetails -> UsageDetails :=
-  fun ud =>
-    let 'UD ud_env_0__ ud_z_many_1__ ud_z_in_lam_2__ ud_z_no_tail_3__ := ud in
-    UD ud_env_0__ ud_z_many_1__ (ud_env ud) ud_z_no_tail_3__.
-
-Axiom loopBreakNodes : nat ->
-                       Core.VarSet -> Core.VarSet -> list LetrecNode -> list Binding -> list Binding.
-
-Definition isRhsEnv : OccEnv -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Mk_OccEnv OccRhs _ _ _ _ => true
-    | Mk_OccEnv OccVanilla _ _ _ _ => false
-    end.
-
-Definition isEmptyDetails : UsageDetails -> bool :=
-  Core.isEmptyVarEnv GHC.Base.∘ ud_env.
-
-Definition initOccEnv : (BasicTypes.Activation -> bool) -> OccEnv :=
-  fun active_rule => Mk_OccEnv OccVanilla nil Core.emptyVarSet active_rule true.
-
-Definition occurAnalyseExpr' : bool -> Core.CoreExpr -> Core.CoreExpr :=
-  fun enable_binder_swap expr =>
-    let all_active_rules := fun arg_0__ => true in
-    let env :=
-      let 'Mk_OccEnv occ_encl_2__ occ_one_shots_3__ occ_gbl_scrut_4__ occ_rule_act_5__
-         occ_binder_swap_6__ := (initOccEnv all_active_rules) in
-      Mk_OccEnv occ_encl_2__ occ_one_shots_3__ occ_gbl_scrut_4__ occ_rule_act_5__
-                enable_binder_swap in
-    Data.Tuple.snd (occAnal env expr).
-
-Definition occurAnalyseExpr : Core.CoreExpr -> Core.CoreExpr :=
-  occurAnalyseExpr' true.
-
-Definition occurAnalyseExpr_NoBinderSwap : Core.CoreExpr -> Core.CoreExpr :=
-  occurAnalyseExpr' false.
-
-Definition extendFvs
-   : UniqFM.UniqFM Core.VarSet -> Core.VarSet -> (Core.VarSet * bool)%type :=
-  fun env s =>
-    let extras : Core.VarSet :=
-      UniqFM.nonDetFoldUFM Core.unionVarSet Core.emptyVarSet (UniqFM.intersectUFM_C
-                                                              (fun arg_0__ arg_1__ =>
-                                                                 match arg_0__, arg_1__ with
-                                                                 | x, _ => x
-                                                                 end) env (UniqSet.getUniqSet s)) in
-    if UniqFM.isNullUFM env : bool then pair s true else
-    pair (Core.unionVarSet s extras) (Core.subVarSet extras s).
-
-Definition extendFvs_
-   : UniqFM.UniqFM Core.VarSet -> Core.VarSet -> Core.VarSet :=
-  fun env s => Data.Tuple.fst (extendFvs env s).
-
-Definition emptyDetails : UsageDetails :=
-  UD Core.emptyVarEnv Core.emptyVarEnv Core.emptyVarEnv Core.emptyVarEnv.
-
-Definition mkOneOcc
-   : OccEnv ->
-     Core.Id -> BasicTypes.InterestingCxt -> BasicTypes.JoinArity -> UsageDetails :=
-  fun env id int_cxt arity =>
-    let singleton :=
-      fun info =>
-        let 'UD ud_env_0__ ud_z_many_1__ ud_z_in_lam_2__ ud_z_no_tail_3__ :=
-          emptyDetails in
-        UD (Core.unitVarEnv id info) ud_z_many_1__ ud_z_in_lam_2__ ud_z_no_tail_3__ in
-    if Core.isLocalId id : bool
-    then singleton (BasicTypes.OneOcc false true int_cxt
-                                      (BasicTypes.AlwaysTailCalled arity)) else
-    if Core.elemVarSet id (occ_gbl_scrut env) : bool
-    then singleton BasicTypes.noOccInfo else
-    emptyDetails.
-
-Definition doZappingByUnique
-   : UsageDetails -> Unique.Unique -> BasicTypes.OccInfo -> BasicTypes.OccInfo :=
-  fun ud uniq =>
-    let in_subset := fun field => Core.elemVarEnvByKey uniq (field ud) in
-    (if in_subset ud_z_many : bool then markMany else
-     if in_subset ud_z_in_lam : bool then markInsideLam else
-     GHC.Base.id) GHC.Base.∘
-    (if in_subset ud_z_no_tail : bool then markNonTailCalled else
-     GHC.Base.id).
-
-Definition doZapping
-   : UsageDetails -> Core.Var -> BasicTypes.OccInfo -> BasicTypes.OccInfo :=
-  fun ud var occ => doZappingByUnique ud (Core.varUnique var) occ.
+Definition occAnalUnfolding
+   : OccEnv -> BasicTypes.RecFlag -> Core.Id -> option UsageDetails :=
+  fun env rec_flag id => let scrut_0__ := Id.realIdUnfolding id in None.
 
 Definition lookupDetails : UsageDetails -> Core.Id -> BasicTypes.OccInfo :=
   fun ud id =>
@@ -577,134 +485,6 @@ Definition decideJoinPointHood
         all_ok
     end.
 
-Definition combineUsageDetailsWith
-   : (BasicTypes.OccInfo -> BasicTypes.OccInfo -> BasicTypes.OccInfo) ->
-     UsageDetails -> UsageDetails -> UsageDetails :=
-  fun plus_occ_info ud1 ud2 =>
-    if isEmptyDetails ud1 : bool then ud2 else
-    if isEmptyDetails ud2 : bool then ud1 else
-    UD (Core.plusVarEnv_C plus_occ_info (ud_env ud1) (ud_env ud2)) (Core.plusVarEnv
-        (ud_z_many ud1) (ud_z_many ud2)) (Core.plusVarEnv (ud_z_in_lam ud1) (ud_z_in_lam
-                                                                             ud2)) (Core.plusVarEnv (ud_z_no_tail ud1)
-        (ud_z_no_tail ud2)).
-
-Axiom cheapExprSize : Core.CoreExpr -> nat.
-
-Definition nodeScore
-   : Core.Id -> Core.Id -> Core.CoreExpr -> Core.VarSet -> NodeScore :=
-  fun old_bndr new_bndr bind_rhs lb_deps =>
-    let fix is_con_app arg_0__
-              := match arg_0__ with
-                 | Core.Mk_Var v => Id.isConLikeId v
-                 | Core.App f _ => is_con_app f
-                 | Core.Lam _ e => is_con_app e
-                 | _ => false
-                 end in
-    let id_unfolding := Id.realIdUnfolding old_bndr in
-    let can_unfold := Core.canUnfold id_unfolding in
-    let rhs := bind_rhs in
-    let rhs_size := cheapExprSize rhs in
-    let is_lb := BasicTypes.isStrongLoopBreaker (Id.idOccInfo old_bndr) in
-    let mk_score : nat -> NodeScore :=
-      fun rank => pair (pair rank rhs_size) is_lb in
-    if negb (Core.isId old_bndr) : bool then pair (pair #100 #0) false else
-    if Core.elemVarSet old_bndr lb_deps : bool then pair (pair #0 #0) true else
-    if CoreUtils.exprIsTrivial rhs : bool then mk_score #10 else
-    if is_con_app rhs : bool then mk_score #5 else
-    if andb (Core.isStableUnfolding id_unfolding) can_unfold : bool
-    then mk_score #3 else
-    if BasicTypes.isOneOcc (Id.idOccInfo new_bndr) : bool then mk_score #2 else
-    if can_unfold : bool then mk_score #1 else
-    pair (pair #0 #0) is_lb.
-
-Definition betterLB : NodeScore -> NodeScore -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | pair (pair rank1 size1) lb1, pair (pair rank2 size2) _ =>
-        if rank1 GHC.Base.< rank2 : bool then true else
-        if rank1 GHC.Base.> rank2 : bool then false else
-        if size1 GHC.Base.< size2 : bool then false else
-        if size1 GHC.Base.> size2 : bool then true else
-        if lb1 : bool then true else
-        false
-    end.
-
-Fixpoint chooseLoopBreaker (arg_0__ : bool) (arg_1__ : NodeScore) (arg_2__
-                            arg_3__ arg_4__
-                             : list LetrecNode) : (list LetrecNode * list LetrecNode)%type
-           := match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__ with
-              | _, _, loop_nodes, acc, nil => pair loop_nodes acc
-              | approx_lb, loop_sc, loop_nodes, acc, cons node nodes =>
-                  let sc := nd_score (Digraph.node_payload node) in
-                  if andb approx_lb (rank sc GHC.Base.== rank loop_sc) : bool
-                  then chooseLoopBreaker approx_lb loop_sc (cons node loop_nodes) acc nodes else
-                  if betterLB sc loop_sc : bool
-                  then chooseLoopBreaker approx_lb sc (cons node nil) (Coq.Init.Datatypes.app
-                                                                       loop_nodes acc) nodes else
-                  chooseLoopBreaker approx_lb loop_sc loop_nodes (cons node acc) nodes
-              end.
-
-Definition argCtxt : OccEnv -> list OneShots -> (OccEnv * list OneShots)%type :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | env, nil =>
-        pair (let 'Mk_OccEnv occ_encl_2__ occ_one_shots_3__ occ_gbl_scrut_4__
-                 occ_rule_act_5__ occ_binder_swap_6__ := env in
-              Mk_OccEnv OccVanilla nil occ_gbl_scrut_4__ occ_rule_act_5__ occ_binder_swap_6__)
-             nil
-    | env, cons one_shots one_shots_s =>
-        pair (let 'Mk_OccEnv occ_encl_10__ occ_one_shots_11__ occ_gbl_scrut_12__
-                 occ_rule_act_13__ occ_binder_swap_14__ := env in
-              Mk_OccEnv OccVanilla one_shots occ_gbl_scrut_12__ occ_rule_act_13__
-                        occ_binder_swap_14__) one_shots_s
-    end.
-
-Definition andTailCallInfo
-   : BasicTypes.TailCallInfo ->
-     BasicTypes.TailCallInfo -> BasicTypes.TailCallInfo :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | (BasicTypes.AlwaysTailCalled arity1 as info)
-    , BasicTypes.AlwaysTailCalled arity2 =>
-        if arity1 GHC.Base.== arity2 : bool then info else
-        BasicTypes.NoTailCallInfo
-    | _, _ => BasicTypes.NoTailCallInfo
-    end.
-
-Definition orOccInfo
-   : BasicTypes.OccInfo -> BasicTypes.OccInfo -> BasicTypes.OccInfo :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | BasicTypes.OneOcc in_lam1 _ int_cxt1 tail1
-    , BasicTypes.OneOcc in_lam2 _ int_cxt2 tail2 =>
-        BasicTypes.OneOcc (orb in_lam1 in_lam2) false (andb int_cxt1 int_cxt2)
-                          (andTailCallInfo tail1 tail2)
-    | a1, a2 =>
-        if andb Util.debugIsOn (negb (negb (orb (BasicTypes.isDeadOcc a1)
-                                                (BasicTypes.isDeadOcc a2)))) : bool
-        then (Panic.assertPanic (GHC.Base.hs_string__
-                                 "ghc/compiler/simplCore/OccurAnal.hs") #2842)
-        else BasicTypes.ManyOccs (andTailCallInfo (BasicTypes.tailCallInfo a1)
-                                                  (BasicTypes.tailCallInfo a2))
-    end.
-
-Definition combineAltsUsageDetails
-   : UsageDetails -> UsageDetails -> UsageDetails :=
-  combineUsageDetailsWith orOccInfo.
-
-Definition alterZappedSets
-   : UsageDetails -> (ZappedSet -> ZappedSet) -> UsageDetails :=
-  fun ud f =>
-    let 'UD ud_env_0__ ud_z_many_1__ ud_z_in_lam_2__ ud_z_no_tail_3__ := ud in
-    UD ud_env_0__ (f (ud_z_many ud)) (f (ud_z_in_lam ud)) (f (ud_z_no_tail ud)).
-
-Definition flattenUsageDetails : UsageDetails -> UsageDetails :=
-  fun ud =>
-    alterZappedSets (let 'UD ud_env_0__ ud_z_many_1__ ud_z_in_lam_2__
-                        ud_z_no_tail_3__ := ud in
-                     UD (UniqFM.mapUFM_Directly (doZappingByUnique ud) (ud_env ud)) ud_z_many_1__
-                        ud_z_in_lam_2__ ud_z_no_tail_3__) (GHC.Base.const Core.emptyVarEnv).
-
 Definition alterUsageDetails
    : UsageDetails -> (OccInfoEnv -> OccInfoEnv) -> UsageDetails :=
   fun ud f =>
@@ -715,6 +495,16 @@ Definition alterUsageDetails
 Definition delDetails : UsageDetails -> Core.Id -> UsageDetails :=
   fun ud bndr =>
     alterUsageDetails ud (fun arg_0__ => Core.delVarEnv arg_0__ bndr).
+
+Definition setBinderOcc
+   : BasicTypes.OccInfo -> Core.CoreBndr -> Core.CoreBndr :=
+  fun occ_info bndr =>
+    if Core.isTyVar bndr : bool then bndr else
+    if Core.isExportedId bndr : bool
+    then if BasicTypes.isManyOccs (Id.idOccInfo bndr) : bool
+         then bndr
+         else Id.setIdOccInfo bndr BasicTypes.noOccInfo else
+    Id.setIdOccInfo bndr occ_info.
 
 Definition tagNonRecBinder
    : BasicTypes.TopLevelFlag ->
@@ -733,60 +523,107 @@ Definition tagNonRecBinder
     let binder' := setBinderOcc occ' binder in
     GHC.Prim.seq usage' (pair usage' binder').
 
-Definition delDetailsList : UsageDetails -> list Core.Id -> UsageDetails :=
-  fun ud bndrs =>
-    alterUsageDetails ud (fun arg_0__ => Core.delVarEnvList arg_0__ bndrs).
+Definition usedIn : Core.Id -> UsageDetails -> bool :=
+  fun v ud => orb (Core.isExportedId v) (Core.elemVarEnv v (ud_env ud)).
 
-Definition adjustRhsUsage
-   : option BasicTypes.JoinArity ->
-     BasicTypes.RecFlag -> list Core.CoreBndr -> UsageDetails -> UsageDetails :=
-  fun mb_join_arity rec_flag bndrs usage =>
-    let exact_join :=
-      match mb_join_arity with
-      | Some join_arity => Util.lengthIs bndrs join_arity
-      | _ => false
+Definition willBeJoinId_maybe : Core.CoreBndr -> option BasicTypes.JoinArity :=
+  fun bndr =>
+    match BasicTypes.tailCallInfo (Id.idOccInfo bndr) with
+    | BasicTypes.AlwaysTailCalled arity => Some arity
+    | _ => Id.isJoinId_maybe bndr
+    end.
+
+Definition occAnalNonRecBind
+   : OccEnv ->
+     BasicTypes.TopLevelFlag ->
+     ImpRuleEdges ->
+     Core.Var ->
+     Core.CoreExpr -> UsageDetails -> (UsageDetails * list Core.CoreBind)%type :=
+  fun env lvl imp_rule_edges binder rhs body_usage =>
+    let 'pair bndrs body := Core.collectBinders rhs in
+    let 'pair body_usage' tagged_binder := tagNonRecBinder lvl body_usage binder in
+    let mb_join_arity := willBeJoinId_maybe tagged_binder in
+    let 'pair (pair rhs_usage1 bndrs') body' := occAnalNonRecRhs env tagged_binder
+                                                  bndrs body in
+    let rhs' := Core.mkLams (markJoinOneShots mb_join_arity bndrs') body' in
+    let rhs_usage2 :=
+      match occAnalUnfolding env BasicTypes.NonRecursive binder with
+      | Some unf_usage => rhs_usage1 +++ unf_usage
+      | None => rhs_usage1
       end in
-    let one_shot :=
-      match mb_join_arity with
-      | Some join_arity =>
-          if BasicTypes.isRec rec_flag : bool then false else
-          Data.Foldable.all Id.isOneShotBndr (Coq.Lists.List.skipn join_arity bndrs)
-      | None => Data.Foldable.all Id.isOneShotBndr bndrs
-      end in
-    let maybe_drop_tails :=
-      fun ud => if exact_join : bool then ud else markAllNonTailCalled ud in
-    let maybe_mark_lam :=
-      fun ud => if one_shot : bool then ud else markAllInsideLam ud in
-    maybe_mark_lam (maybe_drop_tails usage).
+    let rules_w_uds :=
+      occAnalRules env mb_join_arity BasicTypes.NonRecursive tagged_binder in
+    let rhs_usage3 :=
+      rhs_usage2 +++
+      combineUsageDetailsList (GHC.Base.map (fun '(pair (pair _ l) r) => l +++ r)
+                               rules_w_uds) in
+    let rhs_usage4 :=
+      Data.Maybe.maybe rhs_usage3 (addManyOccsSet rhs_usage3) (Core.lookupVarEnv
+                                                               imp_rule_edges binder) in
+    let rhs_usage' :=
+      adjustRhsUsage mb_join_arity BasicTypes.NonRecursive bndrs' rhs_usage4 in
+    if Core.isTyVar binder : bool
+    then pair body_usage (cons (Core.NonRec binder rhs) nil) else
+    if negb (usedIn binder body_usage) : bool then pair body_usage nil else
+    pair (body_usage' +++ rhs_usage') (cons (Core.NonRec tagged_binder rhs') nil).
 
-Definition addOccInfo
-   : BasicTypes.OccInfo -> BasicTypes.OccInfo -> BasicTypes.OccInfo :=
-  fun a1 a2 =>
-    if andb Util.debugIsOn (negb (negb (orb (BasicTypes.isDeadOcc a1)
-                                            (BasicTypes.isDeadOcc a2)))) : bool
-    then (Panic.assertPanic (GHC.Base.hs_string__
-                             "ghc/compiler/simplCore/OccurAnal.hs") #2825)
-    else BasicTypes.ManyOccs (andTailCallInfo (BasicTypes.tailCallInfo a1)
-                                              (BasicTypes.tailCallInfo a2)).
+Axiom occAnalRecBind : OccEnv ->
+                       BasicTypes.TopLevelFlag ->
+                       ImpRuleEdges ->
+                       list (Core.Var * Core.CoreExpr)%type ->
+                       UsageDetails -> (UsageDetails * list Core.CoreBind)%type.
 
-Definition addOneOcc
-   : UsageDetails -> Core.Id -> BasicTypes.OccInfo -> UsageDetails :=
-  fun ud id info =>
-    let plus_zapped := fun old new => addOccInfo (doZapping ud id old) new in
-    alterZappedSets (let 'UD ud_env_1__ ud_z_many_2__ ud_z_in_lam_3__
-                        ud_z_no_tail_4__ := ud in
-                     UD (Core.extendVarEnv_C plus_zapped (ud_env ud) id info) ud_z_many_2__
-                        ud_z_in_lam_3__ ud_z_no_tail_4__) (fun arg_7__ => Core.delVarEnv arg_7__ id).
+(* Skipping definition `OccurAnal.occAnalRec' *)
 
-Definition op_zpzpzp__ : UsageDetails -> UsageDetails -> UsageDetails :=
-  combineUsageDetailsWith addOccInfo.
+Axiom loopBreakNodes : nat ->
+                       Core.VarSet -> Core.VarSet -> list LetrecNode -> list Binding -> list Binding.
 
-Notation "'_+++_'" := (op_zpzpzp__).
+Axiom reOrderNodes : nat ->
+                     Core.VarSet -> Core.VarSet -> list LetrecNode -> list Binding -> list Binding.
 
-Infix "+++" := (_+++_) (at level 99).
+Axiom mk_loop_breaker : LetrecNode -> Binding.
 
-Definition combineUsageDetailsList : list UsageDetails -> UsageDetails :=
-  Data.Foldable.foldl _+++_ emptyDetails.
+Axiom mk_non_loop_breaker : Core.VarSet -> LetrecNode -> Binding.
+
+Definition betterLB : NodeScore -> NodeScore -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | pair (pair rank1 size1) lb1, pair (pair rank2 size2) _ =>
+        if rank1 GHC.Base.< rank2 : bool then true else
+        if rank1 GHC.Base.> rank2 : bool then false else
+        if size1 GHC.Base.< size2 : bool then false else
+        if size1 GHC.Base.> size2 : bool then true else
+        if lb1 : bool then true else
+        false
+    end.
+
+Definition rank : NodeScore -> nat :=
+  fun '(pair (pair r _) _) => r.
+
+Fixpoint chooseLoopBreaker (arg_0__ : bool) (arg_1__ : NodeScore) (arg_2__
+                            arg_3__ arg_4__
+                             : list LetrecNode) : (list LetrecNode * list LetrecNode)%type
+           := match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__ with
+              | _, _, loop_nodes, acc, nil => pair loop_nodes acc
+              | approx_lb, loop_sc, loop_nodes, acc, cons node nodes =>
+                  let sc := nd_score (Digraph.node_payload node) in
+                  if andb approx_lb (rank sc GHC.Base.== rank loop_sc) : bool
+                  then chooseLoopBreaker approx_lb loop_sc (cons node loop_nodes) acc nodes else
+                  if betterLB sc loop_sc : bool
+                  then chooseLoopBreaker approx_lb sc (cons node nil) (Coq.Init.Datatypes.app
+                                                                       loop_nodes acc) nodes else
+                  chooseLoopBreaker approx_lb loop_sc loop_nodes (cons node acc) nodes
+              end.
+
+Definition noImpRuleEdges : ImpRuleEdges :=
+  Core.emptyVarEnv.
+
+Axiom occAnalRecRhs : OccEnv ->
+                      list Core.CoreBndr ->
+                      Core.CoreExpr -> (UsageDetails * list Core.CoreBndr * Core.CoreExpr)%type.
+
+Definition udFreeVars : Core.VarSet -> UsageDetails -> Core.VarSet :=
+  fun bndrs ud => UniqSet.restrictUniqSetToUFM bndrs (ud_env ud).
 
 Definition makeNode
    : OccEnv ->
@@ -838,6 +675,55 @@ Definition makeNode
                                                            node_fvs)
     end.
 
+Definition extendFvs
+   : UniqFM.UniqFM Core.VarSet -> Core.VarSet -> (Core.VarSet * bool)%type :=
+  fun env s =>
+    let extras : Core.VarSet :=
+      UniqFM.nonDetFoldUFM Core.unionVarSet Core.emptyVarSet (UniqFM.intersectUFM_C
+                                                              (fun arg_0__ arg_1__ =>
+                                                                 match arg_0__, arg_1__ with
+                                                                 | x, _ => x
+                                                                 end) env (UniqSet.getUniqSet s)) in
+    if UniqFM.isNullUFM env : bool then pair s true else
+    pair (Core.unionVarSet s extras) (Core.subVarSet extras s).
+
+Definition extendFvs_
+   : UniqFM.UniqFM Core.VarSet -> Core.VarSet -> Core.VarSet :=
+  fun env s => Data.Tuple.fst (extendFvs env s).
+
+Axiom cheapExprSize : Core.CoreExpr -> nat.
+
+Definition nodeScore
+   : Core.Id -> Core.Id -> Core.CoreExpr -> Core.VarSet -> NodeScore :=
+  fun old_bndr new_bndr bind_rhs lb_deps =>
+    let fix is_con_app arg_0__
+              := match arg_0__ with
+                 | Core.Mk_Var v => Id.isConLikeId v
+                 | Core.App f _ => is_con_app f
+                 | Core.Lam _ e => is_con_app e
+                 | _ => false
+                 end in
+    let id_unfolding := Id.realIdUnfolding old_bndr in
+    let can_unfold := Core.canUnfold id_unfolding in
+    let rhs := bind_rhs in
+    let rhs_size := cheapExprSize rhs in
+    let is_lb := BasicTypes.isStrongLoopBreaker (Id.idOccInfo old_bndr) in
+    let mk_score : nat -> NodeScore :=
+      fun rank => pair (pair rank rhs_size) is_lb in
+    if negb (Core.isId old_bndr) : bool then pair (pair #100 #0) false else
+    if Core.elemVarSet old_bndr lb_deps : bool then pair (pair #0 #0) true else
+    if CoreUtils.exprIsTrivial rhs : bool then mk_score #10 else
+    if is_con_app rhs : bool then mk_score #5 else
+    if andb (Core.isStableUnfolding id_unfolding) can_unfold : bool
+    then mk_score #3 else
+    if BasicTypes.isOneOcc (Id.idOccInfo new_bndr) : bool then mk_score #2 else
+    if can_unfold : bool then mk_score #1 else
+    pair (pair #0 #0) is_lb.
+
+Definition delDetailsList : UsageDetails -> list Core.Id -> UsageDetails :=
+  fun ud bndrs =>
+    alterUsageDetails ud (fun arg_0__ => Core.delVarEnvList arg_0__ bndrs).
+
 Definition tagRecBinders
    : BasicTypes.TopLevelFlag ->
      UsageDetails ->
@@ -869,6 +755,8 @@ Definition tagRecBinders
       Coq.Lists.List.flat_map (fun bndr =>
                                  cons (setBinderOcc (lookupDetails adj_uds bndr) bndr) nil) bndrs in
     let usage' := delDetailsList adj_uds bndrs in pair usage' bndrs'.
+
+Axiom transClosureFV : UniqFM.UniqFM Core.VarSet -> UniqFM.UniqFM Core.VarSet.
 
 Definition mkLoopBreakerNodes
    : BasicTypes.TopLevelFlag ->
@@ -905,45 +793,108 @@ Definition mkLoopBreakerNodes
                                                                             nd)) nil) details_s) in
     pair final_uds (GHC.List.zipWith mk_lb_node details_s bndrs').
 
-Definition addManyOccs : Core.Var -> UsageDetails -> UsageDetails :=
-  fun v u => if Core.isId v : bool then addOneOcc u v BasicTypes.noOccInfo else u.
+Definition maxExprSize : nat :=
+  #20.
 
-Definition addManyOccsSet : UsageDetails -> Core.VarSet -> UsageDetails :=
-  fun usage id_set => UniqSet.nonDetFoldUniqSet addManyOccs usage id_set.
-
-Definition occAnalNonRecBind
+Definition occAnalRhs
    : OccEnv ->
-     BasicTypes.TopLevelFlag ->
-     ImpRuleEdges ->
-     Core.Var ->
-     Core.CoreExpr -> UsageDetails -> (UsageDetails * list Core.CoreBind)%type :=
-  fun env lvl imp_rule_edges binder rhs body_usage =>
-    let 'pair bndrs body := Core.collectBinders rhs in
-    let 'pair body_usage' tagged_binder := tagNonRecBinder lvl body_usage binder in
-    let mb_join_arity := willBeJoinId_maybe tagged_binder in
-    let 'pair (pair rhs_usage1 bndrs') body' := occAnalNonRecRhs env tagged_binder
-                                                  bndrs body in
-    let rhs' := Core.mkLams (markJoinOneShots mb_join_arity bndrs') body' in
-    let rhs_usage2 :=
-      match occAnalUnfolding env BasicTypes.NonRecursive binder with
-      | Some unf_usage => rhs_usage1 +++ unf_usage
-      | None => rhs_usage1
-      end in
-    let rules_w_uds :=
-      occAnalRules env mb_join_arity BasicTypes.NonRecursive tagged_binder in
-    let rhs_usage3 :=
-      rhs_usage2 +++
-      combineUsageDetailsList (GHC.Base.map (fun '(pair (pair _ l) r) => l +++ r)
-                               rules_w_uds) in
-    let rhs_usage4 :=
-      Data.Maybe.maybe rhs_usage3 (addManyOccsSet rhs_usage3) (Core.lookupVarEnv
-                                                               imp_rule_edges binder) in
-    let rhs_usage' :=
-      adjustRhsUsage mb_join_arity BasicTypes.NonRecursive bndrs' rhs_usage4 in
-    if Core.isTyVar binder : bool
-    then pair body_usage (cons (Core.NonRec binder rhs) nil) else
-    if negb (usedIn binder body_usage) : bool then pair body_usage nil else
-    pair (body_usage' +++ rhs_usage') (cons (Core.NonRec tagged_binder rhs') nil).
+     BasicTypes.RecFlag ->
+     Core.Id ->
+     list Core.CoreBndr ->
+     Core.CoreExpr -> (UsageDetails * list Core.CoreBndr * Core.CoreExpr)%type :=
+  fun arg_0__ arg_1__ arg_2__ arg_3__ arg_4__ =>
+    match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__ with
+    | env, BasicTypes.Recursive, _, bndrs, body => occAnalRecRhs env bndrs body
+    | env, BasicTypes.NonRecursive, id, bndrs, body =>
+        occAnalNonRecRhs env id bndrs body
+    end.
+
+Axiom occAnalArgs : OccEnv ->
+                    list Core.CoreExpr -> list OneShots -> (UsageDetails * list Core.CoreExpr)%type.
+
+Definition addAppCtxt : OccEnv -> list (Core.Arg Core.CoreBndr) -> OccEnv :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | (Mk_OccEnv _ ctxt _ _ _ as env), args =>
+        let 'Mk_OccEnv occ_encl_2__ occ_one_shots_3__ occ_gbl_scrut_4__ occ_rule_act_5__
+           occ_binder_swap_6__ := env in
+        Mk_OccEnv occ_encl_2__ (Coq.Init.Datatypes.app (Coq.Lists.List.repeat
+                                                        BasicTypes.OneShotLam (Core.valArgCount args)) ctxt)
+                  occ_gbl_scrut_4__ occ_rule_act_5__ occ_binder_swap_6__
+    end.
+
+Definition isRhsEnv : OccEnv -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Mk_OccEnv OccRhs _ _ _ _ => true
+    | Mk_OccEnv OccVanilla _ _ _ _ => false
+    end.
+
+Definition mkOneOcc
+   : OccEnv ->
+     Core.Id -> BasicTypes.InterestingCxt -> BasicTypes.JoinArity -> UsageDetails :=
+  fun env id int_cxt arity =>
+    let singleton :=
+      fun info =>
+        let 'UD ud_env_0__ ud_z_many_1__ ud_z_in_lam_2__ ud_z_no_tail_3__ :=
+          emptyDetails in
+        UD (Core.unitVarEnv id info) ud_z_many_1__ ud_z_in_lam_2__ ud_z_no_tail_3__ in
+    if Core.isLocalId id : bool
+    then singleton (BasicTypes.OneOcc false true int_cxt
+                                      (BasicTypes.AlwaysTailCalled arity)) else
+    if Core.elemVarSet id (occ_gbl_scrut env) : bool
+    then singleton BasicTypes.noOccInfo else
+    emptyDetails.
+
+Definition occAnalApp
+   : OccEnv ->
+     (Core.Expr Core.CoreBndr * list (Core.Arg Core.CoreBndr) *
+      list (Core.Tickish Core.Id))%type ->
+     (UsageDetails * Core.Expr Core.CoreBndr)%type :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | env, pair (pair (Core.Mk_Var fun_) args) ticks =>
+        let n_args := Coq.Lists.List.length args in
+        let n_val_args := Core.valArgCount args in
+        let fun_uds := mkOneOcc env fun_ (n_val_args GHC.Base.> #0) n_args in
+        let is_exp := CoreUtils.isExpandableApp fun_ n_val_args in
+        let guaranteed_val_args :=
+          n_val_args GHC.Num.+
+          Coq.Lists.List.length (GHC.List.takeWhile BasicTypes.isOneShotInfo
+                                 (occ_one_shots env)) in
+        let one_shots := Core.argsOneShots (Id.idStrictness fun_) guaranteed_val_args in
+        let 'pair args_uds args' := occAnalArgs env args one_shots in
+        let final_args_uds :=
+          if andb (isRhsEnv env) is_exp : bool
+          then markAllNonTailCalled (markAllInsideLam args_uds) else
+          markAllNonTailCalled args_uds in
+        let uds := fun_uds +++ final_args_uds in
+        if Data.Foldable.null ticks : bool
+        then pair uds (Core.mkApps (Core.Mk_Var fun_) args') else
+        pair uds (Core.mkApps (Core.Mk_Var fun_) args')
+    | _, _ =>
+        match arg_0__, arg_1__ with
+        | env, pair (pair fun_ args) ticks =>
+            let 'pair args_uds args' := occAnalArgs env args nil in
+            let 'pair fun_uds fun' := occAnal (addAppCtxt env args) fun_ in
+            pair (markAllNonTailCalled (fun_uds +++ args_uds)) (Core.mkApps fun' args')
+        end
+    end.
+
+Definition markAllMany : UsageDetails -> UsageDetails :=
+  fun ud =>
+    let 'UD ud_env_0__ ud_z_many_1__ ud_z_in_lam_2__ ud_z_no_tail_3__ := ud in
+    UD ud_env_0__ (ud_env ud) ud_z_in_lam_2__ ud_z_no_tail_3__.
+
+Definition zapDetails : UsageDetails -> UsageDetails :=
+  markAllMany GHC.Base.∘ markAllNonTailCalled.
+
+Definition zapDetailsIf : bool -> UsageDetails -> UsageDetails :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | true, uds => zapDetails uds
+    | false, uds => uds
+    end.
 
 Definition tagLamBinders
    : UsageDetails -> list Core.Id -> (UsageDetails * list IdWithOccInfo)%type :=
@@ -1000,60 +951,109 @@ Definition occAnalAlt
         pair alt_usg' (pair (pair con tagged_bndrs) rhs2)
     end.
 
-Definition addAppCtxt : OccEnv -> list (Core.Arg Core.CoreBndr) -> OccEnv :=
+Definition vanillaCtxt : OccEnv -> OccEnv :=
+  fun '(Mk_OccEnv occ_encl_0__ occ_one_shots_1__ occ_gbl_scrut_2__
+  occ_rule_act_3__ occ_binder_swap_4__) =>
+    Mk_OccEnv OccVanilla nil occ_gbl_scrut_2__ occ_rule_act_3__ occ_binder_swap_4__.
+
+Definition argCtxt : OccEnv -> list OneShots -> (OccEnv * list OneShots)%type :=
   fun arg_0__ arg_1__ =>
     match arg_0__, arg_1__ with
-    | (Mk_OccEnv _ ctxt _ _ _ as env), args =>
-        let 'Mk_OccEnv occ_encl_2__ occ_one_shots_3__ occ_gbl_scrut_4__ occ_rule_act_5__
-           occ_binder_swap_6__ := env in
-        Mk_OccEnv occ_encl_2__ (Coq.Init.Datatypes.app (Coq.Lists.List.repeat
-                                                        BasicTypes.OneShotLam (Core.valArgCount args)) ctxt)
-                  occ_gbl_scrut_4__ occ_rule_act_5__ occ_binder_swap_6__
+    | env, nil =>
+        pair (let 'Mk_OccEnv occ_encl_2__ occ_one_shots_3__ occ_gbl_scrut_4__
+                 occ_rule_act_5__ occ_binder_swap_6__ := env in
+              Mk_OccEnv OccVanilla nil occ_gbl_scrut_4__ occ_rule_act_5__ occ_binder_swap_6__)
+             nil
+    | env, cons one_shots one_shots_s =>
+        pair (let 'Mk_OccEnv occ_encl_10__ occ_one_shots_11__ occ_gbl_scrut_12__
+                 occ_rule_act_13__ occ_binder_swap_14__ := env in
+              Mk_OccEnv OccVanilla one_shots occ_gbl_scrut_12__ occ_rule_act_13__
+                        occ_binder_swap_14__) one_shots_s
     end.
 
-Definition occAnalApp
-   : OccEnv ->
-     (Core.Expr Core.CoreBndr * list (Core.Arg Core.CoreBndr) *
-      list (Core.Tickish Core.Id))%type ->
-     (UsageDetails * Core.Expr Core.CoreBndr)%type :=
+Definition oneShotGroup
+   : OccEnv -> list Core.CoreBndr -> (OccEnv * list Core.CoreBndr)%type :=
   fun arg_0__ arg_1__ =>
     match arg_0__, arg_1__ with
-    | env, pair (pair (Core.Mk_Var fun_) args) ticks =>
-        let n_args := Coq.Lists.List.length args in
-        let n_val_args := Core.valArgCount args in
-        let fun_uds := mkOneOcc env fun_ (n_val_args GHC.Base.> #0) n_args in
-        let is_exp := CoreUtils.isExpandableApp fun_ n_val_args in
-        let guaranteed_val_args :=
-          n_val_args GHC.Num.+
-          Coq.Lists.List.length (GHC.List.takeWhile BasicTypes.isOneShotInfo
-                                 (occ_one_shots env)) in
-        let one_shots := Core.argsOneShots (Id.idStrictness fun_) guaranteed_val_args in
-        let 'pair args_uds args' := occAnalArgs env args one_shots in
-        let final_args_uds :=
-          if andb (isRhsEnv env) is_exp : bool
-          then markAllNonTailCalled (markAllInsideLam args_uds) else
-          markAllNonTailCalled args_uds in
-        let uds := fun_uds +++ final_args_uds in
-        if Data.Foldable.null ticks : bool
-        then pair uds (Core.mkApps (Core.Mk_Var fun_) args') else
-        pair uds (Core.mkApps (Core.Mk_Var fun_) args')
-    | _, _ =>
-        match arg_0__, arg_1__ with
-        | env, pair (pair fun_ args) ticks =>
-            let 'pair args_uds args' := occAnalArgs env args nil in
-            let 'pair fun_uds fun' := occAnal (addAppCtxt env args) fun_ in
-            pair (markAllNonTailCalled (fun_uds +++ args_uds)) (Core.mkApps fun' args')
+    | (Mk_OccEnv _ ctxt _ _ _ as env), bndrs =>
+        let fix go arg_2__ arg_3__ arg_4__
+                  := match arg_2__, arg_3__, arg_4__ with
+                     | ctxt, nil, rev_bndrs =>
+                         pair (let 'Mk_OccEnv occ_encl_5__ occ_one_shots_6__ occ_gbl_scrut_7__
+                                  occ_rule_act_8__ occ_binder_swap_9__ := env in
+                               Mk_OccEnv OccVanilla ctxt occ_gbl_scrut_7__ occ_rule_act_8__
+                                         occ_binder_swap_9__) (GHC.List.reverse rev_bndrs)
+                     | nil, bndrs, rev_bndrs =>
+                         pair (let 'Mk_OccEnv occ_encl_13__ occ_one_shots_14__ occ_gbl_scrut_15__
+                                  occ_rule_act_16__ occ_binder_swap_17__ := env in
+                               Mk_OccEnv OccVanilla nil occ_gbl_scrut_15__ occ_rule_act_16__
+                                         occ_binder_swap_17__) (Coq.Init.Datatypes.app (GHC.List.reverse rev_bndrs)
+                                                                                       bndrs)
+                     | (cons one_shot ctxt' as ctxt), cons bndr bndrs, rev_bndrs =>
+                         let bndr' := Id.updOneShotInfo bndr one_shot in
+                         if Core.isId bndr : bool then go ctxt' bndrs (cons bndr' rev_bndrs) else
+                         go ctxt bndrs (cons bndr rev_bndrs)
+                     end in
+        go ctxt bndrs nil
+    end.
+
+Definition mkAltEnv
+   : OccEnv ->
+     Core.CoreExpr ->
+     Core.Id -> (OccEnv * option (Core.Id * Core.CoreExpr)%type)%type :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | (Mk_OccEnv _ _ pe _ _ as env), scrut, case_bndr =>
+        let localise :=
+          fun scrut_var =>
+            Id.mkLocalIdOrCoVar (Name.localiseName (Id.idName scrut_var)) (Id.idType
+                                                                           scrut_var) in
+        let case_bndr' := Core.Mk_Var (Id.zapIdOccInfo case_bndr) in
+        let add_scrut :=
+          fun v rhs =>
+            pair (let 'Mk_OccEnv occ_encl_5__ occ_one_shots_6__ occ_gbl_scrut_7__
+                     occ_rule_act_8__ occ_binder_swap_9__ := env in
+                  Mk_OccEnv OccVanilla occ_one_shots_6__ (Core.extendVarSet pe v) occ_rule_act_8__
+                            occ_binder_swap_9__) (Some (pair (localise v) rhs)) in
+        match CoreUtils.stripTicksTopE (GHC.Base.const true) scrut with
+        | Core.Mk_Var v => add_scrut v case_bndr'
+        | Core.Cast (Core.Mk_Var v) co =>
+            add_scrut v (Core.Cast case_bndr' (Core.mkSymCo co))
+        | _ =>
+            pair (let 'Mk_OccEnv occ_encl_16__ occ_one_shots_17__ occ_gbl_scrut_18__
+                     occ_rule_act_19__ occ_binder_swap_20__ := env in
+                  Mk_OccEnv OccVanilla occ_one_shots_17__ occ_gbl_scrut_18__ occ_rule_act_19__
+                            occ_binder_swap_20__) None
         end
     end.
 
-(* Skipping all instances of class `Outputable.Outputable', including
-   `OccurAnal.Outputable__OccEncl' *)
+Definition orOccInfo
+   : BasicTypes.OccInfo -> BasicTypes.OccInfo -> BasicTypes.OccInfo :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | BasicTypes.OneOcc in_lam1 _ int_cxt1 tail1
+    , BasicTypes.OneOcc in_lam2 _ int_cxt2 tail2 =>
+        BasicTypes.OneOcc (orb in_lam1 in_lam2) false (andb int_cxt1 int_cxt2)
+                          (andTailCallInfo tail1 tail2)
+    | a1, a2 =>
+        if andb Util.debugIsOn (negb (negb (orb (BasicTypes.isDeadOcc a1)
+                                                (BasicTypes.isDeadOcc a2)))) : bool
+        then (Panic.assertPanic (GHC.Base.hs_string__
+                                 "ghc/compiler/simplCore/OccurAnal.hs") #2842)
+        else BasicTypes.ManyOccs (andTailCallInfo (BasicTypes.tailCallInfo a1)
+                                                  (BasicTypes.tailCallInfo a2))
+    end.
 
-(* Skipping all instances of class `Outputable.Outputable', including
-   `OccurAnal.Outputable__UsageDetails' *)
+Definition combineAltsUsageDetails
+   : UsageDetails -> UsageDetails -> UsageDetails :=
+  combineUsageDetailsWith orOccInfo.
 
-(* Skipping all instances of class `Outputable.Outputable', including
-   `OccurAnal.Outputable__Details' *)
+Definition flattenUsageDetails : UsageDetails -> UsageDetails :=
+  fun ud =>
+    alterZappedSets (let 'UD ud_env_0__ ud_z_many_1__ ud_z_in_lam_2__
+                        ud_z_no_tail_3__ := ud in
+                     UD (UniqFM.mapUFM_Directly (doZappingByUnique ud) (ud_env ud)) ud_z_many_1__
+                        ud_z_in_lam_2__ ud_z_no_tail_3__) (GHC.Base.const Core.emptyVarEnv).
 
 Module Notations.
 Notation "'_OccurAnal.+++_'" := (op_zpzpzp__).

--- a/examples/ghc/lib/OrdList.v
+++ b/examples/ghc/lib/OrdList.v
@@ -48,70 +48,8 @@ Arguments Two {_} _ _.
 
 (* Converted value declarations: *)
 
-Definition unitOL {a} : a -> OrdList a :=
-  fun as_ => One as_.
-
-Definition toOL {a} : list a -> OrdList a :=
-  fun arg_0__ => match arg_0__ with | nil => None | xs => Many xs end.
-
-Definition snocOL {a} : OrdList a -> a -> OrdList a :=
-  fun as_ b => Snoc as_ b.
-
-Definition nilOL {a} : OrdList a :=
-  None.
-
-Fixpoint mapOL {a} {b} (arg_0__ : (a -> b)) (arg_1__ : OrdList a) : OrdList b
-           := match arg_0__, arg_1__ with
-              | _, None => None
-              | f, One x => One (f x)
-              | f, Cons x xs => Cons (f x) (mapOL f xs)
-              | f, Snoc xs x => Snoc (mapOL f xs) (f x)
-              | f, Two x y => Two (mapOL f x) (mapOL f y)
-              | f, Many xs => Many (GHC.Base.map f xs)
-              end.
-
-(* Skipping definition `OrdList.lastOL' *)
-
-Definition isNilOL {a} : OrdList a -> bool :=
-  fun arg_0__ => match arg_0__ with | None => true | _ => false end.
-
-Definition fromOL {a} : OrdList a -> list a :=
-  fun a =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | None, acc => acc
-                 | One a, acc => cons a acc
-                 | Cons a b, acc => cons a (go b acc)
-                 | Snoc a b, acc => go a (cons b acc)
-                 | Two a b, acc => go a (go b acc)
-                 | Many xs, acc => Coq.Init.Datatypes.app xs acc
-                 end in
-    go a nil.
-
-Fixpoint foldrOL {a} {b} (arg_0__ : (a -> b -> b)) (arg_1__ : b) (arg_2__
-                   : OrdList a) : b
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, z, None => z
-              | k, z, One x => k x z
-              | k, z, Cons x xs => k x (foldrOL k z xs)
-              | k, z, Snoc xs x => foldrOL k (k x z) xs
-              | k, z, Two b1 b2 => foldrOL k (foldrOL k z b2) b1
-              | k, z, Many xs => Data.Foldable.foldr k z xs
-              end.
-
-Fixpoint foldlOL {b} {a} (arg_0__ : (b -> a -> b)) (arg_1__ : b) (arg_2__
-                   : OrdList a) : b
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, z, None => z
-              | k, z, One x => k z x
-              | k, z, Cons x xs => foldlOL k (k z x) xs
-              | k, z, Snoc xs x => k (foldlOL k z xs) x
-              | k, z, Two b1 b2 => foldlOL k (foldlOL k z b1) b2
-              | k, z, Many xs => Data.Foldable.foldl k z xs
-              end.
-
-Definition consOL {a} : a -> OrdList a -> OrdList a :=
-  fun a bs => Cons a bs.
+(* Skipping all instances of class `Outputable.Outputable', including
+   `OrdList.Outputable__OrdList' *)
 
 Definition appOL {a} : OrdList a -> OrdList a -> OrdList a :=
   fun arg_0__ arg_1__ =>
@@ -123,29 +61,70 @@ Definition appOL {a} : OrdList a -> OrdList a -> OrdList a :=
     | a, b => Two a b
     end.
 
+Local Definition Semigroup__OrdList_op_zlzlzgzg__ {inst_a}
+   : (OrdList inst_a) -> (OrdList inst_a) -> (OrdList inst_a) :=
+  appOL.
+
+Program Instance Semigroup__OrdList {a} : GHC.Base.Semigroup (OrdList a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__OrdList_op_zlzlzgzg__ |}.
+
+Local Definition Monoid__OrdList_mappend {inst_a}
+   : (OrdList inst_a) -> (OrdList inst_a) -> (OrdList inst_a) :=
+  _GHC.Base.<<>>_.
+
 Definition concatOL {a} : list (OrdList a) -> OrdList a :=
   fun aas => Data.Foldable.foldr appOL None aas.
 
-Local Definition Traversable__OrdList_traverse
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f}, (a -> f b) -> OrdList a -> f (OrdList b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun f xs => toOL Data.Functor.<$> Data.Traversable.traverse f (fromOL xs).
+Local Definition Monoid__OrdList_mconcat {inst_a}
+   : list (OrdList inst_a) -> (OrdList inst_a) :=
+  concatOL.
 
-Local Definition Traversable__OrdList_mapM
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m}, (a -> m b) -> OrdList a -> m (OrdList b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__OrdList_traverse.
+Definition nilOL {a} : OrdList a :=
+  None.
 
-Local Definition Traversable__OrdList_sequenceA
-   : forall {f} {a},
-     forall `{GHC.Base.Applicative f}, OrdList (f a) -> f (OrdList a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} =>
-    Traversable__OrdList_traverse GHC.Base.id.
+Local Definition Monoid__OrdList_mempty {inst_a} : (OrdList inst_a) :=
+  nilOL.
 
-Local Definition Traversable__OrdList_sequence
-   : forall {m} {a}, forall `{GHC.Base.Monad m}, OrdList (m a) -> m (OrdList a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__OrdList_sequenceA.
+Program Instance Monoid__OrdList {a} : GHC.Base.Monoid (OrdList a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.mappend__ := Monoid__OrdList_mappend ;
+           GHC.Base.mconcat__ := Monoid__OrdList_mconcat ;
+           GHC.Base.mempty__ := Monoid__OrdList_mempty |}.
+
+Fixpoint mapOL {a} {b} (arg_0__ : (a -> b)) (arg_1__ : OrdList a) : OrdList b
+           := match arg_0__, arg_1__ with
+              | _, None => None
+              | f, One x => One (f x)
+              | f, Cons x xs => Cons (f x) (mapOL f xs)
+              | f, Snoc xs x => Snoc (mapOL f xs) (f x)
+              | f, Two x y => Two (mapOL f x) (mapOL f y)
+              | f, Many xs => Many (GHC.Base.map f xs)
+              end.
+
+Local Definition Functor__OrdList_fmap
+   : forall {a} {b}, (a -> b) -> OrdList a -> OrdList b :=
+  fun {a} {b} => mapOL.
+
+Local Definition Functor__OrdList_op_zlzd__
+   : forall {a} {b}, a -> OrdList b -> OrdList a :=
+  fun {a} {b} => Functor__OrdList_fmap GHC.Base.∘ GHC.Base.const.
+
+Program Instance Functor__OrdList : GHC.Base.Functor OrdList :=
+  fun _ k__ =>
+    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__OrdList_fmap ;
+           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__OrdList_op_zlzd__ |}.
+
+Fixpoint foldrOL {a} {b} (arg_0__ : (a -> b -> b)) (arg_1__ : b) (arg_2__
+                   : OrdList a) : b
+           := match arg_0__, arg_1__, arg_2__ with
+              | _, z, None => z
+              | k, z, One x => k x z
+              | k, z, Cons x xs => k x (foldrOL k z xs)
+              | k, z, Snoc xs x => foldrOL k (k x z) xs
+              | k, z, Two b1 b2 => foldrOL k (foldrOL k z b2) b1
+              | k, z, Many xs => Data.Foldable.foldr k z xs
+              end.
 
 Local Definition Foldable__OrdList_foldr
    : forall {a} {b}, (a -> b -> b) -> b -> OrdList a -> b :=
@@ -228,18 +207,42 @@ Program Instance Foldable__OrdList : Data.Foldable.Foldable OrdList :=
            Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__OrdList_sum ;
            Data.Foldable.toList__ := fun {a} => Foldable__OrdList_toList |}.
 
-Local Definition Functor__OrdList_fmap
-   : forall {a} {b}, (a -> b) -> OrdList a -> OrdList b :=
-  fun {a} {b} => mapOL.
+Definition fromOL {a} : OrdList a -> list a :=
+  fun a =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | None, acc => acc
+                 | One a, acc => cons a acc
+                 | Cons a b, acc => cons a (go b acc)
+                 | Snoc a b, acc => go a (cons b acc)
+                 | Two a b, acc => go a (go b acc)
+                 | Many xs, acc => Coq.Init.Datatypes.app xs acc
+                 end in
+    go a nil.
 
-Local Definition Functor__OrdList_op_zlzd__
-   : forall {a} {b}, a -> OrdList b -> OrdList a :=
-  fun {a} {b} => Functor__OrdList_fmap GHC.Base.∘ GHC.Base.const.
+Definition toOL {a} : list a -> OrdList a :=
+  fun arg_0__ => match arg_0__ with | nil => None | xs => Many xs end.
 
-Program Instance Functor__OrdList : GHC.Base.Functor OrdList :=
-  fun _ k__ =>
-    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__OrdList_fmap ;
-           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__OrdList_op_zlzd__ |}.
+Local Definition Traversable__OrdList_traverse
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f}, (a -> f b) -> OrdList a -> f (OrdList b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+    fun f xs => toOL Data.Functor.<$> Data.Traversable.traverse f (fromOL xs).
+
+Local Definition Traversable__OrdList_mapM
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m}, (a -> m b) -> OrdList a -> m (OrdList b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__OrdList_traverse.
+
+Local Definition Traversable__OrdList_sequenceA
+   : forall {f} {a},
+     forall `{GHC.Base.Applicative f}, OrdList (f a) -> f (OrdList a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} =>
+    Traversable__OrdList_traverse GHC.Base.id.
+
+Local Definition Traversable__OrdList_sequence
+   : forall {m} {a}, forall `{GHC.Base.Monad m}, OrdList (m a) -> m (OrdList a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__OrdList_sequenceA.
 
 Program Instance Traversable__OrdList : Data.Traversable.Traversable OrdList :=
   fun _ k__ =>
@@ -252,33 +255,30 @@ Program Instance Traversable__OrdList : Data.Traversable.Traversable OrdList :=
            Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
              Traversable__OrdList_traverse |}.
 
-Local Definition Semigroup__OrdList_op_zlzlzgzg__ {inst_a}
-   : (OrdList inst_a) -> (OrdList inst_a) -> (OrdList inst_a) :=
-  appOL.
+Definition unitOL {a} : a -> OrdList a :=
+  fun as_ => One as_.
 
-Program Instance Semigroup__OrdList {a} : GHC.Base.Semigroup (OrdList a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__OrdList_op_zlzlzgzg__ |}.
+Definition snocOL {a} : OrdList a -> a -> OrdList a :=
+  fun as_ b => Snoc as_ b.
 
-Local Definition Monoid__OrdList_mappend {inst_a}
-   : (OrdList inst_a) -> (OrdList inst_a) -> (OrdList inst_a) :=
-  _GHC.Base.<<>>_.
+Definition consOL {a} : a -> OrdList a -> OrdList a :=
+  fun a bs => Cons a bs.
 
-Local Definition Monoid__OrdList_mconcat {inst_a}
-   : list (OrdList inst_a) -> (OrdList inst_a) :=
-  concatOL.
+(* Skipping definition `OrdList.lastOL' *)
 
-Local Definition Monoid__OrdList_mempty {inst_a} : (OrdList inst_a) :=
-  nilOL.
+Definition isNilOL {a} : OrdList a -> bool :=
+  fun arg_0__ => match arg_0__ with | None => true | _ => false end.
 
-Program Instance Monoid__OrdList {a} : GHC.Base.Monoid (OrdList a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.mappend__ := Monoid__OrdList_mappend ;
-           GHC.Base.mconcat__ := Monoid__OrdList_mconcat ;
-           GHC.Base.mempty__ := Monoid__OrdList_mempty |}.
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `OrdList.Outputable__OrdList' *)
+Fixpoint foldlOL {b} {a} (arg_0__ : (b -> a -> b)) (arg_1__ : b) (arg_2__
+                   : OrdList a) : b
+           := match arg_0__, arg_1__, arg_2__ with
+              | _, z, None => z
+              | k, z, One x => k z x
+              | k, z, Cons x xs => foldlOL k (k z x) xs
+              | k, z, Snoc xs x => k (foldlOL k z xs) x
+              | k, z, Two b1 b2 => foldlOL k (foldlOL k z b1) b2
+              | k, z, Many xs => Data.Foldable.foldl k z xs
+              end.
 
 (* External variables:
      bool cons false list nil true Coq.Init.Datatypes.app Coq.Program.Basics.compose

--- a/examples/ghc/lib/Pair.v
+++ b/examples/ghc/lib/Pair.v
@@ -39,87 +39,49 @@ Definition pSnd {a} (arg_0__ : Pair a) :=
 
 (* Converted value declarations: *)
 
-Definition unPair {a} : Pair a -> (a * a)%type :=
-  fun '(Mk_Pair x y) => pair x y.
-
-Definition toPair {a} : (a * a)%type -> Pair a :=
-  fun '(pair x y) => Mk_Pair x y.
-
-Definition swap {a} : Pair a -> Pair a :=
-  fun '(Mk_Pair x y) => Mk_Pair y x.
-
-Definition pLiftSnd {a} : (a -> a) -> Pair a -> Pair a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, Mk_Pair a b => Mk_Pair a (f b)
-    end.
-
-Definition pLiftFst {a} : (a -> a) -> Pair a -> Pair a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, Mk_Pair a b => Mk_Pair (f a) b
-    end.
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Pair.Outputable__Pair' *)
-
-Local Definition Semigroup__Pair_op_zlzlzgzg__ {inst_a} `{GHC.Base.Semigroup
-  inst_a}
-   : (Pair inst_a) -> (Pair inst_a) -> (Pair inst_a) :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_Pair a1 b1, Mk_Pair a2 b2 =>
-        Mk_Pair (a1 GHC.Base.<<>> a2) (b1 GHC.Base.<<>> b2)
-    end.
-
-Program Instance Semigroup__Pair {a} `{GHC.Base.Semigroup a}
-   : GHC.Base.Semigroup (Pair a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__Pair_op_zlzlzgzg__ |}.
-
-Local Definition Monoid__Pair_mappend {inst_a} `{GHC.Base.Semigroup inst_a}
-  `{GHC.Base.Monoid inst_a}
-   : (Pair inst_a) -> (Pair inst_a) -> (Pair inst_a) :=
-  _GHC.Base.<<>>_.
-
-Local Definition Monoid__Pair_mempty {inst_a} `{GHC.Base.Semigroup inst_a}
-  `{GHC.Base.Monoid inst_a}
-   : (Pair inst_a) :=
-  Mk_Pair GHC.Base.mempty GHC.Base.mempty.
-
-Local Definition Monoid__Pair_mconcat {inst_a} `{GHC.Base.Semigroup inst_a}
-  `{GHC.Base.Monoid inst_a}
-   : list (Pair inst_a) -> (Pair inst_a) :=
-  GHC.Base.foldr Monoid__Pair_mappend Monoid__Pair_mempty.
-
-Program Instance Monoid__Pair {a} `{GHC.Base.Semigroup a} `{GHC.Base.Monoid a}
-   : GHC.Base.Monoid (Pair a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.mappend__ := Monoid__Pair_mappend ;
-           GHC.Base.mconcat__ := Monoid__Pair_mconcat ;
-           GHC.Base.mempty__ := Monoid__Pair_mempty |}.
-
-Local Definition Traversable__Pair_traverse
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f}, (a -> f b) -> Pair a -> f (Pair b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+Local Definition Functor__Pair_fmap
+   : forall {a} {b}, (a -> b) -> Pair a -> Pair b :=
+  fun {a} {b} =>
     fun arg_0__ arg_1__ =>
       match arg_0__, arg_1__ with
-      | f, Mk_Pair x y => (Mk_Pair Data.Functor.<$> f x) GHC.Base.<*> f y
+      | f, Mk_Pair x y => Mk_Pair (f x) (f y)
       end.
 
-Local Definition Traversable__Pair_mapM
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m}, (a -> m b) -> Pair a -> m (Pair b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Pair_traverse.
+Local Definition Functor__Pair_op_zlzd__
+   : forall {a} {b}, a -> Pair b -> Pair a :=
+  fun {a} {b} => Functor__Pair_fmap GHC.Base.∘ GHC.Base.const.
 
-Local Definition Traversable__Pair_sequenceA
-   : forall {f} {a}, forall `{GHC.Base.Applicative f}, Pair (f a) -> f (Pair a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} => Traversable__Pair_traverse GHC.Base.id.
+Program Instance Functor__Pair : GHC.Base.Functor Pair :=
+  fun _ k__ =>
+    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Pair_fmap ;
+           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Pair_op_zlzd__ |}.
 
-Local Definition Traversable__Pair_sequence
-   : forall {m} {a}, forall `{GHC.Base.Monad m}, Pair (m a) -> m (Pair a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Pair_sequenceA.
+Local Definition Applicative__Pair_op_zlztzg__
+   : forall {a} {b}, Pair (a -> b) -> Pair a -> Pair b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | Mk_Pair f g, Mk_Pair x y => Mk_Pair (f x) (g y)
+      end.
+
+Local Definition Applicative__Pair_liftA2
+   : forall {a} {b} {c}, (a -> b -> c) -> Pair a -> Pair b -> Pair c :=
+  fun {a} {b} {c} => fun f x => Applicative__Pair_op_zlztzg__ (GHC.Base.fmap f x).
+
+Local Definition Applicative__Pair_op_ztzg__
+   : forall {a} {b}, Pair a -> Pair b -> Pair b :=
+  fun {a} {b} =>
+    fun a1 a2 => Applicative__Pair_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
+
+Local Definition Applicative__Pair_pure : forall {a}, a -> Pair a :=
+  fun {a} => fun x => Mk_Pair x x.
+
+Program Instance Applicative__Pair : GHC.Base.Applicative Pair :=
+  fun _ k__ =>
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Pair_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Pair_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Pair_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__Pair_pure |}.
 
 Local Definition Foldable__Pair_foldMap
    : forall {m} {a}, forall `{GHC.Base.Monoid m}, (a -> m) -> Pair a -> m :=
@@ -203,22 +165,27 @@ Program Instance Foldable__Pair : Data.Foldable.Foldable Pair :=
            Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Pair_sum ;
            Data.Foldable.toList__ := fun {a} => Foldable__Pair_toList |}.
 
-Local Definition Functor__Pair_fmap
-   : forall {a} {b}, (a -> b) -> Pair a -> Pair b :=
-  fun {a} {b} =>
+Local Definition Traversable__Pair_traverse
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f}, (a -> f b) -> Pair a -> f (Pair b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
     fun arg_0__ arg_1__ =>
       match arg_0__, arg_1__ with
-      | f, Mk_Pair x y => Mk_Pair (f x) (f y)
+      | f, Mk_Pair x y => (Mk_Pair Data.Functor.<$> f x) GHC.Base.<*> f y
       end.
 
-Local Definition Functor__Pair_op_zlzd__
-   : forall {a} {b}, a -> Pair b -> Pair a :=
-  fun {a} {b} => Functor__Pair_fmap GHC.Base.∘ GHC.Base.const.
+Local Definition Traversable__Pair_mapM
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m}, (a -> m b) -> Pair a -> m (Pair b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Pair_traverse.
 
-Program Instance Functor__Pair : GHC.Base.Functor Pair :=
-  fun _ k__ =>
-    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Pair_fmap ;
-           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Pair_op_zlzd__ |}.
+Local Definition Traversable__Pair_sequenceA
+   : forall {f} {a}, forall `{GHC.Base.Applicative f}, Pair (f a) -> f (Pair a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} => Traversable__Pair_traverse GHC.Base.id.
+
+Local Definition Traversable__Pair_sequence
+   : forall {m} {a}, forall `{GHC.Base.Monad m}, Pair (m a) -> m (Pair a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Pair_sequenceA.
 
 Program Instance Traversable__Pair : Data.Traversable.Traversable Pair :=
   fun _ k__ =>
@@ -231,32 +198,65 @@ Program Instance Traversable__Pair : Data.Traversable.Traversable Pair :=
            Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
              Traversable__Pair_traverse |}.
 
-Local Definition Applicative__Pair_op_zlztzg__
-   : forall {a} {b}, Pair (a -> b) -> Pair a -> Pair b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | Mk_Pair f g, Mk_Pair x y => Mk_Pair (f x) (g y)
-      end.
+Local Definition Semigroup__Pair_op_zlzlzgzg__ {inst_a} `{GHC.Base.Semigroup
+  inst_a}
+   : (Pair inst_a) -> (Pair inst_a) -> (Pair inst_a) :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_Pair a1 b1, Mk_Pair a2 b2 =>
+        Mk_Pair (a1 GHC.Base.<<>> a2) (b1 GHC.Base.<<>> b2)
+    end.
 
-Local Definition Applicative__Pair_liftA2
-   : forall {a} {b} {c}, (a -> b -> c) -> Pair a -> Pair b -> Pair c :=
-  fun {a} {b} {c} => fun f x => Applicative__Pair_op_zlztzg__ (GHC.Base.fmap f x).
-
-Local Definition Applicative__Pair_op_ztzg__
-   : forall {a} {b}, Pair a -> Pair b -> Pair b :=
-  fun {a} {b} =>
-    fun a1 a2 => Applicative__Pair_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
-
-Local Definition Applicative__Pair_pure : forall {a}, a -> Pair a :=
-  fun {a} => fun x => Mk_Pair x x.
-
-Program Instance Applicative__Pair : GHC.Base.Applicative Pair :=
+Program Instance Semigroup__Pair {a} `{GHC.Base.Semigroup a}
+   : GHC.Base.Semigroup (Pair a) :=
   fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Pair_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Pair_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Pair_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__Pair_pure |}.
+    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__Pair_op_zlzlzgzg__ |}.
+
+Local Definition Monoid__Pair_mappend {inst_a} `{GHC.Base.Semigroup inst_a}
+  `{GHC.Base.Monoid inst_a}
+   : (Pair inst_a) -> (Pair inst_a) -> (Pair inst_a) :=
+  _GHC.Base.<<>>_.
+
+Local Definition Monoid__Pair_mempty {inst_a} `{GHC.Base.Semigroup inst_a}
+  `{GHC.Base.Monoid inst_a}
+   : (Pair inst_a) :=
+  Mk_Pair GHC.Base.mempty GHC.Base.mempty.
+
+Local Definition Monoid__Pair_mconcat {inst_a} `{GHC.Base.Semigroup inst_a}
+  `{GHC.Base.Monoid inst_a}
+   : list (Pair inst_a) -> (Pair inst_a) :=
+  GHC.Base.foldr Monoid__Pair_mappend Monoid__Pair_mempty.
+
+Program Instance Monoid__Pair {a} `{GHC.Base.Semigroup a} `{GHC.Base.Monoid a}
+   : GHC.Base.Monoid (Pair a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.mappend__ := Monoid__Pair_mappend ;
+           GHC.Base.mconcat__ := Monoid__Pair_mconcat ;
+           GHC.Base.mempty__ := Monoid__Pair_mempty |}.
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Pair.Outputable__Pair' *)
+
+Definition unPair {a} : Pair a -> (a * a)%type :=
+  fun '(Mk_Pair x y) => pair x y.
+
+Definition toPair {a} : (a * a)%type -> Pair a :=
+  fun '(pair x y) => Mk_Pair x y.
+
+Definition swap {a} : Pair a -> Pair a :=
+  fun '(Mk_Pair x y) => Mk_Pair y x.
+
+Definition pLiftFst {a} : (a -> a) -> Pair a -> Pair a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, Mk_Pair a b => Mk_Pair (f a) b
+    end.
+
+Definition pLiftSnd {a} : (a -> a) -> Pair a -> Pair a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, Mk_Pair a b => Mk_Pair a (f b)
+    end.
 
 (* External variables:
      bool false list op_zt__ pair true Coq.Program.Basics.compose

--- a/examples/ghc/lib/Panic.v
+++ b/examples/ghc/lib/Panic.v
@@ -32,51 +32,51 @@ Inductive GhcException : Type
 
 (* Converted value declarations: *)
 
-(* Skipping definition `Panic.withSignalHandlers' *)
+(* Skipping all instances of class `GHC.Exception.Exception', including
+   `Panic.Exception__GhcException' *)
 
-(* Skipping definition `Panic.tryMost' *)
-
-(* Skipping definition `Panic.throwGhcExceptionIO' *)
-
-Axiom throwGhcException : forall {a} `{GHC.Err.Default a}, GhcException -> a.
-
-Axiom sorryDoc : forall {a} `{GHC.Err.Default a},
-                 GHC.Base.String -> GHC.Base.String -> a.
-
-Axiom sorry : forall {a} `{GHC.Err.Default a}, GHC.Base.String -> a.
-
-(* Skipping definition `Panic.signalHandlersRefCount' *)
-
-(* Skipping definition `Panic.showGhcException' *)
-
-(* Skipping definition `Panic.showException' *)
-
-Axiom short_usage : GHC.Base.String.
-
-(* Skipping definition `Panic.safeShowException' *)
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Panic.Show__GhcException' *)
 
 Axiom progName : GHC.Base.String.
 
-Axiom pgmErrorDoc : forall {a} `{GHC.Err.Default a},
-                    GHC.Base.String -> GHC.Base.String -> a.
+Axiom short_usage : GHC.Base.String.
+
+(* Skipping definition `Panic.showException' *)
+
+(* Skipping definition `Panic.safeShowException' *)
+
+(* Skipping definition `Panic.showGhcException' *)
+
+Axiom throwGhcException : forall {a} `{GHC.Err.Default a}, GhcException -> a.
+
+(* Skipping definition `Panic.throwGhcExceptionIO' *)
+
+(* Skipping definition `Panic.handleGhcException' *)
+
+Axiom panic : forall {a} `{GHC.Err.Default a}, GHC.Base.String -> a.
+
+Axiom sorry : forall {a} `{GHC.Err.Default a}, GHC.Base.String -> a.
 
 Axiom pgmError : forall {a} `{GHC.Err.Default a}, GHC.Base.String -> a.
 
 Axiom panicDoc : forall {a} `{GHC.Err.Default a},
                  GHC.Base.String -> GHC.Base.String -> a.
 
-Axiom panic : forall {a} `{GHC.Err.Default a}, GHC.Base.String -> a.
+Axiom sorryDoc : forall {a} `{GHC.Err.Default a},
+                 GHC.Base.String -> GHC.Base.String -> a.
 
-(* Skipping definition `Panic.handleGhcException' *)
+Axiom pgmErrorDoc : forall {a} `{GHC.Err.Default a},
+                    GHC.Base.String -> GHC.Base.String -> a.
 
 Axiom assertPanic : forall {a} `{GHC.Err.Default a},
                     GHC.Base.String -> GHC.Num.Int -> a.
 
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Panic.Show__GhcException' *)
+(* Skipping definition `Panic.tryMost' *)
 
-(* Skipping all instances of class `GHC.Exception.Exception', including
-   `Panic.Exception__GhcException' *)
+(* Skipping definition `Panic.signalHandlersRefCount' *)
+
+(* Skipping definition `Panic.withSignalHandlers' *)
 
 Axiom panicStr : forall {a} `{GHC.Err.Default a},
                  GHC.Base.String -> GHC.Base.String -> a.

--- a/examples/ghc/lib/PrelNames.v
+++ b/examples/ghc/lib/PrelNames.v
@@ -33,804 +33,337 @@ Import GHC.Num.Notations.
 
 (* Converted value declarations: *)
 
-Definition zipIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #33.
+Definition int8X16PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #300.
 
-Definition xorIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #93.
+Definition int16X8PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #301.
 
-Definition wordTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #60.
+Definition int32X4PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #302.
 
-Definition wordToIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #97.
+Definition int64X2PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #303.
 
-Definition wordPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #59.
+Definition int8X32PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #304.
 
-Definition wordDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #16.
+Definition int16X16PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #305.
 
-Definition word8X64PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #320.
+Definition int32X8PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #306.
 
-Definition word8X32PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #316.
+Definition int64X4PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #307.
+
+Definition int8X64PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #308.
+
+Definition int16X32PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #309.
+
+Definition int32X16PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #310.
+
+Definition int64X8PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #311.
 
 Definition word8X16PrimTyConKey : Unique.Unique :=
   Unique.mkPreludeTyConUnique #312.
 
-Definition word8TyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #61.
-
-Definition word8DataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #13.
-
-Definition word64X8PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #323.
-
-Definition word64X4PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #319.
-
-Definition word64X2PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #315.
-
-Definition word64TyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #66.
-
-Definition word64ToIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #98.
-
-Definition word64PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #65.
-
-Definition word32X8PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #318.
+Definition word16X8PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #313.
 
 Definition word32X4PrimTyConKey : Unique.Unique :=
   Unique.mkPreludeTyConUnique #314.
 
-Definition word32X16PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #322.
+Definition word64X2PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #315.
 
-Definition word32TyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #64.
-
-Definition word32PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #63.
-
-Definition word16X8PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #313.
-
-Definition word16X32PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #321.
+Definition word8X32PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #316.
 
 Definition word16X16PrimTyConKey : Unique.Unique :=
   Unique.mkPreludeTyConUnique #317.
 
-Definition word16TyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #62.
+Definition word32X8PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #318.
 
-Definition wildCardKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #0.
+Definition word64X4PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #319.
 
-Definition wildCardName : Name.Name :=
-  Name.mkSystemVarName wildCardKey (FastString.fsLit (GHC.Base.hs_string__
-                                                      "wild")).
+Definition word8X64PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #320.
 
-Definition weakPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #27.
+Definition word16X32PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #321.
 
-Definition voidPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #58.
+Definition word32X16PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #322.
 
-Definition voidPrimIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #21.
+Definition word64X8PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #323.
 
-Definition voidArgIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #40.
+Definition floatX4PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #324.
 
-Definition vecRepDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #71.
+Definition doubleX2PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #325.
 
-Definition vecElemTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #97.
+Definition floatX8PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #326.
 
-Definition vecElemDataConKeys : list Unique.Unique :=
-  GHC.Base.map Unique.mkPreludeDataConUnique (GHC.Enum.enumFromTo #89 #98).
+Definition doubleX4PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #327.
 
-Definition vecCountTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #96.
+Definition floatX16PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #328.
 
-Definition vecCountDataConKeys : list Unique.Unique :=
-  GHC.Base.map Unique.mkPreludeDataConUnique (GHC.Enum.enumFromTo #83 #88).
+Definition doubleX8PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #329.
 
-Axiom RdrName : Type.
+Axiom allNameStrings : list GHC.Base.String.
 
-Axiom varQual_RDR : Module.Module -> FastString.FastString -> RdrName.
-
-Definition v1TyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #135.
-
-Definition unsafeCoerceIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #30.
-
-Definition unpackCStringUtf8IdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #17.
-
-Definition unpackCStringIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #20.
-
-Definition unpackCStringFoldrIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #19.
-
-Definition unpackCStringAppendIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #18.
-
-Definition unmarshalStringIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #153.
-
-Definition unmarshalObjectIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #150.
-
-Definition unliftedConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #68.
-
-Definition unknownTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #129.
-
-Definition unknown3TyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #132.
-
-Definition unknown2TyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #131.
-
-Definition unknown1TyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #130.
-
-Definition unicodeStarKindTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #94.
-
-Definition undefinedKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #155.
+Definition itName : Unique.Unique -> SrcLoc.SrcSpan -> Name.Name :=
+  fun uniq loc =>
+    Name.mkInternalName uniq (OccName.mkOccNameFS OccName.varName (FastString.fsLit
+                                                                   (GHC.Base.hs_string__ "it"))) loc.
 
 Definition unboundKey : Unique.Unique :=
   Unique.mkPreludeMiscIdUnique #158.
 
-Definition uWordTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #163.
+Definition mkUnboundName : OccName.OccName -> Name.Name :=
+  fun occ => Name.mkInternalName unboundKey occ SrcLoc.noSrcSpan.
 
-Definition uRecTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #157.
+Definition isUnboundName : Name.Name -> bool :=
+  fun name => Unique.hasKey name unboundKey.
 
-Definition uIntTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #162.
+Axiom basicKnownKeyNames : list Name.Name.
 
-Definition uFloatTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #161.
+Axiom genericTyConNames : list Name.Name.
 
-Definition uDoubleTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #160.
-
-Definition uCharTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #159.
-
-Definition uAddrTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #158.
-
-Definition u1TyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #136.
-
-Definition typeableClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #20.
-
-Definition typeable7ClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #27.
-
-Definition typeable6ClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #26.
-
-Definition typeable5ClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #25.
-
-Definition typeable4ClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #24.
-
-Definition typeable3ClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #23.
-
-Definition typeable2ClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #22.
-
-Definition typeable1ClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #21.
-
-Definition typeSymbolTypeRepKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #508.
-
-Definition typeSymbolKindConNameKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #165.
-
-Definition typeSymbolCmpTyFamNameKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #171.
-
-Definition typeSymbolAppendFamNameKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #190.
-
-Definition typeRepTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #187.
-
-Definition typeRepIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #509.
-
-Definition typeNatTypeRepKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #507.
-
-Definition typeNatSubTyFamNameKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #170.
-
-Definition typeNatMulTyFamNameKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #167.
-
-Definition typeNatModTyFamNameKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #174.
-
-Definition typeNatLogTyFamNameKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #175.
-
-Definition typeNatLeqTyFamNameKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #169.
-
-Definition typeNatKindConNameKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #164.
-
-Definition typeNatExpTyFamNameKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #168.
-
-Definition typeNatDivTyFamNameKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #173.
-
-Definition typeNatCmpTyFamNameKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #172.
-
-Definition typeNatAddTyFamNameKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #166.
-
-Definition typeLitSymbolDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #107.
-
-Definition typeLitSortTyConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #49.
-
-Definition typeLitNatDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #108.
-
-Definition typeErrorVAppendDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #52.
-
-Definition typeErrorTextDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #50.
-
-Definition typeErrorShowTypeDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #53.
-
-Definition typeErrorIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #22.
-
-Definition typeErrorAppendDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #51.
-
-Definition typeConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #72.
-
-Definition tupleRepDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #72.
-
-Definition trueDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #15.
-
-Definition traversableClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #36.
-
-Definition traceKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #108.
-
-Definition trTyConTyConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #40.
-
-Definition trTyConDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #41.
-
-Definition trTYPEKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #511.
-
-Definition trTYPE'PtrRepLiftedKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #512.
-
-Definition trRuntimeRepKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #513.
-
-Definition trNameTyConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #44.
-
-Definition trNameSDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #45.
-
-Definition trNameDDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #46.
-
-Definition trModuleTyConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #42.
-
-Definition trModuleDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #43.
-
-Definition trGhcPrimModuleKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #47.
-
-Definition tr'PtrRepLiftedKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #514.
-
-Definition toRationalClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #193.
-
-Definition toListClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #501.
-
-Definition toIntegerClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #192.
-
-Definition toDynIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #550.
-
-Definition toAnnotationWrapperIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #187.
-
-Definition timesIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #67.
-
-Definition threadIdPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #73.
-
-Definition thenMClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #172.
-
-Definition thenIOIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #103.
-
-Definition thenAClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #753.
-
-Axiom tcQual_RDR : Module.Module -> FastString.FastString -> RdrName.
-
-Definition tYPETyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #88.
-
-Definition tVarPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #77.
-
-Definition sumTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #141.
-
-Definition sumRepDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #73.
-
-Definition staticPtrTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #184.
-
-Definition staticPtrInfoTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #185.
-
-Definition staticPtrInfoDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #34.
-
-Definition staticPtrDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #33.
-
-Definition statePrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #50.
-
-Definition starKindTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #93.
-
-Definition starKindRepKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #520.
-
-Definition starArrStarKindRepKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #521.
-
-Definition starArrStarArrStarKindRepKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #522.
-
-Definition stablePtrTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #36.
-
-Definition stablePtrPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #35.
-
-Definition stableNameTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #52.
-
-Definition stableNamePrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #51.
-
-Definition stableNameDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #14.
-
-Definition srcLocDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #37.
-
-Definition specTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #180.
-
-Definition sourceUnpackDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #59.
-
-Definition sourceStrictDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #63.
-
-Definition sourceNoUnpackDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #60.
-
-Definition sourceLazyDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #62.
-
-Definition someTypeRepTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #188.
-
-Definition someTypeRepDataConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #189.
-
-Definition sndIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #42.
-
-Definition smallMutableArrayPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #183.
-
-Definition smallIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #61.
-
-Definition smallArrayPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #182.
-
-Definition signumIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #73.
-
-Definition showClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #17.
-
-Definition shiftRIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #96.
-
-Definition shiftLIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #95.
-
-Definition seqIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #8.
-
-Definition semigroupClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #46.
-
-Definition selectorClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #41.
-
-Definition sappendClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #554.
-
-Definition sTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #148.
-
-Definition s1TyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #153.
-
-Definition runtimeRepTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #95.
-
-Definition runtimeErrorIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #13.
-
-Definition runRWKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #107.
-
-Definition runMainKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #102.
-
-Definition rootMainKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #101.
-
-Definition rightDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #26.
-
-Definition rightAssociativeDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #57.
-
-Definition returnMClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #174.
-
-Definition returnIOIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #35.
-
-Definition repTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #155.
-
-Definition rep1TyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #156.
-
-Definition remIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #80.
-
-Definition recSelErrorIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #7.
-
-Definition recConErrorIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #16.
-
-Definition rec1TyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #138.
-
-Definition rec0TyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #149.
-
-Definition realWorldTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #34.
-
-Definition realWorldPrimIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #15.
-
-Definition realToFracIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #191.
-
-Definition realFracClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #16.
-
-Definition realFloatClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #15.
-
-Definition realClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #14.
-
-Definition readClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #13.
-
-Definition rationalTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #33.
-
-Definition rationalToFloatIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #130.
-
-Definition rationalToDoubleIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #131.
-
-Definition ratioTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #32.
-
-Definition ratioDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #12.
-
-Definition randomGenClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #32.
-
-Definition randomClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #31.
-
-Definition rTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #144.
-
-Definition quotRemIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #84.
-
-Definition quotIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #79.
-
-Definition pushCallStackKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #559.
-
-Definition pureAClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #752.
-
-Definition ptrTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #75.
-
-Definition proxyPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #179.
-
-Definition proxyHashKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #502.
-
-Definition prodTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #142.
-
-Definition printIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #37.
-
-Axiom pretendNameIsInScope : Name.Name -> bool.
-
-Definition prefixIDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #54.
-
-Definition plusIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #66.
-
-Definition pluginTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #102.
-
-Definition patErrorIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #14.
-
-Definition parrTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #82.
-
-Definition parrDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #24.
-
-Definition par1TyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #137.
+Definition mkBaseModule_ : Module.ModuleName -> Module.Module :=
+  fun m => Module.mkModule Module.baseUnitId m.
 
 Definition pRELUDE_NAME : Module.ModuleName :=
   Module.mkModuleNameFS (FastString.fsLit (GHC.Base.hs_string__ "Prelude")).
 
-Definition otherwiseIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #43.
-
-Definition orderingTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #30.
-
-Definition ordClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #12.
-
-Definition orIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #92.
-
-Definition opaqueTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #133.
-
-Definition oneShotKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #106.
-
-Definition objectTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #83.
-
-Definition numClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #11.
-
-Definition nullAddrIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #39.
-
-Definition ntTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #177.
-
-Definition nothingDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #8.
-
-Definition notAssociativeDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #58.
-
-Definition nonExhaustiveGuardsErrorIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #12.
-
-Definition noinlineIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #125.
-
-Definition noSourceUnpackednessDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #61.
-
-Definition noSourceStrictnessDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #64.
-
-Definition noSelTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #154.
-
-Definition noMethodBindingErrorIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #11.
-
-Definition nilDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #11.
-
-Definition newStablePtrIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #36.
-
-Definition neqIntegerPrimIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #71.
-
-Definition negateIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #69.
-
-Definition negateClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #169.
-
-Definition naturalTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #23.
-
-Definition naturalFromIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #562.
-
-Definition mzipIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #196.
-
-Definition mutableByteArrayPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #29.
-
-Definition mutableArrayPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #28.
-
-Definition mutableArrayArrayPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #41.
-
-Definition mutVarPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #56.
-
-Definition monoidClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #47.
-
-Definition monadPlusClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #30.
-
-Definition monadFixClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #28.
-
-Definition monadFailClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #29.
-
-Definition monadClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #8.
-
-Definition modIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #82.
-
-Definition modIntIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #24.
-
-Definition mk_known_key_name
-   : OccName.NameSpace ->
-     Module.Module -> FastString.FastString -> Unique.Unique -> Name.Name :=
-  fun space modu str unique =>
-    Name.mkExternalName unique modu (OccName.mkOccNameFS space str)
-    SrcLoc.noSrcSpan.
-
-Definition tcQual
-   : Module.Module -> FastString.FastString -> Unique.Unique -> Name.Name :=
-  mk_known_key_name OccName.tcName.
-
-Definition varQual
-   : Module.Module -> FastString.FastString -> Unique.Unique -> Name.Name :=
-  mk_known_key_name OccName.varName.
-
-Definition mkUnboundName : OccName.OccName -> Name.Name :=
-  fun occ => Name.mkInternalName unboundKey occ SrcLoc.noSrcSpan.
-
-Definition mkTyConKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #503.
-
-Definition mkTrTypeKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #504.
-
-Definition mkTrFunKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #510.
-
-Definition mkTrConKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #505.
-
-Definition mkTrAppKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #506.
-
-Definition mkThisGhcModule_ : Module.ModuleName -> Module.Module :=
-  fun m => Module.mkModule Module.thisGhcUnitId m.
-
-Definition mkThisGhcModule : FastString.FastString -> Module.Module :=
-  fun m => Module.mkModule Module.thisGhcUnitId (Module.mkModuleNameFS m).
-
-Definition pLUGINS : Module.Module :=
-  mkThisGhcModule (FastString.fsLit (GHC.Base.hs_string__ "Plugins")).
-
-Definition pluginTyConName : Name.Name :=
-  tcQual pLUGINS (FastString.fsLit (GHC.Base.hs_string__ "Plugin"))
-  pluginTyConKey.
+Definition pRELUDE : Module.Module :=
+  mkBaseModule_ pRELUDE_NAME.
 
 Definition mkPrimModule : FastString.FastString -> Module.Module :=
   fun m => Module.mkModule Module.primUnitId (Module.mkModuleNameFS m).
 
+Definition gHC_PRIM : Module.Module :=
+  mkPrimModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Prim")).
+
+Definition gHC_TYPES : Module.Module :=
+  mkPrimModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Types")).
+
+Definition gHC_MAGIC : Module.Module :=
+  mkPrimModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Magic")).
+
+Definition gHC_CSTRING : Module.Module :=
+  mkPrimModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.CString")).
+
+Definition gHC_CLASSES : Module.Module :=
+  mkPrimModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Classes")).
+
+Definition mkBaseModule : FastString.FastString -> Module.Module :=
+  fun m => Module.mkModule Module.baseUnitId (Module.mkModuleNameFS m).
+
+Definition gHC_BASE : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Base")).
+
+Definition gHC_ENUM : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Enum")).
+
+Definition gHC_GHCI : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.GHCi")).
+
+Definition gHC_SHOW : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Show")).
+
+Definition gHC_READ : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Read")).
+
+Definition gHC_NUM : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Num")).
+
+Axiom mkIntegerModule : FastString.FastString -> Module.Module.
+
+Definition gHC_INTEGER_TYPE : Module.Module :=
+  mkIntegerModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Integer.Type")).
+
+Definition gHC_NATURAL : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Natural")).
+
+Definition gHC_LIST : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.List")).
+
+Definition gHC_TUPLE : Module.Module :=
+  mkPrimModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Tuple")).
+
+Definition dATA_TUPLE : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Data.Tuple")).
+
+Definition dATA_EITHER : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Data.Either")).
+
+Definition dATA_STRING : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Data.String")).
+
+Definition dATA_FOLDABLE : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Data.Foldable")).
+
+Definition dATA_TRAVERSABLE : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Data.Traversable")).
+
+Definition gHC_CONC : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Conc")).
+
+Definition gHC_IO : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.IO")).
+
+Definition gHC_IO_Exception : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.IO.Exception")).
+
+Definition gHC_ST : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.ST")).
+
+Definition gHC_ARR : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Arr")).
+
+Definition gHC_STABLE : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Stable")).
+
+Definition gHC_PTR : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Ptr")).
+
+Definition gHC_ERR : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Err")).
+
+Definition gHC_REAL : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Real")).
+
+Definition gHC_FLOAT : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Float")).
+
+Definition gHC_TOP_HANDLER : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.TopHandler")).
+
+Definition sYSTEM_IO : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "System.IO")).
+
+Definition dYNAMIC : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Data.Dynamic")).
+
+Definition tYPEABLE : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Data.Typeable")).
+
+Definition tYPEABLE_INTERNAL : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Data.Typeable.Internal")).
+
+Definition gENERICS : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Data.Data")).
+
+Definition rEAD_PREC : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__
+                                  "Text.ParserCombinators.ReadPrec")).
+
+Definition lEX : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Text.Read.Lex")).
+
+Definition gHC_INT : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Int")).
+
+Definition gHC_WORD : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Word")).
+
+Definition mONAD : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Control.Monad")).
+
+Definition mONAD_FIX : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Control.Monad.Fix")).
+
+Definition mONAD_ZIP : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Control.Monad.Zip")).
+
+Definition mONAD_FAIL : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Control.Monad.Fail")).
+
+Definition aRROW : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Control.Arrow")).
+
+Definition cONTROL_APPLICATIVE : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Control.Applicative")).
+
+Definition gHC_DESUGAR : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Desugar")).
+
+Definition rANDOM : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "System.Random")).
+
+Definition gHC_EXTS : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Exts")).
+
+Definition cONTROL_EXCEPTION_BASE : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Control.Exception.Base")).
+
+Definition gHC_GENERICS : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Generics")).
+
+Definition gHC_TYPELITS : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.TypeLits")).
+
+Definition gHC_TYPENATS : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.TypeNats")).
+
+Definition dATA_TYPE_EQUALITY : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Data.Type.Equality")).
+
+Definition dATA_COERCE : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Data.Coerce")).
+
+Definition dEBUG_TRACE : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Debug.Trace")).
+
+Definition gHC_PARR' : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.PArr")).
+
+Definition gHC_SRCLOC : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.SrcLoc")).
+
+Definition gHC_STACK : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Stack")).
+
+Definition gHC_STACK_TYPES : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Stack.Types")).
+
+Definition gHC_STATICPTR : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.StaticPtr")).
+
+Definition gHC_STATICPTR_INTERNAL : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.StaticPtr.Internal")).
+
+Definition gHC_FINGERPRINT_TYPE : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Fingerprint.Type")).
+
+Definition gHC_OVER_LABELS : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.OverloadedLabels")).
+
+Definition gHC_RECORDS : Module.Module :=
+  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Records")).
+
+Definition mAIN_NAME : Module.ModuleName :=
+  Module.mkModuleNameFS (FastString.fsLit (GHC.Base.hs_string__ "Main")).
+
 Definition mkMainModule_ : Module.ModuleName -> Module.Module :=
   fun m => Module.mkModule Module.mainUnitId m.
+
+Definition mAIN : Module.Module :=
+  mkMainModule_ mAIN_NAME.
 
 Definition mkMainModule : FastString.FastString -> Module.Module :=
   fun m => Module.mkModule Module.mainUnitId (Module.mkModuleNameFS m).
@@ -840,1088 +373,52 @@ Definition rOOT_MAIN : Module.Module :=
 
 Axiom mkInteractiveModule : nat -> Module.Module.
 
-Axiom mkIntegerModule : FastString.FastString -> Module.Module.
+Definition dATA_ARRAY_PARALLEL_NAME : Module.ModuleName :=
+  Module.mkModuleNameFS (FastString.fsLit (GHC.Base.hs_string__
+                                           "Data.Array.Parallel")).
 
-Definition mkIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #60.
+Definition dATA_ARRAY_PARALLEL_PRIM_NAME : Module.ModuleName :=
+  Module.mkModuleNameFS (FastString.fsLit (GHC.Base.hs_string__
+                                           "Data.Array.Parallel.Prim")).
 
-Definition mkBaseModule_ : Module.ModuleName -> Module.Module :=
-  fun m => Module.mkModule Module.baseUnitId m.
+Definition mkThisGhcModule : FastString.FastString -> Module.Module :=
+  fun m => Module.mkModule Module.thisGhcUnitId (Module.mkModuleNameFS m).
 
-Definition pRELUDE : Module.Module :=
-  mkBaseModule_ pRELUDE_NAME.
+Definition mkThisGhcModule_ : Module.ModuleName -> Module.Module :=
+  fun m => Module.mkModule Module.thisGhcUnitId m.
 
-Definition mkBaseModule : FastString.FastString -> Module.Module :=
-  fun m => Module.mkModule Module.baseUnitId (Module.mkModuleNameFS m).
-
-Definition rANDOM : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "System.Random")).
-
-Definition rEAD_PREC : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__
-                                  "Text.ParserCombinators.ReadPrec")).
-
-Definition pfail_RDR : RdrName :=
-  varQual_RDR rEAD_PREC (FastString.fsLit (GHC.Base.hs_string__ "pfail")).
-
-Definition prec_RDR : RdrName :=
-  varQual_RDR rEAD_PREC (FastString.fsLit (GHC.Base.hs_string__ "prec")).
-
-Definition reset_RDR : RdrName :=
-  varQual_RDR rEAD_PREC (FastString.fsLit (GHC.Base.hs_string__ "reset")).
-
-Definition step_RDR : RdrName :=
-  varQual_RDR rEAD_PREC (FastString.fsLit (GHC.Base.hs_string__ "step")).
-
-Definition sYSTEM_IO : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "System.IO")).
-
-Definition printName : Name.Name :=
-  varQual sYSTEM_IO (FastString.fsLit (GHC.Base.hs_string__ "print")) printIdKey.
-
-Definition tYPEABLE : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Data.Typeable")).
-
-Definition tYPEABLE_INTERNAL : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Data.Typeable.Internal")).
-
-Definition mkTrAppName : Name.Name :=
-  varQual tYPEABLE_INTERNAL (FastString.fsLit (GHC.Base.hs_string__ "mkTrApp"))
-  mkTrAppKey.
-
-Definition mkTrConName : Name.Name :=
-  varQual tYPEABLE_INTERNAL (FastString.fsLit (GHC.Base.hs_string__ "mkTrCon"))
-  mkTrConKey.
-
-Definition mkTrFunName : Name.Name :=
-  varQual tYPEABLE_INTERNAL (FastString.fsLit (GHC.Base.hs_string__ "mkTrFun"))
-  mkTrFunKey.
-
-Definition mkTrTypeName : Name.Name :=
-  varQual tYPEABLE_INTERNAL (FastString.fsLit (GHC.Base.hs_string__ "mkTrType"))
-  mkTrTypeKey.
-
-Definition someTypeRepTyConName : Name.Name :=
-  tcQual tYPEABLE_INTERNAL (FastString.fsLit (GHC.Base.hs_string__ "SomeTypeRep"))
-  someTypeRepTyConKey.
-
-Definition typeNatTypeRepName : Name.Name :=
-  varQual tYPEABLE_INTERNAL (FastString.fsLit (GHC.Base.hs_string__
-                                               "typeNatTypeRep")) typeNatTypeRepKey.
-
-Definition typeRepIdName : Name.Name :=
-  varQual tYPEABLE_INTERNAL (FastString.fsLit (GHC.Base.hs_string__ "typeRep#"))
-  typeRepIdKey.
-
-Definition typeRepTyConName : Name.Name :=
-  tcQual tYPEABLE_INTERNAL (FastString.fsLit (GHC.Base.hs_string__ "TypeRep"))
-  typeRepTyConKey.
-
-Definition typeSymbolTypeRepName : Name.Name :=
-  varQual tYPEABLE_INTERNAL (FastString.fsLit (GHC.Base.hs_string__
-                                               "typeSymbolTypeRep")) typeSymbolTypeRepKey.
-
-Definition minusIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #68.
-
-Definition minusClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #161.
-
-Definition mfixIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #175.
-
-Definition metaSelDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #70.
-
-Definition metaDataDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #68.
-
-Definition metaConsDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #69.
-
-Definition memptyClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #555.
-
-Definition mconcatClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #557.
-
-Definition maybeTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #26.
-
-Definition marshalStringIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #152.
-
-Definition marshalObjectIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #151.
-
-Definition mappendClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #556.
-
-Definition mapIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #121.
-
-Definition makeStaticKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #561.
+Axiom RdrName : Type.
 
 Axiom main_RDR_Unqual : RdrName.
 
-Definition magicDictKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #156.
+Axiom forall_tv_RDR : RdrName.
 
-Definition mVarPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #31.
+Axiom dot_tv_RDR : RdrName.
 
-Definition mONAD_ZIP : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Control.Monad.Zip")).
+Definition eqClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #167.
 
-Definition mzipName : Name.Name :=
-  varQual mONAD_ZIP (FastString.fsLit (GHC.Base.hs_string__ "mzip")) mzipIdKey.
+Definition mk_known_key_name
+   : OccName.NameSpace ->
+     Module.Module -> FastString.FastString -> Unique.Unique -> Name.Name :=
+  fun space modu str unique =>
+    Name.mkExternalName unique modu (OccName.mkOccNameFS space str)
+    SrcLoc.noSrcSpan.
 
-Definition mONAD_FIX : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Control.Monad.Fix")).
+Definition varQual
+   : Module.Module -> FastString.FastString -> Unique.Unique -> Name.Name :=
+  mk_known_key_name OccName.varName.
 
-Definition mfixName : Name.Name :=
-  varQual mONAD_FIX (FastString.fsLit (GHC.Base.hs_string__ "mfix")) mfixIdKey.
-
-Definition mONAD_FAIL : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Control.Monad.Fail")).
-
-Definition mONAD : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Control.Monad")).
-
-Definition mAIN_NAME : Module.ModuleName :=
-  Module.mkModuleNameFS (FastString.fsLit (GHC.Base.hs_string__ "Main")).
-
-Definition mAIN : Module.Module :=
-  mkMainModule_ mAIN_NAME.
-
-Definition m1TyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #140.
-
-Definition ltIntegerPrimIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #76.
-
-Definition ltDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #27.
-
-Definition loopAIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #185.
-
-Definition listTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #24.
-
-Definition liftedTypeKindTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #87.
-
-Definition liftedConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #67.
-
-Definition liftMIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #195.
-
-Definition liftMName : Name.Name :=
-  varQual mONAD (FastString.fsLit (GHC.Base.hs_string__ "liftM")) liftMIdKey.
-
-Definition leftDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #25.
-
-Definition leftAssociativeDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #56.
-
-Definition leIntegerPrimIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #74.
-
-Definition lcmIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #90.
-
-Definition lazyIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #104.
-
-Definition lEX : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Text.Read.Lex")).
-
-Definition knownSymbolClassNameKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #43.
-
-Definition knownNatClassNameKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #42.
-
-Definition kindRepVarDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #101.
-
-Definition kindRepTypeLitSDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #105.
-
-Definition kindRepTypeLitDDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #106.
-
-Definition kindRepTyConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #48.
-
-Definition kindRepTyConAppDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #100.
-
-Definition kindRepTYPEDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #104.
-
-Definition kindRepFunDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #103.
-
-Definition kindRepAppDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #102.
-
-Definition kindConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #70.
-
-Definition k1TyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #139.
-
-Definition justDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #9.
-
-Definition joinMIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #750.
-
-Definition ixClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #18.
-
-Definition itName : Unique.Unique -> SrcLoc.SrcSpan -> Name.Name :=
-  fun uniq loc =>
-    Name.mkInternalName uniq (OccName.mkOccNameFS OccName.varName (FastString.fsLit
-                                                                   (GHC.Base.hs_string__ "it"))) loc.
-
-Definition isUnboundName : Name.Name -> bool :=
-  fun name => Unique.hasKey name unboundKey.
-
-Definition isStringClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #33.
-
-Definition isListClassKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #198.
-
-Definition isLabelClassNameKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #45.
-
-Definition irrefutPatErrorIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #9.
-
-Definition ipClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #48.
-
-Definition ioTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #57.
-
-Definition ioDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #17.
-
-Definition integralClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #7.
-
-Definition integerTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #22.
-
-Definition integerToWordIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #62.
-
-Definition integerToWord64IdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #64.
-
-Definition integerToIntIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #63.
-
-Definition integerToInt64IdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #65.
-
-Axiom integerSDataConName : Name.Name.
-
-Definition integerSDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #7.
-
-Definition integerDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #18.
-
-Definition intTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #15.
-
-Definition intPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #14.
-
-Definition intDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #6.
-
-Definition int8X64PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #308.
-
-Definition int8X32PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #304.
-
-Definition int8X16PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #300.
-
-Definition int8TyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #16.
-
-Definition int64X8PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #311.
-
-Definition int64X4PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #307.
-
-Definition int64X2PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #303.
-
-Definition int64TyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #21.
-
-Definition int64ToIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #99.
-
-Definition int64PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #20.
-
-Definition int32X8PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #306.
-
-Definition int32X4PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #302.
-
-Definition int32X16PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #310.
-
-Definition int32TyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #19.
-
-Definition int32PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #18.
-
-Definition int16X8PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #301.
-
-Definition int16X32PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #309.
-
-Definition int16X16PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #305.
-
-Definition int16TyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #17.
-
-Definition inrDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #22.
-
-Definition inlineIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #120.
-
-Definition inlDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #21.
-
-Definition infixIDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #55.
-
-Definition heqTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #39.
-
-Definition heqSCSelIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #552.
-
-Definition heqDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #19.
-
-Definition hasFieldClassNameKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #49.
-
-Definition guardMIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #194.
-
-Definition guardMName : Name.Name :=
-  varQual mONAD (FastString.fsLit (GHC.Base.hs_string__ "guard")) guardMIdKey.
-
-Definition gtIntegerPrimIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #75.
-
-Definition gtDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #29.
-
-Definition groupWithIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #122.
-
-Definition ghciStepIoMClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #197.
-
-Definition ghciIoClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #44.
-
-Axiom genericTyConNames : list Name.Name.
-
-Definition genUnitDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #23.
-
-Definition genClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #37.
-
-Definition gen1ClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #38.
-
-Definition geIntegerPrimIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #77.
-
-Definition geClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #168.
-
-Definition gcdIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #89.
-
-Definition gHC_WORD : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Word")).
-
-Definition word16TyConName : Name.Name :=
-  tcQual gHC_WORD (FastString.fsLit (GHC.Base.hs_string__ "Word16"))
-  word16TyConKey.
-
-Definition word32TyConName : Name.Name :=
-  tcQual gHC_WORD (FastString.fsLit (GHC.Base.hs_string__ "Word32"))
-  word32TyConKey.
-
-Definition word64TyConName : Name.Name :=
-  tcQual gHC_WORD (FastString.fsLit (GHC.Base.hs_string__ "Word64"))
-  word64TyConKey.
-
-Definition gHC_TYPES : Module.Module :=
-  mkPrimModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Types")).
-
-Definition ioTyConName : Name.Name :=
-  tcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "IO")) ioTyConKey.
-
-Definition kindRepTyConName : Name.Name :=
-  tcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "KindRep"))
-  kindRepTyConKey.
-
-Definition orderingTyConName : Name.Name :=
-  tcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "Ordering"))
-  orderingTyConKey.
-
-Definition specTyConName : Name.Name :=
-  tcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "SPEC")) specTyConKey.
-
-Definition starArrStarArrStarKindRepName : Name.Name :=
-  varQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "krep$*->*->*"))
-  starArrStarArrStarKindRepKey.
-
-Definition starArrStarKindRepName : Name.Name :=
-  varQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "krep$*Arr*"))
-  starArrStarKindRepKey.
-
-Definition starKindRepName : Name.Name :=
-  varQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "krep$*"))
-  starKindRepKey.
-
-Definition trGhcPrimModuleName : Name.Name :=
-  varQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "tr$ModuleGHCPrim"))
-  trGhcPrimModuleKey.
-
-Definition trModuleTyConName : Name.Name :=
-  tcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "Module"))
-  trModuleTyConKey.
-
-Definition trNameTyConName : Name.Name :=
-  tcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "TrName"))
-  trNameTyConKey.
-
-Definition trTyConTyConName : Name.Name :=
-  tcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "TyCon"))
-  trTyConTyConKey.
-
-Definition typeLitSortTyConName : Name.Name :=
-  tcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "TypeLitSort"))
-  typeLitSortTyConKey.
-
-Definition gHC_TYPENATS : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.TypeNats")).
-
-Definition gHC_TYPELITS : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.TypeLits")).
-
-Definition gHC_TUPLE : Module.Module :=
-  mkPrimModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Tuple")).
-
-Definition gHC_TOP_HANDLER : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.TopHandler")).
-
-Definition runMainIOName : Name.Name :=
-  varQual gHC_TOP_HANDLER (FastString.fsLit (GHC.Base.hs_string__ "runMainIO"))
-  runMainKey.
-
-Definition gHC_STATICPTR_INTERNAL : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.StaticPtr.Internal")).
-
-Definition makeStaticName : Name.Name :=
-  varQual gHC_STATICPTR_INTERNAL (FastString.fsLit (GHC.Base.hs_string__
-                                                    "makeStatic")) makeStaticKey.
-
-Definition gHC_STATICPTR : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.StaticPtr")).
-
-Definition staticPtrInfoTyConName : Name.Name :=
-  tcQual gHC_STATICPTR (FastString.fsLit (GHC.Base.hs_string__ "StaticPtrInfo"))
-  staticPtrInfoTyConKey.
-
-Definition staticPtrTyConName : Name.Name :=
-  tcQual gHC_STATICPTR (FastString.fsLit (GHC.Base.hs_string__ "StaticPtr"))
-  staticPtrTyConKey.
-
-Definition gHC_STACK_TYPES : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Stack.Types")).
-
-Definition pushCallStackName : Name.Name :=
-  varQual gHC_STACK_TYPES (FastString.fsLit (GHC.Base.hs_string__
-                                             "pushCallStack")) pushCallStackKey.
-
-Definition gHC_STACK : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Stack")).
-
-Definition gHC_STABLE : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Stable")).
-
-Definition newStablePtrName : Name.Name :=
-  varQual gHC_STABLE (FastString.fsLit (GHC.Base.hs_string__ "newStablePtr"))
-  newStablePtrIdKey.
+Definition eqName : Name.Name :=
+  varQual gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ "==")) eqClassOpKey.
 
 Axiom nameRdrName : Name.Name -> RdrName.
 
-Definition newStablePtr_RDR : RdrName :=
-  nameRdrName newStablePtrName.
-
-Definition stablePtrTyConName : Name.Name :=
-  tcQual gHC_STABLE (FastString.fsLit (GHC.Base.hs_string__ "StablePtr"))
-  stablePtrTyConKey.
-
-Definition gHC_ST : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.ST")).
-
-Definition gHC_SRCLOC : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.SrcLoc")).
-
-Definition gHC_SHOW : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Show")).
-
-Definition showCommaSpace_RDR : RdrName :=
-  varQual_RDR gHC_SHOW (FastString.fsLit (GHC.Base.hs_string__ "showCommaSpace")).
-
-Definition showParen_RDR : RdrName :=
-  varQual_RDR gHC_SHOW (FastString.fsLit (GHC.Base.hs_string__ "showParen")).
-
-Definition showSpace_RDR : RdrName :=
-  varQual_RDR gHC_SHOW (FastString.fsLit (GHC.Base.hs_string__ "showSpace")).
-
-Definition showString_RDR : RdrName :=
-  varQual_RDR gHC_SHOW (FastString.fsLit (GHC.Base.hs_string__ "showString")).
-
-Definition showsPrec_RDR : RdrName :=
-  varQual_RDR gHC_SHOW (FastString.fsLit (GHC.Base.hs_string__ "showsPrec")).
-
-Definition shows_RDR : RdrName :=
-  varQual_RDR gHC_SHOW (FastString.fsLit (GHC.Base.hs_string__ "shows")).
-
-Definition gHC_RECORDS : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Records")).
-
-Definition gHC_REAL : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Real")).
-
-Definition ratioTyConName : Name.Name :=
-  tcQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ "Ratio")) ratioTyConKey.
-
-Definition rationalTyConName : Name.Name :=
-  tcQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ "Rational"))
-  rationalTyConKey.
-
-Definition realToFracName : Name.Name :=
-  varQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ "realToFrac"))
-  realToFracIdKey.
-
-Definition toIntegerName : Name.Name :=
-  varQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ "toInteger"))
-  toIntegerClassOpKey.
-
-Definition toInteger_RDR : RdrName :=
-  nameRdrName toIntegerName.
-
-Definition toRationalName : Name.Name :=
-  varQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ "toRational"))
-  toRationalClassOpKey.
-
-Definition toRational_RDR : RdrName :=
-  nameRdrName toRationalName.
-
-Definition gHC_READ : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Read")).
-
-Definition lexP_RDR : RdrName :=
-  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__ "lexP")).
-
-Definition parens_RDR : RdrName :=
-  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__ "parens")).
-
-Definition readFieldHash_RDR : RdrName :=
-  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__ "readFieldHash")).
-
-Definition readField_RDR : RdrName :=
-  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__ "readField")).
-
-Definition readListDefault_RDR : RdrName :=
-  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__
-                                          "readListDefault")).
-
-Definition readListPrecDefault_RDR : RdrName :=
-  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__
-                                          "readListPrecDefault")).
-
-Definition readListPrec_RDR : RdrName :=
-  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__ "readListPrec")).
-
-Definition readList_RDR : RdrName :=
-  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__ "readList")).
-
-Definition readPrec_RDR : RdrName :=
-  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__ "readPrec")).
-
-Definition readSymField_RDR : RdrName :=
-  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__ "readSymField")).
-
-Definition gHC_PTR : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Ptr")).
-
-Definition ptrTyConName : Name.Name :=
-  tcQual gHC_PTR (FastString.fsLit (GHC.Base.hs_string__ "Ptr")) ptrTyConKey.
-
-Definition gHC_PRIM : Module.Module :=
-  mkPrimModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Prim")).
-
-Definition gHC_PARR' : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.PArr")).
-
-Definition gHC_OVER_LABELS : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.OverloadedLabels")).
-
-Definition gHC_NUM : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Num")).
-
-Definition minusName : Name.Name :=
-  varQual gHC_NUM (FastString.fsLit (GHC.Base.hs_string__ "-")) minusClassOpKey.
-
-Definition minus_RDR : RdrName :=
-  nameRdrName minusName.
-
-Definition negateName : Name.Name :=
-  varQual gHC_NUM (FastString.fsLit (GHC.Base.hs_string__ "negate"))
-  negateClassOpKey.
-
-Definition plus_RDR : RdrName :=
-  varQual_RDR gHC_NUM (FastString.fsLit (GHC.Base.hs_string__ "+")).
-
-Definition times_RDR : RdrName :=
-  varQual_RDR gHC_NUM (FastString.fsLit (GHC.Base.hs_string__ "*")).
-
-Definition gHC_NATURAL : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Natural")).
-
-Definition naturalFromIntegerName : Name.Name :=
-  varQual gHC_NATURAL (FastString.fsLit (GHC.Base.hs_string__
-                                         "naturalFromInteger")) naturalFromIntegerIdKey.
-
-Definition naturalTyConName : Name.Name :=
-  tcQual gHC_NATURAL (FastString.fsLit (GHC.Base.hs_string__ "Natural"))
-  naturalTyConKey.
-
-Definition gHC_MAGIC : Module.Module :=
-  mkPrimModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Magic")).
-
-Definition inlineIdName : Name.Name :=
-  varQual gHC_MAGIC (FastString.fsLit (GHC.Base.hs_string__ "inline"))
-  inlineIdKey.
-
-Definition gHC_LIST : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.List")).
-
-Definition zipName : Name.Name :=
-  varQual gHC_LIST (FastString.fsLit (GHC.Base.hs_string__ "zip")) zipIdKey.
-
-Definition gHC_IO_Exception : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.IO.Exception")).
-
-Definition gHC_IO : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.IO")).
-
-Definition gHC_INTEGER_TYPE : Module.Module :=
-  mkIntegerModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Integer.Type")).
-
-Definition gcdIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "gcdInteger"))
-  gcdIntegerIdKey.
-
-Definition geIntegerPrimName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "geInteger#"))
-  geIntegerPrimIdKey.
-
-Definition gtIntegerPrimName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "gtInteger#"))
-  gtIntegerPrimIdKey.
-
-Definition int64ToIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "int64ToInteger")) int64ToIntegerIdKey.
-
-Definition integerToInt64Name : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "integerToInt64")) integerToInt64IdKey.
-
-Definition integerToIntName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "integerToInt")) integerToIntIdKey.
-
-Definition integerToWord64Name : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "integerToWord64")) integerToWord64IdKey.
-
-Definition integerToWordName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "integerToWord")) integerToWordIdKey.
-
-Definition integerTyConName : Name.Name :=
-  tcQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "Integer"))
-  integerTyConKey.
-
-Definition lcmIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "lcmInteger"))
-  lcmIntegerIdKey.
-
-Definition leIntegerPrimName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "leInteger#"))
-  leIntegerPrimIdKey.
-
-Definition ltIntegerPrimName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "ltInteger#"))
-  ltIntegerPrimIdKey.
-
-Definition minusIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "minusInteger")) minusIntegerIdKey.
-
-Definition mkIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "mkInteger"))
-  mkIntegerIdKey.
-
-Definition modIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "modInteger"))
-  modIntegerIdKey.
-
-Definition negateIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "negateInteger")) negateIntegerIdKey.
-
-Definition neqIntegerPrimName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "neqInteger#"))
-  neqIntegerPrimIdKey.
-
-Definition orIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "orInteger"))
-  orIntegerIdKey.
-
-Definition plusIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "plusInteger"))
-  plusIntegerIdKey.
-
-Definition plusInteger_RDR : RdrName :=
-  nameRdrName plusIntegerName.
-
-Definition quotIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "quotInteger"))
-  quotIntegerIdKey.
-
-Definition quotRemIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "quotRemInteger")) quotRemIntegerIdKey.
-
-Definition remIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "remInteger"))
-  remIntegerIdKey.
-
-Definition shiftLIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "shiftLInteger")) shiftLIntegerIdKey.
-
-Definition shiftRIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "shiftRInteger")) shiftRIntegerIdKey.
-
-Definition signumIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "signumInteger")) signumIntegerIdKey.
-
-Definition smallIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "smallInteger")) smallIntegerIdKey.
-
-Definition timesIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "timesInteger")) timesIntegerIdKey.
-
-Definition timesInteger_RDR : RdrName :=
-  nameRdrName timesIntegerName.
-
-Definition word64ToIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "word64ToInteger")) word64ToIntegerIdKey.
-
-Definition wordToIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "wordToInteger")) wordToIntegerIdKey.
-
-Definition xorIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "xorInteger"))
-  xorIntegerIdKey.
-
-Definition gHC_INT : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Int")).
-
-Definition int16TyConName : Name.Name :=
-  tcQual gHC_INT (FastString.fsLit (GHC.Base.hs_string__ "Int16")) int16TyConKey.
-
-Definition int32TyConName : Name.Name :=
-  tcQual gHC_INT (FastString.fsLit (GHC.Base.hs_string__ "Int32")) int32TyConKey.
-
-Definition int64TyConName : Name.Name :=
-  tcQual gHC_INT (FastString.fsLit (GHC.Base.hs_string__ "Int64")) int64TyConKey.
-
-Definition int8TyConName : Name.Name :=
-  tcQual gHC_INT (FastString.fsLit (GHC.Base.hs_string__ "Int8")) int8TyConKey.
-
-Definition gHC_GHCI : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.GHCi")).
-
-Definition ghciStepIoMName : Name.Name :=
-  varQual gHC_GHCI (FastString.fsLit (GHC.Base.hs_string__ "ghciStepIO"))
-  ghciStepIoMClassOpKey.
-
-Definition gHC_GENERICS : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Generics")).
-
-Definition isNewtypeName_RDR : RdrName :=
-  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "isNewtype")).
-
-Definition k1TyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "K1")) k1TyConKey.
-
-Definition m1TyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "M1")) m1TyConKey.
-
-Definition moduleName_RDR : RdrName :=
-  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "moduleName")).
-
-Definition noSelTyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "NoSelector"))
-  noSelTyConKey.
-
-Definition packageName_RDR : RdrName :=
-  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__
-                                              "packageName")).
-
-Definition par1TyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Par1"))
-  par1TyConKey.
-
-Definition prodTyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ ":*:"))
-  prodTyConKey.
-
-Definition rTyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "R")) rTyConKey.
-
-Definition rec0TyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Rec0"))
-  rec0TyConKey.
-
-Definition rec1TyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Rec1"))
-  rec1TyConKey.
-
-Definition rep1TyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Rep1"))
-  rep1TyConKey.
-
-Definition repTyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Rep")) repTyConKey.
-
-Definition s1TyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "S1")) s1TyConKey.
-
-Definition sTyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "S")) sTyConKey.
-
-Definition selName_RDR : RdrName :=
-  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "selName")).
-
-Definition sumTyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ ":+:")) sumTyConKey.
-
-Definition to1_RDR : RdrName :=
-  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "to1")).
-
-Definition to_RDR : RdrName :=
-  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "to")).
-
-Definition u1TyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "U1")) u1TyConKey.
-
-Definition uAddrHash_RDR : RdrName :=
-  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "uAddr#")).
-
-Definition uAddrTyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "UAddr"))
-  uAddrTyConKey.
-
-Definition uCharHash_RDR : RdrName :=
-  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "uChar#")).
-
-Definition uCharTyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "UChar"))
-  uCharTyConKey.
-
-Definition uDoubleHash_RDR : RdrName :=
-  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "uDouble#")).
-
-Definition uDoubleTyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "UDouble"))
-  uDoubleTyConKey.
-
-Definition uFloatHash_RDR : RdrName :=
-  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "uFloat#")).
-
-Definition uFloatTyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "UFloat"))
-  uFloatTyConKey.
-
-Definition uIntHash_RDR : RdrName :=
-  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "uInt#")).
-
-Definition uIntTyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "UInt"))
-  uIntTyConKey.
-
-Definition uRecTyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "URec"))
-  uRecTyConKey.
-
-Definition uWordHash_RDR : RdrName :=
-  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "uWord#")).
-
-Definition uWordTyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "UWord"))
-  uWordTyConKey.
-
-Definition unComp1_RDR : RdrName :=
-  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "unComp1")).
-
-Definition unK1_RDR : RdrName :=
-  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "unK1")).
-
-Definition unPar1_RDR : RdrName :=
-  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "unPar1")).
-
-Definition unRec1_RDR : RdrName :=
-  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "unRec1")).
-
-Definition v1TyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "V1")) v1TyConKey.
-
-Definition gHC_FLOAT : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Float")).
-
-Definition rationalToDoubleName : Name.Name :=
-  varQual gHC_FLOAT (FastString.fsLit (GHC.Base.hs_string__ "rationalToDouble"))
-  rationalToDoubleIdKey.
-
-Definition rationalToFloatName : Name.Name :=
-  varQual gHC_FLOAT (FastString.fsLit (GHC.Base.hs_string__ "rationalToFloat"))
-  rationalToFloatIdKey.
-
-Definition gHC_FINGERPRINT_TYPE : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Fingerprint.Type")).
-
-Definition gHC_EXTS : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Exts")).
-
-Definition groupWithName : Name.Name :=
-  varQual gHC_EXTS (FastString.fsLit (GHC.Base.hs_string__ "groupWith"))
-  groupWithIdKey.
-
-Definition toListName : Name.Name :=
-  varQual gHC_EXTS (FastString.fsLit (GHC.Base.hs_string__ "toList"))
-  toListClassOpKey.
-
-Definition toList_RDR : RdrName :=
-  nameRdrName toListName.
-
-Definition gHC_ERR : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Err")).
-
-Definition undefined_RDR : RdrName :=
-  varQual_RDR gHC_ERR (FastString.fsLit (GHC.Base.hs_string__ "undefined")).
-
-Definition gHC_ENUM : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Enum")).
-
-Definition maxBound_RDR : RdrName :=
-  varQual_RDR gHC_ENUM (FastString.fsLit (GHC.Base.hs_string__ "maxBound")).
-
-Definition minBound_RDR : RdrName :=
-  varQual_RDR gHC_ENUM (FastString.fsLit (GHC.Base.hs_string__ "minBound")).
-
-Definition pred_RDR : RdrName :=
-  varQual_RDR gHC_ENUM (FastString.fsLit (GHC.Base.hs_string__ "pred")).
-
-Definition succ_RDR : RdrName :=
-  varQual_RDR gHC_ENUM (FastString.fsLit (GHC.Base.hs_string__ "succ")).
-
-Definition toEnum_RDR : RdrName :=
-  varQual_RDR gHC_ENUM (FastString.fsLit (GHC.Base.hs_string__ "toEnum")).
-
-Definition gHC_DESUGAR : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Desugar")).
-
-Definition toAnnotationWrapperName : Name.Name :=
-  varQual gHC_DESUGAR (FastString.fsLit (GHC.Base.hs_string__
-                                         "toAnnotationWrapper")) toAnnotationWrapperIdKey.
-
-Definition gHC_CSTRING : Module.Module :=
-  mkPrimModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.CString")).
-
-Definition unpackCStringFoldrName : Name.Name :=
-  varQual gHC_CSTRING (FastString.fsLit (GHC.Base.hs_string__
-                                         "unpackFoldrCString#")) unpackCStringFoldrIdKey.
-
-Definition unpackCStringFoldr_RDR : RdrName :=
-  nameRdrName unpackCStringFoldrName.
-
-Definition unpackCStringName : Name.Name :=
-  varQual gHC_CSTRING (FastString.fsLit (GHC.Base.hs_string__ "unpackCString#"))
-  unpackCStringIdKey.
-
-Definition unpackCString_RDR : RdrName :=
-  nameRdrName unpackCStringName.
-
-Definition unpackCStringUtf8Name : Name.Name :=
-  varQual gHC_CSTRING (FastString.fsLit (GHC.Base.hs_string__
-                                         "unpackCStringUtf8#")) unpackCStringUtf8IdKey.
-
-Definition unpackCStringUtf8_RDR : RdrName :=
-  nameRdrName unpackCStringUtf8Name.
-
-Definition gHC_CONC : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Conc")).
-
-Definition gHC_CLASSES : Module.Module :=
-  mkPrimModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Classes")).
+Definition eq_RDR : RdrName :=
+  nameRdrName eqName.
+
+Definition geClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #168.
 
 Definition geName : Name.Name :=
   varQual gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ ">=")) geClassOpKey.
@@ -1929,8 +426,7 @@ Definition geName : Name.Name :=
 Definition ge_RDR : RdrName :=
   nameRdrName geName.
 
-Definition gt_RDR : RdrName :=
-  varQual_RDR gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ ">")).
+Axiom varQual_RDR : Module.Module -> FastString.FastString -> RdrName.
 
 Definition le_RDR : RdrName :=
   varQual_RDR gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ "<=")).
@@ -1938,217 +434,78 @@ Definition le_RDR : RdrName :=
 Definition lt_RDR : RdrName :=
   varQual_RDR gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ "<")).
 
-Definition modIntName : Name.Name :=
-  varQual gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ "modInt#"))
-  modIntIdKey.
+Definition gt_RDR : RdrName :=
+  varQual_RDR gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ ">")).
 
-Definition not_RDR : RdrName :=
-  varQual_RDR gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ "not")).
+Definition compare_RDR : RdrName :=
+  varQual_RDR gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ "compare")).
 
-Definition gHC_BASE : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Base")).
+Axiom dataQual_RDR : Module.Module -> FastString.FastString -> RdrName.
 
-Definition getTag_RDR : RdrName :=
-  varQual_RDR gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "getTag")).
+Definition ltTag_RDR : RdrName :=
+  dataQual_RDR gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "LT")).
 
-Definition joinMName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "join")) joinMIdKey.
+Definition eqTag_RDR : RdrName :=
+  dataQual_RDR gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "EQ")).
 
-Definition liftA2_RDR : RdrName :=
-  varQual_RDR gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "liftA2")).
+Definition gtTag_RDR : RdrName :=
+  dataQual_RDR gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "GT")).
 
-Definition mapName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "map")) mapIdKey.
+Definition clsQual
+   : Module.Module -> FastString.FastString -> Unique.Unique -> Name.Name :=
+  mk_known_key_name OccName.clsName.
+
+Definition eqClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #3.
+
+Definition eqClassName : Name.Name :=
+  clsQual gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ "Eq")) eqClassKey.
+
+Definition eqClass_RDR : RdrName :=
+  nameRdrName eqClassName.
+
+Definition numClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #11.
+
+Definition numClassName : Name.Name :=
+  clsQual gHC_NUM (FastString.fsLit (GHC.Base.hs_string__ "Num")) numClassKey.
+
+Definition numClass_RDR : RdrName :=
+  nameRdrName numClassName.
+
+Definition ordClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #12.
+
+Definition ordClassName : Name.Name :=
+  clsQual gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ "Ord")) ordClassKey.
+
+Definition ordClass_RDR : RdrName :=
+  nameRdrName ordClassName.
+
+Definition enumClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #2.
+
+Definition enumClassName : Name.Name :=
+  clsQual gHC_ENUM (FastString.fsLit (GHC.Base.hs_string__ "Enum")) enumClassKey.
+
+Definition enumClass_RDR : RdrName :=
+  nameRdrName enumClassName.
+
+Definition monadClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #8.
+
+Definition monadClassName : Name.Name :=
+  clsQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "Monad"))
+  monadClassKey.
+
+Definition monadClass_RDR : RdrName :=
+  nameRdrName monadClassName.
 
 Definition map_RDR : RdrName :=
   varQual_RDR gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "map")).
 
-Definition mappendName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "mappend"))
-  mappendClassOpKey.
-
-Definition mappend_RDR : RdrName :=
-  varQual_RDR gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "mappend")).
-
-Definition mconcatName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "mconcat"))
-  mconcatClassOpKey.
-
-Definition memptyName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "mempty"))
-  memptyClassOpKey.
-
-Definition mempty_RDR : RdrName :=
-  varQual_RDR gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "mempty")).
-
-Definition opaqueTyConName : Name.Name :=
-  tcQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "Opaque"))
-  opaqueTyConKey.
-
-Definition otherwiseIdName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "otherwise"))
-  otherwiseIdKey.
-
-Definition pureAName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "pure"))
-  pureAClassOpKey.
-
-Definition pure_RDR : RdrName :=
-  nameRdrName pureAName.
-
-Definition replace_RDR : RdrName :=
-  varQual_RDR gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "<$")).
-
-Definition returnIOName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "returnIO"))
-  returnIOIdKey.
-
-Definition returnIO_RDR : RdrName :=
-  nameRdrName returnIOName.
-
-Definition returnMName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "return"))
-  returnMClassOpKey.
-
-Definition returnM_RDR : RdrName :=
-  nameRdrName returnMName.
-
-Definition sappendName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "<>"))
-  sappendClassOpKey.
-
-Definition stringTy_RDR : RdrName :=
-  tcQual_RDR gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "String")).
-
-Definition thenAName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "*>")) thenAClassOpKey.
-
-Definition thenIOName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "thenIO")) thenIOIdKey.
-
-Definition thenMName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ ">>")) thenMClassOpKey.
-
-Definition gHC_ARR : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "GHC.Arr")).
-
-Definition inRange_RDR : RdrName :=
-  varQual_RDR gHC_ARR (FastString.fsLit (GHC.Base.hs_string__ "inRange")).
-
-Definition index_RDR : RdrName :=
-  varQual_RDR gHC_ARR (FastString.fsLit (GHC.Base.hs_string__ "index")).
-
-Definition range_RDR : RdrName :=
-  varQual_RDR gHC_ARR (FastString.fsLit (GHC.Base.hs_string__ "range")).
-
-Definition unsafeIndex_RDR : RdrName :=
-  varQual_RDR gHC_ARR (FastString.fsLit (GHC.Base.hs_string__ "unsafeIndex")).
-
-Definition unsafeRangeSize_RDR : RdrName :=
-  varQual_RDR gHC_ARR (FastString.fsLit (GHC.Base.hs_string__ "unsafeRangeSize")).
-
-Definition gENERICS : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Data.Data")).
-
-Definition functorClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #10.
-
-Definition funTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #13.
-
-Definition funPtrTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #76.
-
-Definition funPtrTyConName : Name.Name :=
-  tcQual gHC_PTR (FastString.fsLit (GHC.Base.hs_string__ "FunPtr"))
-  funPtrTyConKey.
-
-Definition fstIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #41.
-
-Definition frontendPluginTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #103.
-
-Definition frontendPluginTyConName : Name.Name :=
-  tcQual pLUGINS (FastString.fsLit (GHC.Base.hs_string__ "FrontendPlugin"))
-  frontendPluginTyConKey.
-
-Definition from_RDR : RdrName :=
-  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "from")).
-
-Definition fromStringClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #186.
-
-Definition fromStaticPtrClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #560.
-
-Definition fromStaticPtrName : Name.Name :=
-  varQual gHC_STATICPTR (FastString.fsLit (GHC.Base.hs_string__ "fromStaticPtr"))
-  fromStaticPtrClassOpKey.
-
-Definition fromRationalClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #162.
-
-Definition fromRationalName : Name.Name :=
-  varQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ "fromRational"))
-  fromRationalClassOpKey.
-
-Definition fromRational_RDR : RdrName :=
-  nameRdrName fromRationalName.
-
-Definition fromListNClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #500.
-
-Definition fromListNName : Name.Name :=
-  varQual gHC_EXTS (FastString.fsLit (GHC.Base.hs_string__ "fromListN"))
-  fromListNClassOpKey.
-
-Definition fromListN_RDR : RdrName :=
-  nameRdrName fromListNName.
-
-Definition fromListClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #199.
-
-Definition fromListName : Name.Name :=
-  varQual gHC_EXTS (FastString.fsLit (GHC.Base.hs_string__ "fromList"))
-  fromListClassOpKey.
-
-Definition fromList_RDR : RdrName :=
-  nameRdrName fromListName.
-
-Definition fromIntegralIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #190.
-
-Definition fromIntegralName : Name.Name :=
-  varQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ "fromIntegral"))
-  fromIntegralIdKey.
-
-Definition fromIntegral_RDR : RdrName :=
-  nameRdrName fromIntegralName.
-
-Definition fromIntegerClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #160.
-
-Definition fromIntegerName : Name.Name :=
-  varQual gHC_NUM (FastString.fsLit (GHC.Base.hs_string__ "fromInteger"))
-  fromIntegerClassOpKey.
-
-Definition fromInteger_RDR : RdrName :=
-  nameRdrName fromIntegerName.
-
-Definition fromEnum_RDR : RdrName :=
-  varQual_RDR gHC_ENUM (FastString.fsLit (GHC.Base.hs_string__ "fromEnum")).
-
-Definition from1_RDR : RdrName :=
-  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "from1")).
-
-Definition fractionalClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #6.
-
-Definition foreignObjPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #25.
-
-Axiom forall_tv_RDR : RdrName.
+Definition append_RDR : RdrName :=
+  varQual_RDR gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "++")).
 
 Definition foldrIdKey : Unique.Unique :=
   Unique.mkPreludeMiscIdUnique #6.
@@ -2159,69 +516,34 @@ Definition foldrName : Name.Name :=
 Definition foldr_RDR : RdrName :=
   nameRdrName foldrName.
 
-Definition foldableClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #35.
+Definition buildIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #4.
 
-Definition fmap_RDR : RdrName :=
-  varQual_RDR gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "fmap")).
+Definition buildName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "build")) buildIdKey.
 
-Definition fmapClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #173.
+Definition build_RDR : RdrName :=
+  nameRdrName buildName.
 
-Definition fmapName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "fmap"))
-  fmapClassOpKey.
+Definition returnMClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #174.
 
-Definition floatingClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #5.
+Definition returnMName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "return"))
+  returnMClassOpKey.
 
-Definition fractionalClassKeys : list Unique.Unique :=
-  cons fractionalClassKey (cons floatingClassKey (cons realFracClassKey (cons
-                                                        realFloatClassKey nil))).
+Definition returnM_RDR : RdrName :=
+  nameRdrName returnMName.
 
-Definition numericClassKeys : list Unique.Unique :=
-  Coq.Init.Datatypes.app (cons numClassKey (cons realClassKey (cons
-                                                  integralClassKey nil))) fractionalClassKeys.
+Definition bindMClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #171.
 
-Definition floatX8PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #326.
+Definition bindMName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ ">>="))
+  bindMClassOpKey.
 
-Definition floatX4PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #324.
-
-Definition floatX16PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #328.
-
-Definition floatTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #12.
-
-Definition floatPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #11.
-
-Definition floatFromIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #85.
-
-Definition floatFromIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "floatFromInteger")) floatFromIntegerIdKey.
-
-Definition floatDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #5.
-
-Definition firstAIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #182.
-
-Definition fingerprintDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #35.
-
-Definition filterIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #32.
-
-Definition filterName : Name.Name :=
-  varQual gHC_LIST (FastString.fsLit (GHC.Base.hs_string__ "filter")) filterIdKey.
-
-Definition falseDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #4.
+Definition bindM_RDR : RdrName :=
+  nameRdrName bindMName.
 
 Definition failMClassOpKey_preMFP : Unique.Unique :=
   Unique.mkPreludeMiscIdUnique #170.
@@ -2243,101 +565,35 @@ Definition failMName : Name.Name :=
 Definition failM_RDR : RdrName :=
   nameRdrName failMName.
 
-Definition failIOIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #38.
+Definition dcQual
+   : Module.Module -> FastString.FastString -> Unique.Unique -> Name.Name :=
+  mk_known_key_name OccName.dataName.
 
-Definition failIOName : Name.Name :=
-  varQual gHC_IO (FastString.fsLit (GHC.Base.hs_string__ "failIO")) failIOIdKey.
+Definition leftDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #25.
 
-Definition expectP_RDR : RdrName :=
-  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__ "expectP")).
+Definition leftDataConName : Name.Name :=
+  dcQual dATA_EITHER (FastString.fsLit (GHC.Base.hs_string__ "Left"))
+  leftDataConKey.
 
-Definition error_RDR : RdrName :=
-  varQual_RDR gHC_ERR (FastString.fsLit (GHC.Base.hs_string__ "error")).
+Definition left_RDR : RdrName :=
+  nameRdrName leftDataConName.
 
-Definition errorMessageTypeErrorFamKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #176.
+Definition rightDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #26.
 
-Definition errorMessageTypeErrorFamName : Name.Name :=
-  tcQual gHC_TYPELITS (FastString.fsLit (GHC.Base.hs_string__ "TypeError"))
-  errorMessageTypeErrorFamKey.
+Definition rightDataConName : Name.Name :=
+  dcQual dATA_EITHER (FastString.fsLit (GHC.Base.hs_string__ "Right"))
+  rightDataConKey.
 
-Definition errorIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #5.
+Definition right_RDR : RdrName :=
+  nameRdrName rightDataConName.
 
-Definition eqTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #38.
+Definition fromEnum_RDR : RdrName :=
+  varQual_RDR gHC_ENUM (FastString.fsLit (GHC.Base.hs_string__ "fromEnum")).
 
-Definition eqStringIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #10.
-
-Definition eqStringName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "eqString"))
-  eqStringIdKey.
-
-Definition eqString_RDR : RdrName :=
-  nameRdrName eqStringName.
-
-Definition eqReprPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #54.
-
-Definition eqPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #53.
-
-Definition eqPhantPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #55.
-
-Definition eqIntegerPrimIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #70.
-
-Definition eqIntegerPrimName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "eqInteger#"))
-  eqIntegerPrimIdKey.
-
-Definition eqDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #28.
-
-Definition eqClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #167.
-
-Definition eqName : Name.Name :=
-  varQual gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ "==")) eqClassOpKey.
-
-Definition eq_RDR : RdrName :=
-  nameRdrName eqName.
-
-Definition eqClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #3.
-
-Definition enumFromToClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #165.
-
-Definition enumFromToName : Name.Name :=
-  varQual gHC_ENUM (FastString.fsLit (GHC.Base.hs_string__ "enumFromTo"))
-  enumFromToClassOpKey.
-
-Definition enumFromTo_RDR : RdrName :=
-  nameRdrName enumFromToName.
-
-Definition enumFromThenToClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #166.
-
-Definition enumFromThenToName : Name.Name :=
-  varQual gHC_ENUM (FastString.fsLit (GHC.Base.hs_string__ "enumFromThenTo"))
-  enumFromThenToClassOpKey.
-
-Definition enumFromThenTo_RDR : RdrName :=
-  nameRdrName enumFromThenToName.
-
-Definition enumFromThenClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #164.
-
-Definition enumFromThenName : Name.Name :=
-  varQual gHC_ENUM (FastString.fsLit (GHC.Base.hs_string__ "enumFromThen"))
-  enumFromThenClassOpKey.
-
-Definition enumFromThen_RDR : RdrName :=
-  nameRdrName enumFromThenName.
+Definition toEnum_RDR : RdrName :=
+  varQual_RDR gHC_ENUM (FastString.fsLit (GHC.Base.hs_string__ "toEnum")).
 
 Definition enumFromClassOpKey : Unique.Unique :=
   Unique.mkPreludeMiscIdUnique #163.
@@ -2349,198 +605,38 @@ Definition enumFromName : Name.Name :=
 Definition enumFrom_RDR : RdrName :=
   nameRdrName enumFromName.
 
-Definition enumClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #2.
+Definition enumFromToClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #165.
 
-Definition encodeFloatIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #87.
+Definition enumFromToName : Name.Name :=
+  varQual gHC_ENUM (FastString.fsLit (GHC.Base.hs_string__ "enumFromTo"))
+  enumFromToClassOpKey.
 
-Definition encodeFloatIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "encodeFloatInteger")) encodeFloatIntegerIdKey.
+Definition enumFromTo_RDR : RdrName :=
+  nameRdrName enumFromToName.
 
-Definition encodeDoubleIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #88.
+Definition enumFromThenClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #164.
 
-Definition encodeDoubleIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "encodeDoubleInteger")) encodeDoubleIntegerIdKey.
+Definition enumFromThenName : Name.Name :=
+  varQual gHC_ENUM (FastString.fsLit (GHC.Base.hs_string__ "enumFromThen"))
+  enumFromThenClassOpKey.
 
-Definition emptyCallStackKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #558.
+Definition enumFromThen_RDR : RdrName :=
+  nameRdrName enumFromThenName.
 
-Definition emptyCallStackName : Name.Name :=
-  varQual gHC_STACK_TYPES (FastString.fsLit (GHC.Base.hs_string__
-                                             "emptyCallStack")) emptyCallStackKey.
+Definition enumFromThenToClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #166.
 
-Definition eitherTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #84.
+Definition enumFromThenToName : Name.Name :=
+  varQual gHC_ENUM (FastString.fsLit (GHC.Base.hs_string__ "enumFromThenTo"))
+  enumFromThenToClassOpKey.
 
-Definition doubleX8PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #329.
+Definition enumFromThenTo_RDR : RdrName :=
+  nameRdrName enumFromThenToName.
 
-Definition doubleX4PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #327.
-
-Definition doubleX2PrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #325.
-
-Definition doubleTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #10.
-
-Definition doublePrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #9.
-
-Definition doubleFromIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #86.
-
-Definition doubleFromIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "doubleFromInteger")) doubleFromIntegerIdKey.
-
-Definition doubleDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #3.
-
-Axiom dot_tv_RDR : RdrName.
-
-Definition dollarIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #123.
-
-Definition divModIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #83.
-
-Definition divModIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "divModInteger")) divModIntegerIdKey.
-
-Definition divIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #81.
-
-Definition divIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "divInteger"))
-  divIntegerIdKey.
-
-Definition divIntIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #23.
-
-Definition divIntName : Name.Name :=
-  varQual gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ "divInt#"))
-  divIntIdKey.
-
-Definition decodeDoubleIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #100.
-
-Definition decodeDoubleIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "decodeDoubleInteger")) decodeDoubleIntegerIdKey.
-
-Definition decidedUnpackDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #67.
-
-Definition decidedStrictDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #66.
-
-Definition decidedLazyDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #65.
-
-Definition dcQual
-   : Module.Module -> FastString.FastString -> Unique.Unique -> Name.Name :=
-  mk_known_key_name OccName.dataName.
-
-Definition decidedLazyDataConName : Name.Name :=
-  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "DecidedLazy"))
-  decidedLazyDataConKey.
-
-Definition decidedStrictDataConName : Name.Name :=
-  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "DecidedStrict"))
-  decidedStrictDataConKey.
-
-Definition decidedUnpackDataConName : Name.Name :=
-  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "DecidedUnpack"))
-  decidedUnpackDataConKey.
-
-Definition eqDataConName : Name.Name :=
-  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "EQ")) eqDataConKey.
-
-Definition fingerprintDataConName : Name.Name :=
-  dcQual gHC_FINGERPRINT_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                                 "Fingerprint")) fingerprintDataConKey.
-
-Definition gtDataConName : Name.Name :=
-  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "GT")) gtDataConKey.
-
-Definition infixIDataConName : Name.Name :=
-  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "InfixI"))
-  infixIDataConKey.
-
-Definition ioDataConName : Name.Name :=
-  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "IO")) ioDataConKey.
-
-Definition ioDataCon_RDR : RdrName :=
-  nameRdrName ioDataConName.
-
-Definition kindRepAppDataConName : Name.Name :=
-  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "KindRepApp"))
-  kindRepAppDataConKey.
-
-Definition kindRepFunDataConName : Name.Name :=
-  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "KindRepFun"))
-  kindRepFunDataConKey.
-
-Definition kindRepTYPEDataConName : Name.Name :=
-  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "KindRepTYPE"))
-  kindRepTYPEDataConKey.
-
-Definition kindRepTyConAppDataConName : Name.Name :=
-  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "KindRepTyConApp"))
-  kindRepTyConAppDataConKey.
-
-Definition kindRepTypeLitDDataConName : Name.Name :=
-  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "KindRepTypeLitD"))
-  kindRepTypeLitDDataConKey.
-
-Definition kindRepTypeLitSDataConName : Name.Name :=
-  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "KindRepTypeLitS"))
-  kindRepTypeLitSDataConKey.
-
-Definition kindRepVarDataConName : Name.Name :=
-  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "KindRepVar"))
-  kindRepVarDataConKey.
-
-Definition leftAssociativeDataConName : Name.Name :=
-  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "LeftAssociative"))
-  leftAssociativeDataConKey.
-
-Definition ltDataConName : Name.Name :=
-  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "LT")) ltDataConKey.
-
-Definition metaConsDataConName : Name.Name :=
-  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "MetaCons"))
-  metaConsDataConKey.
-
-Definition metaDataDataConName : Name.Name :=
-  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "MetaData"))
-  metaDataDataConKey.
-
-Definition metaSelDataConName : Name.Name :=
-  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "MetaSel"))
-  metaSelDataConKey.
-
-Definition noSourceStrictnessDataConName : Name.Name :=
-  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__
-                                         "NoSourceStrictness")) noSourceStrictnessDataConKey.
-
-Definition noSourceUnpackednessDataConName : Name.Name :=
-  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__
-                                         "NoSourceUnpackedness")) noSourceUnpackednessDataConKey.
-
-Definition notAssociativeDataConName : Name.Name :=
-  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "NotAssociative"))
-  notAssociativeDataConKey.
-
-Definition prefixIDataConName : Name.Name :=
-  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "PrefixI"))
-  prefixIDataConKey.
+Definition ratioDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #12.
 
 Definition ratioDataConName : Name.Name :=
   dcQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ ":%")) ratioDataConKey.
@@ -2548,150 +644,434 @@ Definition ratioDataConName : Name.Name :=
 Definition ratioDataCon_RDR : RdrName :=
   nameRdrName ratioDataConName.
 
-Definition rightAssociativeDataConName : Name.Name :=
-  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "RightAssociative"))
-  rightAssociativeDataConKey.
+Definition plusIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #66.
 
-Definition someTypeRepDataConName : Name.Name :=
-  dcQual tYPEABLE_INTERNAL (FastString.fsLit (GHC.Base.hs_string__ "SomeTypeRep"))
-  someTypeRepDataConKey.
+Definition plusIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "plusInteger"))
+  plusIntegerIdKey.
 
-Definition sourceLazyDataConName : Name.Name :=
-  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "SourceLazy"))
-  sourceLazyDataConKey.
+Definition plusInteger_RDR : RdrName :=
+  nameRdrName plusIntegerName.
 
-Definition sourceNoUnpackDataConName : Name.Name :=
-  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "SourceNoUnpack"))
-  sourceNoUnpackDataConKey.
+Definition timesIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #67.
 
-Definition sourceStrictDataConName : Name.Name :=
-  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "SourceStrict"))
-  sourceStrictDataConKey.
+Definition timesIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "timesInteger")) timesIntegerIdKey.
 
-Definition sourceUnpackDataConName : Name.Name :=
-  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "SourceUnpack"))
-  sourceUnpackDataConKey.
+Definition timesInteger_RDR : RdrName :=
+  nameRdrName timesIntegerName.
 
-Definition srcLocDataConName : Name.Name :=
-  dcQual gHC_STACK_TYPES (FastString.fsLit (GHC.Base.hs_string__ "SrcLoc"))
-  srcLocDataConKey.
+Definition ioDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #17.
 
-Definition staticPtrDataConName : Name.Name :=
-  dcQual gHC_STATICPTR (FastString.fsLit (GHC.Base.hs_string__ "StaticPtr"))
-  staticPtrDataConKey.
+Definition ioDataConName : Name.Name :=
+  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "IO")) ioDataConKey.
 
-Definition staticPtrInfoDataConName : Name.Name :=
-  dcQual gHC_STATICPTR (FastString.fsLit (GHC.Base.hs_string__ "StaticPtrInfo"))
-  staticPtrInfoDataConKey.
+Definition ioDataCon_RDR : RdrName :=
+  nameRdrName ioDataConName.
 
-Definition trModuleDataConName : Name.Name :=
-  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "Module"))
-  trModuleDataConKey.
+Definition eqStringIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #10.
 
-Definition trNameDDataConName : Name.Name :=
-  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "TrNameD"))
-  trNameDDataConKey.
+Definition eqStringName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "eqString"))
+  eqStringIdKey.
 
-Definition trNameSDataConName : Name.Name :=
-  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "TrNameS"))
-  trNameSDataConKey.
+Definition eqString_RDR : RdrName :=
+  nameRdrName eqStringName.
 
-Definition trTyConDataConName : Name.Name :=
-  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "TyCon"))
-  trTyConDataConKey.
+Definition unpackCStringIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #20.
 
-Definition typeErrorAppendDataConName : Name.Name :=
-  dcQual gHC_TYPELITS (FastString.fsLit (GHC.Base.hs_string__ ":<>:"))
-  typeErrorAppendDataConKey.
+Definition unpackCStringName : Name.Name :=
+  varQual gHC_CSTRING (FastString.fsLit (GHC.Base.hs_string__ "unpackCString#"))
+  unpackCStringIdKey.
 
-Definition typeErrorShowTypeDataConName : Name.Name :=
-  dcQual gHC_TYPELITS (FastString.fsLit (GHC.Base.hs_string__ "ShowType"))
-  typeErrorShowTypeDataConKey.
+Definition unpackCString_RDR : RdrName :=
+  nameRdrName unpackCStringName.
 
-Definition typeErrorTextDataConName : Name.Name :=
-  dcQual gHC_TYPELITS (FastString.fsLit (GHC.Base.hs_string__ "Text"))
-  typeErrorTextDataConKey.
+Definition unpackCStringFoldrIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #19.
 
-Definition typeErrorVAppendDataConName : Name.Name :=
-  dcQual gHC_TYPELITS (FastString.fsLit (GHC.Base.hs_string__ ":$$:"))
-  typeErrorVAppendDataConKey.
+Definition unpackCStringFoldrName : Name.Name :=
+  varQual gHC_CSTRING (FastString.fsLit (GHC.Base.hs_string__
+                                         "unpackFoldrCString#")) unpackCStringFoldrIdKey.
 
-Definition typeLitNatDataConName : Name.Name :=
-  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "TypeLitNat"))
-  typeLitNatDataConKey.
+Definition unpackCStringFoldr_RDR : RdrName :=
+  nameRdrName unpackCStringFoldrName.
 
-Definition typeLitSymbolDataConName : Name.Name :=
-  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "TypeLitSymbol"))
-  typeLitSymbolDataConKey.
+Definition unpackCStringUtf8IdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #17.
+
+Definition unpackCStringUtf8Name : Name.Name :=
+  varQual gHC_CSTRING (FastString.fsLit (GHC.Base.hs_string__
+                                         "unpackCStringUtf8#")) unpackCStringUtf8IdKey.
+
+Definition unpackCStringUtf8_RDR : RdrName :=
+  nameRdrName unpackCStringUtf8Name.
+
+Definition newStablePtrIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #36.
+
+Definition newStablePtrName : Name.Name :=
+  varQual gHC_STABLE (FastString.fsLit (GHC.Base.hs_string__ "newStablePtr"))
+  newStablePtrIdKey.
+
+Definition newStablePtr_RDR : RdrName :=
+  nameRdrName newStablePtrName.
+
+Definition bindIOIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #34.
+
+Definition bindIOName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "bindIO")) bindIOIdKey.
+
+Definition bindIO_RDR : RdrName :=
+  nameRdrName bindIOName.
+
+Definition returnIOIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #35.
+
+Definition returnIOName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "returnIO"))
+  returnIOIdKey.
+
+Definition returnIO_RDR : RdrName :=
+  nameRdrName returnIOName.
+
+Definition fromIntegerClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #160.
+
+Definition fromIntegerName : Name.Name :=
+  varQual gHC_NUM (FastString.fsLit (GHC.Base.hs_string__ "fromInteger"))
+  fromIntegerClassOpKey.
+
+Definition fromInteger_RDR : RdrName :=
+  nameRdrName fromIntegerName.
+
+Definition fromRationalClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #162.
+
+Definition fromRationalName : Name.Name :=
+  varQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ "fromRational"))
+  fromRationalClassOpKey.
+
+Definition fromRational_RDR : RdrName :=
+  nameRdrName fromRationalName.
+
+Definition minusClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #161.
+
+Definition minusName : Name.Name :=
+  varQual gHC_NUM (FastString.fsLit (GHC.Base.hs_string__ "-")) minusClassOpKey.
+
+Definition minus_RDR : RdrName :=
+  nameRdrName minusName.
+
+Definition times_RDR : RdrName :=
+  varQual_RDR gHC_NUM (FastString.fsLit (GHC.Base.hs_string__ "*")).
+
+Definition plus_RDR : RdrName :=
+  varQual_RDR gHC_NUM (FastString.fsLit (GHC.Base.hs_string__ "+")).
+
+Definition toIntegerClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #192.
+
+Definition toIntegerName : Name.Name :=
+  varQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ "toInteger"))
+  toIntegerClassOpKey.
+
+Definition toInteger_RDR : RdrName :=
+  nameRdrName toIntegerName.
+
+Definition toRationalClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #193.
+
+Definition toRationalName : Name.Name :=
+  varQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ "toRational"))
+  toRationalClassOpKey.
+
+Definition toRational_RDR : RdrName :=
+  nameRdrName toRationalName.
+
+Definition fromIntegralIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #190.
+
+Definition fromIntegralName : Name.Name :=
+  varQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ "fromIntegral"))
+  fromIntegralIdKey.
+
+Definition fromIntegral_RDR : RdrName :=
+  nameRdrName fromIntegralName.
+
+Axiom tcQual_RDR : Module.Module -> FastString.FastString -> RdrName.
+
+Definition stringTy_RDR : RdrName :=
+  tcQual_RDR gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "String")).
+
+Definition fromStringClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #186.
+
+Definition fromStringName : Name.Name :=
+  varQual dATA_STRING (FastString.fsLit (GHC.Base.hs_string__ "fromString"))
+  fromStringClassOpKey.
+
+Definition fromString_RDR : RdrName :=
+  nameRdrName fromStringName.
+
+Definition fromListClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #199.
+
+Definition fromListName : Name.Name :=
+  varQual gHC_EXTS (FastString.fsLit (GHC.Base.hs_string__ "fromList"))
+  fromListClassOpKey.
+
+Definition fromList_RDR : RdrName :=
+  nameRdrName fromListName.
+
+Definition fromListNClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #500.
+
+Definition fromListNName : Name.Name :=
+  varQual gHC_EXTS (FastString.fsLit (GHC.Base.hs_string__ "fromListN"))
+  fromListNClassOpKey.
+
+Definition fromListN_RDR : RdrName :=
+  nameRdrName fromListNName.
+
+Definition toListClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #501.
+
+Definition toListName : Name.Name :=
+  varQual gHC_EXTS (FastString.fsLit (GHC.Base.hs_string__ "toList"))
+  toListClassOpKey.
+
+Definition toList_RDR : RdrName :=
+  nameRdrName toListName.
+
+Definition compose_RDR : RdrName :=
+  varQual_RDR gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ ".")).
+
+Definition and_RDR : RdrName :=
+  varQual_RDR gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ "&&")).
+
+Definition not_RDR : RdrName :=
+  varQual_RDR gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ "not")).
+
+Definition getTag_RDR : RdrName :=
+  varQual_RDR gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "getTag")).
+
+Definition succ_RDR : RdrName :=
+  varQual_RDR gHC_ENUM (FastString.fsLit (GHC.Base.hs_string__ "succ")).
+
+Definition pred_RDR : RdrName :=
+  varQual_RDR gHC_ENUM (FastString.fsLit (GHC.Base.hs_string__ "pred")).
+
+Definition minBound_RDR : RdrName :=
+  varQual_RDR gHC_ENUM (FastString.fsLit (GHC.Base.hs_string__ "minBound")).
+
+Definition maxBound_RDR : RdrName :=
+  varQual_RDR gHC_ENUM (FastString.fsLit (GHC.Base.hs_string__ "maxBound")).
+
+Definition range_RDR : RdrName :=
+  varQual_RDR gHC_ARR (FastString.fsLit (GHC.Base.hs_string__ "range")).
+
+Definition inRange_RDR : RdrName :=
+  varQual_RDR gHC_ARR (FastString.fsLit (GHC.Base.hs_string__ "inRange")).
+
+Definition index_RDR : RdrName :=
+  varQual_RDR gHC_ARR (FastString.fsLit (GHC.Base.hs_string__ "index")).
+
+Definition unsafeIndex_RDR : RdrName :=
+  varQual_RDR gHC_ARR (FastString.fsLit (GHC.Base.hs_string__ "unsafeIndex")).
+
+Definition unsafeRangeSize_RDR : RdrName :=
+  varQual_RDR gHC_ARR (FastString.fsLit (GHC.Base.hs_string__ "unsafeRangeSize")).
+
+Definition readList_RDR : RdrName :=
+  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__ "readList")).
+
+Definition readListDefault_RDR : RdrName :=
+  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__
+                                          "readListDefault")).
+
+Definition readListPrec_RDR : RdrName :=
+  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__ "readListPrec")).
+
+Definition readListPrecDefault_RDR : RdrName :=
+  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__
+                                          "readListPrecDefault")).
+
+Definition readPrec_RDR : RdrName :=
+  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__ "readPrec")).
+
+Definition parens_RDR : RdrName :=
+  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__ "parens")).
+
+Definition choose_RDR : RdrName :=
+  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__ "choose")).
+
+Definition lexP_RDR : RdrName :=
+  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__ "lexP")).
+
+Definition expectP_RDR : RdrName :=
+  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__ "expectP")).
+
+Definition readField_RDR : RdrName :=
+  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__ "readField")).
+
+Definition readFieldHash_RDR : RdrName :=
+  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__ "readFieldHash")).
+
+Definition readSymField_RDR : RdrName :=
+  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__ "readSymField")).
+
+Definition punc_RDR : RdrName :=
+  dataQual_RDR lEX (FastString.fsLit (GHC.Base.hs_string__ "Punc")).
+
+Definition ident_RDR : RdrName :=
+  dataQual_RDR lEX (FastString.fsLit (GHC.Base.hs_string__ "Ident")).
+
+Definition symbol_RDR : RdrName :=
+  dataQual_RDR lEX (FastString.fsLit (GHC.Base.hs_string__ "Symbol")).
+
+Definition step_RDR : RdrName :=
+  varQual_RDR rEAD_PREC (FastString.fsLit (GHC.Base.hs_string__ "step")).
+
+Definition alt_RDR : RdrName :=
+  varQual_RDR rEAD_PREC (FastString.fsLit (GHC.Base.hs_string__ "+++")).
+
+Definition reset_RDR : RdrName :=
+  varQual_RDR rEAD_PREC (FastString.fsLit (GHC.Base.hs_string__ "reset")).
+
+Definition prec_RDR : RdrName :=
+  varQual_RDR rEAD_PREC (FastString.fsLit (GHC.Base.hs_string__ "prec")).
+
+Definition pfail_RDR : RdrName :=
+  varQual_RDR rEAD_PREC (FastString.fsLit (GHC.Base.hs_string__ "pfail")).
+
+Definition showsPrec_RDR : RdrName :=
+  varQual_RDR gHC_SHOW (FastString.fsLit (GHC.Base.hs_string__ "showsPrec")).
+
+Definition shows_RDR : RdrName :=
+  varQual_RDR gHC_SHOW (FastString.fsLit (GHC.Base.hs_string__ "shows")).
+
+Definition showString_RDR : RdrName :=
+  varQual_RDR gHC_SHOW (FastString.fsLit (GHC.Base.hs_string__ "showString")).
+
+Definition showSpace_RDR : RdrName :=
+  varQual_RDR gHC_SHOW (FastString.fsLit (GHC.Base.hs_string__ "showSpace")).
+
+Definition showCommaSpace_RDR : RdrName :=
+  varQual_RDR gHC_SHOW (FastString.fsLit (GHC.Base.hs_string__ "showCommaSpace")).
+
+Definition showParen_RDR : RdrName :=
+  varQual_RDR gHC_SHOW (FastString.fsLit (GHC.Base.hs_string__ "showParen")).
+
+Definition undefined_RDR : RdrName :=
+  varQual_RDR gHC_ERR (FastString.fsLit (GHC.Base.hs_string__ "undefined")).
+
+Definition error_RDR : RdrName :=
+  varQual_RDR gHC_ERR (FastString.fsLit (GHC.Base.hs_string__ "error")).
+
+Definition u1DataCon_RDR : RdrName :=
+  dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "U1")).
+
+Definition par1DataCon_RDR : RdrName :=
+  dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Par1")).
+
+Definition rec1DataCon_RDR : RdrName :=
+  dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Rec1")).
+
+Definition k1DataCon_RDR : RdrName :=
+  dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "K1")).
+
+Definition m1DataCon_RDR : RdrName :=
+  dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "M1")).
+
+Definition l1DataCon_RDR : RdrName :=
+  dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "L1")).
+
+Definition r1DataCon_RDR : RdrName :=
+  dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "R1")).
+
+Definition prodDataCon_RDR : RdrName :=
+  dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ ":*:")).
+
+Definition comp1DataCon_RDR : RdrName :=
+  dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Comp1")).
+
+Definition unPar1_RDR : RdrName :=
+  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "unPar1")).
+
+Definition unRec1_RDR : RdrName :=
+  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "unRec1")).
+
+Definition unK1_RDR : RdrName :=
+  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "unK1")).
+
+Definition unComp1_RDR : RdrName :=
+  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "unComp1")).
+
+Definition from_RDR : RdrName :=
+  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "from")).
+
+Definition from1_RDR : RdrName :=
+  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "from1")).
+
+Definition to_RDR : RdrName :=
+  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "to")).
+
+Definition to1_RDR : RdrName :=
+  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "to1")).
 
 Definition datatypeName_RDR : RdrName :=
   varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__
                                               "datatypeName")).
 
-Definition datatypeClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #39.
+Definition moduleName_RDR : RdrName :=
+  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "moduleName")).
 
-Axiom dataQual_RDR : Module.Module -> FastString.FastString -> RdrName.
+Definition packageName_RDR : RdrName :=
+  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__
+                                              "packageName")).
 
-Definition eqTag_RDR : RdrName :=
-  dataQual_RDR gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "EQ")).
+Definition isNewtypeName_RDR : RdrName :=
+  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "isNewtype")).
 
-Definition gtTag_RDR : RdrName :=
-  dataQual_RDR gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "GT")).
+Definition selName_RDR : RdrName :=
+  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "selName")).
 
-Definition ident_RDR : RdrName :=
-  dataQual_RDR lEX (FastString.fsLit (GHC.Base.hs_string__ "Ident")).
+Definition conName_RDR : RdrName :=
+  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "conName")).
+
+Definition conFixity_RDR : RdrName :=
+  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "conFixity")).
+
+Definition conIsRecord_RDR : RdrName :=
+  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__
+                                              "conIsRecord")).
+
+Definition prefixDataCon_RDR : RdrName :=
+  dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Prefix")).
 
 Definition infixDataCon_RDR : RdrName :=
   dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Infix")).
-
-Definition k1DataCon_RDR : RdrName :=
-  dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "K1")).
-
-Definition l1DataCon_RDR : RdrName :=
-  dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "L1")).
 
 Definition leftAssocDataCon_RDR : RdrName :=
   dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__
                                                "LeftAssociative")).
 
-Definition ltTag_RDR : RdrName :=
-  dataQual_RDR gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "LT")).
-
-Definition m1DataCon_RDR : RdrName :=
-  dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "M1")).
-
-Definition notAssocDataCon_RDR : RdrName :=
-  dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__
-                                               "NotAssociative")).
-
-Definition par1DataCon_RDR : RdrName :=
-  dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Par1")).
-
-Definition prefixDataCon_RDR : RdrName :=
-  dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Prefix")).
-
-Definition prodDataCon_RDR : RdrName :=
-  dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ ":*:")).
-
-Definition punc_RDR : RdrName :=
-  dataQual_RDR lEX (FastString.fsLit (GHC.Base.hs_string__ "Punc")).
-
-Definition r1DataCon_RDR : RdrName :=
-  dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "R1")).
-
-Definition rec1DataCon_RDR : RdrName :=
-  dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Rec1")).
-
 Definition rightAssocDataCon_RDR : RdrName :=
   dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__
                                                "RightAssociative")).
 
-Definition symbol_RDR : RdrName :=
-  dataQual_RDR lEX (FastString.fsLit (GHC.Base.hs_string__ "Symbol")).
-
-Definition u1DataCon_RDR : RdrName :=
-  dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "U1")).
+Definition notAssocDataCon_RDR : RdrName :=
+  dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__
+                                               "NotAssociative")).
 
 Definition uAddrDataCon_RDR : RdrName :=
   dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "UAddr")).
@@ -2711,568 +1091,39 @@ Definition uIntDataCon_RDR : RdrName :=
 Definition uWordDataCon_RDR : RdrName :=
   dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "UWord")).
 
-Definition dataClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #9.
+Definition uAddrHash_RDR : RdrName :=
+  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "uAddr#")).
 
-Definition dYNAMIC : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Data.Dynamic")).
+Definition uCharHash_RDR : RdrName :=
+  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "uChar#")).
 
-Definition toDynName : Name.Name :=
-  varQual dYNAMIC (FastString.fsLit (GHC.Base.hs_string__ "toDyn")) toDynIdKey.
+Definition uDoubleHash_RDR : RdrName :=
+  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "uDouble#")).
 
-Definition dTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #146.
+Definition uFloatHash_RDR : RdrName :=
+  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "uFloat#")).
 
-Definition dTyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "D")) dTyConKey.
+Definition uIntHash_RDR : RdrName :=
+  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "uInt#")).
 
-Definition dEBUG_TRACE : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Debug.Trace")).
+Definition uWordHash_RDR : RdrName :=
+  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "uWord#")).
 
-Definition traceName : Name.Name :=
-  varQual dEBUG_TRACE (FastString.fsLit (GHC.Base.hs_string__ "trace")) traceKey.
+Definition fmap_RDR : RdrName :=
+  varQual_RDR gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "fmap")).
 
-Definition dATA_TYPE_EQUALITY : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Data.Type.Equality")).
+Definition replace_RDR : RdrName :=
+  varQual_RDR gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "<$")).
 
-Definition eqTyConName : Name.Name :=
-  tcQual dATA_TYPE_EQUALITY (FastString.fsLit (GHC.Base.hs_string__ "~"))
-  eqTyConKey.
+Definition pureAClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #752.
 
-Definition eqTyCon_RDR : RdrName :=
-  tcQual_RDR dATA_TYPE_EQUALITY (FastString.fsLit (GHC.Base.hs_string__ "~")).
+Definition pureAName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "pure"))
+  pureAClassOpKey.
 
-Definition dATA_TUPLE : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Data.Tuple")).
-
-Definition fstName : Name.Name :=
-  varQual dATA_TUPLE (FastString.fsLit (GHC.Base.hs_string__ "fst")) fstIdKey.
-
-Definition sndName : Name.Name :=
-  varQual dATA_TUPLE (FastString.fsLit (GHC.Base.hs_string__ "snd")) sndIdKey.
-
-Definition dATA_TRAVERSABLE : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Data.Traversable")).
-
-Definition traverse_RDR : RdrName :=
-  varQual_RDR dATA_TRAVERSABLE (FastString.fsLit (GHC.Base.hs_string__
-                                                  "traverse")).
-
-Definition dATA_STRING : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Data.String")).
-
-Definition fromStringName : Name.Name :=
-  varQual dATA_STRING (FastString.fsLit (GHC.Base.hs_string__ "fromString"))
-  fromStringClassOpKey.
-
-Definition fromString_RDR : RdrName :=
-  nameRdrName fromStringName.
-
-Definition dATA_FOLDABLE : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Data.Foldable")).
-
-Definition foldMap_RDR : RdrName :=
-  varQual_RDR dATA_FOLDABLE (FastString.fsLit (GHC.Base.hs_string__ "foldMap")).
-
-Definition foldable_foldr_RDR : RdrName :=
-  varQual_RDR dATA_FOLDABLE (FastString.fsLit (GHC.Base.hs_string__ "foldr")).
-
-Definition null_RDR : RdrName :=
-  varQual_RDR dATA_FOLDABLE (FastString.fsLit (GHC.Base.hs_string__ "null")).
-
-Definition dATA_EITHER : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Data.Either")).
-
-Definition eitherTyConName : Name.Name :=
-  tcQual dATA_EITHER (FastString.fsLit (GHC.Base.hs_string__ "Either"))
-  eitherTyConKey.
-
-Definition leftDataConName : Name.Name :=
-  dcQual dATA_EITHER (FastString.fsLit (GHC.Base.hs_string__ "Left"))
-  leftDataConKey.
-
-Definition left_RDR : RdrName :=
-  nameRdrName leftDataConName.
-
-Definition rightDataConName : Name.Name :=
-  dcQual dATA_EITHER (FastString.fsLit (GHC.Base.hs_string__ "Right"))
-  rightDataConKey.
-
-Definition right_RDR : RdrName :=
-  nameRdrName rightDataConName.
-
-Definition dATA_COERCE : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Data.Coerce")).
-
-Definition dATA_ARRAY_PARALLEL_PRIM_NAME : Module.ModuleName :=
-  Module.mkModuleNameFS (FastString.fsLit (GHC.Base.hs_string__
-                                           "Data.Array.Parallel.Prim")).
-
-Definition dATA_ARRAY_PARALLEL_NAME : Module.ModuleName :=
-  Module.mkModuleNameFS (FastString.fsLit (GHC.Base.hs_string__
-                                           "Data.Array.Parallel")).
-
-Definition d1TyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #151.
-
-Definition d1TyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "D1")) d1TyConKey.
-
-Definition crossDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #20.
-
-Definition constructorClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #40.
-
-Definition constraintKindTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #92.
-
-Definition consDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #2.
-
-Definition concatIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #31.
-
-Definition concatName : Name.Name :=
-  varQual gHC_LIST (FastString.fsLit (GHC.Base.hs_string__ "concat")) concatIdKey.
-
-Definition conName_RDR : RdrName :=
-  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "conName")).
-
-Definition conIsRecord_RDR : RdrName :=
-  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__
-                                              "conIsRecord")).
-
-Definition conFixity_RDR : RdrName :=
-  varQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "conFixity")).
-
-Definition compose_RDR : RdrName :=
-  varQual_RDR gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ ".")).
-
-Definition composeAIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #181.
-
-Definition composeAName : Name.Name :=
-  varQual gHC_DESUGAR (FastString.fsLit (GHC.Base.hs_string__ ">>>"))
-  composeAIdKey.
-
-Definition complementIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #94.
-
-Definition complementIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "complementInteger")) complementIntegerIdKey.
-
-Definition compare_RDR : RdrName :=
-  varQual_RDR gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ "compare")).
-
-Definition compareIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #78.
-
-Definition compareIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
-                                              "compareInteger")) compareIntegerIdKey.
-
-Definition compactPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #78.
-
-Definition compTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #143.
-
-Definition compTyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ ":.:"))
-  compTyConKey.
-
-Definition comp1DataCon_RDR : RdrName :=
-  dataQual_RDR gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Comp1")).
-
-Definition coercionTokenIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #124.
-
-Definition coercibleTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #178.
-
-Definition coercibleSCSelIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #553.
-
-Definition coercibleDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #32.
-
-Definition coerceKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #157.
-
-Axiom clsQual_RDR : Module.Module -> FastString.FastString -> RdrName.
-
-Definition clsQual
-   : Module.Module -> FastString.FastString -> Unique.Unique -> Name.Name :=
-  mk_known_key_name OccName.clsName.
-
-Definition constructorClassName : Name.Name :=
-  clsQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Constructor"))
-  constructorClassKey.
-
-Definition dataClassName : Name.Name :=
-  clsQual gENERICS (FastString.fsLit (GHC.Base.hs_string__ "Data")) dataClassKey.
-
-Definition datatypeClassName : Name.Name :=
-  clsQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Datatype"))
-  datatypeClassKey.
-
-Definition enumClassName : Name.Name :=
-  clsQual gHC_ENUM (FastString.fsLit (GHC.Base.hs_string__ "Enum")) enumClassKey.
-
-Definition enumClass_RDR : RdrName :=
-  nameRdrName enumClassName.
-
-Definition eqClassName : Name.Name :=
-  clsQual gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ "Eq")) eqClassKey.
-
-Definition eqClass_RDR : RdrName :=
-  nameRdrName eqClassName.
-
-Definition floatingClassName : Name.Name :=
-  clsQual gHC_FLOAT (FastString.fsLit (GHC.Base.hs_string__ "Floating"))
-  floatingClassKey.
-
-Definition foldableClassName : Name.Name :=
-  clsQual dATA_FOLDABLE (FastString.fsLit (GHC.Base.hs_string__ "Foldable"))
-  foldableClassKey.
-
-Definition fractionalClassName : Name.Name :=
-  clsQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ "Fractional"))
-  fractionalClassKey.
-
-Definition functorClassName : Name.Name :=
-  clsQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "Functor"))
-  functorClassKey.
-
-Definition gen1ClassName : Name.Name :=
-  clsQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Generic1"))
-  gen1ClassKey.
-
-Definition genClassName : Name.Name :=
-  clsQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Generic"))
-  genClassKey.
-
-Definition genericClassNames : list Name.Name :=
-  cons genClassName (cons gen1ClassName nil).
-
-Definition ghciIoClassName : Name.Name :=
-  clsQual gHC_GHCI (FastString.fsLit (GHC.Base.hs_string__ "GHCiSandboxIO"))
-  ghciIoClassKey.
-
-Definition hasFieldClassName : Name.Name :=
-  clsQual gHC_RECORDS (FastString.fsLit (GHC.Base.hs_string__ "HasField"))
-  hasFieldClassNameKey.
-
-Definition integralClassName : Name.Name :=
-  clsQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ "Integral"))
-  integralClassKey.
-
-Definition ipClassName : Name.Name :=
-  clsQual gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ "IP")) ipClassKey.
-
-Definition isLabelClassName : Name.Name :=
-  clsQual gHC_OVER_LABELS (FastString.fsLit (GHC.Base.hs_string__ "IsLabel"))
-  isLabelClassNameKey.
-
-Definition isListClassName : Name.Name :=
-  clsQual gHC_EXTS (FastString.fsLit (GHC.Base.hs_string__ "IsList"))
-  isListClassKey.
-
-Definition isStringClassName : Name.Name :=
-  clsQual dATA_STRING (FastString.fsLit (GHC.Base.hs_string__ "IsString"))
-  isStringClassKey.
-
-Definition ixClassName : Name.Name :=
-  clsQual gHC_ARR (FastString.fsLit (GHC.Base.hs_string__ "Ix")) ixClassKey.
-
-Definition knownNatClassName : Name.Name :=
-  clsQual gHC_TYPENATS (FastString.fsLit (GHC.Base.hs_string__ "KnownNat"))
-  knownNatClassNameKey.
-
-Definition knownSymbolClassName : Name.Name :=
-  clsQual gHC_TYPELITS (FastString.fsLit (GHC.Base.hs_string__ "KnownSymbol"))
-  knownSymbolClassNameKey.
-
-Definition monadClassName : Name.Name :=
-  clsQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "Monad"))
-  monadClassKey.
-
-Definition monadClass_RDR : RdrName :=
-  nameRdrName monadClassName.
-
-Definition monadFailClassName : Name.Name :=
-  clsQual mONAD_FAIL (FastString.fsLit (GHC.Base.hs_string__ "MonadFail"))
-  monadFailClassKey.
-
-Definition monadFixClassName : Name.Name :=
-  clsQual mONAD_FIX (FastString.fsLit (GHC.Base.hs_string__ "MonadFix"))
-  monadFixClassKey.
-
-Definition monadPlusClassName : Name.Name :=
-  clsQual mONAD (FastString.fsLit (GHC.Base.hs_string__ "MonadPlus"))
-  monadPlusClassKey.
-
-Definition monoidClassName : Name.Name :=
-  clsQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "Monoid"))
-  monoidClassKey.
-
-Definition numClassName : Name.Name :=
-  clsQual gHC_NUM (FastString.fsLit (GHC.Base.hs_string__ "Num")) numClassKey.
-
-Definition numClass_RDR : RdrName :=
-  nameRdrName numClassName.
-
-Definition ordClassName : Name.Name :=
-  clsQual gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ "Ord")) ordClassKey.
-
-Definition ordClass_RDR : RdrName :=
-  nameRdrName ordClassName.
-
-Definition randomClassName : Name.Name :=
-  clsQual rANDOM (FastString.fsLit (GHC.Base.hs_string__ "Random"))
-  randomClassKey.
-
-Definition randomGenClassName : Name.Name :=
-  clsQual rANDOM (FastString.fsLit (GHC.Base.hs_string__ "RandomGen"))
-  randomGenClassKey.
-
-Definition readClassName : Name.Name :=
-  clsQual gHC_READ (FastString.fsLit (GHC.Base.hs_string__ "Read")) readClassKey.
-
-Definition realClassName : Name.Name :=
-  clsQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ "Real")) realClassKey.
-
-Definition realFloatClassName : Name.Name :=
-  clsQual gHC_FLOAT (FastString.fsLit (GHC.Base.hs_string__ "RealFloat"))
-  realFloatClassKey.
-
-Definition realFracClassName : Name.Name :=
-  clsQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ "RealFrac"))
-  realFracClassKey.
-
-Definition selectorClassName : Name.Name :=
-  clsQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Selector"))
-  selectorClassKey.
-
-Definition semigroupClassName : Name.Name :=
-  clsQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "Semigroup"))
-  semigroupClassKey.
-
-Definition showClassName : Name.Name :=
-  clsQual gHC_SHOW (FastString.fsLit (GHC.Base.hs_string__ "Show")) showClassKey.
-
-Definition traversableClassName : Name.Name :=
-  clsQual dATA_TRAVERSABLE (FastString.fsLit (GHC.Base.hs_string__ "Traversable"))
-  traversableClassKey.
-
-Definition interactiveClassNames : list Name.Name :=
-  cons showClassName (cons eqClassName (cons ordClassName (cons foldableClassName
-                                                                (cons traversableClassName nil)))).
-
-Definition interactiveClassKeys : list Unique.Unique :=
-  GHC.Base.map Unique.getUnique interactiveClassNames.
-
-Definition typeableClassName : Name.Name :=
-  clsQual tYPEABLE_INTERNAL (FastString.fsLit (GHC.Base.hs_string__ "Typeable"))
-  typeableClassKey.
-
-Definition choose_RDR : RdrName :=
-  varQual_RDR gHC_READ (FastString.fsLit (GHC.Base.hs_string__ "choose")).
-
-Definition choiceAIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #184.
-
-Definition checkDotnetResNameIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #154.
-
-Definition charTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #8.
-
-Definition charPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #7.
-
-Definition charDataConKey : Unique.Unique :=
-  Unique.mkPreludeDataConUnique #1.
-
-Definition callStackTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #186.
-
-Definition callStackTyConName : Name.Name :=
-  tcQual gHC_STACK_TYPES (FastString.fsLit (GHC.Base.hs_string__ "CallStack"))
-  callStackTyConKey.
-
-Definition cTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #147.
-
-Definition cTyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "C")) cTyConKey.
-
-Definition cONTROL_EXCEPTION_BASE : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Control.Exception.Base")).
-
-Definition cONTROL_APPLICATIVE : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Control.Applicative")).
-
-Definition c1TyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #152.
-
-Definition c1TyConName : Name.Name :=
-  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "C1")) c1TyConKey.
-
-Definition byteArrayPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #5.
-
-Definition buildIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #4.
-
-Definition buildName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "build")) buildIdKey.
-
-Definition build_RDR : RdrName :=
-  nameRdrName buildName.
-
-Definition breakpointJumpIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #113.
-
-Definition breakpointJumpName : Name.Name :=
-  Name.mkInternalName breakpointJumpIdKey (OccName.mkOccNameFS OccName.varName
-                                           (FastString.fsLit (GHC.Base.hs_string__ "breakpointJump"))) SrcLoc.noSrcSpan.
-
-Definition breakpointIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #110.
-
-Definition breakpointName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "breakpoint"))
-  breakpointIdKey.
-
-Definition breakpointCondJumpIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #114.
-
-Definition breakpointCondJumpName : Name.Name :=
-  Name.mkInternalName breakpointCondJumpIdKey (OccName.mkOccNameFS OccName.varName
-                                               (FastString.fsLit (GHC.Base.hs_string__ "breakpointCondJump")))
-  SrcLoc.noSrcSpan.
-
-Definition breakpointCondIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #111.
-
-Definition breakpointCondName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "breakpointCond"))
-  breakpointCondIdKey.
-
-Definition breakpointAutoJumpIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #115.
-
-Definition breakpointAutoJumpName : Name.Name :=
-  Name.mkInternalName breakpointAutoJumpIdKey (OccName.mkOccNameFS OccName.varName
-                                               (FastString.fsLit (GHC.Base.hs_string__ "breakpointAutoJump")))
-  SrcLoc.noSrcSpan.
-
-Definition breakpointAutoIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #112.
-
-Definition breakpointAutoName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "breakpointAuto"))
-  breakpointAutoIdKey.
-
-Definition boxityConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #71.
-
-Definition boundedClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #1.
-
-Definition boundedClassName : Name.Name :=
-  clsQual gHC_ENUM (FastString.fsLit (GHC.Base.hs_string__ "Bounded"))
-  boundedClassKey.
-
-Definition derivableClassKeys : list Unique.Unique :=
-  cons eqClassKey (cons ordClassKey (cons enumClassKey (cons ixClassKey (cons
-                                                              boundedClassKey (cons showClassKey (cons readClassKey
-                                                                                                       nil)))))).
-
-Definition boolTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #4.
-
-Definition bitIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #551.
-
-Definition bitIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "bitInteger"))
-  bitIntegerIdKey.
-
-Definition bindMClassOpKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #171.
-
-Definition bindMName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ ">>="))
-  bindMClassOpKey.
-
-Definition bindM_RDR : RdrName :=
-  nameRdrName bindMName.
-
-Definition bindIOIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #34.
-
-Definition bindIOName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "bindIO")) bindIOIdKey.
-
-Definition bindIO_RDR : RdrName :=
-  nameRdrName bindIOName.
-
-Definition bcoPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #74.
-
-Axiom basicKnownKeyNames : list Name.Name.
-
-Definition augmentIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #2.
-
-Definition augmentName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "augment"))
-  augmentIdKey.
-
-Definition assertIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #44.
-
-Definition assertName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "assert")) assertIdKey.
-
-Definition assertErrorIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #105.
-
-Definition assertErrorName : Name.Name :=
-  varQual gHC_IO_Exception (FastString.fsLit (GHC.Base.hs_string__ "assertError"))
-  assertErrorIdKey.
-
-Definition arrayPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #3.
-
-Definition arrayArrayPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #40.
-
-Definition arrAIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #180.
-
-Definition applicativeClassKey : Unique.Unique :=
-  Unique.mkPreludeClassUnique #34.
-
-Definition applicativeClassName : Name.Name :=
-  clsQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "Applicative"))
-  applicativeClassKey.
-
-Definition append_RDR : RdrName :=
-  varQual_RDR gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "++")).
-
-Definition appendIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #3.
-
-Definition appendName : Name.Name :=
-  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "++")) appendIdKey.
-
-Definition appAIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #183.
+Definition pure_RDR : RdrName :=
+  nameRdrName pureAName.
 
 Definition apAClassOpKey : Unique.Unique :=
   Unique.mkPreludeMiscIdUnique #751.
@@ -3283,14 +1134,865 @@ Definition apAName : Name.Name :=
 Definition ap_RDR : RdrName :=
   nameRdrName apAName.
 
-Definition anyTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #181.
+Definition liftA2_RDR : RdrName :=
+  varQual_RDR gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "liftA2")).
 
-Definition anyBoxConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #69.
+Definition foldable_foldr_RDR : RdrName :=
+  varQual_RDR dATA_FOLDABLE (FastString.fsLit (GHC.Base.hs_string__ "foldr")).
 
-Definition and_RDR : RdrName :=
-  varQual_RDR gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ "&&")).
+Definition foldMap_RDR : RdrName :=
+  varQual_RDR dATA_FOLDABLE (FastString.fsLit (GHC.Base.hs_string__ "foldMap")).
+
+Definition null_RDR : RdrName :=
+  varQual_RDR dATA_FOLDABLE (FastString.fsLit (GHC.Base.hs_string__ "null")).
+
+Definition all_RDR : RdrName :=
+  varQual_RDR dATA_FOLDABLE (FastString.fsLit (GHC.Base.hs_string__ "all")).
+
+Definition traverse_RDR : RdrName :=
+  varQual_RDR dATA_TRAVERSABLE (FastString.fsLit (GHC.Base.hs_string__
+                                                  "traverse")).
+
+Definition mempty_RDR : RdrName :=
+  varQual_RDR gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "mempty")).
+
+Definition mappend_RDR : RdrName :=
+  varQual_RDR gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "mappend")).
+
+Definition eqTyCon_RDR : RdrName :=
+  tcQual_RDR dATA_TYPE_EQUALITY (FastString.fsLit (GHC.Base.hs_string__ "~")).
+
+Axiom clsQual_RDR : Module.Module -> FastString.FastString -> RdrName.
+
+Definition wildCardKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #0.
+
+Definition wildCardName : Name.Name :=
+  Name.mkSystemVarName wildCardKey (FastString.fsLit (GHC.Base.hs_string__
+                                                      "wild")).
+
+Definition runMainKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #102.
+
+Definition runMainIOName : Name.Name :=
+  varQual gHC_TOP_HANDLER (FastString.fsLit (GHC.Base.hs_string__ "runMainIO"))
+  runMainKey.
+
+Definition orderingTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #30.
+
+Definition tcQual
+   : Module.Module -> FastString.FastString -> Unique.Unique -> Name.Name :=
+  mk_known_key_name OccName.tcName.
+
+Definition orderingTyConName : Name.Name :=
+  tcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "Ordering"))
+  orderingTyConKey.
+
+Definition ltDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #27.
+
+Definition ltDataConName : Name.Name :=
+  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "LT")) ltDataConKey.
+
+Definition eqDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #28.
+
+Definition eqDataConName : Name.Name :=
+  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "EQ")) eqDataConKey.
+
+Definition gtDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #29.
+
+Definition gtDataConName : Name.Name :=
+  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "GT")) gtDataConKey.
+
+Definition specTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #180.
+
+Definition specTyConName : Name.Name :=
+  tcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "SPEC")) specTyConKey.
+
+Definition eitherTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #84.
+
+Definition eitherTyConName : Name.Name :=
+  tcQual dATA_EITHER (FastString.fsLit (GHC.Base.hs_string__ "Either"))
+  eitherTyConKey.
+
+Definition v1TyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #135.
+
+Definition v1TyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "V1")) v1TyConKey.
+
+Definition u1TyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #136.
+
+Definition u1TyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "U1")) u1TyConKey.
+
+Definition par1TyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #137.
+
+Definition par1TyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Par1"))
+  par1TyConKey.
+
+Definition rec1TyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #138.
+
+Definition rec1TyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Rec1"))
+  rec1TyConKey.
+
+Definition k1TyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #139.
+
+Definition k1TyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "K1")) k1TyConKey.
+
+Definition m1TyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #140.
+
+Definition m1TyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "M1")) m1TyConKey.
+
+Definition sumTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #141.
+
+Definition sumTyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ ":+:")) sumTyConKey.
+
+Definition prodTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #142.
+
+Definition prodTyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ ":*:"))
+  prodTyConKey.
+
+Definition compTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #143.
+
+Definition compTyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ ":.:"))
+  compTyConKey.
+
+Definition rTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #144.
+
+Definition rTyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "R")) rTyConKey.
+
+Definition dTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #146.
+
+Definition dTyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "D")) dTyConKey.
+
+Definition cTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #147.
+
+Definition cTyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "C")) cTyConKey.
+
+Definition sTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #148.
+
+Definition sTyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "S")) sTyConKey.
+
+Definition rec0TyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #149.
+
+Definition rec0TyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Rec0"))
+  rec0TyConKey.
+
+Definition d1TyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #151.
+
+Definition d1TyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "D1")) d1TyConKey.
+
+Definition c1TyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #152.
+
+Definition c1TyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "C1")) c1TyConKey.
+
+Definition s1TyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #153.
+
+Definition s1TyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "S1")) s1TyConKey.
+
+Definition noSelTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #154.
+
+Definition noSelTyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "NoSelector"))
+  noSelTyConKey.
+
+Definition repTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #155.
+
+Definition repTyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Rep")) repTyConKey.
+
+Definition rep1TyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #156.
+
+Definition rep1TyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Rep1"))
+  rep1TyConKey.
+
+Definition uRecTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #157.
+
+Definition uRecTyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "URec"))
+  uRecTyConKey.
+
+Definition uAddrTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #158.
+
+Definition uAddrTyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "UAddr"))
+  uAddrTyConKey.
+
+Definition uCharTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #159.
+
+Definition uCharTyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "UChar"))
+  uCharTyConKey.
+
+Definition uDoubleTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #160.
+
+Definition uDoubleTyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "UDouble"))
+  uDoubleTyConKey.
+
+Definition uFloatTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #161.
+
+Definition uFloatTyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "UFloat"))
+  uFloatTyConKey.
+
+Definition uIntTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #162.
+
+Definition uIntTyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "UInt"))
+  uIntTyConKey.
+
+Definition uWordTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #163.
+
+Definition uWordTyConName : Name.Name :=
+  tcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "UWord"))
+  uWordTyConKey.
+
+Definition prefixIDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #54.
+
+Definition prefixIDataConName : Name.Name :=
+  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "PrefixI"))
+  prefixIDataConKey.
+
+Definition infixIDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #55.
+
+Definition infixIDataConName : Name.Name :=
+  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "InfixI"))
+  infixIDataConKey.
+
+Definition leftAssociativeDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #56.
+
+Definition leftAssociativeDataConName : Name.Name :=
+  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "LeftAssociative"))
+  leftAssociativeDataConKey.
+
+Definition rightAssociativeDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #57.
+
+Definition rightAssociativeDataConName : Name.Name :=
+  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "RightAssociative"))
+  rightAssociativeDataConKey.
+
+Definition notAssociativeDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #58.
+
+Definition notAssociativeDataConName : Name.Name :=
+  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "NotAssociative"))
+  notAssociativeDataConKey.
+
+Definition sourceUnpackDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #59.
+
+Definition sourceUnpackDataConName : Name.Name :=
+  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "SourceUnpack"))
+  sourceUnpackDataConKey.
+
+Definition sourceNoUnpackDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #60.
+
+Definition sourceNoUnpackDataConName : Name.Name :=
+  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "SourceNoUnpack"))
+  sourceNoUnpackDataConKey.
+
+Definition noSourceUnpackednessDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #61.
+
+Definition noSourceUnpackednessDataConName : Name.Name :=
+  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__
+                                         "NoSourceUnpackedness")) noSourceUnpackednessDataConKey.
+
+Definition sourceLazyDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #62.
+
+Definition sourceLazyDataConName : Name.Name :=
+  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "SourceLazy"))
+  sourceLazyDataConKey.
+
+Definition sourceStrictDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #63.
+
+Definition sourceStrictDataConName : Name.Name :=
+  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "SourceStrict"))
+  sourceStrictDataConKey.
+
+Definition noSourceStrictnessDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #64.
+
+Definition noSourceStrictnessDataConName : Name.Name :=
+  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__
+                                         "NoSourceStrictness")) noSourceStrictnessDataConKey.
+
+Definition decidedLazyDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #65.
+
+Definition decidedLazyDataConName : Name.Name :=
+  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "DecidedLazy"))
+  decidedLazyDataConKey.
+
+Definition decidedStrictDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #66.
+
+Definition decidedStrictDataConName : Name.Name :=
+  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "DecidedStrict"))
+  decidedStrictDataConKey.
+
+Definition decidedUnpackDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #67.
+
+Definition decidedUnpackDataConName : Name.Name :=
+  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "DecidedUnpack"))
+  decidedUnpackDataConKey.
+
+Definition metaDataDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #68.
+
+Definition metaDataDataConName : Name.Name :=
+  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "MetaData"))
+  metaDataDataConKey.
+
+Definition metaConsDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #69.
+
+Definition metaConsDataConName : Name.Name :=
+  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "MetaCons"))
+  metaConsDataConKey.
+
+Definition metaSelDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #70.
+
+Definition metaSelDataConName : Name.Name :=
+  dcQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "MetaSel"))
+  metaSelDataConKey.
+
+Definition divIntIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #23.
+
+Definition divIntName : Name.Name :=
+  varQual gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ "divInt#"))
+  divIntIdKey.
+
+Definition modIntIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #24.
+
+Definition modIntName : Name.Name :=
+  varQual gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ "modInt#"))
+  modIntIdKey.
+
+Definition inlineIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #120.
+
+Definition inlineIdName : Name.Name :=
+  varQual gHC_MAGIC (FastString.fsLit (GHC.Base.hs_string__ "inline"))
+  inlineIdKey.
+
+Definition functorClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #10.
+
+Definition functorClassName : Name.Name :=
+  clsQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "Functor"))
+  functorClassKey.
+
+Definition fmapClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #173.
+
+Definition fmapName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "fmap"))
+  fmapClassOpKey.
+
+Definition thenMClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #172.
+
+Definition thenMName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ ">>")) thenMClassOpKey.
+
+Definition monadFailClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #29.
+
+Definition monadFailClassName : Name.Name :=
+  clsQual mONAD_FAIL (FastString.fsLit (GHC.Base.hs_string__ "MonadFail"))
+  monadFailClassKey.
+
+Definition applicativeClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #34.
+
+Definition applicativeClassName : Name.Name :=
+  clsQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "Applicative"))
+  applicativeClassKey.
+
+Definition thenAClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #753.
+
+Definition thenAName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "*>")) thenAClassOpKey.
+
+Definition foldableClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #35.
+
+Definition foldableClassName : Name.Name :=
+  clsQual dATA_FOLDABLE (FastString.fsLit (GHC.Base.hs_string__ "Foldable"))
+  foldableClassKey.
+
+Definition traversableClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #36.
+
+Definition traversableClassName : Name.Name :=
+  clsQual dATA_TRAVERSABLE (FastString.fsLit (GHC.Base.hs_string__ "Traversable"))
+  traversableClassKey.
+
+Definition semigroupClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #46.
+
+Definition semigroupClassName : Name.Name :=
+  clsQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "Semigroup"))
+  semigroupClassKey.
+
+Definition sappendClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #554.
+
+Definition sappendName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "<>"))
+  sappendClassOpKey.
+
+Definition monoidClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #47.
+
+Definition monoidClassName : Name.Name :=
+  clsQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "Monoid"))
+  monoidClassKey.
+
+Definition memptyClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #555.
+
+Definition memptyName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "mempty"))
+  memptyClassOpKey.
+
+Definition mappendClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #556.
+
+Definition mappendName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "mappend"))
+  mappendClassOpKey.
+
+Definition mconcatClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #557.
+
+Definition mconcatName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "mconcat"))
+  mconcatClassOpKey.
+
+Definition joinMIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #750.
+
+Definition joinMName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "join")) joinMIdKey.
+
+Definition alternativeClassKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #754.
+
+Definition alternativeClassName : Name.Name :=
+  clsQual mONAD (FastString.fsLit (GHC.Base.hs_string__ "Alternative"))
+  alternativeClassKey.
+
+Definition groupWithIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #122.
+
+Definition groupWithName : Name.Name :=
+  varQual gHC_EXTS (FastString.fsLit (GHC.Base.hs_string__ "groupWith"))
+  groupWithIdKey.
+
+Definition otherwiseIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #43.
+
+Definition otherwiseIdName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "otherwise"))
+  otherwiseIdKey.
+
+Definition augmentIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #2.
+
+Definition augmentName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "augment"))
+  augmentIdKey.
+
+Definition mapIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #121.
+
+Definition mapName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "map")) mapIdKey.
+
+Definition appendIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #3.
+
+Definition appendName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "++")) appendIdKey.
+
+Definition assertIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #44.
+
+Definition assertName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "assert")) assertIdKey.
+
+Definition breakpointIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #110.
+
+Definition breakpointName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "breakpoint"))
+  breakpointIdKey.
+
+Definition breakpointCondIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #111.
+
+Definition breakpointCondName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "breakpointCond"))
+  breakpointCondIdKey.
+
+Definition breakpointAutoIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #112.
+
+Definition breakpointAutoName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "breakpointAuto"))
+  breakpointAutoIdKey.
+
+Definition opaqueTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #133.
+
+Definition opaqueTyConName : Name.Name :=
+  tcQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "Opaque"))
+  opaqueTyConKey.
+
+Definition breakpointJumpIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #113.
+
+Definition breakpointJumpName : Name.Name :=
+  Name.mkInternalName breakpointJumpIdKey (OccName.mkOccNameFS OccName.varName
+                                           (FastString.fsLit (GHC.Base.hs_string__ "breakpointJump"))) SrcLoc.noSrcSpan.
+
+Definition breakpointCondJumpIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #114.
+
+Definition breakpointCondJumpName : Name.Name :=
+  Name.mkInternalName breakpointCondJumpIdKey (OccName.mkOccNameFS OccName.varName
+                                               (FastString.fsLit (GHC.Base.hs_string__ "breakpointCondJump")))
+  SrcLoc.noSrcSpan.
+
+Definition breakpointAutoJumpIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #115.
+
+Definition breakpointAutoJumpName : Name.Name :=
+  Name.mkInternalName breakpointAutoJumpIdKey (OccName.mkOccNameFS OccName.varName
+                                               (FastString.fsLit (GHC.Base.hs_string__ "breakpointAutoJump")))
+  SrcLoc.noSrcSpan.
+
+Definition fstIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #41.
+
+Definition fstName : Name.Name :=
+  varQual dATA_TUPLE (FastString.fsLit (GHC.Base.hs_string__ "fst")) fstIdKey.
+
+Definition sndIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #42.
+
+Definition sndName : Name.Name :=
+  varQual dATA_TUPLE (FastString.fsLit (GHC.Base.hs_string__ "snd")) sndIdKey.
+
+Definition negateClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #169.
+
+Definition negateName : Name.Name :=
+  varQual gHC_NUM (FastString.fsLit (GHC.Base.hs_string__ "negate"))
+  negateClassOpKey.
+
+Definition integerTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #22.
+
+Definition integerTyConName : Name.Name :=
+  tcQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "Integer"))
+  integerTyConKey.
+
+Axiom integerSDataConName : Name.Name.
+
+Definition mkIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #60.
+
+Definition mkIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "mkInteger"))
+  mkIntegerIdKey.
+
+Definition integerToWord64IdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #64.
+
+Definition integerToWord64Name : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "integerToWord64")) integerToWord64IdKey.
+
+Definition integerToInt64IdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #65.
+
+Definition integerToInt64Name : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "integerToInt64")) integerToInt64IdKey.
+
+Definition word64ToIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #98.
+
+Definition word64ToIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "word64ToInteger")) word64ToIntegerIdKey.
+
+Definition int64ToIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #99.
+
+Definition int64ToIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "int64ToInteger")) int64ToIntegerIdKey.
+
+Definition smallIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #61.
+
+Definition smallIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "smallInteger")) smallIntegerIdKey.
+
+Definition wordToIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #97.
+
+Definition wordToIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "wordToInteger")) wordToIntegerIdKey.
+
+Definition integerToWordIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #62.
+
+Definition integerToWordName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "integerToWord")) integerToWordIdKey.
+
+Definition integerToIntIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #63.
+
+Definition integerToIntName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "integerToInt")) integerToIntIdKey.
+
+Definition minusIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #68.
+
+Definition minusIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "minusInteger")) minusIntegerIdKey.
+
+Definition negateIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #69.
+
+Definition negateIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "negateInteger")) negateIntegerIdKey.
+
+Definition eqIntegerPrimIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #70.
+
+Definition eqIntegerPrimName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "eqInteger#"))
+  eqIntegerPrimIdKey.
+
+Definition neqIntegerPrimIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #71.
+
+Definition neqIntegerPrimName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "neqInteger#"))
+  neqIntegerPrimIdKey.
+
+Definition absIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #72.
+
+Definition absIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "absInteger"))
+  absIntegerIdKey.
+
+Definition signumIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #73.
+
+Definition signumIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "signumInteger")) signumIntegerIdKey.
+
+Definition leIntegerPrimIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #74.
+
+Definition leIntegerPrimName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "leInteger#"))
+  leIntegerPrimIdKey.
+
+Definition gtIntegerPrimIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #75.
+
+Definition gtIntegerPrimName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "gtInteger#"))
+  gtIntegerPrimIdKey.
+
+Definition ltIntegerPrimIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #76.
+
+Definition ltIntegerPrimName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "ltInteger#"))
+  ltIntegerPrimIdKey.
+
+Definition geIntegerPrimIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #77.
+
+Definition geIntegerPrimName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "geInteger#"))
+  geIntegerPrimIdKey.
+
+Definition compareIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #78.
+
+Definition compareIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "compareInteger")) compareIntegerIdKey.
+
+Definition quotRemIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #84.
+
+Definition quotRemIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "quotRemInteger")) quotRemIntegerIdKey.
+
+Definition divModIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #83.
+
+Definition divModIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "divModInteger")) divModIntegerIdKey.
+
+Definition quotIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #79.
+
+Definition quotIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "quotInteger"))
+  quotIntegerIdKey.
+
+Definition remIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #80.
+
+Definition remIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "remInteger"))
+  remIntegerIdKey.
+
+Definition divIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #81.
+
+Definition divIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "divInteger"))
+  divIntegerIdKey.
+
+Definition modIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #82.
+
+Definition modIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "modInteger"))
+  modIntegerIdKey.
+
+Definition floatFromIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #85.
+
+Definition floatFromIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "floatFromInteger")) floatFromIntegerIdKey.
+
+Definition doubleFromIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #86.
+
+Definition doubleFromIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "doubleFromInteger")) doubleFromIntegerIdKey.
+
+Definition encodeFloatIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #87.
+
+Definition encodeFloatIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "encodeFloatInteger")) encodeFloatIntegerIdKey.
+
+Definition encodeDoubleIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #88.
+
+Definition encodeDoubleIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "encodeDoubleInteger")) encodeDoubleIntegerIdKey.
+
+Definition decodeDoubleIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #100.
+
+Definition decodeDoubleIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "decodeDoubleInteger")) decodeDoubleIntegerIdKey.
+
+Definition gcdIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #89.
+
+Definition gcdIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "gcdInteger"))
+  gcdIntegerIdKey.
+
+Definition lcmIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #90.
+
+Definition lcmIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "lcmInteger"))
+  lcmIntegerIdKey.
 
 Definition andIntegerIdKey : Unique.Unique :=
   Unique.mkPreludeMiscIdUnique #91.
@@ -3299,12 +2001,1343 @@ Definition andIntegerName : Name.Name :=
   varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "andInteger"))
   andIntegerIdKey.
 
-Definition alternativeClassKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #754.
+Definition orIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #92.
 
-Definition alternativeClassName : Name.Name :=
-  clsQual mONAD (FastString.fsLit (GHC.Base.hs_string__ "Alternative"))
-  alternativeClassKey.
+Definition orIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "orInteger"))
+  orIntegerIdKey.
+
+Definition xorIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #93.
+
+Definition xorIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "xorInteger"))
+  xorIntegerIdKey.
+
+Definition complementIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #94.
+
+Definition complementIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "complementInteger")) complementIntegerIdKey.
+
+Definition shiftLIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #95.
+
+Definition shiftLIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "shiftLInteger")) shiftLIntegerIdKey.
+
+Definition shiftRIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #96.
+
+Definition shiftRIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                              "shiftRInteger")) shiftRIntegerIdKey.
+
+Definition bitIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #551.
+
+Definition bitIntegerName : Name.Name :=
+  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "bitInteger"))
+  bitIntegerIdKey.
+
+Definition naturalTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #23.
+
+Definition naturalTyConName : Name.Name :=
+  tcQual gHC_NATURAL (FastString.fsLit (GHC.Base.hs_string__ "Natural"))
+  naturalTyConKey.
+
+Definition naturalFromIntegerIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #562.
+
+Definition naturalFromIntegerName : Name.Name :=
+  varQual gHC_NATURAL (FastString.fsLit (GHC.Base.hs_string__
+                                         "naturalFromInteger")) naturalFromIntegerIdKey.
+
+Definition rationalTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #33.
+
+Definition rationalTyConName : Name.Name :=
+  tcQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ "Rational"))
+  rationalTyConKey.
+
+Definition ratioTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #32.
+
+Definition ratioTyConName : Name.Name :=
+  tcQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ "Ratio")) ratioTyConKey.
+
+Definition realClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #14.
+
+Definition realClassName : Name.Name :=
+  clsQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ "Real")) realClassKey.
+
+Definition integralClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #7.
+
+Definition integralClassName : Name.Name :=
+  clsQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ "Integral"))
+  integralClassKey.
+
+Definition realFracClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #16.
+
+Definition realFracClassName : Name.Name :=
+  clsQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ "RealFrac"))
+  realFracClassKey.
+
+Definition fractionalClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #6.
+
+Definition fractionalClassName : Name.Name :=
+  clsQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ "Fractional"))
+  fractionalClassKey.
+
+Definition realToFracIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #191.
+
+Definition realToFracName : Name.Name :=
+  varQual gHC_REAL (FastString.fsLit (GHC.Base.hs_string__ "realToFrac"))
+  realToFracIdKey.
+
+Definition floatingClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #5.
+
+Definition floatingClassName : Name.Name :=
+  clsQual gHC_FLOAT (FastString.fsLit (GHC.Base.hs_string__ "Floating"))
+  floatingClassKey.
+
+Definition realFloatClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #15.
+
+Definition realFloatClassName : Name.Name :=
+  clsQual gHC_FLOAT (FastString.fsLit (GHC.Base.hs_string__ "RealFloat"))
+  realFloatClassKey.
+
+Definition rationalToFloatIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #130.
+
+Definition rationalToFloatName : Name.Name :=
+  varQual gHC_FLOAT (FastString.fsLit (GHC.Base.hs_string__ "rationalToFloat"))
+  rationalToFloatIdKey.
+
+Definition rationalToDoubleIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #131.
+
+Definition rationalToDoubleName : Name.Name :=
+  varQual gHC_FLOAT (FastString.fsLit (GHC.Base.hs_string__ "rationalToDouble"))
+  rationalToDoubleIdKey.
+
+Definition ixClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #18.
+
+Definition ixClassName : Name.Name :=
+  clsQual gHC_ARR (FastString.fsLit (GHC.Base.hs_string__ "Ix")) ixClassKey.
+
+Definition trModuleTyConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #42.
+
+Definition trModuleTyConName : Name.Name :=
+  tcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "Module"))
+  trModuleTyConKey.
+
+Definition trModuleDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #43.
+
+Definition trModuleDataConName : Name.Name :=
+  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "Module"))
+  trModuleDataConKey.
+
+Definition trNameTyConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #44.
+
+Definition trNameTyConName : Name.Name :=
+  tcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "TrName"))
+  trNameTyConKey.
+
+Definition trNameSDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #45.
+
+Definition trNameSDataConName : Name.Name :=
+  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "TrNameS"))
+  trNameSDataConKey.
+
+Definition trNameDDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #46.
+
+Definition trNameDDataConName : Name.Name :=
+  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "TrNameD"))
+  trNameDDataConKey.
+
+Definition trTyConTyConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #40.
+
+Definition trTyConTyConName : Name.Name :=
+  tcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "TyCon"))
+  trTyConTyConKey.
+
+Definition trTyConDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #41.
+
+Definition trTyConDataConName : Name.Name :=
+  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "TyCon"))
+  trTyConDataConKey.
+
+Definition kindRepTyConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #48.
+
+Definition kindRepTyConName : Name.Name :=
+  tcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "KindRep"))
+  kindRepTyConKey.
+
+Definition kindRepTyConAppDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #100.
+
+Definition kindRepTyConAppDataConName : Name.Name :=
+  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "KindRepTyConApp"))
+  kindRepTyConAppDataConKey.
+
+Definition kindRepVarDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #101.
+
+Definition kindRepVarDataConName : Name.Name :=
+  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "KindRepVar"))
+  kindRepVarDataConKey.
+
+Definition kindRepAppDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #102.
+
+Definition kindRepAppDataConName : Name.Name :=
+  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "KindRepApp"))
+  kindRepAppDataConKey.
+
+Definition kindRepFunDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #103.
+
+Definition kindRepFunDataConName : Name.Name :=
+  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "KindRepFun"))
+  kindRepFunDataConKey.
+
+Definition kindRepTYPEDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #104.
+
+Definition kindRepTYPEDataConName : Name.Name :=
+  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "KindRepTYPE"))
+  kindRepTYPEDataConKey.
+
+Definition kindRepTypeLitSDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #105.
+
+Definition kindRepTypeLitSDataConName : Name.Name :=
+  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "KindRepTypeLitS"))
+  kindRepTypeLitSDataConKey.
+
+Definition kindRepTypeLitDDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #106.
+
+Definition kindRepTypeLitDDataConName : Name.Name :=
+  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "KindRepTypeLitD"))
+  kindRepTypeLitDDataConKey.
+
+Definition typeLitSortTyConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #49.
+
+Definition typeLitSortTyConName : Name.Name :=
+  tcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "TypeLitSort"))
+  typeLitSortTyConKey.
+
+Definition typeLitSymbolDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #107.
+
+Definition typeLitSymbolDataConName : Name.Name :=
+  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "TypeLitSymbol"))
+  typeLitSymbolDataConKey.
+
+Definition typeLitNatDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #108.
+
+Definition typeLitNatDataConName : Name.Name :=
+  dcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "TypeLitNat"))
+  typeLitNatDataConKey.
+
+Definition typeableClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #20.
+
+Definition typeableClassName : Name.Name :=
+  clsQual tYPEABLE_INTERNAL (FastString.fsLit (GHC.Base.hs_string__ "Typeable"))
+  typeableClassKey.
+
+Definition typeRepTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #187.
+
+Definition typeRepTyConName : Name.Name :=
+  tcQual tYPEABLE_INTERNAL (FastString.fsLit (GHC.Base.hs_string__ "TypeRep"))
+  typeRepTyConKey.
+
+Definition someTypeRepTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #188.
+
+Definition someTypeRepTyConName : Name.Name :=
+  tcQual tYPEABLE_INTERNAL (FastString.fsLit (GHC.Base.hs_string__ "SomeTypeRep"))
+  someTypeRepTyConKey.
+
+Definition someTypeRepDataConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #189.
+
+Definition someTypeRepDataConName : Name.Name :=
+  dcQual tYPEABLE_INTERNAL (FastString.fsLit (GHC.Base.hs_string__ "SomeTypeRep"))
+  someTypeRepDataConKey.
+
+Definition typeRepIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #509.
+
+Definition typeRepIdName : Name.Name :=
+  varQual tYPEABLE_INTERNAL (FastString.fsLit (GHC.Base.hs_string__ "typeRep#"))
+  typeRepIdKey.
+
+Definition mkTrTypeKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #504.
+
+Definition mkTrTypeName : Name.Name :=
+  varQual tYPEABLE_INTERNAL (FastString.fsLit (GHC.Base.hs_string__ "mkTrType"))
+  mkTrTypeKey.
+
+Definition mkTrConKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #505.
+
+Definition mkTrConName : Name.Name :=
+  varQual tYPEABLE_INTERNAL (FastString.fsLit (GHC.Base.hs_string__ "mkTrCon"))
+  mkTrConKey.
+
+Definition mkTrAppKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #506.
+
+Definition mkTrAppName : Name.Name :=
+  varQual tYPEABLE_INTERNAL (FastString.fsLit (GHC.Base.hs_string__ "mkTrApp"))
+  mkTrAppKey.
+
+Definition mkTrFunKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #510.
+
+Definition mkTrFunName : Name.Name :=
+  varQual tYPEABLE_INTERNAL (FastString.fsLit (GHC.Base.hs_string__ "mkTrFun"))
+  mkTrFunKey.
+
+Definition typeNatTypeRepKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #507.
+
+Definition typeNatTypeRepName : Name.Name :=
+  varQual tYPEABLE_INTERNAL (FastString.fsLit (GHC.Base.hs_string__
+                                               "typeNatTypeRep")) typeNatTypeRepKey.
+
+Definition typeSymbolTypeRepKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #508.
+
+Definition typeSymbolTypeRepName : Name.Name :=
+  varQual tYPEABLE_INTERNAL (FastString.fsLit (GHC.Base.hs_string__
+                                               "typeSymbolTypeRep")) typeSymbolTypeRepKey.
+
+Definition trGhcPrimModuleKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #47.
+
+Definition trGhcPrimModuleName : Name.Name :=
+  varQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "tr$ModuleGHCPrim"))
+  trGhcPrimModuleKey.
+
+Definition starKindRepKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #520.
+
+Definition starKindRepName : Name.Name :=
+  varQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "krep$*"))
+  starKindRepKey.
+
+Definition starArrStarKindRepKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #521.
+
+Definition starArrStarKindRepName : Name.Name :=
+  varQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "krep$*Arr*"))
+  starArrStarKindRepKey.
+
+Definition starArrStarArrStarKindRepKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #522.
+
+Definition starArrStarArrStarKindRepName : Name.Name :=
+  varQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "krep$*->*->*"))
+  starArrStarArrStarKindRepKey.
+
+Definition errorMessageTypeErrorFamKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #176.
+
+Definition errorMessageTypeErrorFamName : Name.Name :=
+  tcQual gHC_TYPELITS (FastString.fsLit (GHC.Base.hs_string__ "TypeError"))
+  errorMessageTypeErrorFamKey.
+
+Definition typeErrorTextDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #50.
+
+Definition typeErrorTextDataConName : Name.Name :=
+  dcQual gHC_TYPELITS (FastString.fsLit (GHC.Base.hs_string__ "Text"))
+  typeErrorTextDataConKey.
+
+Definition typeErrorAppendDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #51.
+
+Definition typeErrorAppendDataConName : Name.Name :=
+  dcQual gHC_TYPELITS (FastString.fsLit (GHC.Base.hs_string__ ":<>:"))
+  typeErrorAppendDataConKey.
+
+Definition typeErrorVAppendDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #52.
+
+Definition typeErrorVAppendDataConName : Name.Name :=
+  dcQual gHC_TYPELITS (FastString.fsLit (GHC.Base.hs_string__ ":$$:"))
+  typeErrorVAppendDataConKey.
+
+Definition typeErrorShowTypeDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #53.
+
+Definition typeErrorShowTypeDataConName : Name.Name :=
+  dcQual gHC_TYPELITS (FastString.fsLit (GHC.Base.hs_string__ "ShowType"))
+  typeErrorShowTypeDataConKey.
+
+Definition toDynIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #550.
+
+Definition toDynName : Name.Name :=
+  varQual dYNAMIC (FastString.fsLit (GHC.Base.hs_string__ "toDyn")) toDynIdKey.
+
+Definition dataClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #9.
+
+Definition dataClassName : Name.Name :=
+  clsQual gENERICS (FastString.fsLit (GHC.Base.hs_string__ "Data")) dataClassKey.
+
+Definition assertErrorIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #105.
+
+Definition assertErrorName : Name.Name :=
+  varQual gHC_IO_Exception (FastString.fsLit (GHC.Base.hs_string__ "assertError"))
+  assertErrorIdKey.
+
+Definition traceKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #108.
+
+Definition traceName : Name.Name :=
+  varQual dEBUG_TRACE (FastString.fsLit (GHC.Base.hs_string__ "trace")) traceKey.
+
+Definition boundedClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #1.
+
+Definition boundedClassName : Name.Name :=
+  clsQual gHC_ENUM (FastString.fsLit (GHC.Base.hs_string__ "Bounded"))
+  boundedClassKey.
+
+Definition concatIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #31.
+
+Definition concatName : Name.Name :=
+  varQual gHC_LIST (FastString.fsLit (GHC.Base.hs_string__ "concat")) concatIdKey.
+
+Definition filterIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #32.
+
+Definition filterName : Name.Name :=
+  varQual gHC_LIST (FastString.fsLit (GHC.Base.hs_string__ "filter")) filterIdKey.
+
+Definition zipIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #33.
+
+Definition zipName : Name.Name :=
+  varQual gHC_LIST (FastString.fsLit (GHC.Base.hs_string__ "zip")) zipIdKey.
+
+Definition isListClassKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #198.
+
+Definition isListClassName : Name.Name :=
+  clsQual gHC_EXTS (FastString.fsLit (GHC.Base.hs_string__ "IsList"))
+  isListClassKey.
+
+Definition showClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #17.
+
+Definition showClassName : Name.Name :=
+  clsQual gHC_SHOW (FastString.fsLit (GHC.Base.hs_string__ "Show")) showClassKey.
+
+Definition readClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #13.
+
+Definition readClassName : Name.Name :=
+  clsQual gHC_READ (FastString.fsLit (GHC.Base.hs_string__ "Read")) readClassKey.
+
+Definition genClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #37.
+
+Definition genClassName : Name.Name :=
+  clsQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Generic"))
+  genClassKey.
+
+Definition gen1ClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #38.
+
+Definition gen1ClassName : Name.Name :=
+  clsQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Generic1"))
+  gen1ClassKey.
+
+Definition datatypeClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #39.
+
+Definition datatypeClassName : Name.Name :=
+  clsQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Datatype"))
+  datatypeClassKey.
+
+Definition constructorClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #40.
+
+Definition constructorClassName : Name.Name :=
+  clsQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Constructor"))
+  constructorClassKey.
+
+Definition selectorClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #41.
+
+Definition selectorClassName : Name.Name :=
+  clsQual gHC_GENERICS (FastString.fsLit (GHC.Base.hs_string__ "Selector"))
+  selectorClassKey.
+
+Definition genericClassNames : list Name.Name :=
+  cons genClassName (cons gen1ClassName nil).
+
+Definition ghciIoClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #44.
+
+Definition ghciIoClassName : Name.Name :=
+  clsQual gHC_GHCI (FastString.fsLit (GHC.Base.hs_string__ "GHCiSandboxIO"))
+  ghciIoClassKey.
+
+Definition ghciStepIoMClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #197.
+
+Definition ghciStepIoMName : Name.Name :=
+  varQual gHC_GHCI (FastString.fsLit (GHC.Base.hs_string__ "ghciStepIO"))
+  ghciStepIoMClassOpKey.
+
+Definition ioTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #57.
+
+Definition ioTyConName : Name.Name :=
+  tcQual gHC_TYPES (FastString.fsLit (GHC.Base.hs_string__ "IO")) ioTyConKey.
+
+Definition thenIOIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #103.
+
+Definition thenIOName : Name.Name :=
+  varQual gHC_BASE (FastString.fsLit (GHC.Base.hs_string__ "thenIO")) thenIOIdKey.
+
+Definition failIOIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #38.
+
+Definition failIOName : Name.Name :=
+  varQual gHC_IO (FastString.fsLit (GHC.Base.hs_string__ "failIO")) failIOIdKey.
+
+Definition printIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #37.
+
+Definition printName : Name.Name :=
+  varQual sYSTEM_IO (FastString.fsLit (GHC.Base.hs_string__ "print")) printIdKey.
+
+Definition int8TyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #16.
+
+Definition int8TyConName : Name.Name :=
+  tcQual gHC_INT (FastString.fsLit (GHC.Base.hs_string__ "Int8")) int8TyConKey.
+
+Definition int16TyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #17.
+
+Definition int16TyConName : Name.Name :=
+  tcQual gHC_INT (FastString.fsLit (GHC.Base.hs_string__ "Int16")) int16TyConKey.
+
+Definition int32TyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #19.
+
+Definition int32TyConName : Name.Name :=
+  tcQual gHC_INT (FastString.fsLit (GHC.Base.hs_string__ "Int32")) int32TyConKey.
+
+Definition int64TyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #21.
+
+Definition int64TyConName : Name.Name :=
+  tcQual gHC_INT (FastString.fsLit (GHC.Base.hs_string__ "Int64")) int64TyConKey.
+
+Definition word16TyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #62.
+
+Definition word16TyConName : Name.Name :=
+  tcQual gHC_WORD (FastString.fsLit (GHC.Base.hs_string__ "Word16"))
+  word16TyConKey.
+
+Definition word32TyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #64.
+
+Definition word32TyConName : Name.Name :=
+  tcQual gHC_WORD (FastString.fsLit (GHC.Base.hs_string__ "Word32"))
+  word32TyConKey.
+
+Definition word64TyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #66.
+
+Definition word64TyConName : Name.Name :=
+  tcQual gHC_WORD (FastString.fsLit (GHC.Base.hs_string__ "Word64"))
+  word64TyConKey.
+
+Definition ptrTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #75.
+
+Definition ptrTyConName : Name.Name :=
+  tcQual gHC_PTR (FastString.fsLit (GHC.Base.hs_string__ "Ptr")) ptrTyConKey.
+
+Definition funPtrTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #76.
+
+Definition funPtrTyConName : Name.Name :=
+  tcQual gHC_PTR (FastString.fsLit (GHC.Base.hs_string__ "FunPtr"))
+  funPtrTyConKey.
+
+Definition stablePtrTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #36.
+
+Definition stablePtrTyConName : Name.Name :=
+  tcQual gHC_STABLE (FastString.fsLit (GHC.Base.hs_string__ "StablePtr"))
+  stablePtrTyConKey.
+
+Definition monadFixClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #28.
+
+Definition monadFixClassName : Name.Name :=
+  clsQual mONAD_FIX (FastString.fsLit (GHC.Base.hs_string__ "MonadFix"))
+  monadFixClassKey.
+
+Definition mfixIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #175.
+
+Definition mfixName : Name.Name :=
+  varQual mONAD_FIX (FastString.fsLit (GHC.Base.hs_string__ "mfix")) mfixIdKey.
+
+Definition arrAIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #180.
+
+Definition arrAName : Name.Name :=
+  varQual aRROW (FastString.fsLit (GHC.Base.hs_string__ "arr")) arrAIdKey.
+
+Definition composeAIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #181.
+
+Definition composeAName : Name.Name :=
+  varQual gHC_DESUGAR (FastString.fsLit (GHC.Base.hs_string__ ">>>"))
+  composeAIdKey.
+
+Definition firstAIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #182.
+
+Definition firstAName : Name.Name :=
+  varQual aRROW (FastString.fsLit (GHC.Base.hs_string__ "first")) firstAIdKey.
+
+Definition appAIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #183.
+
+Definition appAName : Name.Name :=
+  varQual aRROW (FastString.fsLit (GHC.Base.hs_string__ "app")) appAIdKey.
+
+Definition choiceAIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #184.
+
+Definition choiceAName : Name.Name :=
+  varQual aRROW (FastString.fsLit (GHC.Base.hs_string__ "|||")) choiceAIdKey.
+
+Definition loopAIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #185.
+
+Definition loopAName : Name.Name :=
+  varQual aRROW (FastString.fsLit (GHC.Base.hs_string__ "loop")) loopAIdKey.
+
+Definition guardMIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #194.
+
+Definition guardMName : Name.Name :=
+  varQual mONAD (FastString.fsLit (GHC.Base.hs_string__ "guard")) guardMIdKey.
+
+Definition liftMIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #195.
+
+Definition liftMName : Name.Name :=
+  varQual mONAD (FastString.fsLit (GHC.Base.hs_string__ "liftM")) liftMIdKey.
+
+Definition mzipIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #196.
+
+Definition mzipName : Name.Name :=
+  varQual mONAD_ZIP (FastString.fsLit (GHC.Base.hs_string__ "mzip")) mzipIdKey.
+
+Definition toAnnotationWrapperIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #187.
+
+Definition toAnnotationWrapperName : Name.Name :=
+  varQual gHC_DESUGAR (FastString.fsLit (GHC.Base.hs_string__
+                                         "toAnnotationWrapper")) toAnnotationWrapperIdKey.
+
+Definition monadPlusClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #30.
+
+Definition monadPlusClassName : Name.Name :=
+  clsQual mONAD (FastString.fsLit (GHC.Base.hs_string__ "MonadPlus"))
+  monadPlusClassKey.
+
+Definition randomClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #31.
+
+Definition randomClassName : Name.Name :=
+  clsQual rANDOM (FastString.fsLit (GHC.Base.hs_string__ "Random"))
+  randomClassKey.
+
+Definition randomGenClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #32.
+
+Definition randomGenClassName : Name.Name :=
+  clsQual rANDOM (FastString.fsLit (GHC.Base.hs_string__ "RandomGen"))
+  randomGenClassKey.
+
+Definition isStringClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #33.
+
+Definition isStringClassName : Name.Name :=
+  clsQual dATA_STRING (FastString.fsLit (GHC.Base.hs_string__ "IsString"))
+  isStringClassKey.
+
+Definition knownNatClassNameKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #42.
+
+Definition knownNatClassName : Name.Name :=
+  clsQual gHC_TYPENATS (FastString.fsLit (GHC.Base.hs_string__ "KnownNat"))
+  knownNatClassNameKey.
+
+Definition knownSymbolClassNameKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #43.
+
+Definition knownSymbolClassName : Name.Name :=
+  clsQual gHC_TYPELITS (FastString.fsLit (GHC.Base.hs_string__ "KnownSymbol"))
+  knownSymbolClassNameKey.
+
+Definition isLabelClassNameKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #45.
+
+Definition isLabelClassName : Name.Name :=
+  clsQual gHC_OVER_LABELS (FastString.fsLit (GHC.Base.hs_string__ "IsLabel"))
+  isLabelClassNameKey.
+
+Definition ipClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #48.
+
+Definition ipClassName : Name.Name :=
+  clsQual gHC_CLASSES (FastString.fsLit (GHC.Base.hs_string__ "IP")) ipClassKey.
+
+Definition hasFieldClassNameKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #49.
+
+Definition hasFieldClassName : Name.Name :=
+  clsQual gHC_RECORDS (FastString.fsLit (GHC.Base.hs_string__ "HasField"))
+  hasFieldClassNameKey.
+
+Definition callStackTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #186.
+
+Definition callStackTyConName : Name.Name :=
+  tcQual gHC_STACK_TYPES (FastString.fsLit (GHC.Base.hs_string__ "CallStack"))
+  callStackTyConKey.
+
+Definition emptyCallStackKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #558.
+
+Definition emptyCallStackName : Name.Name :=
+  varQual gHC_STACK_TYPES (FastString.fsLit (GHC.Base.hs_string__
+                                             "emptyCallStack")) emptyCallStackKey.
+
+Definition pushCallStackKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #559.
+
+Definition pushCallStackName : Name.Name :=
+  varQual gHC_STACK_TYPES (FastString.fsLit (GHC.Base.hs_string__
+                                             "pushCallStack")) pushCallStackKey.
+
+Definition srcLocDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #37.
+
+Definition srcLocDataConName : Name.Name :=
+  dcQual gHC_STACK_TYPES (FastString.fsLit (GHC.Base.hs_string__ "SrcLoc"))
+  srcLocDataConKey.
+
+Definition pLUGINS : Module.Module :=
+  mkThisGhcModule (FastString.fsLit (GHC.Base.hs_string__ "Plugins")).
+
+Definition pluginTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #102.
+
+Definition pluginTyConName : Name.Name :=
+  tcQual pLUGINS (FastString.fsLit (GHC.Base.hs_string__ "Plugin"))
+  pluginTyConKey.
+
+Definition frontendPluginTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #103.
+
+Definition frontendPluginTyConName : Name.Name :=
+  tcQual pLUGINS (FastString.fsLit (GHC.Base.hs_string__ "FrontendPlugin"))
+  frontendPluginTyConKey.
+
+Definition makeStaticKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #561.
+
+Definition makeStaticName : Name.Name :=
+  varQual gHC_STATICPTR_INTERNAL (FastString.fsLit (GHC.Base.hs_string__
+                                                    "makeStatic")) makeStaticKey.
+
+Definition staticPtrInfoTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #185.
+
+Definition staticPtrInfoTyConName : Name.Name :=
+  tcQual gHC_STATICPTR (FastString.fsLit (GHC.Base.hs_string__ "StaticPtrInfo"))
+  staticPtrInfoTyConKey.
+
+Definition staticPtrInfoDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #34.
+
+Definition staticPtrInfoDataConName : Name.Name :=
+  dcQual gHC_STATICPTR (FastString.fsLit (GHC.Base.hs_string__ "StaticPtrInfo"))
+  staticPtrInfoDataConKey.
+
+Definition staticPtrTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #184.
+
+Definition staticPtrTyConName : Name.Name :=
+  tcQual gHC_STATICPTR (FastString.fsLit (GHC.Base.hs_string__ "StaticPtr"))
+  staticPtrTyConKey.
+
+Definition staticPtrDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #33.
+
+Definition staticPtrDataConName : Name.Name :=
+  dcQual gHC_STATICPTR (FastString.fsLit (GHC.Base.hs_string__ "StaticPtr"))
+  staticPtrDataConKey.
+
+Definition fromStaticPtrClassOpKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #560.
+
+Definition fromStaticPtrName : Name.Name :=
+  varQual gHC_STATICPTR (FastString.fsLit (GHC.Base.hs_string__ "fromStaticPtr"))
+  fromStaticPtrClassOpKey.
+
+Definition fingerprintDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #35.
+
+Definition fingerprintDataConName : Name.Name :=
+  dcQual gHC_FINGERPRINT_TYPE (FastString.fsLit (GHC.Base.hs_string__
+                                                 "Fingerprint")) fingerprintDataConKey.
+
+Definition eqTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #38.
+
+Definition eqTyConName : Name.Name :=
+  tcQual dATA_TYPE_EQUALITY (FastString.fsLit (GHC.Base.hs_string__ "~"))
+  eqTyConKey.
+
+Definition typeable1ClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #21.
+
+Definition typeable2ClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #22.
+
+Definition typeable3ClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #23.
+
+Definition typeable4ClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #24.
+
+Definition typeable5ClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #25.
+
+Definition typeable6ClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #26.
+
+Definition typeable7ClassKey : Unique.Unique :=
+  Unique.mkPreludeClassUnique #27.
+
+Definition addrPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #1.
+
+Definition arrayPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #3.
+
+Definition boolTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #4.
+
+Definition byteArrayPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #5.
+
+Definition charPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #7.
+
+Definition charTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #8.
+
+Definition doublePrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #9.
+
+Definition doubleTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #10.
+
+Definition floatPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #11.
+
+Definition floatTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #12.
+
+Definition funTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #13.
+
+Definition intPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #14.
+
+Definition intTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #15.
+
+Definition int32PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #18.
+
+Definition int64PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #20.
+
+Definition listTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #24.
+
+Definition foreignObjPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #25.
+
+Definition maybeTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #26.
+
+Definition weakPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #27.
+
+Definition mutableArrayPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #28.
+
+Definition mutableByteArrayPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #29.
+
+Definition mVarPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #31.
+
+Definition realWorldTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #34.
+
+Definition stablePtrPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #35.
+
+Definition heqTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #39.
+
+Definition arrayArrayPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #40.
+
+Definition mutableArrayArrayPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #41.
+
+Definition statePrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #50.
+
+Definition stableNamePrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #51.
+
+Definition stableNameTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #52.
+
+Definition eqPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #53.
+
+Definition eqReprPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #54.
+
+Definition eqPhantPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #55.
+
+Definition mutVarPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #56.
+
+Definition voidPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #58.
+
+Definition wordPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #59.
+
+Definition wordTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #60.
+
+Definition word8TyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #61.
+
+Definition word32PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #63.
+
+Definition word64PrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #65.
+
+Definition liftedConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #67.
+
+Definition unliftedConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #68.
+
+Definition anyBoxConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #69.
+
+Definition kindConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #70.
+
+Definition boxityConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #71.
+
+Definition typeConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #72.
+
+Definition threadIdPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #73.
+
+Definition bcoPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #74.
+
+Definition tVarPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #77.
+
+Definition compactPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #78.
+
+Definition parrTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #82.
+
+Definition objectTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #83.
+
+Definition liftedTypeKindTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #87.
+
+Definition tYPETyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #88.
+
+Definition constraintKindTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #92.
+
+Definition starKindTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #93.
+
+Definition unicodeStarKindTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #94.
+
+Definition runtimeRepTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #95.
+
+Definition vecCountTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #96.
+
+Definition vecElemTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #97.
+
+Definition unknownTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #129.
+
+Definition unknown1TyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #130.
+
+Definition unknown2TyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #131.
+
+Definition unknown3TyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #132.
+
+Definition typeNatKindConNameKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #164.
+
+Definition typeSymbolKindConNameKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #165.
+
+Definition typeNatAddTyFamNameKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #166.
+
+Definition typeNatMulTyFamNameKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #167.
+
+Definition typeNatExpTyFamNameKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #168.
+
+Definition typeNatLeqTyFamNameKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #169.
+
+Definition typeNatSubTyFamNameKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #170.
+
+Definition typeSymbolCmpTyFamNameKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #171.
+
+Definition typeNatCmpTyFamNameKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #172.
+
+Definition typeNatDivTyFamNameKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #173.
+
+Definition typeNatModTyFamNameKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #174.
+
+Definition typeNatLogTyFamNameKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #175.
+
+Definition ntTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #177.
+
+Definition coercibleTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #178.
+
+Definition proxyPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #179.
+
+Definition anyTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #181.
+
+Definition smallArrayPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #182.
+
+Definition smallMutableArrayPrimTyConKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #183.
+
+Definition typeSymbolAppendFamNameKey : Unique.Unique :=
+  Unique.mkPreludeTyConUnique #190.
+
+Definition charDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #1.
+
+Definition consDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #2.
+
+Definition doubleDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #3.
+
+Definition falseDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #4.
+
+Definition floatDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #5.
+
+Definition intDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #6.
+
+Definition integerSDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #7.
+
+Definition nothingDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #8.
+
+Definition justDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #9.
+
+Definition nilDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #11.
+
+Definition word8DataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #13.
+
+Definition stableNameDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #14.
+
+Definition trueDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #15.
+
+Definition wordDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #16.
+
+Definition integerDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #18.
+
+Definition heqDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #19.
+
+Definition crossDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #20.
+
+Definition inlDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #21.
+
+Definition inrDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #22.
+
+Definition genUnitDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #23.
+
+Definition parrDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #24.
+
+Definition coercibleDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #32.
+
+Definition vecRepDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #71.
+
+Definition tupleRepDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #72.
+
+Definition sumRepDataConKey : Unique.Unique :=
+  Unique.mkPreludeDataConUnique #73.
+
+Definition vecCountDataConKeys : list Unique.Unique :=
+  GHC.Base.map Unique.mkPreludeDataConUnique (GHC.Enum.enumFromTo #83 #88).
+
+Definition vecElemDataConKeys : list Unique.Unique :=
+  GHC.Base.map Unique.mkPreludeDataConUnique (GHC.Enum.enumFromTo #89 #98).
+
+Definition absentErrorIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #1.
+
+Definition errorIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #5.
+
+Definition recSelErrorIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #7.
+
+Definition seqIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #8.
+
+Definition irrefutPatErrorIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #9.
+
+Definition noMethodBindingErrorIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #11.
+
+Definition nonExhaustiveGuardsErrorIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #12.
+
+Definition runtimeErrorIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #13.
+
+Definition patErrorIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #14.
+
+Definition realWorldPrimIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #15.
+
+Definition recConErrorIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #16.
+
+Definition unpackCStringAppendIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #18.
+
+Definition voidPrimIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #21.
+
+Definition typeErrorIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #22.
+
+Definition absentSumFieldErrorIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #25.
+
+Definition unsafeCoerceIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #30.
+
+Definition nullAddrIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #39.
+
+Definition voidArgIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #40.
+
+Definition rootMainKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #101.
+
+Definition lazyIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #104.
+
+Definition oneShotKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #106.
+
+Definition runRWKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #107.
+
+Definition dollarIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #123.
+
+Definition coercionTokenIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #124.
+
+Definition noinlineIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #125.
+
+Definition unmarshalObjectIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #150.
+
+Definition marshalObjectIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #151.
+
+Definition marshalStringIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #152.
+
+Definition unmarshalStringIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #153.
+
+Definition checkDotnetResNameIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #154.
+
+Definition undefinedKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #155.
+
+Definition magicDictKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #156.
+
+Definition coerceKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #157.
+
+Definition proxyHashKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #502.
+
+Definition mkTyConKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #503.
+
+Definition trTYPEKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #511.
+
+Definition trTYPE'PtrRepLiftedKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #512.
+
+Definition trRuntimeRepKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #513.
+
+Definition tr'PtrRepLiftedKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #514.
+
+Definition heqSCSelIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #552.
+
+Definition coercibleSCSelIdKey : Unique.Unique :=
+  Unique.mkPreludeMiscIdUnique #553.
+
+Definition fractionalClassKeys : list Unique.Unique :=
+  cons fractionalClassKey (cons floatingClassKey (cons realFracClassKey (cons
+                                                        realFloatClassKey nil))).
+
+Definition numericClassKeys : list Unique.Unique :=
+  Coq.Init.Datatypes.app (cons numClassKey (cons realClassKey (cons
+                                                  integralClassKey nil))) fractionalClassKeys.
+
+Definition derivableClassKeys : list Unique.Unique :=
+  cons eqClassKey (cons ordClassKey (cons enumClassKey (cons ixClassKey (cons
+                                                              boundedClassKey (cons showClassKey (cons readClassKey
+                                                                                                       nil)))))).
 
 Definition standardClassKeys : list Unique.Unique :=
   Coq.Init.Datatypes.app derivableClassKeys (Coq.Init.Datatypes.app
@@ -3324,47 +3357,14 @@ Definition standardClassKeys : list Unique.Unique :=
                                                                                                       alternativeClassKey
                                                                                                       nil)))))))))))))).
 
-Definition alt_RDR : RdrName :=
-  varQual_RDR rEAD_PREC (FastString.fsLit (GHC.Base.hs_string__ "+++")).
+Definition interactiveClassNames : list Name.Name :=
+  cons showClassName (cons eqClassName (cons ordClassName (cons foldableClassName
+                                                                (cons traversableClassName nil)))).
 
-Definition all_RDR : RdrName :=
-  varQual_RDR dATA_FOLDABLE (FastString.fsLit (GHC.Base.hs_string__ "all")).
+Definition interactiveClassKeys : list Unique.Unique :=
+  GHC.Base.map Unique.getUnique interactiveClassNames.
 
-Axiom allNameStrings : list GHC.Base.String.
-
-Definition addrPrimTyConKey : Unique.Unique :=
-  Unique.mkPreludeTyConUnique #1.
-
-Definition absentSumFieldErrorIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #25.
-
-Definition absentErrorIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #1.
-
-Definition absIntegerIdKey : Unique.Unique :=
-  Unique.mkPreludeMiscIdUnique #72.
-
-Definition absIntegerName : Name.Name :=
-  varQual gHC_INTEGER_TYPE (FastString.fsLit (GHC.Base.hs_string__ "absInteger"))
-  absIntegerIdKey.
-
-Definition aRROW : Module.Module :=
-  mkBaseModule (FastString.fsLit (GHC.Base.hs_string__ "Control.Arrow")).
-
-Definition appAName : Name.Name :=
-  varQual aRROW (FastString.fsLit (GHC.Base.hs_string__ "app")) appAIdKey.
-
-Definition arrAName : Name.Name :=
-  varQual aRROW (FastString.fsLit (GHC.Base.hs_string__ "arr")) arrAIdKey.
-
-Definition choiceAName : Name.Name :=
-  varQual aRROW (FastString.fsLit (GHC.Base.hs_string__ "|||")) choiceAIdKey.
-
-Definition firstAName : Name.Name :=
-  varQual aRROW (FastString.fsLit (GHC.Base.hs_string__ "first")) firstAIdKey.
-
-Definition loopAName : Name.Name :=
-  varQual aRROW (FastString.fsLit (GHC.Base.hs_string__ "loop")) loopAIdKey.
+Axiom pretendNameIsInScope : Name.Name -> bool.
 
 (* External variables:
      Type bool cons list nat nil Coq.Init.Datatypes.app FastString.FastString

--- a/examples/ghc/lib/SetLevels.v
+++ b/examples/ghc/lib/SetLevels.v
@@ -81,64 +81,85 @@ Definition le_switches (arg_0__ : LevelEnv) :=
 
 (* Converted value declarations: *)
 
+Instance Eq___LevelType : GHC.Base.Eq_ LevelType.
+Proof.
+Admitted.
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `SetLevels.Outputable__FloatSpec' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `SetLevels.Outputable__Level' *)
+
+Instance Eq___Level : GHC.Base.Eq_ Level.
+Proof.
+Admitted.
+
+Axiom floatSpecLevel : FloatSpec -> Level.
+
 Axiom tOP_LEVEL : Level.
 
-Axiom substBndrsSL : BasicTypes.RecFlag ->
-                     LevelEnv -> list Core.InVar -> (LevelEnv * list Core.OutVar)%type.
+Axiom incMajorLvl : Level -> Level.
 
-Axiom substAndLvlBndrs : BasicTypes.RecFlag ->
-                         LevelEnv -> Level -> list Core.InVar -> (LevelEnv * list LevelledBndr)%type.
+Axiom incMinorLvl : Level -> Level.
 
-Axiom stayPut : Level -> Core.OutVar -> LevelledBndr.
+Axiom asJoinCeilLvl : Level -> Level.
+
+Axiom maxLvl : Level -> Level -> Level.
+
+Axiom ltLvl : Level -> Level -> bool.
+
+Axiom ltMajLvl : Level -> Level -> bool.
+
+Axiom isTopLvl : Level -> bool.
+
+Axiom isJoinCeilLvl : Level -> bool.
 
 Axiom setLevels : CoreMonad.FloatOutSwitches ->
                   Core.CoreProgram -> UniqSupply.UniqSupply -> list LevelledBind.
 
-Axiom profitableFloat : LevelEnv -> Level -> bool.
-
-Axiom placeJoinCeiling : LevelEnv -> LevelEnv.
-
-Axiom notWorthFloating : Core.CoreExpr -> list Core.Var -> bool.
-
-Axiom newPolyBndrs : Level ->
-                     LevelEnv ->
-                     list Core.OutVar -> list Core.InId -> LvlM (LevelEnv * list Core.OutId)%type.
-
-Axiom newLvlVar : LevelledExpr ->
-                  option BasicTypes.JoinArity -> bool -> LvlM Core.Id.
-
-Axiom maxLvl : Level -> Level -> Level.
-
-Axiom maxIn : (Core.Var -> bool) -> LevelEnv -> Core.InVar -> Level -> Level.
-
-Axiom maxFvLevel' : (Core.Var -> bool) -> LevelEnv -> Core.TyCoVarSet -> Level.
-
-Axiom maxFvLevel : (Core.Var -> bool) -> LevelEnv -> Core.DVarSet -> Level.
+Axiom lvlTopBind : LevelEnv ->
+                   Core.Bind Core.Id -> LvlM (LevelledBind * LevelEnv)%type.
 
 Axiom lvl_top : LevelEnv ->
                 BasicTypes.RecFlag -> Core.Id -> Core.CoreExpr -> LvlM LevelledExpr.
 
-Axiom lvlTopBind : LevelEnv ->
-                   Core.Bind Core.Id -> LvlM (LevelledBind * LevelEnv)%type.
+Axiom lvlExpr : LevelEnv -> CoreFVs.CoreExprWithFVs -> LvlM LevelledExpr.
+
+Axiom lvlNonTailExpr : LevelEnv -> CoreFVs.CoreExprWithFVs -> LvlM LevelledExpr.
+
+Axiom lvlApp : LevelEnv ->
+               CoreFVs.CoreExprWithFVs ->
+               (CoreFVs.CoreExprWithFVs * list CoreFVs.CoreExprWithFVs)%type ->
+               LvlM LevelledExpr.
+
+Axiom lvlCase : LevelEnv ->
+                Core.DVarSet ->
+                LevelledExpr ->
+                Core.Id ->
+                AxiomatizedTypes.Type_ -> list CoreFVs.CoreAltWithFVs -> LvlM LevelledExpr.
+
+Axiom lvlNonTailMFE : LevelEnv ->
+                      bool -> CoreFVs.CoreExprWithFVs -> LvlM LevelledExpr.
+
+Axiom lvlMFE : LevelEnv -> bool -> CoreFVs.CoreExprWithFVs -> LvlM LevelledExpr.
+
+Axiom isBottomThunk : forall {s}, option (BasicTypes.Arity * s)%type -> bool.
+
+Axiom annotateBotStr : Core.Id ->
+                       BasicTypes.Arity -> option (BasicTypes.Arity * Core.StrictSig)%type -> Core.Id.
+
+Axiom notWorthFloating : Core.CoreExpr -> list Core.Var -> bool.
+
+Axiom lvlBind : LevelEnv ->
+                CoreFVs.CoreBindWithFVs -> LvlM (LevelledBind * LevelEnv)%type.
+
+Axiom profitableFloat : LevelEnv -> Level -> bool.
 
 Axiom lvlRhs : LevelEnv ->
                BasicTypes.RecFlag ->
                bool ->
                option BasicTypes.JoinArity -> CoreFVs.CoreExprWithFVs -> LvlM LevelledExpr.
-
-Axiom lvlNonTailMFE : LevelEnv ->
-                      bool -> CoreFVs.CoreExprWithFVs -> LvlM LevelledExpr.
-
-Axiom lvlNonTailExpr : LevelEnv -> CoreFVs.CoreExprWithFVs -> LvlM LevelledExpr.
-
-Axiom lvlMFE : LevelEnv -> bool -> CoreFVs.CoreExprWithFVs -> LvlM LevelledExpr.
-
-Axiom lvlLamBndrs : LevelEnv ->
-                    Level -> list Core.OutVar -> (LevelEnv * list LevelledBndr)%type.
-
-Axiom lvlJoinBndrs : LevelEnv ->
-                     Level ->
-                     BasicTypes.RecFlag -> list Core.OutVar -> (LevelEnv * list LevelledBndr)%type.
 
 Axiom lvlFloatRhs : list Core.OutVar ->
                     Level ->
@@ -148,103 +169,82 @@ Axiom lvlFloatRhs : list Core.OutVar ->
                     option BasicTypes.JoinArity ->
                     CoreFVs.CoreExprWithFVs -> LvlM (Core.Expr LevelledBndr).
 
-Axiom lvlExpr : LevelEnv -> CoreFVs.CoreExprWithFVs -> LvlM LevelledExpr.
+Axiom substAndLvlBndrs : BasicTypes.RecFlag ->
+                         LevelEnv -> Level -> list Core.InVar -> (LevelEnv * list LevelledBndr)%type.
 
-Axiom lvlCase : LevelEnv ->
-                Core.DVarSet ->
-                LevelledExpr ->
-                Core.Id ->
-                AxiomatizedTypes.Type_ -> list CoreFVs.CoreAltWithFVs -> LvlM LevelledExpr.
+Axiom substBndrsSL : BasicTypes.RecFlag ->
+                     LevelEnv -> list Core.InVar -> (LevelEnv * list Core.OutVar)%type.
+
+Axiom lvlLamBndrs : LevelEnv ->
+                    Level -> list Core.OutVar -> (LevelEnv * list LevelledBndr)%type.
+
+Axiom lvlJoinBndrs : LevelEnv ->
+                     Level ->
+                     BasicTypes.RecFlag -> list Core.OutVar -> (LevelEnv * list LevelledBndr)%type.
 
 Axiom lvlBndrs : LevelEnv ->
                  Level -> list Core.CoreBndr -> (LevelEnv * list LevelledBndr)%type.
 
-Axiom lvlBind : LevelEnv ->
-                CoreFVs.CoreBindWithFVs -> LvlM (LevelledBind * LevelEnv)%type.
+Axiom stayPut : Level -> Core.OutVar -> LevelledBndr.
 
-Axiom lvlApp : LevelEnv ->
-               CoreFVs.CoreExprWithFVs ->
-               (CoreFVs.CoreExprWithFVs * list CoreFVs.CoreExprWithFVs)%type ->
-               LvlM LevelledExpr.
-
-Axiom ltMajLvl : Level -> Level -> bool.
-
-Axiom ltLvl : Level -> Level -> bool.
-
-Axiom lookupVar : LevelEnv -> Core.Id -> LevelledExpr.
-
-Axiom joinCeilingLevel : LevelEnv -> Level.
-
-Axiom isTopLvl : Level -> bool.
-
-Instance Eq___LevelType : GHC.Base.Eq_ LevelType.
-Proof.
-Admitted.
-
-Instance Eq___Level : GHC.Base.Eq_ Level.
-Proof.
-Admitted.
-
-Axiom isJoinCeilLvl : Level -> bool.
+Axiom destLevel : LevelEnv ->
+                  Core.DVarSet -> Core.TyCoVarSet -> bool -> bool -> bool -> Level.
 
 Axiom isFunction : CoreFVs.CoreExprWithFVs -> bool.
 
-Axiom isBottomThunk : forall {s}, option (BasicTypes.Arity * s)%type -> bool.
+Axiom countFreeIds : Core.DVarSet -> nat.
 
 Axiom initialEnv : CoreMonad.FloatOutSwitches -> LevelEnv.
 
-Axiom initLvl : forall {a}, UniqSupply.UniqSupply -> UniqSupply.UniqSM a -> a.
+Axiom addLvl : Level -> Core.VarEnv Level -> Core.OutVar -> Core.VarEnv Level.
 
-Axiom incMinorLvlFrom : LevelEnv -> Level.
-
-Axiom incMinorLvl : Level -> Level.
-
-Axiom incMajorLvl : Level -> Level.
-
-Axiom floatTopLvlOnly : LevelEnv -> bool.
-
-Axiom floatSpecLevel : FloatSpec -> Level.
-
-Axiom floatOverSat : LevelEnv -> bool.
+Axiom addLvls : Level ->
+                Core.VarEnv Level -> list Core.OutVar -> Core.VarEnv Level.
 
 Axiom floatLams : LevelEnv -> option nat.
 
 Axiom floatConsts : LevelEnv -> bool.
 
+Axiom floatOverSat : LevelEnv -> bool.
+
+Axiom floatTopLvlOnly : LevelEnv -> bool.
+
+Axiom incMinorLvlFrom : LevelEnv -> Level.
+
 Axiom extendCaseBndrEnv : LevelEnv ->
                           Core.Id -> Core.Expr LevelledBndr -> LevelEnv.
 
-Axiom destLevel : LevelEnv ->
-                  Core.DVarSet -> Core.TyCoVarSet -> bool -> bool -> bool -> Level.
+Axiom placeJoinCeiling : LevelEnv -> LevelEnv.
 
-Axiom countFreeIds : Core.DVarSet -> nat.
+Axiom maxFvLevel : (Core.Var -> bool) -> LevelEnv -> Core.DVarSet -> Level.
 
-Axiom cloneLetVars : BasicTypes.RecFlag ->
-                     LevelEnv -> Level -> list Core.InVar -> LvlM (LevelEnv * list Core.OutVar)%type.
+Axiom maxFvLevel' : (Core.Var -> bool) -> LevelEnv -> Core.TyCoVarSet -> Level.
+
+Axiom maxIn : (Core.Var -> bool) -> LevelEnv -> Core.InVar -> Level -> Level.
+
+Axiom lookupVar : LevelEnv -> Core.Id -> LevelledExpr.
+
+Axiom joinCeilingLevel : LevelEnv -> Level.
+
+Axiom abstractVars : Level -> LevelEnv -> Core.DVarSet -> list Core.OutVar.
+
+Axiom initLvl : forall {a}, UniqSupply.UniqSupply -> UniqSupply.UniqSM a -> a.
+
+Axiom newPolyBndrs : Level ->
+                     LevelEnv ->
+                     list Core.OutVar -> list Core.InId -> LvlM (LevelEnv * list Core.OutId)%type.
+
+Axiom newLvlVar : LevelledExpr ->
+                  option BasicTypes.JoinArity -> bool -> LvlM Core.Id.
 
 Axiom cloneCaseBndrs : LevelEnv ->
                        Level -> list Core.Var -> LvlM (LevelEnv * list Core.Var)%type.
 
-Axiom asJoinCeilLvl : Level -> Level.
-
-Axiom annotateBotStr : Core.Id ->
-                       BasicTypes.Arity -> option (BasicTypes.Arity * Core.StrictSig)%type -> Core.Id.
+Axiom cloneLetVars : BasicTypes.RecFlag ->
+                     LevelEnv -> Level -> list Core.InVar -> LvlM (LevelEnv * list Core.OutVar)%type.
 
 Axiom add_id : Core.IdEnv (list Core.Var * LevelledExpr)%type ->
                (Core.Var * Core.Var)%type -> Core.IdEnv (list Core.Var * LevelledExpr)%type.
-
-Axiom addLvls : Level ->
-                Core.VarEnv Level -> list Core.OutVar -> Core.VarEnv Level.
-
-Axiom addLvl : Level -> Core.VarEnv Level -> Core.OutVar -> Core.VarEnv Level.
-
-Axiom abstractVars : Level -> LevelEnv -> Core.DVarSet -> list Core.OutVar.
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `SetLevels.Outputable__Level' *)
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `SetLevels.Outputable__FloatSpec' *)
 
 Instance Default__Level : GHC.Err.Default Level :=
   GHC.Err.Build_Default _ (Mk_Level GHC.Err.default GHC.Err.default

--- a/examples/ghc/lib/SrcLoc.v
+++ b/examples/ghc/lib/SrcLoc.v
@@ -102,191 +102,6 @@ Definition Ord__RealSrcLoc_op_zl : RealSrcLoc -> RealSrcLoc -> bool :=
 
 (* Converted value declarations: *)
 
-Definition wiredInSrcSpan : SrcSpan :=
-  UnhelpfulSpan (FastString.fsLit (GHC.Base.hs_string__ "<wired into compiler>")).
-
-Definition unLoc {l} {e} : GenLocated l e -> e :=
-  fun '(L _ e) => e.
-
-Definition srcSpanStartLine : RealSrcSpan -> GHC.Num.Int :=
-  fun '(RealSrcSpan' _ l _ _ _) => l.
-
-Definition srcSpanStartCol : RealSrcSpan -> GHC.Num.Int :=
-  fun '(RealSrcSpan' _ _ l _ _) => l.
-
-Definition srcSpanFileName_maybe : SrcSpan -> option FastString.FastString :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | ARealSrcSpan s => Some (srcSpanFile s)
-    | UnhelpfulSpan _ => None
-    end.
-
-Definition srcSpanEndLine : RealSrcSpan -> GHC.Num.Int :=
-  fun '(RealSrcSpan' _ _ _ l _) => l.
-
-Definition srcSpanEndCol : RealSrcSpan -> GHC.Num.Int :=
-  fun '(RealSrcSpan' _ _ _ _ c) => c.
-
-Definition srcLocLine : RealSrcLoc -> GHC.Num.Int :=
-  fun '(ASrcLoc _ l _) => l.
-
-Definition srcLocFile : RealSrcLoc -> FastString.FastString :=
-  fun '(ASrcLoc fname _ _) => fname.
-
-Definition srcLocCol : RealSrcLoc -> GHC.Num.Int :=
-  fun '(ASrcLoc _ _ c) => c.
-
-(* Skipping definition `SrcLoc.spans' *)
-
-(* Skipping definition `SrcLoc.sortLocated' *)
-
-(* Skipping definition `SrcLoc.rightmost' *)
-
-Definition realSrcLocSpan : RealSrcLoc -> RealSrcSpan :=
-  fun '(ASrcLoc file line col) => RealSrcSpan' file line col line col.
-
-Definition srcLocSpan : SrcLoc -> SrcSpan :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | UnhelpfulLoc str => UnhelpfulSpan str
-    | ARealSrcLoc l => ARealSrcSpan (realSrcLocSpan l)
-    end.
-
-(* Skipping definition `SrcLoc.pprUserSpan' *)
-
-(* Skipping definition `SrcLoc.pprUserRealSpan' *)
-
-Definition noSrcSpan : SrcSpan :=
-  UnhelpfulSpan (FastString.fsLit (GHC.Base.hs_string__ "<no location info>")).
-
-Definition noSrcLoc : SrcLoc :=
-  UnhelpfulLoc (FastString.fsLit (GHC.Base.hs_string__ "<no location info>")).
-
-Definition noLoc {e} : e -> Located e :=
-  fun e => L noSrcSpan e.
-
-Definition mkRealSrcSpan : RealSrcLoc -> RealSrcLoc -> RealSrcSpan :=
-  fun loc1 loc2 =>
-    let file := srcLocFile loc1 in
-    let col2 := srcLocCol loc2 in
-    let col1 := srcLocCol loc1 in
-    let line2 := srcLocLine loc2 in
-    let line1 := srcLocLine loc1 in RealSrcSpan' file line1 col1 line2 col2.
-
-Definition mkSrcSpan : SrcLoc -> SrcLoc -> SrcSpan :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | UnhelpfulLoc str, _ => UnhelpfulSpan str
-    | _, UnhelpfulLoc str => UnhelpfulSpan str
-    | ARealSrcLoc loc1, ARealSrcLoc loc2 => ARealSrcSpan (mkRealSrcSpan loc1 loc2)
-    end.
-
-Definition mkRealSrcLoc
-   : FastString.FastString -> GHC.Num.Int -> GHC.Num.Int -> RealSrcLoc :=
-  fun x line col => ASrcLoc x line col.
-
-Definition mkSrcLoc
-   : FastString.FastString -> GHC.Num.Int -> GHC.Num.Int -> SrcLoc :=
-  fun x line col => ARealSrcLoc (mkRealSrcLoc x line col).
-
-Definition realSrcSpanEnd : RealSrcSpan -> RealSrcLoc :=
-  fun s => mkRealSrcLoc (srcSpanFile s) (srcSpanEndLine s) (srcSpanEndCol s).
-
-Definition srcSpanEnd : SrcSpan -> SrcLoc :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | UnhelpfulSpan str => UnhelpfulLoc str
-    | ARealSrcSpan s => ARealSrcLoc (realSrcSpanEnd s)
-    end.
-
-Definition realSrcSpanStart : RealSrcSpan -> RealSrcLoc :=
-  fun s => mkRealSrcLoc (srcSpanFile s) (srcSpanStartLine s) (srcSpanStartCol s).
-
-Definition srcSpanFirstCharacter : SrcSpan -> SrcSpan :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | (UnhelpfulSpan _ as l) => l
-    | ARealSrcSpan span =>
-        let '(ASrcLoc f l c as loc1) := realSrcSpanStart span in
-        let loc2 := ASrcLoc f l (c GHC.Num.+ #1) in
-        ARealSrcSpan (mkRealSrcSpan loc1 loc2)
-    end.
-
-Definition srcSpanStart : SrcSpan -> SrcLoc :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | UnhelpfulSpan str => UnhelpfulLoc str
-    | ARealSrcSpan s => ARealSrcLoc (realSrcSpanStart s)
-    end.
-
-Definition mkGeneralSrcSpan : FastString.FastString -> SrcSpan :=
-  UnhelpfulSpan.
-
-Definition mkGeneralSrcLoc : FastString.FastString -> SrcLoc :=
-  UnhelpfulLoc.
-
-Definition mkGeneralLocated {e} : GHC.Base.String -> e -> Located e :=
-  fun s e => L (mkGeneralSrcSpan (FastString.fsLit s)) e.
-
-(* Skipping definition `SrcLoc.leftmost_smallest' *)
-
-(* Skipping definition `SrcLoc.leftmost_largest' *)
-
-(* Skipping definition `SrcLoc.isSubspanOf' *)
-
-Definition isPointRealSpan : RealSrcSpan -> bool :=
-  fun '(RealSrcSpan' _ line1 col1 line2 col2) =>
-    andb (line1 GHC.Base.== line2) (col1 GHC.Base.== col2).
-
-Definition isOneLineSpan : SrcSpan -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | ARealSrcSpan s => srcSpanStartLine s GHC.Base.== srcSpanEndLine s
-    | UnhelpfulSpan _ => false
-    end.
-
-Definition isOneLineRealSpan : RealSrcSpan -> bool :=
-  fun '(RealSrcSpan' _ line1 _ line2 _) => line1 GHC.Base.== line2.
-
-Definition isGoodSrcSpan : SrcSpan -> bool :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | ARealSrcSpan _ => true
-    | UnhelpfulSpan _ => false
-    end.
-
-Definition interactiveSrcSpan : SrcSpan :=
-  UnhelpfulSpan (FastString.fsLit (GHC.Base.hs_string__ "<interactive>")).
-
-Definition interactiveSrcLoc : SrcLoc :=
-  UnhelpfulLoc (FastString.fsLit (GHC.Base.hs_string__ "<interactive>")).
-
-Definition getLoc {l} {e} : GenLocated l e -> l :=
-  fun '(L l _) => l.
-
-Definition generatedSrcLoc : SrcLoc :=
-  UnhelpfulLoc (FastString.fsLit (GHC.Base.hs_string__
-                                  "<compiler-generated code>")).
-
-Definition eqLocated {a} `{GHC.Base.Eq_ a} : Located a -> Located a -> bool :=
-  fun a b => unLoc a GHC.Base.== unLoc b.
-
-(* Skipping definition `SrcLoc.containsSpan' *)
-
-(* Skipping definition `SrcLoc.combineSrcSpans' *)
-
-(* Skipping definition `SrcLoc.combineRealSrcSpans' *)
-
-(* Skipping definition `SrcLoc.combineLocs' *)
-
-Definition cmpLocated {a} `{GHC.Base.Ord a}
-   : Located a -> Located a -> comparison :=
-  fun a b => GHC.Base.compare (unLoc a) (unLoc b).
-
-(* Skipping definition `SrcLoc.advanceSrcLoc' *)
-
-(* Skipping definition `SrcLoc.addCLoc' *)
-
 Local Definition Eq___RealSrcLoc_op_zeze__ : RealSrcLoc -> RealSrcLoc -> bool :=
   fun arg_0__ arg_1__ =>
     match arg_0__, arg_1__ with
@@ -336,14 +151,6 @@ Local Definition Ord__RealSrcLoc_min : RealSrcLoc -> RealSrcLoc -> RealSrcLoc :=
 Local Definition Ord__RealSrcLoc_max : RealSrcLoc -> RealSrcLoc -> RealSrcLoc :=
   fun x y => if Ord__RealSrcLoc_op_zlze__ x y : bool then y else x.
 
-Local Definition Eq___SrcLoc_op_zeze__ : SrcLoc -> SrcLoc -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | ARealSrcLoc a1, ARealSrcLoc b1 => ((a1 GHC.Base.== b1))
-    | UnhelpfulLoc a1, UnhelpfulLoc b1 => ((a1 GHC.Base.== b1))
-    | _, _ => false
-    end.
-
 Program Instance Ord__RealSrcLoc : GHC.Base.Ord RealSrcLoc :=
   fun _ k__ =>
     k__ {| GHC.Base.op_zl____ := Ord__RealSrcLoc_op_zl__ ;
@@ -353,6 +160,14 @@ Program Instance Ord__RealSrcLoc : GHC.Base.Ord RealSrcLoc :=
            GHC.Base.compare__ := Ord__RealSrcLoc_compare ;
            GHC.Base.max__ := Ord__RealSrcLoc_max ;
            GHC.Base.min__ := Ord__RealSrcLoc_min |}.
+
+Local Definition Eq___SrcLoc_op_zeze__ : SrcLoc -> SrcLoc -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | ARealSrcLoc a1, ARealSrcLoc b1 => ((a1 GHC.Base.== b1))
+    | UnhelpfulLoc a1, UnhelpfulLoc b1 => ((a1 GHC.Base.== b1))
+    | _, _ => false
+    end.
 
 Local Definition Eq___SrcLoc_op_zsze__ : SrcLoc -> SrcLoc -> bool :=
   fun x y => negb (Eq___SrcLoc_op_zeze__ x y).
@@ -582,20 +397,48 @@ Program Instance Traversable__GenLocated {l}
            Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
              Traversable__GenLocated_traverse |}.
 
-(* Skipping all instances of class `GHC.Show.Show', including
-   `SrcLoc.Show__RealSrcLoc' *)
-
 (* Skipping all instances of class `Outputable.Outputable', including
    `SrcLoc.Outputable__RealSrcLoc' *)
 
 (* Skipping all instances of class `Outputable.Outputable', including
    `SrcLoc.Outputable__SrcLoc' *)
 
-(* Skipping all instances of class `Outputable.Outputable', including
-   `SrcLoc.Outputable__RealSrcSpan' *)
+(* Skipping all instances of class `Data.Data.Data', including
+   `SrcLoc.Data__RealSrcSpan' *)
 
-(* Skipping all instances of class `GHC.Show.Show', including
-   `SrcLoc.Show__RealSrcSpan' *)
+(* Skipping all instances of class `Data.Data.Data', including
+   `SrcLoc.Data__SrcSpan' *)
+
+(* Skipping all instances of class `Json.ToJson', including
+   `SrcLoc.ToJson__SrcSpan' *)
+
+(* Skipping all instances of class `Json.ToJson', including
+   `SrcLoc.ToJson__RealSrcSpan' *)
+
+(* Skipping all instances of class `Control.DeepSeq.NFData', including
+   `SrcLoc.NFData__SrcSpan' *)
+
+Definition mkRealSrcLoc
+   : FastString.FastString -> GHC.Num.Int -> GHC.Num.Int -> RealSrcLoc :=
+  fun x line col => ASrcLoc x line col.
+
+Definition srcSpanEndCol : RealSrcSpan -> GHC.Num.Int :=
+  fun '(RealSrcSpan' _ _ _ _ c) => c.
+
+Definition srcSpanEndLine : RealSrcSpan -> GHC.Num.Int :=
+  fun '(RealSrcSpan' _ _ _ l _) => l.
+
+Definition realSrcSpanEnd : RealSrcSpan -> RealSrcLoc :=
+  fun s => mkRealSrcLoc (srcSpanFile s) (srcSpanEndLine s) (srcSpanEndCol s).
+
+Definition srcSpanStartCol : RealSrcSpan -> GHC.Num.Int :=
+  fun '(RealSrcSpan' _ _ l _ _) => l.
+
+Definition srcSpanStartLine : RealSrcSpan -> GHC.Num.Int :=
+  fun '(RealSrcSpan' _ l _ _ _) => l.
+
+Definition realSrcSpanStart : RealSrcSpan -> RealSrcLoc :=
+  fun s => mkRealSrcLoc (srcSpanFile s) (srcSpanStartLine s) (srcSpanStartCol s).
 
 Local Definition Ord__RealSrcSpan_compare
    : RealSrcSpan -> RealSrcSpan -> comparison :=
@@ -637,26 +480,183 @@ Program Instance Ord__RealSrcSpan : GHC.Base.Ord RealSrcSpan :=
            GHC.Base.max__ := Ord__RealSrcSpan_max ;
            GHC.Base.min__ := Ord__RealSrcSpan_min |}.
 
-(* Skipping all instances of class `Json.ToJson', including
-   `SrcLoc.ToJson__RealSrcSpan' *)
+(* Skipping all instances of class `GHC.Show.Show', including
+   `SrcLoc.Show__RealSrcLoc' *)
 
-(* Skipping all instances of class `Data.Data.Data', including
-   `SrcLoc.Data__RealSrcSpan' *)
+(* Skipping all instances of class `GHC.Show.Show', including
+   `SrcLoc.Show__RealSrcSpan' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `SrcLoc.Outputable__RealSrcSpan' *)
 
 (* Skipping all instances of class `Outputable.Outputable', including
    `SrcLoc.Outputable__SrcSpan' *)
 
-(* Skipping all instances of class `Control.DeepSeq.NFData', including
-   `SrcLoc.NFData__SrcSpan' *)
-
-(* Skipping all instances of class `Json.ToJson', including
-   `SrcLoc.ToJson__SrcSpan' *)
-
-(* Skipping all instances of class `Data.Data.Data', including
-   `SrcLoc.Data__SrcSpan' *)
-
 (* Skipping all instances of class `Outputable.Outputable', including
    `SrcLoc.Outputable__GenLocated' *)
+
+Definition mkSrcLoc
+   : FastString.FastString -> GHC.Num.Int -> GHC.Num.Int -> SrcLoc :=
+  fun x line col => ARealSrcLoc (mkRealSrcLoc x line col).
+
+Definition noSrcLoc : SrcLoc :=
+  UnhelpfulLoc (FastString.fsLit (GHC.Base.hs_string__ "<no location info>")).
+
+Definition generatedSrcLoc : SrcLoc :=
+  UnhelpfulLoc (FastString.fsLit (GHC.Base.hs_string__
+                                  "<compiler-generated code>")).
+
+Definition interactiveSrcLoc : SrcLoc :=
+  UnhelpfulLoc (FastString.fsLit (GHC.Base.hs_string__ "<interactive>")).
+
+Definition mkGeneralSrcLoc : FastString.FastString -> SrcLoc :=
+  UnhelpfulLoc.
+
+Definition srcLocFile : RealSrcLoc -> FastString.FastString :=
+  fun '(ASrcLoc fname _ _) => fname.
+
+Definition srcLocLine : RealSrcLoc -> GHC.Num.Int :=
+  fun '(ASrcLoc _ l _) => l.
+
+Definition srcLocCol : RealSrcLoc -> GHC.Num.Int :=
+  fun '(ASrcLoc _ _ c) => c.
+
+(* Skipping definition `SrcLoc.advanceSrcLoc' *)
+
+(* Skipping definition `SrcLoc.sortLocated' *)
+
+Definition noSrcSpan : SrcSpan :=
+  UnhelpfulSpan (FastString.fsLit (GHC.Base.hs_string__ "<no location info>")).
+
+Definition wiredInSrcSpan : SrcSpan :=
+  UnhelpfulSpan (FastString.fsLit (GHC.Base.hs_string__ "<wired into compiler>")).
+
+Definition interactiveSrcSpan : SrcSpan :=
+  UnhelpfulSpan (FastString.fsLit (GHC.Base.hs_string__ "<interactive>")).
+
+Definition mkGeneralSrcSpan : FastString.FastString -> SrcSpan :=
+  UnhelpfulSpan.
+
+Definition realSrcLocSpan : RealSrcLoc -> RealSrcSpan :=
+  fun '(ASrcLoc file line col) => RealSrcSpan' file line col line col.
+
+Definition srcLocSpan : SrcLoc -> SrcSpan :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | UnhelpfulLoc str => UnhelpfulSpan str
+    | ARealSrcLoc l => ARealSrcSpan (realSrcLocSpan l)
+    end.
+
+Definition mkRealSrcSpan : RealSrcLoc -> RealSrcLoc -> RealSrcSpan :=
+  fun loc1 loc2 =>
+    let file := srcLocFile loc1 in
+    let col2 := srcLocCol loc2 in
+    let col1 := srcLocCol loc1 in
+    let line2 := srcLocLine loc2 in
+    let line1 := srcLocLine loc1 in RealSrcSpan' file line1 col1 line2 col2.
+
+Definition isOneLineRealSpan : RealSrcSpan -> bool :=
+  fun '(RealSrcSpan' _ line1 _ line2 _) => line1 GHC.Base.== line2.
+
+Definition isPointRealSpan : RealSrcSpan -> bool :=
+  fun '(RealSrcSpan' _ line1 col1 line2 col2) =>
+    andb (line1 GHC.Base.== line2) (col1 GHC.Base.== col2).
+
+Definition mkSrcSpan : SrcLoc -> SrcLoc -> SrcSpan :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | UnhelpfulLoc str, _ => UnhelpfulSpan str
+    | _, UnhelpfulLoc str => UnhelpfulSpan str
+    | ARealSrcLoc loc1, ARealSrcLoc loc2 => ARealSrcSpan (mkRealSrcSpan loc1 loc2)
+    end.
+
+(* Skipping definition `SrcLoc.combineSrcSpans' *)
+
+(* Skipping definition `SrcLoc.combineRealSrcSpans' *)
+
+Definition srcSpanFirstCharacter : SrcSpan -> SrcSpan :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | (UnhelpfulSpan _ as l) => l
+    | ARealSrcSpan span =>
+        let '(ASrcLoc f l c as loc1) := realSrcSpanStart span in
+        let loc2 := ASrcLoc f l (c GHC.Num.+ #1) in
+        ARealSrcSpan (mkRealSrcSpan loc1 loc2)
+    end.
+
+Definition isGoodSrcSpan : SrcSpan -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | ARealSrcSpan _ => true
+    | UnhelpfulSpan _ => false
+    end.
+
+Definition isOneLineSpan : SrcSpan -> bool :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | ARealSrcSpan s => srcSpanStartLine s GHC.Base.== srcSpanEndLine s
+    | UnhelpfulSpan _ => false
+    end.
+
+(* Skipping definition `SrcLoc.containsSpan' *)
+
+Definition srcSpanStart : SrcSpan -> SrcLoc :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | UnhelpfulSpan str => UnhelpfulLoc str
+    | ARealSrcSpan s => ARealSrcLoc (realSrcSpanStart s)
+    end.
+
+Definition srcSpanEnd : SrcSpan -> SrcLoc :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | UnhelpfulSpan str => UnhelpfulLoc str
+    | ARealSrcSpan s => ARealSrcLoc (realSrcSpanEnd s)
+    end.
+
+Definition srcSpanFileName_maybe : SrcSpan -> option FastString.FastString :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | ARealSrcSpan s => Some (srcSpanFile s)
+    | UnhelpfulSpan _ => None
+    end.
+
+(* Skipping definition `SrcLoc.pprUserSpan' *)
+
+(* Skipping definition `SrcLoc.pprUserRealSpan' *)
+
+Definition unLoc {l} {e} : GenLocated l e -> e :=
+  fun '(L _ e) => e.
+
+Definition getLoc {l} {e} : GenLocated l e -> l :=
+  fun '(L l _) => l.
+
+Definition noLoc {e} : e -> Located e :=
+  fun e => L noSrcSpan e.
+
+Definition mkGeneralLocated {e} : GHC.Base.String -> e -> Located e :=
+  fun s e => L (mkGeneralSrcSpan (FastString.fsLit s)) e.
+
+(* Skipping definition `SrcLoc.combineLocs' *)
+
+(* Skipping definition `SrcLoc.addCLoc' *)
+
+Definition eqLocated {a} `{GHC.Base.Eq_ a} : Located a -> Located a -> bool :=
+  fun a b => unLoc a GHC.Base.== unLoc b.
+
+Definition cmpLocated {a} `{GHC.Base.Ord a}
+   : Located a -> Located a -> comparison :=
+  fun a b => GHC.Base.compare (unLoc a) (unLoc b).
+
+(* Skipping definition `SrcLoc.rightmost' *)
+
+(* Skipping definition `SrcLoc.leftmost_smallest' *)
+
+(* Skipping definition `SrcLoc.leftmost_largest' *)
+
+(* Skipping definition `SrcLoc.spans' *)
+
+(* Skipping definition `SrcLoc.isSubspanOf' *)
 
 (* External variables:
      Eq Gt Lt None Ord__RealSrcLoc_op_zl Some andb bool comparison false list negb

--- a/examples/ghc/lib/State.v
+++ b/examples/ghc/lib/State.v
@@ -28,48 +28,6 @@ Definition runState' {s} {a} (arg_0__ : State s a) :=
 
 (* Converted value declarations: *)
 
-Definition runState {s} {a} : State s a -> s -> (a * s)%type :=
-  fun s i => let 'pair a s' := runState' s i in pair a s'.
-
-Definition put {s} : s -> State s unit :=
-  fun s' => Mk_State (fun arg_0__ => pair tt s').
-
-Definition modify {s} : (s -> s) -> State s unit :=
-  fun f => Mk_State (fun s => pair tt (f s)).
-
-Definition gets {s} {a} : (s -> a) -> State s a :=
-  fun f => Mk_State (fun s => pair (f s) s).
-
-Definition get {s} : State s s :=
-  Mk_State (fun s => pair s s).
-
-Definition execState {s} {a} : State s a -> s -> s :=
-  fun s i => let 'pair _ s' := runState' s i in s'.
-
-Definition evalState {s} {a} : State s a -> s -> a :=
-  fun s i => let 'pair a _ := runState' s i in a.
-
-Local Definition Monad__State_op_zgzgze__ {inst_s}
-   : forall {a} {b},
-     (State inst_s) a -> (a -> (State inst_s) b) -> (State inst_s) b :=
-  fun {a} {b} =>
-    fun m n =>
-      Mk_State (fun s => let 'pair r s' := runState' m s in runState' (n r) s').
-
-Local Definition Monad__State_op_zgzg__ {inst_s}
-   : forall {a} {b}, (State inst_s) a -> (State inst_s) b -> (State inst_s) b :=
-  fun {a} {b} => fun m k => Monad__State_op_zgzgze__ m (fun arg_0__ => k).
-
-Local Definition Applicative__State_op_zlztzg__ {inst_s}
-   : forall {a} {b},
-     (State inst_s) (a -> b) -> (State inst_s) a -> (State inst_s) b :=
-  fun {a} {b} =>
-    fun m n =>
-      Mk_State (fun s =>
-                  let 'pair f s' := runState' m s in
-                  let 'pair x s'' := runState' n s' in
-                  pair (f x) s'').
-
 Local Definition Functor__State_fmap {inst_s}
    : forall {a} {b}, (a -> b) -> (State inst_s) a -> (State inst_s) b :=
   fun {a} {b} =>
@@ -83,6 +41,16 @@ Program Instance Functor__State {s} : GHC.Base.Functor (State s) :=
   fun _ k__ =>
     k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__State_fmap ;
            GHC.Base.op_zlzd____ := fun {a} {b} => Functor__State_op_zlzd__ |}.
+
+Local Definition Applicative__State_op_zlztzg__ {inst_s}
+   : forall {a} {b},
+     (State inst_s) (a -> b) -> (State inst_s) a -> (State inst_s) b :=
+  fun {a} {b} =>
+    fun m n =>
+      Mk_State (fun s =>
+                  let 'pair f s' := runState' m s in
+                  let 'pair x s'' := runState' n s' in
+                  pair (f x) s'').
 
 Local Definition Applicative__State_liftA2 {inst_s}
    : forall {a} {b} {c},
@@ -106,6 +74,17 @@ Program Instance Applicative__State {s} : GHC.Base.Applicative (State s) :=
            GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__State_op_ztzg__ ;
            GHC.Base.pure__ := fun {a} => Applicative__State_pure |}.
 
+Local Definition Monad__State_op_zgzgze__ {inst_s}
+   : forall {a} {b},
+     (State inst_s) a -> (a -> (State inst_s) b) -> (State inst_s) b :=
+  fun {a} {b} =>
+    fun m n =>
+      Mk_State (fun s => let 'pair r s' := runState' m s in runState' (n r) s').
+
+Local Definition Monad__State_op_zgzg__ {inst_s}
+   : forall {a} {b}, (State inst_s) a -> (State inst_s) b -> (State inst_s) b :=
+  fun {a} {b} => fun m k => Monad__State_op_zgzgze__ m (fun arg_0__ => k).
+
 Local Definition Monad__State_return_ {inst_s}
    : forall {a}, a -> (State inst_s) a :=
   fun {a} => GHC.Base.pure.
@@ -115,6 +94,27 @@ Program Instance Monad__State {s} : GHC.Base.Monad (State s) :=
     k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__State_op_zgzg__ ;
            GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__State_op_zgzgze__ ;
            GHC.Base.return___ := fun {a} => Monad__State_return_ |}.
+
+Definition get {s} : State s s :=
+  Mk_State (fun s => pair s s).
+
+Definition gets {s} {a} : (s -> a) -> State s a :=
+  fun f => Mk_State (fun s => pair (f s) s).
+
+Definition put {s} : s -> State s unit :=
+  fun s' => Mk_State (fun arg_0__ => pair tt s').
+
+Definition modify {s} : (s -> s) -> State s unit :=
+  fun f => Mk_State (fun s => pair tt (f s)).
+
+Definition evalState {s} {a} : State s a -> s -> a :=
+  fun s i => let 'pair a _ := runState' s i in a.
+
+Definition execState {s} {a} : State s a -> s -> s :=
+  fun s i => let 'pair _ s' := runState' s i in s'.
+
+Definition runState {s} {a} : State s a -> s -> (a * s)%type :=
+  fun s i => let 'pair a s' := runState' s i in pair a s'.
 
 (* External variables:
      op_zt__ pair tt unit GHC.Base.Applicative GHC.Base.Functor GHC.Base.Monad

--- a/examples/ghc/lib/TrieMap.v
+++ b/examples/ghc/lib/TrieMap.v
@@ -187,7 +187,41 @@ Admitted.
 
 (* Converted value declarations: *)
 
-(* Skipping definition `TrieMap.xtTyLit' *)
+Local Definition TrieMap__IntMap_Key : Type :=
+  Data.IntSet.Internal.Key.
+
+Definition xtInt {a}
+   : Data.IntSet.Internal.Key -> XT a -> IntMap.IntMap a -> IntMap.IntMap a :=
+  fun k f m => IntMap.alter f k m.
+
+Local Definition TrieMap__IntMap_alterTM
+   : forall {b},
+     TrieMap__IntMap_Key -> XT b -> IntMap.IntMap b -> IntMap.IntMap b :=
+  fun {b} => xtInt.
+
+Local Definition TrieMap__IntMap_emptyTM : forall {a}, IntMap.IntMap a :=
+  fun {a} => IntMap.empty.
+
+Local Definition TrieMap__IntMap_foldTM
+   : forall {a} {b}, (a -> b -> b) -> IntMap.IntMap a -> b -> b :=
+  fun {a} {b} => fun k m z => IntMap.foldr k z m.
+
+Local Definition TrieMap__IntMap_lookupTM
+   : forall {b}, TrieMap__IntMap_Key -> IntMap.IntMap b -> option b :=
+  fun {b} => fun k m => IntMap.lookup k m.
+
+Local Definition TrieMap__IntMap_mapTM
+   : forall {a} {b}, (a -> b) -> IntMap.IntMap a -> IntMap.IntMap b :=
+  fun {a} {b} => fun f m => IntMap.map f m.
+
+Program Instance TrieMap__IntMap : TrieMap IntMap.IntMap :=
+  {
+  Key := TrieMap__IntMap_Key ;
+  alterTM := fun {b} => TrieMap__IntMap_alterTM ;
+  emptyTM := fun {a} => TrieMap__IntMap_emptyTM ;
+  foldTM := fun {a} {b} => TrieMap__IntMap_foldTM ;
+  lookupTM := fun {b} => TrieMap__IntMap_lookupTM ;
+  mapTM := fun {a} {b} => TrieMap__IntMap_mapTM }.
 
 Local Definition TrieMap__Map_Key {k} `{GHC.Base.Ord k} : Type :=
   k.
@@ -228,39 +262,405 @@ Program Instance TrieMap__Map {k} `{GHC.Base.Ord k}
   lookupTM := fun {b} => TrieMap__Map_lookupTM ;
   mapTM := fun {a} {b} => TrieMap__Map_mapTM }.
 
-Definition xtTickish {a}
-   : Core.Tickish Core.Id -> XT a -> TickishMap a -> TickishMap a :=
-  alterTM (m := TickishMap).
+Local Definition TrieMap__UniqFM_Key : Type :=
+  Unique.Unique.
 
-Axiom xtT : forall {a},
-            DeBruijn AxiomatizedTypes.Type_ -> XT a -> TypeMapX a -> TypeMapX a.
+Local Definition TrieMap__UniqFM_alterTM
+   : forall {b},
+     TrieMap__UniqFM_Key -> XT b -> UniqFM.UniqFM b -> UniqFM.UniqFM b :=
+  fun {b} => fun k f m => UniqFM.alterUFM f m k.
 
-Definition xtLit {a}
-   : Literal.Literal -> XT a -> LiteralMap a -> LiteralMap a :=
-  alterTM (m := LiteralMap).
+Local Definition TrieMap__UniqFM_emptyTM : forall {a}, UniqFM.UniqFM a :=
+  fun {a} => UniqFM.emptyUFM.
+
+Local Definition TrieMap__UniqFM_foldTM
+   : forall {a} {b}, (a -> b -> b) -> UniqFM.UniqFM a -> b -> b :=
+  fun {a} {b} => fun k m z => UniqFM.nonDetFoldUFM k z m.
+
+Local Definition TrieMap__UniqFM_lookupTM
+   : forall {b}, TrieMap__UniqFM_Key -> UniqFM.UniqFM b -> option b :=
+  fun {b} => fun k m => UniqFM.lookupUFM m k.
+
+Local Definition TrieMap__UniqFM_mapTM
+   : forall {a} {b}, (a -> b) -> UniqFM.UniqFM a -> UniqFM.UniqFM b :=
+  fun {a} {b} => fun f m => UniqFM.mapUFM f m.
+
+Program Instance TrieMap__UniqFM : TrieMap UniqFM.UniqFM :=
+  {
+  Key := TrieMap__UniqFM_Key ;
+  alterTM := fun {b} => TrieMap__UniqFM_alterTM ;
+  emptyTM := fun {a} => TrieMap__UniqFM_emptyTM ;
+  foldTM := fun {a} {b} => TrieMap__UniqFM_foldTM ;
+  lookupTM := fun {b} => TrieMap__UniqFM_lookupTM ;
+  mapTM := fun {a} {b} => TrieMap__UniqFM_mapTM }.
+
+Local Definition TrieMap__MaybeMap_Key {m} `{TrieMap m} : Type :=
+  option (Key m).
+
+Definition op_zbzg__ {a} {b} : a -> (a -> b) -> b :=
+  fun x f => f x.
+
+Notation "'_|>_'" := (op_zbzg__).
+
+Infix "|>" := (_|>_) (at level 99).
+
+Definition xtMaybe {k} {m} {a}
+   : (forall {b}, k -> XT b -> m b -> m b) ->
+     option k -> XT a -> MaybeMap m a -> MaybeMap m a :=
+  fun arg_0__ arg_1__ arg_2__ arg_3__ =>
+    match arg_0__, arg_1__, arg_2__, arg_3__ with
+    | _, None, f, m =>
+        let 'MM mm_nothing_4__ mm_just_5__ := m in
+        MM (f (mm_nothing m)) mm_just_5__
+    | tr, Some x, f, m =>
+        let 'MM mm_nothing_9__ mm_just_10__ := m in
+        MM mm_nothing_9__ (mm_just m |> tr _ x f)
+    end.
+
+Local Definition TrieMap__MaybeMap_alterTM {inst_m} `{TrieMap inst_m}
+   : forall {b},
+     TrieMap__MaybeMap_Key -> XT b -> (MaybeMap inst_m) b -> (MaybeMap inst_m) b :=
+  fun {b} => xtMaybe (fun {b} => alterTM).
+
+Local Definition TrieMap__MaybeMap_emptyTM {inst_m} `{TrieMap inst_m}
+   : forall {a}, (MaybeMap inst_m) a :=
+  fun {a} => MM None emptyTM.
+
+Definition foldMaybe {a} {b} : (a -> b -> b) -> option a -> b -> b :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | _, None, b => b
+    | k, Some a, b => k a b
+    end.
+
+Definition fdMaybe {m} {a} {b} `{TrieMap m}
+   : (a -> b -> b) -> MaybeMap m a -> b -> b :=
+  fun k m => foldMaybe k (mm_nothing m) GHC.Base.∘ foldTM k (mm_just m).
+
+Local Definition TrieMap__MaybeMap_foldTM {inst_m} `{TrieMap inst_m}
+   : forall {a} {b}, (a -> b -> b) -> (MaybeMap inst_m) a -> b -> b :=
+  fun {a} {b} => fdMaybe.
+
+Definition op_zgzizg__ {a} {b} {c} : (a -> b) -> (b -> c) -> a -> c :=
+  fun f g x => g (f x).
+
+Notation "'_>.>_'" := (op_zgzizg__).
+
+Infix ">.>" := (_>.>_) (at level 99).
+
+Definition lkMaybe {k} {m} {a}
+   : (forall {b}, k -> m b -> option b) -> option k -> MaybeMap m a -> option a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | _, None => mm_nothing
+    | lk, Some x => mm_just >.> lk _ x
+    end.
+
+Local Definition TrieMap__MaybeMap_lookupTM {inst_m} `{TrieMap inst_m}
+   : forall {b}, TrieMap__MaybeMap_Key -> (MaybeMap inst_m) b -> option b :=
+  fun {b} => lkMaybe (fun {b} => lookupTM).
+
+Definition mapMb {m} {a} {b} `{TrieMap m}
+   : (a -> b) -> MaybeMap m a -> MaybeMap m b :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, MM mn mj => MM (GHC.Base.fmap f mn) (mapTM f mj)
+    end.
+
+Local Definition TrieMap__MaybeMap_mapTM {inst_m} `{TrieMap inst_m}
+   : forall {a} {b}, (a -> b) -> (MaybeMap inst_m) a -> (MaybeMap inst_m) b :=
+  fun {a} {b} => mapMb.
+
+Program Instance TrieMap__MaybeMap {m} `{TrieMap m} : TrieMap (MaybeMap m) :=
+  {
+  Key := TrieMap__MaybeMap_Key ;
+  alterTM := fun {b} => TrieMap__MaybeMap_alterTM ;
+  emptyTM := fun {a} => TrieMap__MaybeMap_emptyTM ;
+  foldTM := fun {a} {b} => TrieMap__MaybeMap_foldTM ;
+  lookupTM := fun {b} => TrieMap__MaybeMap_lookupTM ;
+  mapTM := fun {a} {b} => TrieMap__MaybeMap_mapTM }.
+
+Local Definition TrieMap__ListMap_Key {m} `{TrieMap m} : Type :=
+  list (Key m).
 
 Axiom xtList : forall {m} {k} {a},
                forall `{TrieMap m},
                (forall {b}, k -> XT b -> m b -> m b) ->
                list k -> XT a -> ListMap m a -> ListMap m a.
 
-Definition xtInt {a}
-   : Data.IntSet.Internal.Key -> XT a -> IntMap.IntMap a -> IntMap.IntMap a :=
-  fun k f m => IntMap.alter f k m.
+Local Definition TrieMap__ListMap_alterTM {inst_m} `{TrieMap inst_m}
+   : forall {b},
+     TrieMap__ListMap_Key -> XT b -> (ListMap inst_m) b -> (ListMap inst_m) b :=
+  fun {b} => xtList (fun {b} => alterTM).
+
+Axiom TrieMap__ListMap_emptyTM : forall {m} {a} `{TrieMap m}, ListMap m a.
+
+Axiom fdList : forall {m} {a} {b},
+               forall `{TrieMap m}, (a -> b -> b) -> ListMap m a -> b -> b.
+
+Local Definition TrieMap__ListMap_foldTM {inst_m} `{TrieMap inst_m}
+   : forall {a} {b}, (a -> b -> b) -> (ListMap inst_m) a -> b -> b :=
+  fun {a} {b} => fdList.
+
+Axiom lkList : forall {m} {k} {a},
+               forall `{TrieMap m},
+               (forall {b}, k -> m b -> option b) -> list k -> ListMap m a -> option a.
+
+Local Definition TrieMap__ListMap_lookupTM {inst_m} `{TrieMap inst_m}
+   : forall {b}, TrieMap__ListMap_Key -> (ListMap inst_m) b -> option b :=
+  fun {b} => lkList (fun {b} => lookupTM).
+
+Axiom mapList : forall {m} {a} {b},
+                forall `{TrieMap m}, (a -> b) -> ListMap m a -> ListMap m b.
+
+Local Definition TrieMap__ListMap_mapTM {inst_m} `{TrieMap inst_m}
+   : forall {a} {b}, (a -> b) -> (ListMap inst_m) a -> (ListMap inst_m) b :=
+  fun {a} {b} => mapList.
+
+Program Instance TrieMap__ListMap {m} `{TrieMap m} : TrieMap (ListMap m) :=
+  {
+  Key := TrieMap__ListMap_Key ;
+  alterTM := fun {b} => TrieMap__ListMap_alterTM ;
+  emptyTM := fun {a} => TrieMap__ListMap_emptyTM ;
+  foldTM := fun {a} {b} => TrieMap__ListMap_foldTM ;
+  lookupTM := fun {b} => TrieMap__ListMap_lookupTM ;
+  mapTM := fun {a} {b} => TrieMap__ListMap_mapTM }.
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `TrieMap.Outputable__ListMap' *)
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `TrieMap.Outputable__GenMap' *)
+
+Axiom GenMap__EmptyMap : forall {m} {a}, GenMap m a.
+
+Axiom fdG : forall {m} {a} {b},
+            forall `{TrieMap m}, (a -> b -> b) -> GenMap m a -> b -> b.
+
+Axiom lkG : forall {m} {a} `{TrieMap m} `{GHC.Base.Eq_ (Key m)},
+            Key m -> GenMap m a -> option a.
+
+Axiom mapG : forall {m} {a} {b},
+             forall `{TrieMap m}, (a -> b) -> GenMap m a -> GenMap m b.
 
 Axiom xtG : forall {m} {a} `{TrieMap m} `{GHC.Base.Eq_ (Key m)},
             Key m -> XT a -> GenMap m a -> GenMap m a.
 
+Instance TrieMap__GenMap {m} `{TrieMap m} `{GHC.Base.Eq_ (Key m)}
+   : TrieMap (GenMap m) :=
+  Build_TrieMap (GenMap m) (Key m) (fun {b} => xtG) (fun {a} => GenMap__EmptyMap)
+                (fun {a} {b} => fdG) (fun {a} => lkG) (fun {a} {b} => mapG).
+
+Local Definition TrieMap__CoreMap_Key : Type :=
+  Core.CoreExpr.
+
+Definition emptyCME : CmEnv :=
+  CME #0 Core.emptyVarEnv.
+
+Definition deBruijnize {a} : a -> DeBruijn a :=
+  D emptyCME.
+
+Local Definition TrieMap__CoreMapX_Key : Type :=
+  DeBruijn Core.CoreExpr.
+
 Axiom xtE : forall {a},
             DeBruijn Core.CoreExpr -> XT a -> CoreMapX a -> CoreMapX a.
+
+Local Definition TrieMap__CoreMapX_alterTM
+   : forall {b}, TrieMap__CoreMapX_Key -> XT b -> CoreMapX b -> CoreMapX b :=
+  fun {b} => xtE.
+
+Axiom emptyE : forall {a}, CoreMapX a.
+
+Local Definition TrieMap__CoreMapX_emptyTM : forall {a}, CoreMapX a :=
+  fun {a} => emptyE.
+
+Axiom fdE : forall {a} {b}, (a -> b -> b) -> CoreMapX a -> b -> b.
+
+Local Definition TrieMap__CoreMapX_foldTM
+   : forall {a} {b}, (a -> b -> b) -> CoreMapX a -> b -> b :=
+  fun {a} {b} => fdE.
+
+Axiom lkE : forall {a}, DeBruijn Core.CoreExpr -> CoreMapX a -> option a.
+
+Local Definition TrieMap__CoreMapX_lookupTM
+   : forall {b}, TrieMap__CoreMapX_Key -> CoreMapX b -> option b :=
+  fun {b} => lkE.
+
+Axiom mapE : forall {a} {b}, (a -> b) -> CoreMapX a -> CoreMapX b.
+
+Local Definition TrieMap__CoreMapX_mapTM
+   : forall {a} {b}, (a -> b) -> CoreMapX a -> CoreMapX b :=
+  fun {a} {b} => mapE.
+
+Instance Eq___DeBruijn__CoreExpr : GHC.Base.Eq_ (DeBruijn Core.CoreExpr).
+Proof.
+Admitted.
+
+Program Instance TrieMap__CoreMapX : TrieMap CoreMapX :=
+  {
+  Key := TrieMap__CoreMapX_Key ;
+  alterTM := fun {b} => TrieMap__CoreMapX_alterTM ;
+  emptyTM := fun {a} => TrieMap__CoreMapX_emptyTM ;
+  foldTM := fun {a} {b} => TrieMap__CoreMapX_foldTM ;
+  lookupTM := fun {b} => TrieMap__CoreMapX_lookupTM ;
+  mapTM := fun {a} {b} => TrieMap__CoreMapX_mapTM }.
+
+Instance TrieMap__CoreMapG : TrieMap CoreMapG := TrieMap__GenMap.
+
+Local Definition TrieMap__CoreMap_alterTM
+   : forall {b}, TrieMap__CoreMap_Key -> XT b -> CoreMap b -> CoreMap b :=
+  fun {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | k, f, Mk_CoreMap m => Mk_CoreMap (alterTM (m := CoreMapG) (deBruijnize k) f m)
+      end.
+
+Local Definition TrieMap__CoreMap_emptyTM : forall {a}, CoreMap a :=
+  fun {a} => Mk_CoreMap emptyTM.
+
+Local Definition TrieMap__CoreMap_foldTM
+   : forall {a} {b}, (a -> b -> b) -> CoreMap a -> b -> b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | k, Mk_CoreMap m => foldTM k m
+      end.
+
+Local Definition TrieMap__CoreMap_lookupTM
+   : forall {b}, TrieMap__CoreMap_Key -> CoreMap b -> option b :=
+  fun {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | k, Mk_CoreMap m => lookupTM (m := CoreMapG) (deBruijnize k) m
+      end.
+
+Local Definition TrieMap__CoreMap_mapTM
+   : forall {a} {b}, (a -> b) -> CoreMap a -> CoreMap b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, Mk_CoreMap m => Mk_CoreMap (mapTM f m)
+      end.
+
+Program Instance TrieMap__CoreMap : TrieMap CoreMap :=
+  {
+  Key := TrieMap__CoreMap_Key ;
+  alterTM := fun {b} => TrieMap__CoreMap_alterTM ;
+  emptyTM := fun {a} => TrieMap__CoreMap_emptyTM ;
+  foldTM := fun {a} {b} => TrieMap__CoreMap_foldTM ;
+  lookupTM := fun {b} => TrieMap__CoreMap_lookupTM ;
+  mapTM := fun {a} {b} => TrieMap__CoreMap_mapTM }.
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `TrieMap.Outputable__CoreMap' *)
+
+Local Definition TrieMap__AltMap_Key : Type :=
+  Core.CoreAlt.
+
+Definition deMaybe {m} {a} `{TrieMap m} : option (m a) -> m a :=
+  fun arg_0__ => match arg_0__ with | None => emptyTM | Some m => m end.
+
+Definition op_zbzgzg__ {m2} {a} {m1} `{TrieMap m2}
+   : (XT (m2 a) -> m1 (m2 a) -> m1 (m2 a)) ->
+     (m2 a -> m2 a) -> m1 (m2 a) -> m1 (m2 a) :=
+  fun f g => f (Some GHC.Base.∘ (g GHC.Base.∘ deMaybe)).
+
+Notation "'_|>>_'" := (op_zbzgzg__).
+
+Infix "|>>" := (_|>>_) (at level 99).
+
+Definition extendCME : CmEnv -> Core.Var -> CmEnv :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | CME bv env, v => CME (bv GHC.Num.+ #1) (Core.extendVarEnv env v bv)
+    end.
+
+Definition extendCMEs : CmEnv -> list Core.Var -> CmEnv :=
+  fun env vs => Data.Foldable.foldl extendCME env vs.
 
 Definition xtDNamed {n} {a} `{Name.NamedThing n}
    : n -> XT a -> NameEnv.DNameEnv a -> NameEnv.DNameEnv a :=
   fun tc f m => NameEnv.alterDNameEnv f m (Name.getName tc).
 
-Definition xtDFreeVar {a}
-   : Core.Var -> XT a -> Core.DVarEnv a -> Core.DVarEnv a :=
-  fun v f m => Core.alterDVarEnv f m v.
+Definition xtLit {a}
+   : Literal.Literal -> XT a -> LiteralMap a -> LiteralMap a :=
+  alterTM (m := LiteralMap).
+
+Definition xtA {a} : CmEnv -> Core.CoreAlt -> XT a -> AltMap a -> AltMap a :=
+  fun arg_0__ arg_1__ arg_2__ arg_3__ =>
+    match arg_0__, arg_1__, arg_2__, arg_3__ with
+    | env, pair (pair Core.DEFAULT _) rhs, f, m =>
+        let 'AM am_deflt_4__ am_data_5__ am_lit_6__ := m in
+        AM (am_deflt m |> xtG (m := CoreMapX) (D env rhs) f) am_data_5__ am_lit_6__
+    | env, pair (pair (Core.LitAlt l) _) rhs, f, m =>
+        let 'AM am_deflt_10__ am_data_11__ am_lit_12__ := m in
+        AM am_deflt_10__ am_data_11__ (am_lit m |>
+            (xtLit (a := CoreMapG a) l |>> xtG (m := CoreMapX) (D env rhs) f))
+    | env, pair (pair (Core.DataAlt d) bs) rhs, f, m =>
+        let 'AM am_deflt_16__ am_data_17__ am_lit_18__ := m in
+        AM am_deflt_16__ (am_data m |>
+            (xtDNamed (a := CoreMapG a) d |>>
+             xtG (m := CoreMapX) (D (extendCMEs env bs) rhs) f)) am_lit_18__
+    end.
+
+Local Definition TrieMap__AltMap_alterTM
+   : forall {b}, TrieMap__AltMap_Key -> XT b -> AltMap b -> AltMap b :=
+  fun {b} => xtA emptyCME.
+
+Definition emptyLiteralMap {a} : LiteralMap a :=
+  emptyTM.
+
+Local Definition TrieMap__AltMap_emptyTM : forall {a}, AltMap a :=
+  fun {a} => AM emptyTM NameEnv.emptyDNameEnv emptyLiteralMap.
+
+Definition fdA {a} {b} : (a -> b -> b) -> AltMap a -> b -> b :=
+  fun k m =>
+    foldTM k (am_deflt m) GHC.Base.∘
+    (foldTM (foldTM k) (am_data m) GHC.Base.∘ foldTM (foldTM k) (am_lit m)).
+
+Local Definition TrieMap__AltMap_foldTM
+   : forall {a} {b}, (a -> b -> b) -> AltMap a -> b -> b :=
+  fun {a} {b} => fdA.
+
+Axiom lkA : forall {a}, CmEnv -> Core.CoreAlt -> AltMap a -> option a.
+
+Local Definition TrieMap__AltMap_lookupTM
+   : forall {b}, TrieMap__AltMap_Key -> AltMap b -> option b :=
+  fun {b} => lkA emptyCME.
+
+Definition mapA {a} {b} : (a -> b) -> AltMap a -> AltMap b :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, AM adeflt adata alit =>
+        AM (mapTM f adeflt) (mapTM (mapTM f) adata) (mapTM (mapTM f) alit)
+    end.
+
+Local Definition TrieMap__AltMap_mapTM
+   : forall {a} {b}, (a -> b) -> AltMap a -> AltMap b :=
+  fun {a} {b} => mapA.
+
+Program Instance TrieMap__AltMap : TrieMap AltMap :=
+  {
+  Key := TrieMap__AltMap_Key ;
+  alterTM := fun {b} => TrieMap__AltMap_alterTM ;
+  emptyTM := fun {a} => TrieMap__AltMap_emptyTM ;
+  foldTM := fun {a} {b} => TrieMap__AltMap_foldTM ;
+  lookupTM := fun {b} => TrieMap__AltMap_lookupTM ;
+  mapTM := fun {a} {b} => TrieMap__AltMap_mapTM }.
+
+Instance Eq___DeBruijn__CoreAlt : GHC.Base.Eq_ (DeBruijn Core.CoreAlt).
+Proof.
+Admitted.
+
+Local Definition TrieMap__CoercionMap_Key : Type :=
+  AxiomatizedTypes.Coercion.
+
+Local Definition TrieMap__CoercionMapX_Key : Type :=
+  DeBruijn AxiomatizedTypes.Coercion.
+
+Axiom xtT : forall {a},
+            DeBruijn AxiomatizedTypes.Type_ -> XT a -> TypeMapX a -> TypeMapX a.
 
 Definition xtC {a}
    : DeBruijn AxiomatizedTypes.Coercion ->
@@ -271,9 +671,10 @@ Definition xtC {a}
         Mk_CoercionMapX (xtT (D env (Core.coercionType co)) f m)
     end.
 
-Instance Eq___DeBruijn__Type_ : GHC.Base.Eq_ (DeBruijn AxiomatizedTypes.Type_).
-Proof.
-Admitted.
+Local Definition TrieMap__CoercionMapX_alterTM
+   : forall {b},
+     TrieMap__CoercionMapX_Key -> XT b -> CoercionMapX b -> CoercionMapX b :=
+  fun {b} => xtC.
 
 Local Definition TrieMap__TypeMapX_Key : Type :=
   DeBruijn AxiomatizedTypes.Type_.
@@ -315,212 +716,126 @@ Program Instance TrieMap__TypeMapX : TrieMap TypeMapX :=
   lookupTM := fun {b} => TrieMap__TypeMapX_lookupTM ;
   mapTM := fun {a} {b} => TrieMap__TypeMapX_mapTM }.
 
-Definition xtBndr {a} : CmEnv -> Core.Var -> XT a -> BndrMap a -> BndrMap a :=
-  fun env v f => xtG (D env (Core.varType v)) f.
+Local Definition TrieMap__CoercionMapX_emptyTM : forall {a}, CoercionMapX a :=
+  fun {a} => Mk_CoercionMapX emptyTM.
 
-Axiom trieMapView : AxiomatizedTypes.Type_ -> option AxiomatizedTypes.Type_.
+Local Definition TrieMap__CoercionMapX_foldTM
+   : forall {a} {b}, (a -> b -> b) -> CoercionMapX a -> b -> b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, Mk_CoercionMapX core_tm => foldTM f core_tm
+      end.
 
-Definition op_zgzizg__ {a} {b} {c} : (a -> b) -> (b -> c) -> a -> c :=
-  fun f g x => g (f x).
-
-Notation "'_>.>_'" := (op_zgzizg__).
-
-Infix ">.>" := (_>.>_) (at level 99).
-
-Definition op_zbzg__ {a} {b} : a -> (a -> b) -> b :=
-  fun x f => f x.
-
-Notation "'_|>_'" := (op_zbzg__).
-
-Infix "|>" := (_|>_) (at level 99).
-
-Definition xtMaybe {k} {m} {a}
-   : (forall {b}, k -> XT b -> m b -> m b) ->
-     option k -> XT a -> MaybeMap m a -> MaybeMap m a :=
-  fun arg_0__ arg_1__ arg_2__ arg_3__ =>
-    match arg_0__, arg_1__, arg_2__, arg_3__ with
-    | _, None, f, m =>
-        let 'MM mm_nothing_4__ mm_just_5__ := m in
-        MM (f (mm_nothing m)) mm_just_5__
-    | tr, Some x, f, m =>
-        let 'MM mm_nothing_9__ mm_just_10__ := m in
-        MM mm_nothing_9__ (mm_just m |> tr _ x f)
-    end.
-
-Local Definition TrieMap__IntMap_Key : Type :=
-  Data.IntSet.Internal.Key.
-
-Local Definition TrieMap__IntMap_alterTM
-   : forall {b},
-     TrieMap__IntMap_Key -> XT b -> IntMap.IntMap b -> IntMap.IntMap b :=
-  fun {b} => xtInt.
-
-Local Definition TrieMap__IntMap_emptyTM : forall {a}, IntMap.IntMap a :=
-  fun {a} => IntMap.empty.
-
-Local Definition TrieMap__IntMap_foldTM
-   : forall {a} {b}, (a -> b -> b) -> IntMap.IntMap a -> b -> b :=
-  fun {a} {b} => fun k m z => IntMap.foldr k z m.
-
-Local Definition TrieMap__IntMap_lookupTM
-   : forall {b}, TrieMap__IntMap_Key -> IntMap.IntMap b -> option b :=
-  fun {b} => fun k m => IntMap.lookup k m.
-
-Local Definition TrieMap__IntMap_mapTM
-   : forall {a} {b}, (a -> b) -> IntMap.IntMap a -> IntMap.IntMap b :=
-  fun {a} {b} => fun f m => IntMap.map f m.
-
-Program Instance TrieMap__IntMap : TrieMap IntMap.IntMap :=
-  {
-  Key := TrieMap__IntMap_Key ;
-  alterTM := fun {b} => TrieMap__IntMap_alterTM ;
-  emptyTM := fun {a} => TrieMap__IntMap_emptyTM ;
-  foldTM := fun {a} {b} => TrieMap__IntMap_foldTM ;
-  lookupTM := fun {b} => TrieMap__IntMap_lookupTM ;
-  mapTM := fun {a} {b} => TrieMap__IntMap_mapTM }.
-
-Local Definition TrieMap__UniqFM_Key : Type :=
-  Unique.Unique.
-
-Local Definition TrieMap__UniqFM_alterTM
-   : forall {b},
-     TrieMap__UniqFM_Key -> XT b -> UniqFM.UniqFM b -> UniqFM.UniqFM b :=
-  fun {b} => fun k f m => UniqFM.alterUFM f m k.
-
-Local Definition TrieMap__UniqFM_emptyTM : forall {a}, UniqFM.UniqFM a :=
-  fun {a} => UniqFM.emptyUFM.
-
-Local Definition TrieMap__UniqFM_foldTM
-   : forall {a} {b}, (a -> b -> b) -> UniqFM.UniqFM a -> b -> b :=
-  fun {a} {b} => fun k m z => UniqFM.nonDetFoldUFM k z m.
-
-Local Definition TrieMap__UniqFM_lookupTM
-   : forall {b}, TrieMap__UniqFM_Key -> UniqFM.UniqFM b -> option b :=
-  fun {b} => fun k m => UniqFM.lookupUFM m k.
-
-Local Definition TrieMap__UniqFM_mapTM
-   : forall {a} {b}, (a -> b) -> UniqFM.UniqFM a -> UniqFM.UniqFM b :=
-  fun {a} {b} => fun f m => UniqFM.mapUFM f m.
-
-Program Instance TrieMap__UniqFM : TrieMap UniqFM.UniqFM :=
-  {
-  Key := TrieMap__UniqFM_Key ;
-  alterTM := fun {b} => TrieMap__UniqFM_alterTM ;
-  emptyTM := fun {a} => TrieMap__UniqFM_emptyTM ;
-  foldTM := fun {a} {b} => TrieMap__UniqFM_foldTM ;
-  lookupTM := fun {b} => TrieMap__UniqFM_lookupTM ;
-  mapTM := fun {a} {b} => TrieMap__UniqFM_mapTM }.
-
-Definition mapVar {a} {b} : (a -> b) -> VarMap a -> VarMap b :=
+Definition lkC {a}
+   : DeBruijn AxiomatizedTypes.Coercion -> CoercionMapX a -> option a :=
   fun arg_0__ arg_1__ =>
     match arg_0__, arg_1__ with
-    | f, VM bv fv => VM (mapTM f bv) (mapTM f fv)
+    | D env co, Mk_CoercionMapX core_tm =>
+        lkT (D env (Core.coercionType co)) core_tm
     end.
 
-Definition mapTyLit {a} {b} : (a -> b) -> TyLitMap a -> TyLitMap b :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, TLM tn ts => TLM (Data.Map.Internal.map f tn) (Data.Map.Internal.map f ts)
-    end.
+Local Definition TrieMap__CoercionMapX_lookupTM
+   : forall {b}, TrieMap__CoercionMapX_Key -> CoercionMapX b -> option b :=
+  fun {b} => lkC.
 
-Definition mapMb {m} {a} {b} `{TrieMap m}
-   : (a -> b) -> MaybeMap m a -> MaybeMap m b :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, MM mn mj => MM (GHC.Base.fmap f mn) (mapTM f mj)
-    end.
+Local Definition TrieMap__CoercionMapX_mapTM
+   : forall {a} {b}, (a -> b) -> CoercionMapX a -> CoercionMapX b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, Mk_CoercionMapX core_tm => Mk_CoercionMapX (mapTM f core_tm)
+      end.
 
-Axiom mapList : forall {m} {a} {b},
-                forall `{TrieMap m}, (a -> b) -> ListMap m a -> ListMap m b.
-
-Axiom mapG : forall {m} {a} {b},
-             forall `{TrieMap m}, (a -> b) -> GenMap m a -> GenMap m b.
-
-Axiom mapE : forall {a} {b}, (a -> b) -> CoreMapX a -> CoreMapX b.
-
-Instance Eq___DeBruijn__CoreExpr : GHC.Base.Eq_ (DeBruijn Core.CoreExpr).
+Instance Eq___DeBruijn__Type_ : GHC.Base.Eq_ (DeBruijn AxiomatizedTypes.Type_).
 Proof.
 Admitted.
 
-Axiom GenMap__EmptyMap : forall {m} {a}, GenMap m a.
-
-Axiom fdG : forall {m} {a} {b},
-            forall `{TrieMap m}, (a -> b -> b) -> GenMap m a -> b -> b.
-
-Axiom lkG : forall {m} {a} `{TrieMap m} `{GHC.Base.Eq_ (Key m)},
-            Key m -> GenMap m a -> option a.
-
-Instance TrieMap__GenMap {m} `{TrieMap m} `{GHC.Base.Eq_ (Key m)}
-   : TrieMap (GenMap m) :=
-  Build_TrieMap (GenMap m) (Key m) (fun {b} => xtG) (fun {a} => GenMap__EmptyMap)
-                (fun {a} {b} => fdG) (fun {a} => lkG) (fun {a} {b} => mapG).
-
-Local Definition TrieMap__CoreMapX_Key : Type :=
-  DeBruijn Core.CoreExpr.
-
-Local Definition TrieMap__CoreMapX_alterTM
-   : forall {b}, TrieMap__CoreMapX_Key -> XT b -> CoreMapX b -> CoreMapX b :=
-  fun {b} => xtE.
-
-Axiom emptyE : forall {a}, CoreMapX a.
-
-Local Definition TrieMap__CoreMapX_emptyTM : forall {a}, CoreMapX a :=
-  fun {a} => emptyE.
-
-Axiom fdE : forall {a} {b}, (a -> b -> b) -> CoreMapX a -> b -> b.
-
-Local Definition TrieMap__CoreMapX_foldTM
-   : forall {a} {b}, (a -> b -> b) -> CoreMapX a -> b -> b :=
-  fun {a} {b} => fdE.
-
-Axiom lkE : forall {a}, DeBruijn Core.CoreExpr -> CoreMapX a -> option a.
-
-Local Definition TrieMap__CoreMapX_lookupTM
-   : forall {b}, TrieMap__CoreMapX_Key -> CoreMapX b -> option b :=
-  fun {b} => lkE.
-
-Local Definition TrieMap__CoreMapX_mapTM
-   : forall {a} {b}, (a -> b) -> CoreMapX a -> CoreMapX b :=
-  fun {a} {b} => mapE.
-
-Program Instance TrieMap__CoreMapX : TrieMap CoreMapX :=
-  {
-  Key := TrieMap__CoreMapX_Key ;
-  alterTM := fun {b} => TrieMap__CoreMapX_alterTM ;
-  emptyTM := fun {a} => TrieMap__CoreMapX_emptyTM ;
-  foldTM := fun {a} {b} => TrieMap__CoreMapX_foldTM ;
-  lookupTM := fun {b} => TrieMap__CoreMapX_lookupTM ;
-  mapTM := fun {a} {b} => TrieMap__CoreMapX_mapTM }.
-
-Instance TrieMap__CoreMapG : TrieMap CoreMapG := TrieMap__GenMap.
-
-Definition mapA {a} {b} : (a -> b) -> AltMap a -> AltMap b :=
+Local Definition Eq___DeBruijn__Coercion_op_zeze__
+   : (DeBruijn AxiomatizedTypes.Coercion) ->
+     (DeBruijn AxiomatizedTypes.Coercion) -> bool :=
   fun arg_0__ arg_1__ =>
     match arg_0__, arg_1__ with
-    | f, AM adeflt adata alit =>
-        AM (mapTM f adeflt) (mapTM (mapTM f) adata) (mapTM (mapTM f) alit)
+    | D env1 co1, D env2 co2 =>
+        D env1 (Core.coercionType co1) GHC.Base.== D env2 (Core.coercionType co2)
     end.
+
+Local Definition Eq___DeBruijn__Coercion_op_zsze__
+   : (DeBruijn AxiomatizedTypes.Coercion) ->
+     (DeBruijn AxiomatizedTypes.Coercion) -> bool :=
+  fun x y => negb (Eq___DeBruijn__Coercion_op_zeze__ x y).
+
+Program Instance Eq___DeBruijn__Coercion
+   : GHC.Base.Eq_ (DeBruijn AxiomatizedTypes.Coercion) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___DeBruijn__Coercion_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___DeBruijn__Coercion_op_zsze__ |}.
+
+Program Instance TrieMap__CoercionMapX : TrieMap CoercionMapX :=
+  {
+  Key := TrieMap__CoercionMapX_Key ;
+  alterTM := fun {b} => TrieMap__CoercionMapX_alterTM ;
+  emptyTM := fun {a} => TrieMap__CoercionMapX_emptyTM ;
+  foldTM := fun {a} {b} => TrieMap__CoercionMapX_foldTM ;
+  lookupTM := fun {b} => TrieMap__CoercionMapX_lookupTM ;
+  mapTM := fun {a} {b} => TrieMap__CoercionMapX_mapTM }.
+
+Instance TrieMap__CoercionMapG : TrieMap CoercionMapG := TrieMap__GenMap.
+
+Local Definition TrieMap__CoercionMap_alterTM
+   : forall {b},
+     TrieMap__CoercionMap_Key -> XT b -> CoercionMap b -> CoercionMap b :=
+  fun {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | k, f, Mk_CoercionMap m => Mk_CoercionMap (alterTM (deBruijnize k) f m)
+      end.
+
+Local Definition TrieMap__CoercionMap_emptyTM : forall {a}, CoercionMap a :=
+  fun {a} => Mk_CoercionMap emptyTM.
+
+Local Definition TrieMap__CoercionMap_foldTM
+   : forall {a} {b}, (a -> b -> b) -> CoercionMap a -> b -> b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | k, Mk_CoercionMap m => foldTM k m
+      end.
+
+Local Definition TrieMap__CoercionMap_lookupTM
+   : forall {b}, TrieMap__CoercionMap_Key -> CoercionMap b -> option b :=
+  fun {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | k, Mk_CoercionMap m => lookupTM (deBruijnize k) m
+      end.
+
+Local Definition TrieMap__CoercionMap_mapTM
+   : forall {a} {b}, (a -> b) -> CoercionMap a -> CoercionMap b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, Mk_CoercionMap m => Mk_CoercionMap (mapTM f m)
+      end.
+
+Program Instance TrieMap__CoercionMap : TrieMap CoercionMap :=
+  {
+  Key := TrieMap__CoercionMap_Key ;
+  alterTM := fun {b} => TrieMap__CoercionMap_alterTM ;
+  emptyTM := fun {a} => TrieMap__CoercionMap_emptyTM ;
+  foldTM := fun {a} {b} => TrieMap__CoercionMap_foldTM ;
+  lookupTM := fun {b} => TrieMap__CoercionMap_lookupTM ;
+  mapTM := fun {a} {b} => TrieMap__CoercionMap_mapTM }.
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `TrieMap.Outputable__TypeMapG' *)
+
+Instance TrieMap__TyLitMap : TrieMap TyLitMap.
+Proof.
+Admitted.
 
 Local Definition TrieMap__TypeMap_Key : Type :=
   AxiomatizedTypes.Type_.
-
-Definition emptyCME : CmEnv :=
-  CME #0 Core.emptyVarEnv.
-
-Definition deBruijnize {a} : a -> DeBruijn a :=
-  D emptyCME.
-
-Definition deMaybe {m} {a} `{TrieMap m} : option (m a) -> m a :=
-  fun arg_0__ => match arg_0__ with | None => emptyTM | Some m => m end.
-
-Definition op_zbzgzg__ {m2} {a} {m1} `{TrieMap m2}
-   : (XT (m2 a) -> m1 (m2 a) -> m1 (m2 a)) ->
-     (m2 a -> m2 a) -> m1 (m2 a) -> m1 (m2 a) :=
-  fun f g => f (Some GHC.Base.∘ (g GHC.Base.∘ deMaybe)).
-
-Notation "'_|>>_'" := (op_zbzgzg__).
-
-Infix "|>>" := (_|>>_) (at level 99).
 
 Instance TrieMap__TypeMapG : TrieMap TypeMapG := TrieMap__GenMap.
 
@@ -579,376 +894,6 @@ Program Instance TrieMap__TypeMap : TrieMap TypeMap :=
   lookupTM := fun {b} => TrieMap__TypeMap_lookupTM ;
   mapTM := fun {a} {b} => TrieMap__TypeMap_mapTM }.
 
-Definition lookupTypeMap {a}
-   : TypeMap a -> AxiomatizedTypes.Type_ -> option a :=
-  fun cm t => lookupTM t cm.
-
-Local Definition TrieMap__CoreMap_Key : Type :=
-  Core.CoreExpr.
-
-Local Definition TrieMap__CoreMap_alterTM
-   : forall {b}, TrieMap__CoreMap_Key -> XT b -> CoreMap b -> CoreMap b :=
-  fun {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | k, f, Mk_CoreMap m => Mk_CoreMap (alterTM (m := CoreMapG) (deBruijnize k) f m)
-      end.
-
-Local Definition TrieMap__CoreMap_emptyTM : forall {a}, CoreMap a :=
-  fun {a} => Mk_CoreMap emptyTM.
-
-Local Definition TrieMap__CoreMap_foldTM
-   : forall {a} {b}, (a -> b -> b) -> CoreMap a -> b -> b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | k, Mk_CoreMap m => foldTM k m
-      end.
-
-Local Definition TrieMap__CoreMap_lookupTM
-   : forall {b}, TrieMap__CoreMap_Key -> CoreMap b -> option b :=
-  fun {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | k, Mk_CoreMap m => lookupTM (m := CoreMapG) (deBruijnize k) m
-      end.
-
-Local Definition TrieMap__CoreMap_mapTM
-   : forall {a} {b}, (a -> b) -> CoreMap a -> CoreMap b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, Mk_CoreMap m => Mk_CoreMap (mapTM f m)
-      end.
-
-Program Instance TrieMap__CoreMap : TrieMap CoreMap :=
-  {
-  Key := TrieMap__CoreMap_Key ;
-  alterTM := fun {b} => TrieMap__CoreMap_alterTM ;
-  emptyTM := fun {a} => TrieMap__CoreMap_emptyTM ;
-  foldTM := fun {a} {b} => TrieMap__CoreMap_foldTM ;
-  lookupTM := fun {b} => TrieMap__CoreMap_lookupTM ;
-  mapTM := fun {a} {b} => TrieMap__CoreMap_mapTM }.
-
-Definition lookupCoreMap {a} : CoreMap a -> Core.CoreExpr -> option a :=
-  fun cm e => lookupTM e cm.
-
-Definition lookupCME : CmEnv -> Core.Var -> option BoundVar :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | CME _ env, v => Core.lookupVarEnv env v
-    end.
-
-Definition xtVar {a} : CmEnv -> Core.Var -> XT a -> VarMap a -> VarMap a :=
-  fun env v f m =>
-    match lookupCME env v with
-    | Some bv =>
-        let 'VM vm_bvar_0__ vm_fvar_1__ := m in
-        VM (vm_bvar m |> alterTM (m := BoundVarMap) bv f) vm_fvar_1__
-    | _ =>
-        let 'VM vm_bvar_4__ vm_fvar_5__ := m in
-        VM vm_bvar_4__ (vm_fvar m |> xtDFreeVar v f)
-    end.
-
-(* Skipping definition `TrieMap.lkTyLit' *)
-
-Definition lkTickish {a} : Core.Tickish Core.Id -> TickishMap a -> option a :=
-  lookupTM (m := TickishMap).
-
-Definition lkMaybe {k} {m} {a}
-   : (forall {b}, k -> m b -> option b) -> option k -> MaybeMap m a -> option a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | _, None => mm_nothing
-    | lk, Some x => mm_just >.> lk _ x
-    end.
-
-Definition lkLit {a} : Literal.Literal -> LiteralMap a -> option a :=
-  lookupTM (m := LiteralMap).
-
-Axiom lkList : forall {m} {k} {a},
-               forall `{TrieMap m},
-               (forall {b}, k -> m b -> option b) -> list k -> ListMap m a -> option a.
-
-Definition lookupTypeMapWithScope {a}
-   : TypeMap a -> CmEnv -> AxiomatizedTypes.Type_ -> option a :=
-  fun m cm t => lkTT (D cm t) m.
-
-Definition lkDNamed {n} {a} `{Name.NamedThing n}
-   : n -> NameEnv.DNameEnv a -> option a :=
-  fun n env => NameEnv.lookupDNameEnv env (Name.getName n).
-
-Definition lkDFreeVar {a} : Core.Var -> Core.DVarEnv a -> option a :=
-  fun var env => Core.lookupDVarEnv env var.
-
-Definition lkVar {a} : CmEnv -> Core.Var -> VarMap a -> option a :=
-  fun env v =>
-    match lookupCME env v with
-    | Some bv => vm_bvar >.> lookupTM (m := BoundVarMap) bv
-    | _ => vm_fvar >.> lkDFreeVar v
-    end.
-
-Definition lkC {a}
-   : DeBruijn AxiomatizedTypes.Coercion -> CoercionMapX a -> option a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | D env co, Mk_CoercionMapX core_tm =>
-        lkT (D env (Core.coercionType co)) core_tm
-    end.
-
-Axiom lkBndr : forall {a}, CmEnv -> Core.Var -> BndrMap a -> option a.
-
-Axiom lkA : forall {a}, CmEnv -> Core.CoreAlt -> AltMap a -> option a.
-
-Definition insertTM {m} {a} `{TrieMap m} : Key m -> a -> m a -> m a :=
-  fun k v m => alterTM k (fun arg_0__ => Some v) m.
-
-Definition foldTypeMap {a} {b} : (a -> b -> b) -> b -> TypeMap a -> b :=
-  fun k z m => foldTM k m z.
-
-Definition foldTyLit {a} {b} : (a -> b -> b) -> TyLitMap a -> b -> b :=
-  fun l m =>
-    GHC.Base.flip (Data.Map.Internal.foldr l) (tlm_string m) GHC.Base.∘
-    GHC.Base.flip (Data.Map.Internal.foldr l) (tlm_number m).
-
-Definition foldMaybe {a} {b} : (a -> b -> b) -> option a -> b -> b :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | _, None, b => b
-    | k, Some a, b => k a b
-    end.
-
-Definition foldCoreMap {a} {b} : (a -> b -> b) -> b -> CoreMap a -> b :=
-  fun k z m => foldTM k m z.
-
-Definition fdVar {a} {b} : (a -> b -> b) -> VarMap a -> b -> b :=
-  fun k m => foldTM k (vm_bvar m) GHC.Base.∘ foldTM k (vm_fvar m).
-
-Definition fdMaybe {m} {a} {b} `{TrieMap m}
-   : (a -> b -> b) -> MaybeMap m a -> b -> b :=
-  fun k m => foldMaybe k (mm_nothing m) GHC.Base.∘ foldTM k (mm_just m).
-
-Axiom fdList : forall {m} {a} {b},
-               forall `{TrieMap m}, (a -> b -> b) -> ListMap m a -> b -> b.
-
-Definition fdA {a} {b} : (a -> b -> b) -> AltMap a -> b -> b :=
-  fun k m =>
-    foldTM k (am_deflt m) GHC.Base.∘
-    (foldTM (foldTM k) (am_data m) GHC.Base.∘ foldTM (foldTM k) (am_lit m)).
-
-Definition extendTypeMap {a}
-   : TypeMap a -> AxiomatizedTypes.Type_ -> a -> TypeMap a :=
-  fun m t v => alterTM (m := TypeMap) t (GHC.Base.const (Some v)) m.
-
-Definition extendCoreMap {a} : CoreMap a -> Core.CoreExpr -> a -> CoreMap a :=
-  fun m e v => alterTM e (fun arg_0__ => Some v) m.
-
-Definition extendCME : CmEnv -> Core.Var -> CmEnv :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | CME bv env, v => CME (bv GHC.Num.+ #1) (Core.extendVarEnv env v bv)
-    end.
-
-Definition extendCMEs : CmEnv -> list Core.Var -> CmEnv :=
-  fun env vs => Data.Foldable.foldl extendCME env vs.
-
-Definition emptyTypeMap {a} : TypeMap a :=
-  emptyTM.
-
-Definition emptyTyLitMap {a} : TyLitMap a :=
-  TLM Data.Map.Internal.empty Data.Map.Internal.empty.
-
-Definition emptyLiteralMap {a} : LiteralMap a :=
-  emptyTM.
-
-Definition emptyCoreMap {a} : CoreMap a :=
-  emptyTM.
-
-Definition mkDeBruijnContext : list Core.Var -> CmEnv :=
-  extendCMEs emptyCME.
-
-Definition deleteTM {m} {a} `{TrieMap m} : Key m -> m a -> m a :=
-  fun k m => alterTM k (fun arg_0__ => None) m.
-
-Definition xtA {a} : CmEnv -> Core.CoreAlt -> XT a -> AltMap a -> AltMap a :=
-  fun arg_0__ arg_1__ arg_2__ arg_3__ =>
-    match arg_0__, arg_1__, arg_2__, arg_3__ with
-    | env, pair (pair Core.DEFAULT _) rhs, f, m =>
-        let 'AM am_deflt_4__ am_data_5__ am_lit_6__ := m in
-        AM (am_deflt m |> xtG (m := CoreMapX) (D env rhs) f) am_data_5__ am_lit_6__
-    | env, pair (pair (Core.LitAlt l) _) rhs, f, m =>
-        let 'AM am_deflt_10__ am_data_11__ am_lit_12__ := m in
-        AM am_deflt_10__ am_data_11__ (am_lit m |>
-            (xtLit (a := CoreMapG a) l |>> xtG (m := CoreMapX) (D env rhs) f))
-    | env, pair (pair (Core.DataAlt d) bs) rhs, f, m =>
-        let 'AM am_deflt_16__ am_data_17__ am_lit_18__ := m in
-        AM am_deflt_16__ (am_data m |>
-            (xtDNamed (a := CoreMapG a) d |>>
-             xtG (m := CoreMapX) (D (extendCMEs env bs) rhs) f)) am_lit_18__
-    end.
-
-Definition extendTypeMapWithScope {a}
-   : TypeMap a -> CmEnv -> AxiomatizedTypes.Type_ -> a -> TypeMap a :=
-  fun m cm t v => xtTT (D cm t) (GHC.Base.const (Some v)) m.
-
-Local Definition TrieMap__MaybeMap_Key {m} `{TrieMap m} : Type :=
-  option (Key m).
-
-Local Definition TrieMap__MaybeMap_alterTM {inst_m} `{TrieMap inst_m}
-   : forall {b},
-     TrieMap__MaybeMap_Key -> XT b -> (MaybeMap inst_m) b -> (MaybeMap inst_m) b :=
-  fun {b} => xtMaybe (fun {b} => alterTM).
-
-Local Definition TrieMap__MaybeMap_emptyTM {inst_m} `{TrieMap inst_m}
-   : forall {a}, (MaybeMap inst_m) a :=
-  fun {a} => MM None emptyTM.
-
-Local Definition TrieMap__MaybeMap_foldTM {inst_m} `{TrieMap inst_m}
-   : forall {a} {b}, (a -> b -> b) -> (MaybeMap inst_m) a -> b -> b :=
-  fun {a} {b} => fdMaybe.
-
-Local Definition TrieMap__MaybeMap_lookupTM {inst_m} `{TrieMap inst_m}
-   : forall {b}, TrieMap__MaybeMap_Key -> (MaybeMap inst_m) b -> option b :=
-  fun {b} => lkMaybe (fun {b} => lookupTM).
-
-Local Definition TrieMap__MaybeMap_mapTM {inst_m} `{TrieMap inst_m}
-   : forall {a} {b}, (a -> b) -> (MaybeMap inst_m) a -> (MaybeMap inst_m) b :=
-  fun {a} {b} => mapMb.
-
-Program Instance TrieMap__MaybeMap {m} `{TrieMap m} : TrieMap (MaybeMap m) :=
-  {
-  Key := TrieMap__MaybeMap_Key ;
-  alterTM := fun {b} => TrieMap__MaybeMap_alterTM ;
-  emptyTM := fun {a} => TrieMap__MaybeMap_emptyTM ;
-  foldTM := fun {a} {b} => TrieMap__MaybeMap_foldTM ;
-  lookupTM := fun {b} => TrieMap__MaybeMap_lookupTM ;
-  mapTM := fun {a} {b} => TrieMap__MaybeMap_mapTM }.
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `TrieMap.Outputable__ListMap' *)
-
-Local Definition TrieMap__ListMap_Key {m} `{TrieMap m} : Type :=
-  list (Key m).
-
-Local Definition TrieMap__ListMap_alterTM {inst_m} `{TrieMap inst_m}
-   : forall {b},
-     TrieMap__ListMap_Key -> XT b -> (ListMap inst_m) b -> (ListMap inst_m) b :=
-  fun {b} => xtList (fun {b} => alterTM).
-
-Axiom TrieMap__ListMap_emptyTM : forall {m} {a} `{TrieMap m}, ListMap m a.
-
-Local Definition TrieMap__ListMap_foldTM {inst_m} `{TrieMap inst_m}
-   : forall {a} {b}, (a -> b -> b) -> (ListMap inst_m) a -> b -> b :=
-  fun {a} {b} => fdList.
-
-Local Definition TrieMap__ListMap_lookupTM {inst_m} `{TrieMap inst_m}
-   : forall {b}, TrieMap__ListMap_Key -> (ListMap inst_m) b -> option b :=
-  fun {b} => lkList (fun {b} => lookupTM).
-
-Local Definition TrieMap__ListMap_mapTM {inst_m} `{TrieMap inst_m}
-   : forall {a} {b}, (a -> b) -> (ListMap inst_m) a -> (ListMap inst_m) b :=
-  fun {a} {b} => mapList.
-
-Program Instance TrieMap__ListMap {m} `{TrieMap m} : TrieMap (ListMap m) :=
-  {
-  Key := TrieMap__ListMap_Key ;
-  alterTM := fun {b} => TrieMap__ListMap_alterTM ;
-  emptyTM := fun {a} => TrieMap__ListMap_emptyTM ;
-  foldTM := fun {a} {b} => TrieMap__ListMap_foldTM ;
-  lookupTM := fun {b} => TrieMap__ListMap_lookupTM ;
-  mapTM := fun {a} {b} => TrieMap__ListMap_mapTM }.
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `TrieMap.Outputable__GenMap' *)
-
-Instance TrieMap__TyLitMap : TrieMap TyLitMap.
-Proof.
-Admitted.
-
-Definition Eq___DeBruijn__list_op_zeze__ {a} `{GHC.Base.Eq_ (DeBruijn a)}
-  (dbl_xs dbl_ys : DeBruijn (list a))
-   : bool :=
-  match dbl_xs, dbl_ys with
-  | D env_xs xs0, D env_ys ys0 =>
-      let fix equal xs ys
-                := match xs, ys with
-                   | nil, nil => true
-                   | cons x xs', cons y ys' =>
-                       andb (D env_xs x GHC.Base.== D env_ys y) (equal xs' ys')
-                   | _, _ => false
-                   end in
-      equal xs0 ys0
-  end.
-
-Local Definition Eq___DeBruijn__list_op_zsze__ {inst_a} `{GHC.Base.Eq_ (DeBruijn
-                                                                        inst_a)}
-   : (DeBruijn (list inst_a)) -> (DeBruijn (list inst_a)) -> bool :=
-  fun x y => negb (Eq___DeBruijn__list_op_zeze__ x y).
-
-Program Instance Eq___DeBruijn__list {a} `{GHC.Base.Eq_ (DeBruijn a)}
-   : GHC.Base.Eq_ (DeBruijn (list a)) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___DeBruijn__list_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___DeBruijn__list_op_zsze__ |}.
-
-Local Definition Eq___DeBruijn__Coercion_op_zeze__
-   : (DeBruijn AxiomatizedTypes.Coercion) ->
-     (DeBruijn AxiomatizedTypes.Coercion) -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | D env1 co1, D env2 co2 =>
-        D env1 (Core.coercionType co1) GHC.Base.== D env2 (Core.coercionType co2)
-    end.
-
-Local Definition Eq___DeBruijn__Coercion_op_zsze__
-   : (DeBruijn AxiomatizedTypes.Coercion) ->
-     (DeBruijn AxiomatizedTypes.Coercion) -> bool :=
-  fun x y => negb (Eq___DeBruijn__Coercion_op_zeze__ x y).
-
-Program Instance Eq___DeBruijn__Coercion
-   : GHC.Base.Eq_ (DeBruijn AxiomatizedTypes.Coercion) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___DeBruijn__Coercion_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___DeBruijn__Coercion_op_zsze__ |}.
-
-Instance Eq___DeBruijn__CoreAlt : GHC.Base.Eq_ (DeBruijn Core.CoreAlt).
-Proof.
-Admitted.
-
-Local Definition TrieMap__VarMap_Key : Type :=
-  Core.Var.
-
-Local Definition TrieMap__VarMap_alterTM
-   : forall {b}, TrieMap__VarMap_Key -> XT b -> VarMap b -> VarMap b :=
-  fun {b} => xtVar emptyCME.
-
-Local Definition TrieMap__VarMap_emptyTM : forall {a}, VarMap a :=
-  fun {a} => VM IntMap.empty Core.emptyDVarEnv.
-
-Local Definition TrieMap__VarMap_foldTM
-   : forall {a} {b}, (a -> b -> b) -> VarMap a -> b -> b :=
-  fun {a} {b} => fdVar.
-
-Local Definition TrieMap__VarMap_lookupTM
-   : forall {b}, TrieMap__VarMap_Key -> VarMap b -> option b :=
-  fun {b} => lkVar emptyCME.
-
-Local Definition TrieMap__VarMap_mapTM
-   : forall {a} {b}, (a -> b) -> VarMap a -> VarMap b :=
-  fun {a} {b} => mapVar.
-
-Program Instance TrieMap__VarMap : TrieMap VarMap :=
-  {
-  Key := TrieMap__VarMap_Key ;
-  alterTM := fun {b} => TrieMap__VarMap_alterTM ;
-  emptyTM := fun {a} => TrieMap__VarMap_emptyTM ;
-  foldTM := fun {a} {b} => TrieMap__VarMap_foldTM ;
-  lookupTM := fun {b} => TrieMap__VarMap_lookupTM ;
-  mapTM := fun {a} {b} => TrieMap__VarMap_mapTM }.
-
-(* Skipping all instances of class `Outputable.Outputable', including
-   `TrieMap.Outputable__TypeMapG' *)
-
 Local Definition TrieMap__LooseTypeMap_Key : Type :=
   AxiomatizedTypes.Type_.
 
@@ -998,135 +943,190 @@ Program Instance TrieMap__LooseTypeMap : TrieMap LooseTypeMap :=
   lookupTM := fun {b} => TrieMap__LooseTypeMap_lookupTM ;
   mapTM := fun {a} {b} => TrieMap__LooseTypeMap_mapTM }.
 
-Local Definition TrieMap__CoercionMapX_Key : Type :=
-  DeBruijn AxiomatizedTypes.Coercion.
+Definition Eq___DeBruijn__list_op_zeze__ {a} `{GHC.Base.Eq_ (DeBruijn a)}
+  (dbl_xs dbl_ys : DeBruijn (list a))
+   : bool :=
+  match dbl_xs, dbl_ys with
+  | D env_xs xs0, D env_ys ys0 =>
+      let fix equal xs ys
+                := match xs, ys with
+                   | nil, nil => true
+                   | cons x xs', cons y ys' =>
+                       andb (D env_xs x GHC.Base.== D env_ys y) (equal xs' ys')
+                   | _, _ => false
+                   end in
+      equal xs0 ys0
+  end.
 
-Local Definition TrieMap__CoercionMapX_alterTM
-   : forall {b},
-     TrieMap__CoercionMapX_Key -> XT b -> CoercionMapX b -> CoercionMapX b :=
-  fun {b} => xtC.
+Local Definition Eq___DeBruijn__list_op_zsze__ {inst_a} `{GHC.Base.Eq_ (DeBruijn
+                                                                        inst_a)}
+   : (DeBruijn (list inst_a)) -> (DeBruijn (list inst_a)) -> bool :=
+  fun x y => negb (Eq___DeBruijn__list_op_zeze__ x y).
 
-Local Definition TrieMap__CoercionMapX_emptyTM : forall {a}, CoercionMapX a :=
-  fun {a} => Mk_CoercionMapX emptyTM.
+Program Instance Eq___DeBruijn__list {a} `{GHC.Base.Eq_ (DeBruijn a)}
+   : GHC.Base.Eq_ (DeBruijn (list a)) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___DeBruijn__list_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___DeBruijn__list_op_zsze__ |}.
 
-Local Definition TrieMap__CoercionMapX_foldTM
-   : forall {a} {b}, (a -> b -> b) -> CoercionMapX a -> b -> b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, Mk_CoercionMapX core_tm => foldTM f core_tm
-      end.
+Local Definition TrieMap__VarMap_Key : Type :=
+  Core.Var.
 
-Local Definition TrieMap__CoercionMapX_lookupTM
-   : forall {b}, TrieMap__CoercionMapX_Key -> CoercionMapX b -> option b :=
-  fun {b} => lkC.
+Definition lookupCME : CmEnv -> Core.Var -> option BoundVar :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | CME _ env, v => Core.lookupVarEnv env v
+    end.
 
-Local Definition TrieMap__CoercionMapX_mapTM
-   : forall {a} {b}, (a -> b) -> CoercionMapX a -> CoercionMapX b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, Mk_CoercionMapX core_tm => Mk_CoercionMapX (mapTM f core_tm)
-      end.
+Definition xtDFreeVar {a}
+   : Core.Var -> XT a -> Core.DVarEnv a -> Core.DVarEnv a :=
+  fun v f m => Core.alterDVarEnv f m v.
 
-Program Instance TrieMap__CoercionMapX : TrieMap CoercionMapX :=
+Definition xtVar {a} : CmEnv -> Core.Var -> XT a -> VarMap a -> VarMap a :=
+  fun env v f m =>
+    match lookupCME env v with
+    | Some bv =>
+        let 'VM vm_bvar_0__ vm_fvar_1__ := m in
+        VM (vm_bvar m |> alterTM (m := BoundVarMap) bv f) vm_fvar_1__
+    | _ =>
+        let 'VM vm_bvar_4__ vm_fvar_5__ := m in
+        VM vm_bvar_4__ (vm_fvar m |> xtDFreeVar v f)
+    end.
+
+Local Definition TrieMap__VarMap_alterTM
+   : forall {b}, TrieMap__VarMap_Key -> XT b -> VarMap b -> VarMap b :=
+  fun {b} => xtVar emptyCME.
+
+Local Definition TrieMap__VarMap_emptyTM : forall {a}, VarMap a :=
+  fun {a} => VM IntMap.empty Core.emptyDVarEnv.
+
+Definition fdVar {a} {b} : (a -> b -> b) -> VarMap a -> b -> b :=
+  fun k m => foldTM k (vm_bvar m) GHC.Base.∘ foldTM k (vm_fvar m).
+
+Local Definition TrieMap__VarMap_foldTM
+   : forall {a} {b}, (a -> b -> b) -> VarMap a -> b -> b :=
+  fun {a} {b} => fdVar.
+
+Definition lkDFreeVar {a} : Core.Var -> Core.DVarEnv a -> option a :=
+  fun var env => Core.lookupDVarEnv env var.
+
+Definition lkVar {a} : CmEnv -> Core.Var -> VarMap a -> option a :=
+  fun env v =>
+    match lookupCME env v with
+    | Some bv => vm_bvar >.> lookupTM (m := BoundVarMap) bv
+    | _ => vm_fvar >.> lkDFreeVar v
+    end.
+
+Local Definition TrieMap__VarMap_lookupTM
+   : forall {b}, TrieMap__VarMap_Key -> VarMap b -> option b :=
+  fun {b} => lkVar emptyCME.
+
+Definition mapVar {a} {b} : (a -> b) -> VarMap a -> VarMap b :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, VM bv fv => VM (mapTM f bv) (mapTM f fv)
+    end.
+
+Local Definition TrieMap__VarMap_mapTM
+   : forall {a} {b}, (a -> b) -> VarMap a -> VarMap b :=
+  fun {a} {b} => mapVar.
+
+Program Instance TrieMap__VarMap : TrieMap VarMap :=
   {
-  Key := TrieMap__CoercionMapX_Key ;
-  alterTM := fun {b} => TrieMap__CoercionMapX_alterTM ;
-  emptyTM := fun {a} => TrieMap__CoercionMapX_emptyTM ;
-  foldTM := fun {a} {b} => TrieMap__CoercionMapX_foldTM ;
-  lookupTM := fun {b} => TrieMap__CoercionMapX_lookupTM ;
-  mapTM := fun {a} {b} => TrieMap__CoercionMapX_mapTM }.
+  Key := TrieMap__VarMap_Key ;
+  alterTM := fun {b} => TrieMap__VarMap_alterTM ;
+  emptyTM := fun {a} => TrieMap__VarMap_emptyTM ;
+  foldTM := fun {a} {b} => TrieMap__VarMap_foldTM ;
+  lookupTM := fun {b} => TrieMap__VarMap_lookupTM ;
+  mapTM := fun {a} {b} => TrieMap__VarMap_mapTM }.
 
-Local Definition TrieMap__CoercionMap_Key : Type :=
-  AxiomatizedTypes.Coercion.
+Definition insertTM {m} {a} `{TrieMap m} : Key m -> a -> m a -> m a :=
+  fun k v m => alterTM k (fun arg_0__ => Some v) m.
 
-Instance TrieMap__CoercionMapG : TrieMap CoercionMapG := TrieMap__GenMap.
+Definition deleteTM {m} {a} `{TrieMap m} : Key m -> m a -> m a :=
+  fun k m => alterTM k (fun arg_0__ => None) m.
 
-Local Definition TrieMap__CoercionMap_alterTM
-   : forall {b},
-     TrieMap__CoercionMap_Key -> XT b -> CoercionMap b -> CoercionMap b :=
-  fun {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | k, f, Mk_CoercionMap m => Mk_CoercionMap (alterTM (deBruijnize k) f m)
-      end.
+Definition lkDNamed {n} {a} `{Name.NamedThing n}
+   : n -> NameEnv.DNameEnv a -> option a :=
+  fun n env => NameEnv.lookupDNameEnv env (Name.getName n).
 
-Local Definition TrieMap__CoercionMap_emptyTM : forall {a}, CoercionMap a :=
-  fun {a} => Mk_CoercionMap emptyTM.
+Definition lkLit {a} : Literal.Literal -> LiteralMap a -> option a :=
+  lookupTM (m := LiteralMap).
 
-Local Definition TrieMap__CoercionMap_foldTM
-   : forall {a} {b}, (a -> b -> b) -> CoercionMap a -> b -> b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | k, Mk_CoercionMap m => foldTM k m
-      end.
+Definition lookupCoreMap {a} : CoreMap a -> Core.CoreExpr -> option a :=
+  fun cm e => lookupTM (m := CoreMap) e cm.
 
-Local Definition TrieMap__CoercionMap_lookupTM
-   : forall {b}, TrieMap__CoercionMap_Key -> CoercionMap b -> option b :=
-  fun {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | k, Mk_CoercionMap m => lookupTM (deBruijnize k) m
-      end.
+Definition extendCoreMap {a} : CoreMap a -> Core.CoreExpr -> a -> CoreMap a :=
+  fun m e v => alterTM (m := CoreMap) e (fun arg_0__ => Some v) m.
 
-Local Definition TrieMap__CoercionMap_mapTM
-   : forall {a} {b}, (a -> b) -> CoercionMap a -> CoercionMap b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, Mk_CoercionMap m => Mk_CoercionMap (mapTM f m)
-      end.
+Definition foldCoreMap {a} {b} : (a -> b -> b) -> b -> CoreMap a -> b :=
+  fun k z m => foldTM k m z.
 
-Program Instance TrieMap__CoercionMap : TrieMap CoercionMap :=
-  {
-  Key := TrieMap__CoercionMap_Key ;
-  alterTM := fun {b} => TrieMap__CoercionMap_alterTM ;
-  emptyTM := fun {a} => TrieMap__CoercionMap_emptyTM ;
-  foldTM := fun {a} {b} => TrieMap__CoercionMap_foldTM ;
-  lookupTM := fun {b} => TrieMap__CoercionMap_lookupTM ;
-  mapTM := fun {a} {b} => TrieMap__CoercionMap_mapTM }.
+Definition emptyCoreMap {a} : CoreMap a :=
+  emptyTM.
 
-Local Definition TrieMap__AltMap_Key : Type :=
-  Core.CoreAlt.
+Definition lkTickish {a} : Core.Tickish Core.Id -> TickishMap a -> option a :=
+  lookupTM (m := TickishMap).
 
-Local Definition TrieMap__AltMap_alterTM
-   : forall {b}, TrieMap__AltMap_Key -> XT b -> AltMap b -> AltMap b :=
-  fun {b} => xtA emptyCME.
+Definition xtTickish {a}
+   : Core.Tickish Core.Id -> XT a -> TickishMap a -> TickishMap a :=
+  alterTM (m := TickishMap).
 
-Local Definition TrieMap__AltMap_emptyTM : forall {a}, AltMap a :=
-  fun {a} => AM emptyTM NameEnv.emptyDNameEnv emptyLiteralMap.
+Axiom trieMapView : AxiomatizedTypes.Type_ -> option AxiomatizedTypes.Type_.
 
-Local Definition TrieMap__AltMap_foldTM
-   : forall {a} {b}, (a -> b -> b) -> AltMap a -> b -> b :=
-  fun {a} {b} => fdA.
+Definition emptyTyLitMap {a} : TyLitMap a :=
+  TLM Data.Map.Internal.empty Data.Map.Internal.empty.
 
-Local Definition TrieMap__AltMap_lookupTM
-   : forall {b}, TrieMap__AltMap_Key -> AltMap b -> option b :=
-  fun {b} => lkA emptyCME.
+Definition mapTyLit {a} {b} : (a -> b) -> TyLitMap a -> TyLitMap b :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, TLM tn ts => TLM (Data.Map.Internal.map f tn) (Data.Map.Internal.map f ts)
+    end.
 
-Local Definition TrieMap__AltMap_mapTM
-   : forall {a} {b}, (a -> b) -> AltMap a -> AltMap b :=
-  fun {a} {b} => mapA.
+(* Skipping definition `TrieMap.lkTyLit' *)
 
-Program Instance TrieMap__AltMap : TrieMap AltMap :=
-  {
-  Key := TrieMap__AltMap_Key ;
-  alterTM := fun {b} => TrieMap__AltMap_alterTM ;
-  emptyTM := fun {a} => TrieMap__AltMap_emptyTM ;
-  foldTM := fun {a} {b} => TrieMap__AltMap_foldTM ;
-  lookupTM := fun {b} => TrieMap__AltMap_lookupTM ;
-  mapTM := fun {a} {b} => TrieMap__AltMap_mapTM }.
+(* Skipping definition `TrieMap.xtTyLit' *)
 
-(* Skipping all instances of class `Outputable.Outputable', including
-   `TrieMap.Outputable__CoreMap' *)
+Definition foldTyLit {a} {b} : (a -> b -> b) -> TyLitMap a -> b -> b :=
+  fun l m =>
+    GHC.Base.flip (Data.Map.Internal.foldr l) (tlm_string m) GHC.Base.∘
+    GHC.Base.flip (Data.Map.Internal.foldr l) (tlm_number m).
+
+Definition foldTypeMap {a} {b} : (a -> b -> b) -> b -> TypeMap a -> b :=
+  fun k z m => foldTM k m z.
+
+Definition emptyTypeMap {a} : TypeMap a :=
+  emptyTM.
+
+Definition lookupTypeMap {a}
+   : TypeMap a -> AxiomatizedTypes.Type_ -> option a :=
+  fun cm t => lookupTM (m := TypeMap) t cm.
+
+Definition extendTypeMap {a}
+   : TypeMap a -> AxiomatizedTypes.Type_ -> a -> TypeMap a :=
+  fun m t v => alterTM (m := TypeMap) t (GHC.Base.const (Some v)) m.
+
+Definition lookupTypeMapWithScope {a}
+   : TypeMap a -> CmEnv -> AxiomatizedTypes.Type_ -> option a :=
+  fun m cm t => lkTT (D cm t) m.
+
+Definition extendTypeMapWithScope {a}
+   : TypeMap a -> CmEnv -> AxiomatizedTypes.Type_ -> a -> TypeMap a :=
+  fun m cm t v => xtTT (D cm t) (GHC.Base.const (Some v)) m.
+
+Definition mkDeBruijnContext : list Core.Var -> CmEnv :=
+  extendCMEs emptyCME.
+
+Axiom lkBndr : forall {a}, CmEnv -> Core.Var -> BndrMap a -> option a.
+
+Definition xtBndr {a} : CmEnv -> Core.Var -> XT a -> BndrMap a -> BndrMap a :=
+  fun env v f => xtG (m := TypeMapX) (D env (Core.varType v)) f.
 
 Module Notations.
-Notation "'_TrieMap.>.>_'" := (op_zgzizg__).
-Infix "TrieMap.>.>" := (_>.>_) (at level 99).
 Notation "'_TrieMap.|>_'" := (op_zbzg__).
 Infix "TrieMap.|>" := (_|>_) (at level 99).
+Notation "'_TrieMap.>.>_'" := (op_zgzizg__).
+Infix "TrieMap.>.>" := (_>.>_) (at level 99).
 Notation "'_TrieMap.|>>_'" := (op_zbzgzg__).
 Infix "TrieMap.|>>" := (_|>>_) (at level 99).
 End Notations.

--- a/examples/ghc/lib/TysWiredIn.v
+++ b/examples/ghc/lib/TysWiredIn.v
@@ -29,168 +29,157 @@ Require Unique.
 
 (* Converted value declarations: *)
 
-Axiom wordTyConName : Name.Name.
+Axiom alpha_tyvar : list Core.TyVar.
 
-Axiom wordTyCon : Core.TyCon.
-
-Axiom wordTy : AxiomatizedTypes.Type_.
-
-Axiom wordDataConName : Name.Name.
-
-Axiom wordDataCon : Core.DataCon.
-
-Axiom word8TyConName : Name.Name.
-
-Axiom word8TyCon : Core.TyCon.
-
-Axiom word8Ty : AxiomatizedTypes.Type_.
-
-Axiom word8DataConName : Name.Name.
-
-Axiom word8DataCon : Core.DataCon.
+Axiom alpha_ty : list AxiomatizedTypes.Type_.
 
 Axiom wiredInTyCons : list Core.TyCon.
 
-Axiom vecRepDataConTyCon : Core.TyCon.
+Axiom mkWiredInTyConName : Name.BuiltInSyntax ->
+                           Module.Module ->
+                           FastString.FastString -> Unique.Unique -> Core.TyCon -> Name.Name.
 
-Axiom vecRepDataConName : Name.Name.
+Axiom mkWiredInDataConName : Name.BuiltInSyntax ->
+                             Module.Module ->
+                             FastString.FastString -> Unique.Unique -> Core.DataCon -> Name.Name.
 
-Axiom vecRepDataCon : Core.DataCon.
+Axiom mkWiredInIdName : Module.Module ->
+                        FastString.FastString -> Unique.Unique -> Core.Id -> Name.Name.
 
-Axiom vecElemTyConName : Name.Name.
+Axiom heqTyConName : Name.Name.
 
-Axiom vecElemTyCon : Core.TyCon.
+Axiom heqDataConName : Name.Name.
 
-Axiom vecElemDataCons : list Core.DataCon.
+Axiom heqSCSelIdName : Name.Name.
 
-Axiom vecElemDataConNames : list Name.Name.
+Axiom coercibleTyConName : Name.Name.
 
-Axiom vecCountTyConName : Name.Name.
+Axiom coercibleDataConName : Name.Name.
 
-Axiom vecCountTyCon : Core.TyCon.
+Axiom coercibleSCSelIdName : Name.Name.
 
-Axiom vecCountDataCons : list Core.DataCon.
+Axiom charTyConName : Name.Name.
 
-Axiom vecCountDataConNames : list Name.Name.
+Axiom charDataConName : Name.Name.
 
-Axiom unitTyConKey : Unique.Unique.
+Axiom intTyConName : Name.Name.
 
-Axiom unitTyCon : Core.TyCon.
+Axiom intDataConName : Name.Name.
 
-Axiom unitTy : AxiomatizedTypes.Type_.
+Axiom boolTyConName : Name.Name.
 
-Axiom unitDataConId : Core.Id.
-
-Axiom unitDataCon : Core.DataCon.
-
-Axiom unicodeStarKindTyConName : Name.Name.
-
-Axiom unicodeStarKindTyCon : Core.TyCon.
-
-Axiom unboxedUnitTyCon : Core.TyCon.
-
-Axiom unboxedUnitDataCon : Core.DataCon.
-
-Axiom unboxedTupleSumKind : Core.TyCon ->
-                            list AxiomatizedTypes.Type_ -> AxiomatizedTypes.Kind.
-
-Axiom unboxedTupleKind : list AxiomatizedTypes.Type_ -> AxiomatizedTypes.Kind.
-
-(* Skipping definition `TysWiredIn.unboxedTupleArr' *)
-
-Axiom unboxedSumKind : list AxiomatizedTypes.Type_ -> AxiomatizedTypes.Kind.
-
-(* Skipping definition `TysWiredIn.unboxedSumArr' *)
-
-Axiom typeSymbolKindConName : Name.Name.
-
-Axiom typeSymbolKindCon : Core.TyCon.
-
-Axiom typeSymbolKind : AxiomatizedTypes.Kind.
-
-Axiom typeNatKindConName : Name.Name.
-
-Axiom typeNatKindCon : Core.TyCon.
-
-Axiom typeNatKind : AxiomatizedTypes.Kind.
-
-Axiom tupleTyConName : BasicTypes.TupleSort -> BasicTypes.Arity -> Name.Name.
-
-Axiom tupleTyCon : BasicTypes.Boxity -> BasicTypes.Arity -> Core.TyCon.
-
-Axiom tupleRepDataConTyCon : Core.TyCon.
-
-Axiom tupleRepDataConName : Name.Name.
-
-Axiom tupleRepDataCon : Core.DataCon.
-
-Axiom tupleDataCon : BasicTypes.Boxity -> BasicTypes.Arity -> Core.DataCon.
-
-Axiom true_RDR : PrelNames.RdrName.
+Axiom falseDataConName : Name.Name.
 
 Axiom trueDataConName : Name.Name.
 
-Axiom trueDataConId : Core.Id.
+Axiom listTyConName : Name.Name.
 
-Axiom trueDataCon : Core.DataCon.
+Axiom nilDataConName : Name.Name.
 
-Axiom sumTyCon : BasicTypes.Arity -> Core.TyCon.
+Axiom consDataConName : Name.Name.
 
-Axiom sumRepDataConTyCon : Core.TyCon.
+Axiom maybeTyConName : Name.Name.
 
-Axiom sumRepDataConName : Name.Name.
+Axiom nothingDataConName : Name.Name.
 
-Axiom sumRepDataCon : Core.DataCon.
+Axiom justDataConName : Name.Name.
 
-Axiom sumDataCon : BasicTypes.ConTag -> BasicTypes.Arity -> Core.DataCon.
+Axiom wordTyConName : Name.Name.
 
-Axiom stringTy : AxiomatizedTypes.Type_.
+Axiom wordDataConName : Name.Name.
+
+Axiom word8TyConName : Name.Name.
+
+Axiom word8DataConName : Name.Name.
+
+Axiom floatTyConName : Name.Name.
+
+Axiom floatDataConName : Name.Name.
+
+Axiom doubleTyConName : Name.Name.
+
+Axiom doubleDataConName : Name.Name.
+
+Axiom anyTyConName : Name.Name.
+
+Axiom anyTyCon : Core.TyCon.
+
+Axiom anyTy : AxiomatizedTypes.Type_.
+
+Axiom anyTypeOfKind : AxiomatizedTypes.Kind -> AxiomatizedTypes.Type_.
+
+Axiom typeNatKindConName : Name.Name.
+
+Axiom typeSymbolKindConName : Name.Name.
+
+Axiom constraintKindTyConName : Name.Name.
+
+Axiom liftedTypeKindTyConName : Name.Name.
 
 Axiom starKindTyConName : Name.Name.
 
-Axiom starKindTyCon : Core.TyCon.
+Axiom unicodeStarKindTyConName : Name.Name.
 
 Axiom runtimeRepTyConName : Name.Name.
 
-Axiom runtimeRepTyCon : Core.TyCon.
+Axiom vecRepDataConName : Name.Name.
 
-Axiom runtimeRepTy : AxiomatizedTypes.Type_.
+Axiom tupleRepDataConName : Name.Name.
+
+Axiom sumRepDataConName : Name.Name.
 
 Axiom runtimeRepSimpleDataConNames : list Name.Name.
 
-Axiom promotedTupleDataCon : BasicTypes.Boxity ->
-                             BasicTypes.Arity -> Core.TyCon.
+Axiom vecCountTyConName : Name.Name.
 
-Axiom promotedTrueDataCon : Core.TyCon.
+Axiom vecCountDataConNames : list Name.Name.
 
-Axiom promotedNothingDataCon : Core.TyCon.
+Axiom vecElemTyConName : Name.Name.
 
-Axiom promotedNilDataCon : Core.TyCon.
+Axiom vecElemDataConNames : list Name.Name.
 
-Axiom promotedLTDataCon : Core.TyCon.
+Axiom mk_special_dc_name : FastString.FastString ->
+                           Unique.Unique -> Core.DataCon -> Name.Name.
 
-Axiom promotedJustDataCon : Core.TyCon.
+Axiom parrTyConName : Name.Name.
 
-Axiom promotedGTDataCon : Core.TyCon.
+Axiom parrDataConName : Name.Name.
 
-Axiom promotedFalseDataCon : Core.TyCon.
+Axiom boolTyCon_RDR : PrelNames.RdrName.
 
-Axiom promotedEQDataCon : Core.TyCon.
+Axiom false_RDR : PrelNames.RdrName.
 
-Axiom promotedConsDataCon : Core.TyCon.
+Axiom true_RDR : PrelNames.RdrName.
+
+Axiom intTyCon_RDR : PrelNames.RdrName.
+
+Axiom charTyCon_RDR : PrelNames.RdrName.
+
+Axiom intDataCon_RDR : PrelNames.RdrName.
+
+Axiom listTyCon_RDR : PrelNames.RdrName.
+
+Axiom consDataCon_RDR : PrelNames.RdrName.
+
+Axiom parrTyCon_RDR : PrelNames.RdrName.
+
+Axiom pcNonEnumTyCon : Name.Name ->
+                       option AxiomatizedTypes.CType ->
+                       list Core.TyVar -> list Core.DataCon -> Core.TyCon.
 
 Axiom pcTyCon : bool ->
                 Name.Name ->
                 option AxiomatizedTypes.CType ->
                 list Core.TyVar -> list Core.DataCon -> Core.TyCon.
 
-Axiom pcSpecialDataCon : Name.Name ->
-                         list AxiomatizedTypes.Type_ ->
-                         Core.TyCon -> Core.RuntimeRepInfo -> Core.DataCon.
+Axiom pcDataCon : Name.Name ->
+                  list Core.TyVar -> list AxiomatizedTypes.Type_ -> Core.TyCon -> Core.DataCon.
 
-Axiom pcNonEnumTyCon : Name.Name ->
-                       option AxiomatizedTypes.CType ->
-                       list Core.TyVar -> list Core.DataCon -> Core.TyCon.
+Axiom pcDataConWithFixity : bool ->
+                            Name.Name ->
+                            list Core.TyVar ->
+                            list Core.TyVar ->
+                            list Core.TyVar -> list AxiomatizedTypes.Type_ -> Core.TyCon -> Core.DataCon.
 
 Axiom pcDataConWithFixity' : bool ->
                              Name.Name ->
@@ -200,85 +189,25 @@ Axiom pcDataConWithFixity' : bool ->
                              list Core.TyVar ->
                              list Core.TyVar -> list AxiomatizedTypes.Type_ -> Core.TyCon -> Core.DataCon.
 
-Axiom pcDataConWithFixity : bool ->
-                            Name.Name ->
-                            list Core.TyVar ->
-                            list Core.TyVar ->
-                            list Core.TyVar -> list AxiomatizedTypes.Type_ -> Core.TyCon -> Core.DataCon.
+Axiom mkDataConWorkerName : Core.DataCon -> Unique.Unique -> Name.Name.
 
-Axiom pcDataCon : Name.Name ->
-                  list Core.TyVar -> list AxiomatizedTypes.Type_ -> Core.TyCon -> Core.DataCon.
+Axiom pcSpecialDataCon : Name.Name ->
+                         list AxiomatizedTypes.Type_ ->
+                         Core.TyCon -> Core.RuntimeRepInfo -> Core.DataCon.
 
-Axiom parrTyCon_RDR : PrelNames.RdrName.
+Axiom typeNatKindCon : Core.TyCon.
 
-Axiom parrTyConName : Name.Name.
+Axiom typeSymbolKindCon : Core.TyCon.
 
-Axiom parrTyCon : Core.TyCon.
+Axiom typeNatKind : AxiomatizedTypes.Kind.
 
-(* Skipping definition `TysWiredIn.parrFakeConArr' *)
+Axiom typeSymbolKind : AxiomatizedTypes.Kind.
 
-Axiom parrFakeCon : BasicTypes.Arity -> Core.DataCon.
+Axiom constraintKindTyCon : Core.TyCon.
 
-Axiom parrDataConName : Name.Name.
+(* Skipping definition `AxiomatizedTypes.liftedTypeKind' *)
 
-Axiom parrDataCon : Core.DataCon.
-
-Axiom pairTyCon : Core.TyCon.
-
-Axiom orderingTyCon : Core.TyCon.
-
-Axiom nothingDataConName : Name.Name.
-
-Axiom nothingDataCon : Core.DataCon.
-
-Axiom nilDataConName : Name.Name.
-
-Axiom nilDataCon : Core.DataCon.
-
-Axiom mk_tuple : BasicTypes.Boxity -> nat -> (Core.TyCon * Core.DataCon)%type.
-
-(* Skipping definition `TysWiredIn.mk_sum' *)
-
-Axiom mk_special_dc_name : FastString.FastString ->
-                           Unique.Unique -> Core.DataCon -> Name.Name.
-
-Axiom mk_class : Core.TyCon ->
-                 AxiomatizedTypes.PredType -> Core.Id -> Core.Class.
-
-Axiom mkWiredInTyConName : Name.BuiltInSyntax ->
-                           Module.Module ->
-                           FastString.FastString -> Unique.Unique -> Core.TyCon -> Name.Name.
-
-Axiom mkWiredInIdName : Module.Module ->
-                        FastString.FastString -> Unique.Unique -> Core.Id -> Name.Name.
-
-Axiom mkWiredInDataConName : Name.BuiltInSyntax ->
-                             Module.Module ->
-                             FastString.FastString -> Unique.Unique -> Core.DataCon -> Name.Name.
-
-Axiom mkUnboxedTupleStr : BasicTypes.Arity -> GHC.Base.String.
-
-Axiom mkTupleTy : BasicTypes.Boxity ->
-                  list AxiomatizedTypes.Type_ -> AxiomatizedTypes.Type_.
-
-Axiom mkTupleOcc : OccName.NameSpace ->
-                   BasicTypes.Boxity -> BasicTypes.Arity -> OccName.OccName.
-
-Axiom mkSumTyConOcc : BasicTypes.Arity -> OccName.OccName.
-
-Axiom mkSumTy : list AxiomatizedTypes.Type_ -> AxiomatizedTypes.Type_.
-
-Axiom mkSumDataConOcc : BasicTypes.ConTag ->
-                        BasicTypes.Arity -> OccName.OccName.
-
-Axiom mkPromotedListTy : AxiomatizedTypes.Kind ->
-                         list AxiomatizedTypes.Type_ -> AxiomatizedTypes.Type_.
-
-Axiom mkPArrTy : AxiomatizedTypes.Type_ -> AxiomatizedTypes.Type_.
-
-Axiom mkPArrFakeCon : nat -> Core.DataCon.
-
-Axiom mkListTy : AxiomatizedTypes.Type_ -> AxiomatizedTypes.Type_.
+(* Skipping definition `AxiomatizedTypes.constraintKind' *)
 
 Axiom mkFunKind : AxiomatizedTypes.Kind ->
                   AxiomatizedTypes.Kind -> AxiomatizedTypes.Kind.
@@ -286,178 +215,249 @@ Axiom mkFunKind : AxiomatizedTypes.Kind ->
 Axiom mkForAllKind : Core.TyVar ->
                      Core.ArgFlag -> AxiomatizedTypes.Kind -> AxiomatizedTypes.Kind.
 
-Axiom mkDataConWorkerName : Core.DataCon -> Unique.Unique -> Name.Name.
+Axiom isBuiltInOcc_maybe : OccName.OccName -> option Name.Name.
 
-Axiom mkConstraintTupleStr : BasicTypes.Arity -> GHC.Base.String.
+Axiom mkTupleOcc : OccName.NameSpace ->
+                   BasicTypes.Boxity -> BasicTypes.Arity -> OccName.OccName.
 
 Axiom mkCTupleOcc : OccName.NameSpace -> BasicTypes.Arity -> OccName.OccName.
 
-Axiom mkBoxedTupleTy : list AxiomatizedTypes.Type_ -> AxiomatizedTypes.Type_.
-
 Axiom mkBoxedTupleStr : BasicTypes.Arity -> GHC.Base.String.
 
-Axiom maybeTyConName : Name.Name.
+Axiom mkUnboxedTupleStr : BasicTypes.Arity -> GHC.Base.String.
 
-Axiom maybeTyCon : Core.TyCon.
-
-Axiom ltDataConId : Core.Id.
-
-Axiom ltDataCon : Core.DataCon.
-
-Axiom listTyCon_RDR : PrelNames.RdrName.
-
-Axiom listTyConName : Name.Name.
-
-Axiom listTyCon : Core.TyCon.
-
-Axiom liftedTypeKindTyConName : Name.Name.
-
-Axiom liftedTypeKindTyCon : Core.TyCon.
-
-Axiom liftedRepTy : AxiomatizedTypes.Type_.
-
-Axiom liftedRepDataConTyCon : Core.TyCon.
-
-Axiom justDataConName : Name.Name.
-
-Axiom justDataCon : Core.DataCon.
-
-Axiom isPArrTyCon : Core.TyCon -> bool.
-
-Axiom isPArrFakeCon : Core.DataCon -> bool.
-
-Axiom isCTupleTyConName : Name.Name -> bool.
-
-Axiom isBuiltInOcc_maybe : OccName.OccName -> option Name.Name.
-
-Axiom intTyCon_RDR : PrelNames.RdrName.
-
-Axiom intTyConName : Name.Name.
-
-Axiom intTyCon : Core.TyCon.
-
-Axiom intTy : AxiomatizedTypes.Type_.
-
-Axiom intDataCon_RDR : PrelNames.RdrName.
-
-Axiom intDataConName : Name.Name.
-
-Axiom intDataCon : Core.DataCon.
-
-Axiom heqTyConName : Name.Name.
-
-Axiom heqSCSelIdName : Name.Name.
-
-Axiom heqDataConName : Name.Name.
-
-Axiom gtDataConId : Core.Id.
-
-Axiom gtDataCon : Core.DataCon.
-
-Axiom floatTyConName : Name.Name.
-
-Axiom floatTyCon : Core.TyCon.
-
-Axiom floatTy : AxiomatizedTypes.Type_.
-
-Axiom floatDataConName : Name.Name.
-
-Axiom floatDataCon : Core.DataCon.
-
-Axiom false_RDR : PrelNames.RdrName.
-
-Axiom falseDataConName : Name.Name.
-
-Axiom falseDataConId : Core.Id.
-
-Axiom falseDataCon : Core.DataCon.
-
-Axiom extractPromotedList : AxiomatizedTypes.Type_ ->
-                            list AxiomatizedTypes.Type_.
-
-Axiom eqDataConId : Core.Id.
-
-Axiom eqDataCon : Core.DataCon.
-
-Axiom doubleTyConName : Name.Name.
-
-Axiom doubleTyCon : Core.TyCon.
-
-Axiom doubleTy : AxiomatizedTypes.Type_.
-
-Axiom doubleDataConName : Name.Name.
-
-Axiom doubleDataCon : Core.DataCon.
-
-Axiom constraintKindTyConName : Name.Name.
-
-Axiom constraintKindTyCon : Core.TyCon.
-
-Axiom consDataCon_RDR : PrelNames.RdrName.
-
-Axiom consDataConName : Name.Name.
-
-Axiom consDataCon : Core.DataCon.
+Axiom mkConstraintTupleStr : BasicTypes.Arity -> GHC.Base.String.
 
 Axiom commas : BasicTypes.Arity -> GHC.Base.String.
 
-Axiom coercibleTyConName : Name.Name.
-
-Axiom coercibleSCSelIdName : Name.Name.
-
-Axiom coercibleDataConName : Name.Name.
-
-Axiom charTyCon_RDR : PrelNames.RdrName.
-
-Axiom charTyConName : Name.Name.
-
-Axiom charTyCon : Core.TyCon.
-
-Axiom charTy : AxiomatizedTypes.Type_.
-
-Axiom charDataConName : Name.Name.
-
-Axiom charDataCon : Core.DataCon.
+Axiom cTupleTyConName : BasicTypes.Arity -> Name.Name.
 
 Axiom cTupleTyConNames : list Name.Name.
 
 Axiom cTupleTyConNameSet : NameSet.NameSet.
 
-Axiom cTupleTyConName : BasicTypes.Arity -> Name.Name.
-
-Axiom cTupleDataConNames : list Name.Name.
+Axiom isCTupleTyConName : Name.Name -> bool.
 
 Axiom cTupleDataConName : BasicTypes.Arity -> Name.Name.
 
-Axiom boxing_constr_env : NameEnv.NameEnv Core.DataCon.
+Axiom cTupleDataConNames : list Name.Name.
 
-Axiom boxingDataCon_maybe : Core.TyCon -> option Core.DataCon.
+Axiom tupleTyCon : BasicTypes.Boxity -> BasicTypes.Arity -> Core.TyCon.
+
+Axiom tupleTyConName : BasicTypes.TupleSort -> BasicTypes.Arity -> Name.Name.
+
+Axiom promotedTupleDataCon : BasicTypes.Boxity ->
+                             BasicTypes.Arity -> Core.TyCon.
+
+Axiom tupleDataCon : BasicTypes.Boxity -> BasicTypes.Arity -> Core.DataCon.
 
 (* Skipping definition `TysWiredIn.boxedTupleArr' *)
 
-Axiom boolTyCon_RDR : PrelNames.RdrName.
+(* Skipping definition `TysWiredIn.unboxedTupleArr' *)
 
-Axiom boolTyConName : Name.Name.
+Axiom unboxedTupleSumKind : Core.TyCon ->
+                            list AxiomatizedTypes.Type_ -> AxiomatizedTypes.Kind.
 
-Axiom boolTyCon : Core.TyCon.
+Axiom unboxedTupleKind : list AxiomatizedTypes.Type_ -> AxiomatizedTypes.Kind.
+
+Axiom mk_tuple : BasicTypes.Boxity -> nat -> (Core.TyCon * Core.DataCon)%type.
+
+Axiom unitTyCon : Core.TyCon.
+
+Axiom unitTyConKey : Unique.Unique.
+
+Axiom unitDataCon : Core.DataCon.
+
+Axiom unitDataConId : Core.Id.
+
+Axiom pairTyCon : Core.TyCon.
+
+Axiom unboxedUnitTyCon : Core.TyCon.
+
+Axiom unboxedUnitDataCon : Core.DataCon.
+
+Axiom mkSumTyConOcc : BasicTypes.Arity -> OccName.OccName.
+
+Axiom mkSumDataConOcc : BasicTypes.ConTag ->
+                        BasicTypes.Arity -> OccName.OccName.
+
+Axiom sumTyCon : BasicTypes.Arity -> Core.TyCon.
+
+Axiom sumDataCon : BasicTypes.ConTag -> BasicTypes.Arity -> Core.DataCon.
+
+(* Skipping definition `TysWiredIn.unboxedSumArr' *)
+
+Axiom unboxedSumKind : list AxiomatizedTypes.Type_ -> AxiomatizedTypes.Kind.
+
+(* Skipping definition `TysWiredIn.mk_sum' *)
+
+Axiom mk_class : Core.TyCon ->
+                 AxiomatizedTypes.PredType -> Core.Id -> Core.Class.
+
+Axiom runtimeRepTy : AxiomatizedTypes.Type_.
+
+Axiom liftedTypeKindTyCon : Core.TyCon.
+
+Axiom starKindTyCon : Core.TyCon.
+
+Axiom unicodeStarKindTyCon : Core.TyCon.
+
+Axiom runtimeRepTyCon : Core.TyCon.
+
+Axiom vecRepDataCon : Core.DataCon.
+
+Axiom vecRepDataConTyCon : Core.TyCon.
+
+Axiom tupleRepDataCon : Core.DataCon.
+
+Axiom tupleRepDataConTyCon : Core.TyCon.
+
+Axiom sumRepDataCon : Core.DataCon.
+
+Axiom sumRepDataConTyCon : Core.TyCon.
+
+Axiom vecCountTyCon : Core.TyCon.
+
+Axiom vecCountDataCons : list Core.DataCon.
+
+Axiom vecElemTyCon : Core.TyCon.
+
+Axiom vecElemDataCons : list Core.DataCon.
+
+Axiom liftedRepDataConTyCon : Core.TyCon.
+
+Axiom liftedRepTy : AxiomatizedTypes.Type_.
+
+Axiom boxingDataCon_maybe : Core.TyCon -> option Core.DataCon.
+
+Axiom boxing_constr_env : NameEnv.NameEnv Core.DataCon.
+
+Axiom charTy : AxiomatizedTypes.Type_.
+
+Axiom charTyCon : Core.TyCon.
+
+Axiom charDataCon : Core.DataCon.
+
+Axiom stringTy : AxiomatizedTypes.Type_.
+
+Axiom intTy : AxiomatizedTypes.Type_.
+
+Axiom intTyCon : Core.TyCon.
+
+Axiom intDataCon : Core.DataCon.
+
+Axiom wordTy : AxiomatizedTypes.Type_.
+
+Axiom wordTyCon : Core.TyCon.
+
+Axiom wordDataCon : Core.DataCon.
+
+Axiom word8Ty : AxiomatizedTypes.Type_.
+
+Axiom word8TyCon : Core.TyCon.
+
+Axiom word8DataCon : Core.DataCon.
+
+Axiom floatTy : AxiomatizedTypes.Type_.
+
+Axiom floatTyCon : Core.TyCon.
+
+Axiom floatDataCon : Core.DataCon.
+
+Axiom doubleTy : AxiomatizedTypes.Type_.
+
+Axiom doubleTyCon : Core.TyCon.
+
+Axiom doubleDataCon : Core.DataCon.
 
 Axiom boolTy : AxiomatizedTypes.Type_.
 
-Axiom anyTypeOfKind : AxiomatizedTypes.Kind -> AxiomatizedTypes.Type_.
+Axiom boolTyCon : Core.TyCon.
 
-Axiom anyTyConName : Name.Name.
+Axiom falseDataCon : Core.DataCon.
 
-Axiom anyTyCon : Core.TyCon.
+Axiom trueDataCon : Core.DataCon.
 
-Axiom anyTy : AxiomatizedTypes.Type_.
+Axiom falseDataConId : Core.Id.
 
-Axiom alpha_tyvar : list Core.TyVar.
+Axiom trueDataConId : Core.Id.
 
-Axiom alpha_ty : list AxiomatizedTypes.Type_.
+Axiom orderingTyCon : Core.TyCon.
 
-(* Skipping definition `AxiomatizedTypes.liftedTypeKind' *)
+Axiom ltDataCon : Core.DataCon.
 
-(* Skipping definition `AxiomatizedTypes.constraintKind' *)
+Axiom eqDataCon : Core.DataCon.
+
+Axiom gtDataCon : Core.DataCon.
+
+Axiom ltDataConId : Core.Id.
+
+Axiom eqDataConId : Core.Id.
+
+Axiom gtDataConId : Core.Id.
+
+Axiom mkListTy : AxiomatizedTypes.Type_ -> AxiomatizedTypes.Type_.
+
+Axiom listTyCon : Core.TyCon.
+
+Axiom nilDataCon : Core.DataCon.
+
+Axiom consDataCon : Core.DataCon.
+
+Axiom maybeTyCon : Core.TyCon.
+
+Axiom nothingDataCon : Core.DataCon.
+
+Axiom justDataCon : Core.DataCon.
+
+Axiom mkTupleTy : BasicTypes.Boxity ->
+                  list AxiomatizedTypes.Type_ -> AxiomatizedTypes.Type_.
+
+Axiom mkBoxedTupleTy : list AxiomatizedTypes.Type_ -> AxiomatizedTypes.Type_.
+
+Axiom unitTy : AxiomatizedTypes.Type_.
+
+Axiom mkSumTy : list AxiomatizedTypes.Type_ -> AxiomatizedTypes.Type_.
+
+Axiom mkPArrTy : AxiomatizedTypes.Type_ -> AxiomatizedTypes.Type_.
+
+Axiom parrTyCon : Core.TyCon.
+
+Axiom parrDataCon : Core.DataCon.
+
+Axiom isPArrTyCon : Core.TyCon -> bool.
+
+Axiom parrFakeCon : BasicTypes.Arity -> Core.DataCon.
+
+(* Skipping definition `TysWiredIn.parrFakeConArr' *)
+
+Axiom mkPArrFakeCon : nat -> Core.DataCon.
+
+Axiom isPArrFakeCon : Core.DataCon -> bool.
+
+Axiom promotedTrueDataCon : Core.TyCon.
+
+Axiom promotedFalseDataCon : Core.TyCon.
+
+Axiom promotedNothingDataCon : Core.TyCon.
+
+Axiom promotedJustDataCon : Core.TyCon.
+
+Axiom promotedLTDataCon : Core.TyCon.
+
+Axiom promotedEQDataCon : Core.TyCon.
+
+Axiom promotedGTDataCon : Core.TyCon.
+
+Axiom promotedConsDataCon : Core.TyCon.
+
+Axiom promotedNilDataCon : Core.TyCon.
+
+Axiom mkPromotedListTy : AxiomatizedTypes.Kind ->
+                         list AxiomatizedTypes.Type_ -> AxiomatizedTypes.Type_.
+
+Axiom extractPromotedList : AxiomatizedTypes.Type_ ->
+                            list AxiomatizedTypes.Type_.
 
 (* External variables:
      bool list nat op_zt__ option AxiomatizedTypes.CType AxiomatizedTypes.Kind

--- a/examples/ghc/lib/UnVarGraph.v
+++ b/examples/ghc/lib/UnVarGraph.v
@@ -50,102 +50,6 @@ Instance Unpeel_UnVarGraph : Prim.Unpeel UnVarGraph (Bag.Bag Gen) :=
 
 (* Converted value declarations: *)
 
-Definition varEnvDom {a} : Core.VarEnv a -> UnVarSet :=
-  fun ae => Mk_UnVarSet (UniqFM.ufmToSet_Directly ae).
-
-Definition unionUnVarSet : UnVarSet -> UnVarSet -> UnVarSet :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_UnVarSet set1, Mk_UnVarSet set2 =>
-        Mk_UnVarSet (Data.IntSet.Internal.union set1 set2)
-    end.
-
-Definition unionUnVarGraph : UnVarGraph -> UnVarGraph -> UnVarGraph :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_UnVarGraph g1, Mk_UnVarGraph g2 => Mk_UnVarGraph (Bag.unionBags g1 g2)
-    end.
-
-Definition k : Core.Var -> GHC.Num.Word :=
-  fun v => Unique.getWordKey (Unique.getUnique v).
-
-Definition mkUnVarSet : list Core.Var -> UnVarSet :=
-  fun vs => Mk_UnVarSet (Data.IntSet.Internal.fromList (GHC.Base.map k vs)).
-
-Definition isEmptyUnVarSet : UnVarSet -> bool :=
-  fun '(Mk_UnVarSet s) => Data.IntSet.Internal.null s.
-
-Definition prune : UnVarGraph -> UnVarGraph :=
-  fun '(Mk_UnVarGraph g) =>
-    let go :=
-      fun arg_1__ =>
-        match arg_1__ with
-        | CG s => negb (isEmptyUnVarSet s)
-        | CBPG s1 s2 => andb (negb (isEmptyUnVarSet s1)) (negb (isEmptyUnVarSet s2))
-        end in
-    Mk_UnVarGraph (Bag.filterBag go g).
-
-Definition emptyUnVarSet : UnVarSet :=
-  Mk_UnVarSet Data.IntSet.Internal.empty.
-
-Definition unionUnVarSets : list UnVarSet -> UnVarSet :=
-  Data.Foldable.foldr unionUnVarSet emptyUnVarSet.
-
-Definition emptyUnVarGraph : UnVarGraph :=
-  Mk_UnVarGraph Bag.emptyBag.
-
-Definition unionUnVarGraphs : list UnVarGraph -> UnVarGraph :=
-  Data.Foldable.foldl' unionUnVarGraph emptyUnVarGraph.
-
-Definition elemUnVarSet : Core.Var -> UnVarSet -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | v, Mk_UnVarSet s => Data.IntSet.Internal.member (k v) s
-    end.
-
-Definition neighbors : UnVarGraph -> Core.Var -> UnVarSet :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_UnVarGraph g, v =>
-        let go :=
-          fun arg_2__ =>
-            match arg_2__ with
-            | CG s => (if elemUnVarSet v s : bool then cons s nil else nil)
-            | CBPG s1 s2 =>
-                Coq.Init.Datatypes.app (if elemUnVarSet v s1 : bool
-                                        then cons s2 nil
-                                        else nil) (if elemUnVarSet v s2 : bool
-                                        then cons s1 nil
-                                        else nil)
-            end in
-        unionUnVarSets (Data.Foldable.concatMap go (Bag.bagToList g))
-    end.
-
-Definition delUnVarSet : UnVarSet -> Core.Var -> UnVarSet :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_UnVarSet s, v => Mk_UnVarSet (Data.IntSet.Internal.delete (k v) s)
-    end.
-
-Definition delNode : UnVarGraph -> Core.Var -> UnVarGraph :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_UnVarGraph g, v =>
-        let go :=
-          fun arg_2__ =>
-            match arg_2__ with
-            | CG s => CG (delUnVarSet s v)
-            | CBPG s1 s2 => CBPG (delUnVarSet s1 v) (delUnVarSet s2 v)
-            end in
-        prune (Mk_UnVarGraph (Bag.mapBag go g))
-    end.
-
-Definition completeGraph : UnVarSet -> UnVarGraph :=
-  fun s => prune (Mk_UnVarGraph (Bag.unitBag (CG s))).
-
-Definition completeBipartiteGraph : UnVarSet -> UnVarSet -> UnVarGraph :=
-  fun s1 s2 => prune (Mk_UnVarGraph (Bag.unitBag (CBPG s1 s2))).
-
 Local Definition Eq___UnVarSet_op_zeze__ : UnVarSet -> UnVarSet -> bool :=
   GHC.Prim.coerce _GHC.Base.==_.
 
@@ -165,6 +69,102 @@ Program Instance Eq___UnVarSet : GHC.Base.Eq_ UnVarSet :=
 
 (* Skipping all instances of class `Outputable.Outputable', including
    `UnVarGraph.Outputable__UnVarGraph' *)
+
+Definition k : Core.Var -> GHC.Num.Word :=
+  fun v => Unique.getWordKey (Unique.getUnique v).
+
+Definition emptyUnVarSet : UnVarSet :=
+  Mk_UnVarSet Data.IntSet.Internal.empty.
+
+Definition elemUnVarSet : Core.Var -> UnVarSet -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | v, Mk_UnVarSet s => Data.IntSet.Internal.member (k v) s
+    end.
+
+Definition isEmptyUnVarSet : UnVarSet -> bool :=
+  fun '(Mk_UnVarSet s) => Data.IntSet.Internal.null s.
+
+Definition delUnVarSet : UnVarSet -> Core.Var -> UnVarSet :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_UnVarSet s, v => Mk_UnVarSet (Data.IntSet.Internal.delete (k v) s)
+    end.
+
+Definition mkUnVarSet : list Core.Var -> UnVarSet :=
+  fun vs => Mk_UnVarSet (Data.IntSet.Internal.fromList (GHC.Base.map k vs)).
+
+Definition varEnvDom {a} : Core.VarEnv a -> UnVarSet :=
+  fun ae => Mk_UnVarSet (UniqFM.ufmToSet_Directly ae).
+
+Definition unionUnVarSet : UnVarSet -> UnVarSet -> UnVarSet :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_UnVarSet set1, Mk_UnVarSet set2 =>
+        Mk_UnVarSet (Data.IntSet.Internal.union set1 set2)
+    end.
+
+Definition unionUnVarSets : list UnVarSet -> UnVarSet :=
+  Data.Foldable.foldr unionUnVarSet emptyUnVarSet.
+
+Definition emptyUnVarGraph : UnVarGraph :=
+  Mk_UnVarGraph Bag.emptyBag.
+
+Definition unionUnVarGraph : UnVarGraph -> UnVarGraph -> UnVarGraph :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_UnVarGraph g1, Mk_UnVarGraph g2 => Mk_UnVarGraph (Bag.unionBags g1 g2)
+    end.
+
+Definition unionUnVarGraphs : list UnVarGraph -> UnVarGraph :=
+  Data.Foldable.foldl' unionUnVarGraph emptyUnVarGraph.
+
+Definition prune : UnVarGraph -> UnVarGraph :=
+  fun '(Mk_UnVarGraph g) =>
+    let go :=
+      fun arg_1__ =>
+        match arg_1__ with
+        | CG s => negb (isEmptyUnVarSet s)
+        | CBPG s1 s2 => andb (negb (isEmptyUnVarSet s1)) (negb (isEmptyUnVarSet s2))
+        end in
+    Mk_UnVarGraph (Bag.filterBag go g).
+
+Definition completeBipartiteGraph : UnVarSet -> UnVarSet -> UnVarGraph :=
+  fun s1 s2 => prune (Mk_UnVarGraph (Bag.unitBag (CBPG s1 s2))).
+
+Definition completeGraph : UnVarSet -> UnVarGraph :=
+  fun s => prune (Mk_UnVarGraph (Bag.unitBag (CG s))).
+
+Definition neighbors : UnVarGraph -> Core.Var -> UnVarSet :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_UnVarGraph g, v =>
+        let go :=
+          fun arg_2__ =>
+            match arg_2__ with
+            | CG s => (if elemUnVarSet v s : bool then cons s nil else nil)
+            | CBPG s1 s2 =>
+                Coq.Init.Datatypes.app (if elemUnVarSet v s1 : bool
+                                        then cons s2 nil
+                                        else nil) (if elemUnVarSet v s2 : bool
+                                        then cons s1 nil
+                                        else nil)
+            end in
+        unionUnVarSets (Data.Foldable.concatMap go (Bag.bagToList g))
+    end.
+
+Definition delNode : UnVarGraph -> Core.Var -> UnVarGraph :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_UnVarGraph g, v =>
+        let go :=
+          fun arg_2__ =>
+            match arg_2__ with
+            | CG s => CG (delUnVarSet s v)
+            | CBPG s1 s2 => CBPG (delUnVarSet s1 v) (delUnVarSet s2 v)
+            end in
+        prune (Mk_UnVarGraph (Bag.mapBag go g))
+    end.
 
 (* External variables:
      andb bool cons list negb nil Bag.Bag Bag.bagToList Bag.emptyBag Bag.filterBag

--- a/examples/ghc/lib/UniqFM.v
+++ b/examples/ghc/lib/UniqFM.v
@@ -35,338 +35,6 @@ Instance Default__UniqFM {a} : Err.Default (UniqFM a) :=
 
 (* Converted value declarations: *)
 
-Definition unitUFM {key} {elt} `{Unique.Uniquable key}
-   : key -> elt -> UniqFM elt :=
-  fun k v => UFM (IntMap.singleton (Unique.getWordKey (Unique.getUnique k)) v).
-
-Definition unitDirectlyUFM {elt} : Unique.Unique -> elt -> UniqFM elt :=
-  fun u v => UFM (IntMap.singleton (Unique.getWordKey u) v).
-
-Definition ufmToSet_Directly {elt}
-   : UniqFM elt -> Data.IntSet.Internal.IntSet :=
-  fun '(UFM m) => IntMap.keysSet m.
-
-Definition ufmToIntMap {elt} : UniqFM elt -> IntMap.IntMap elt :=
-  fun '(UFM m) => m.
-
-Definition sizeUFM {elt} : UniqFM elt -> nat :=
-  fun '(UFM m) => IntMap.size m.
-
-(* Skipping definition `UniqFM.pprUniqFM' *)
-
-(* Skipping definition `UniqFM.pprUFM' *)
-
-Axiom plusUFM_CD : forall {elt},
-                   (elt -> elt -> elt) -> UniqFM elt -> elt -> UniqFM elt -> elt -> UniqFM elt.
-
-Definition plusUFM_C {elt}
-   : (elt -> elt -> elt) -> UniqFM elt -> UniqFM elt -> UniqFM elt :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | f, UFM x, UFM y => UFM (IntMap.unionWith f x y)
-    end.
-
-Definition plusUFM {elt} : UniqFM elt -> UniqFM elt -> UniqFM elt :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | UFM x, UFM y => UFM (IntMap.union y x)
-    end.
-
-Axiom plusMaybeUFM_C : forall {elt},
-                       (elt -> elt -> option elt) -> UniqFM elt -> UniqFM elt -> UniqFM elt.
-
-(* Skipping definition `UniqFM.pluralUFM' *)
-
-Definition partitionUFM {elt}
-   : (elt -> bool) -> UniqFM elt -> (UniqFM elt * UniqFM elt)%type :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | p, UFM m =>
-        let 'pair left_ right_ := IntMap.partition p m in
-        pair (UFM left_) (UFM right_)
-    end.
-
-Definition nonDetUFMToList {elt}
-   : UniqFM elt -> list (Unique.Unique * elt)%type :=
-  fun '(UFM m) =>
-    GHC.Base.map (fun '(pair k v) => pair (Unique.getUnique k) v) (IntMap.toList m).
-
-Definition pprUFMWithKeys {a}
-   : UniqFM a ->
-     (list (Unique.Unique * a)%type -> GHC.Base.String) -> GHC.Base.String :=
-  fun ufm pp => pp (nonDetUFMToList ufm).
-
-Definition nonDetKeysUFM {elt} : UniqFM elt -> list Unique.Unique :=
-  fun '(UFM m) => GHC.Base.map Unique.getUnique (IntMap.keys m).
-
-Definition nonDetFoldUFM_Directly {elt} {a}
-   : (Unique.Unique -> elt -> a -> a) -> a -> UniqFM elt -> a :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | k, z, UFM m => IntMap.foldrWithKey (k GHC.Base.∘ Unique.getUnique) z m
-    end.
-
-Definition nonDetFoldUFM {elt} {a} : (elt -> a -> a) -> a -> UniqFM elt -> a :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | k, z, UFM m => IntMap.foldr k z m
-    end.
-
-Definition nonDetEltsUFM {elt} : UniqFM elt -> list elt :=
-  fun '(UFM m) => IntMap.elems m.
-
-Definition seqEltsUFM {elt} : (list elt -> unit) -> UniqFM elt -> unit :=
-  fun seqList => seqList GHC.Base.∘ nonDetEltsUFM.
-
-Definition minusUFM {elt1} {elt2} : UniqFM elt1 -> UniqFM elt2 -> UniqFM elt1 :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | UFM x, UFM y => UFM (IntMap.difference x y)
-    end.
-
-Definition mapUFM_Directly {elt1} {elt2}
-   : (Unique.Unique -> elt1 -> elt2) -> UniqFM elt1 -> UniqFM elt2 :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, UFM m => UFM (IntMap.mapWithKey (f GHC.Base.∘ Unique.getUnique) m)
-    end.
-
-Definition mapUFM {elt1} {elt2}
-   : (elt1 -> elt2) -> UniqFM elt1 -> UniqFM elt2 :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, UFM m => UFM (IntMap.map f m)
-    end.
-
-Definition lookupWithDefaultUFM_Directly {elt}
-   : UniqFM elt -> elt -> Unique.Unique -> elt :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | UFM m, v, u => IntMap.findWithDefault v (Unique.getWordKey u) m
-    end.
-
-Definition lookupWithDefaultUFM {key} {elt} `{Unique.Uniquable key}
-   : UniqFM elt -> elt -> key -> elt :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | UFM m, v, k =>
-        IntMap.findWithDefault v (Unique.getWordKey (Unique.getUnique k)) m
-    end.
-
-Definition lookupUFM_Directly {elt}
-   : UniqFM elt -> Unique.Unique -> option elt :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | UFM m, u => IntMap.lookup (Unique.getWordKey u) m
-    end.
-
-Definition lookupUFM {key} {elt} `{Unique.Uniquable key}
-   : UniqFM elt -> key -> option elt :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | UFM m, k => IntMap.lookup (Unique.getWordKey (Unique.getUnique k)) m
-    end.
-
-Definition isNullUFM {elt} : UniqFM elt -> bool :=
-  fun '(UFM m) => IntMap.null m.
-
-Definition intersectUFM_C {elt1} {elt2} {elt3}
-   : (elt1 -> elt2 -> elt3) -> UniqFM elt1 -> UniqFM elt2 -> UniqFM elt3 :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | f, UFM x, UFM y => UFM (IntMap.intersectionWith f x y)
-    end.
-
-Definition intersectUFM {elt1} {elt2}
-   : UniqFM elt1 -> UniqFM elt2 -> UniqFM elt1 :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | UFM x, UFM y => UFM (IntMap.intersection x y)
-    end.
-
-Definition foldUFM {elt} {a} : (elt -> a -> a) -> a -> UniqFM elt -> a :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | k, z, UFM m => IntMap.foldr k z m
-    end.
-
-Definition filterUFM_Directly {elt}
-   : (Unique.Unique -> elt -> bool) -> UniqFM elt -> UniqFM elt :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | p, UFM m => UFM (IntMap.filterWithKey (p GHC.Base.∘ Unique.getUnique) m)
-    end.
-
-Definition filterUFM {elt} : (elt -> bool) -> UniqFM elt -> UniqFM elt :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | p, UFM m => UFM (IntMap.filter p m)
-    end.
-
-(* Skipping definition `UniqFM.equalKeysUFM' *)
-
-Definition emptyUFM {elt} : UniqFM elt :=
-  UFM IntMap.empty.
-
-Definition plusUFMList {elt} : list (UniqFM elt) -> UniqFM elt :=
-  Data.Foldable.foldl' plusUFM emptyUFM.
-
-Definition eltsUFM {elt} : UniqFM elt -> list elt :=
-  fun '(UFM m) => IntMap.elems m.
-
-Definition elemUFM_Directly {elt} : Unique.Unique -> UniqFM elt -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | u, UFM m => IntMap.member (Unique.getWordKey u) m
-    end.
-
-Definition elemUFM {key} {elt} `{Unique.Uniquable key}
-   : key -> UniqFM elt -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | k, UFM m => IntMap.member (Unique.getWordKey (Unique.getUnique k)) m
-    end.
-
-Definition disjointUFM {elt1} {elt2} : UniqFM elt1 -> UniqFM elt2 -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | UFM x, UFM y => IntMap.null (IntMap.intersection x y)
-    end.
-
-Definition delFromUFM_Directly {elt}
-   : UniqFM elt -> Unique.Unique -> UniqFM elt :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | UFM m, u => UFM (IntMap.delete (Unique.getWordKey u) m)
-    end.
-
-Definition delListFromUFM_Directly {elt}
-   : UniqFM elt -> list Unique.Unique -> UniqFM elt :=
-  Data.Foldable.foldl delFromUFM_Directly.
-
-Definition delFromUFM {key} {elt} `{Unique.Uniquable key}
-   : UniqFM elt -> key -> UniqFM elt :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | UFM m, k => UFM (IntMap.delete (Unique.getWordKey (Unique.getUnique k)) m)
-    end.
-
-Definition delListFromUFM {key} {elt} `{Unique.Uniquable key}
-   : UniqFM elt -> list key -> UniqFM elt :=
-  Data.Foldable.foldl delFromUFM.
-
-Definition anyUFM {elt} : (elt -> bool) -> UniqFM elt -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | p, UFM m => IntMap.foldr (orb GHC.Base.∘ p) false m
-    end.
-
-Definition alterUFM {key} {elt} `{Unique.Uniquable key}
-   : (option elt -> option elt) -> UniqFM elt -> key -> UniqFM elt :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | f, UFM m, k => UFM (IntMap.alter f (Unique.getWordKey (Unique.getUnique k)) m)
-    end.
-
-Definition allUFM {elt} : (elt -> bool) -> UniqFM elt -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | p, UFM m => IntMap.foldr (andb GHC.Base.∘ p) true m
-    end.
-
-Definition adjustUFM_Directly {elt}
-   : (elt -> elt) -> UniqFM elt -> Unique.Unique -> UniqFM elt :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | f, UFM m, u => UFM (IntMap.adjust f (Unique.getWordKey u) m)
-    end.
-
-Definition adjustUFM {key} {elt} `{Unique.Uniquable key}
-   : (elt -> elt) -> UniqFM elt -> key -> UniqFM elt :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | f, UFM m, k =>
-        UFM (IntMap.adjust f (Unique.getWordKey (Unique.getUnique k)) m)
-    end.
-
-Definition addToUFM_Directly {elt}
-   : UniqFM elt -> Unique.Unique -> elt -> UniqFM elt :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | UFM m, u, v => UFM (IntMap.insert (Unique.getWordKey u) v m)
-    end.
-
-Definition listToUFM_Directly {elt}
-   : list (Unique.Unique * elt)%type -> UniqFM elt :=
-  Data.Foldable.foldl (fun arg_0__ arg_1__ =>
-                         match arg_0__, arg_1__ with
-                         | m, pair u v => addToUFM_Directly m u v
-                         end) emptyUFM.
-
-Definition addToUFM_C {key} {elt} `{Unique.Uniquable key}
-   : (elt -> elt -> elt) -> UniqFM elt -> key -> elt -> UniqFM elt :=
-  fun arg_0__ arg_1__ arg_2__ arg_3__ =>
-    match arg_0__, arg_1__, arg_2__, arg_3__ with
-    | f, UFM m, k, v =>
-        UFM (IntMap.insertWith (GHC.Base.flip f) (Unique.getWordKey (Unique.getUnique
-                                                                     k)) v m)
-    end.
-
-Definition listToUFM_C {key} {elt} `{Unique.Uniquable key}
-   : (elt -> elt -> elt) -> list (key * elt)%type -> UniqFM elt :=
-  fun f =>
-    Data.Foldable.foldl (fun arg_0__ arg_1__ =>
-                           match arg_0__, arg_1__ with
-                           | m, pair k v => addToUFM_C f m k v
-                           end) emptyUFM.
-
-Definition addToUFM_Acc {key} {elt} {elts} `{Unique.Uniquable key}
-   : (elt -> elts -> elts) ->
-     (elt -> elts) -> UniqFM elts -> key -> elt -> UniqFM elts :=
-  fun arg_0__ arg_1__ arg_2__ arg_3__ arg_4__ =>
-    match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__ with
-    | exi, new, UFM m, k, v =>
-        UFM (IntMap.insertWith (fun _new old => exi v old) (Unique.getWordKey
-                                                            (Unique.getUnique k)) (new v) m)
-    end.
-
-Definition addToUFM {key} {elt} `{Unique.Uniquable key}
-   : UniqFM elt -> key -> elt -> UniqFM elt :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | UFM m, k, v =>
-        UFM (IntMap.insert (Unique.getWordKey (Unique.getUnique k)) v m)
-    end.
-
-Definition listToUFM {key} {elt} `{Unique.Uniquable key}
-   : list (key * elt)%type -> UniqFM elt :=
-  Data.Foldable.foldl (fun arg_0__ arg_1__ =>
-                         match arg_0__, arg_1__ with
-                         | m, pair k v => addToUFM m k v
-                         end) emptyUFM.
-
-Definition addListToUFM_Directly {elt}
-   : UniqFM elt -> list (Unique.Unique * elt)%type -> UniqFM elt :=
-  Data.Foldable.foldl (fun arg_0__ arg_1__ =>
-                         match arg_0__, arg_1__ with
-                         | m, pair k v => addToUFM_Directly m k v
-                         end).
-
-Definition addListToUFM_C {key} {elt} `{Unique.Uniquable key}
-   : (elt -> elt -> elt) -> UniqFM elt -> list (key * elt)%type -> UniqFM elt :=
-  fun f =>
-    Data.Foldable.foldl (fun arg_0__ arg_1__ =>
-                           match arg_0__, arg_1__ with
-                           | m, pair k v => addToUFM_C f m k v
-                           end).
-
-Definition addListToUFM {key} {elt} `{Unique.Uniquable key}
-   : UniqFM elt -> list (key * elt)%type -> UniqFM elt :=
-  Data.Foldable.foldl (fun arg_0__ arg_1__ =>
-                         match arg_0__, arg_1__ with
-                         | m, pair k v => addToUFM m k v
-                         end).
-
 (* Skipping all instances of class `Data.Data.Data', including
    `UniqFM.Data__UniqFM' *)
 
@@ -400,8 +68,11 @@ Program Instance Functor__UniqFM : GHC.Base.Functor UniqFM :=
     k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__UniqFM_fmap ;
            GHC.Base.op_zlzd____ := fun {a} {b} => Functor__UniqFM_op_zlzd__ |}.
 
-(* Skipping all instances of class `Outputable.Outputable', including
-   `UniqFM.Outputable__UniqFM' *)
+Definition plusUFM {elt} : UniqFM elt -> UniqFM elt -> UniqFM elt :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | UFM x, UFM y => UFM (IntMap.union y x)
+    end.
 
 Local Definition Semigroup__UniqFM_op_zlzlzgzg__ {inst_a}
    : (UniqFM inst_a) -> (UniqFM inst_a) -> (UniqFM inst_a) :=
@@ -415,6 +86,9 @@ Local Definition Monoid__UniqFM_mappend {inst_a}
    : (UniqFM inst_a) -> (UniqFM inst_a) -> (UniqFM inst_a) :=
   _GHC.Base.<<>>_.
 
+Definition emptyUFM {elt} : UniqFM elt :=
+  UFM IntMap.empty.
+
 Local Definition Monoid__UniqFM_mempty {inst_a} : (UniqFM inst_a) :=
   emptyUFM.
 
@@ -427,6 +101,332 @@ Program Instance Monoid__UniqFM {a} : GHC.Base.Monoid (UniqFM a) :=
     k__ {| GHC.Base.mappend__ := Monoid__UniqFM_mappend ;
            GHC.Base.mconcat__ := Monoid__UniqFM_mconcat ;
            GHC.Base.mempty__ := Monoid__UniqFM_mempty |}.
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `UniqFM.Outputable__UniqFM' *)
+
+Definition isNullUFM {elt} : UniqFM elt -> bool :=
+  fun '(UFM m) => IntMap.null m.
+
+Definition unitUFM {key} {elt} `{Unique.Uniquable key}
+   : key -> elt -> UniqFM elt :=
+  fun k v => UFM (IntMap.singleton (Unique.getWordKey (Unique.getUnique k)) v).
+
+Definition unitDirectlyUFM {elt} : Unique.Unique -> elt -> UniqFM elt :=
+  fun u v => UFM (IntMap.singleton (Unique.getWordKey u) v).
+
+Definition addToUFM {key} {elt} `{Unique.Uniquable key}
+   : UniqFM elt -> key -> elt -> UniqFM elt :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | UFM m, k, v =>
+        UFM (IntMap.insert (Unique.getWordKey (Unique.getUnique k)) v m)
+    end.
+
+Definition listToUFM {key} {elt} `{Unique.Uniquable key}
+   : list (key * elt)%type -> UniqFM elt :=
+  Data.Foldable.foldl (fun arg_0__ arg_1__ =>
+                         match arg_0__, arg_1__ with
+                         | m, pair k v => addToUFM m k v
+                         end) emptyUFM.
+
+Definition addToUFM_Directly {elt}
+   : UniqFM elt -> Unique.Unique -> elt -> UniqFM elt :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | UFM m, u, v => UFM (IntMap.insert (Unique.getWordKey u) v m)
+    end.
+
+Definition listToUFM_Directly {elt}
+   : list (Unique.Unique * elt)%type -> UniqFM elt :=
+  Data.Foldable.foldl (fun arg_0__ arg_1__ =>
+                         match arg_0__, arg_1__ with
+                         | m, pair u v => addToUFM_Directly m u v
+                         end) emptyUFM.
+
+Definition addToUFM_C {key} {elt} `{Unique.Uniquable key}
+   : (elt -> elt -> elt) -> UniqFM elt -> key -> elt -> UniqFM elt :=
+  fun arg_0__ arg_1__ arg_2__ arg_3__ =>
+    match arg_0__, arg_1__, arg_2__, arg_3__ with
+    | f, UFM m, k, v =>
+        UFM (IntMap.insertWith (GHC.Base.flip f) (Unique.getWordKey (Unique.getUnique
+                                                                     k)) v m)
+    end.
+
+Definition listToUFM_C {key} {elt} `{Unique.Uniquable key}
+   : (elt -> elt -> elt) -> list (key * elt)%type -> UniqFM elt :=
+  fun f =>
+    Data.Foldable.foldl (fun arg_0__ arg_1__ =>
+                           match arg_0__, arg_1__ with
+                           | m, pair k v => addToUFM_C f m k v
+                           end) emptyUFM.
+
+Definition addListToUFM {key} {elt} `{Unique.Uniquable key}
+   : UniqFM elt -> list (key * elt)%type -> UniqFM elt :=
+  Data.Foldable.foldl (fun arg_0__ arg_1__ =>
+                         match arg_0__, arg_1__ with
+                         | m, pair k v => addToUFM m k v
+                         end).
+
+Definition addListToUFM_Directly {elt}
+   : UniqFM elt -> list (Unique.Unique * elt)%type -> UniqFM elt :=
+  Data.Foldable.foldl (fun arg_0__ arg_1__ =>
+                         match arg_0__, arg_1__ with
+                         | m, pair k v => addToUFM_Directly m k v
+                         end).
+
+Definition addToUFM_Acc {key} {elt} {elts} `{Unique.Uniquable key}
+   : (elt -> elts -> elts) ->
+     (elt -> elts) -> UniqFM elts -> key -> elt -> UniqFM elts :=
+  fun arg_0__ arg_1__ arg_2__ arg_3__ arg_4__ =>
+    match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__ with
+    | exi, new, UFM m, k, v =>
+        UFM (IntMap.insertWith (fun _new old => exi v old) (Unique.getWordKey
+                                                            (Unique.getUnique k)) (new v) m)
+    end.
+
+Definition alterUFM {key} {elt} `{Unique.Uniquable key}
+   : (option elt -> option elt) -> UniqFM elt -> key -> UniqFM elt :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | f, UFM m, k => UFM (IntMap.alter f (Unique.getWordKey (Unique.getUnique k)) m)
+    end.
+
+Definition addListToUFM_C {key} {elt} `{Unique.Uniquable key}
+   : (elt -> elt -> elt) -> UniqFM elt -> list (key * elt)%type -> UniqFM elt :=
+  fun f =>
+    Data.Foldable.foldl (fun arg_0__ arg_1__ =>
+                           match arg_0__, arg_1__ with
+                           | m, pair k v => addToUFM_C f m k v
+                           end).
+
+Definition adjustUFM {key} {elt} `{Unique.Uniquable key}
+   : (elt -> elt) -> UniqFM elt -> key -> UniqFM elt :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | f, UFM m, k =>
+        UFM (IntMap.adjust f (Unique.getWordKey (Unique.getUnique k)) m)
+    end.
+
+Definition adjustUFM_Directly {elt}
+   : (elt -> elt) -> UniqFM elt -> Unique.Unique -> UniqFM elt :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | f, UFM m, u => UFM (IntMap.adjust f (Unique.getWordKey u) m)
+    end.
+
+Definition delFromUFM {key} {elt} `{Unique.Uniquable key}
+   : UniqFM elt -> key -> UniqFM elt :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | UFM m, k => UFM (IntMap.delete (Unique.getWordKey (Unique.getUnique k)) m)
+    end.
+
+Definition delListFromUFM {key} {elt} `{Unique.Uniquable key}
+   : UniqFM elt -> list key -> UniqFM elt :=
+  Data.Foldable.foldl delFromUFM.
+
+Definition delFromUFM_Directly {elt}
+   : UniqFM elt -> Unique.Unique -> UniqFM elt :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | UFM m, u => UFM (IntMap.delete (Unique.getWordKey u) m)
+    end.
+
+Definition delListFromUFM_Directly {elt}
+   : UniqFM elt -> list Unique.Unique -> UniqFM elt :=
+  Data.Foldable.foldl delFromUFM_Directly.
+
+Definition plusUFM_C {elt}
+   : (elt -> elt -> elt) -> UniqFM elt -> UniqFM elt -> UniqFM elt :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | f, UFM x, UFM y => UFM (IntMap.unionWith f x y)
+    end.
+
+Axiom plusUFM_CD : forall {elt},
+                   (elt -> elt -> elt) -> UniqFM elt -> elt -> UniqFM elt -> elt -> UniqFM elt.
+
+Axiom plusMaybeUFM_C : forall {elt},
+                       (elt -> elt -> option elt) -> UniqFM elt -> UniqFM elt -> UniqFM elt.
+
+Definition plusUFMList {elt} : list (UniqFM elt) -> UniqFM elt :=
+  Data.Foldable.foldl' plusUFM emptyUFM.
+
+Definition minusUFM {elt1} {elt2} : UniqFM elt1 -> UniqFM elt2 -> UniqFM elt1 :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | UFM x, UFM y => UFM (IntMap.difference x y)
+    end.
+
+Definition intersectUFM {elt1} {elt2}
+   : UniqFM elt1 -> UniqFM elt2 -> UniqFM elt1 :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | UFM x, UFM y => UFM (IntMap.intersection x y)
+    end.
+
+Definition intersectUFM_C {elt1} {elt2} {elt3}
+   : (elt1 -> elt2 -> elt3) -> UniqFM elt1 -> UniqFM elt2 -> UniqFM elt3 :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | f, UFM x, UFM y => UFM (IntMap.intersectionWith f x y)
+    end.
+
+Definition disjointUFM {elt1} {elt2} : UniqFM elt1 -> UniqFM elt2 -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | UFM x, UFM y => IntMap.null (IntMap.intersection x y)
+    end.
+
+Definition foldUFM {elt} {a} : (elt -> a -> a) -> a -> UniqFM elt -> a :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | k, z, UFM m => IntMap.foldr k z m
+    end.
+
+Definition mapUFM {elt1} {elt2}
+   : (elt1 -> elt2) -> UniqFM elt1 -> UniqFM elt2 :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, UFM m => UFM (IntMap.map f m)
+    end.
+
+Definition mapUFM_Directly {elt1} {elt2}
+   : (Unique.Unique -> elt1 -> elt2) -> UniqFM elt1 -> UniqFM elt2 :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, UFM m => UFM (IntMap.mapWithKey (f GHC.Base.∘ Unique.getUnique) m)
+    end.
+
+Definition filterUFM {elt} : (elt -> bool) -> UniqFM elt -> UniqFM elt :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | p, UFM m => UFM (IntMap.filter p m)
+    end.
+
+Definition filterUFM_Directly {elt}
+   : (Unique.Unique -> elt -> bool) -> UniqFM elt -> UniqFM elt :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | p, UFM m => UFM (IntMap.filterWithKey (p GHC.Base.∘ Unique.getUnique) m)
+    end.
+
+Definition partitionUFM {elt}
+   : (elt -> bool) -> UniqFM elt -> (UniqFM elt * UniqFM elt)%type :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | p, UFM m =>
+        let 'pair left_ right_ := IntMap.partition p m in
+        pair (UFM left_) (UFM right_)
+    end.
+
+Definition sizeUFM {elt} : UniqFM elt -> nat :=
+  fun '(UFM m) => IntMap.size m.
+
+Definition elemUFM {key} {elt} `{Unique.Uniquable key}
+   : key -> UniqFM elt -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | k, UFM m => IntMap.member (Unique.getWordKey (Unique.getUnique k)) m
+    end.
+
+Definition elemUFM_Directly {elt} : Unique.Unique -> UniqFM elt -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | u, UFM m => IntMap.member (Unique.getWordKey u) m
+    end.
+
+Definition lookupUFM {key} {elt} `{Unique.Uniquable key}
+   : UniqFM elt -> key -> option elt :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | UFM m, k => IntMap.lookup (Unique.getWordKey (Unique.getUnique k)) m
+    end.
+
+Definition lookupUFM_Directly {elt}
+   : UniqFM elt -> Unique.Unique -> option elt :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | UFM m, u => IntMap.lookup (Unique.getWordKey u) m
+    end.
+
+Definition lookupWithDefaultUFM {key} {elt} `{Unique.Uniquable key}
+   : UniqFM elt -> elt -> key -> elt :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | UFM m, v, k =>
+        IntMap.findWithDefault v (Unique.getWordKey (Unique.getUnique k)) m
+    end.
+
+Definition lookupWithDefaultUFM_Directly {elt}
+   : UniqFM elt -> elt -> Unique.Unique -> elt :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | UFM m, v, u => IntMap.findWithDefault v (Unique.getWordKey u) m
+    end.
+
+Definition eltsUFM {elt} : UniqFM elt -> list elt :=
+  fun '(UFM m) => IntMap.elems m.
+
+Definition ufmToSet_Directly {elt}
+   : UniqFM elt -> Data.IntSet.Internal.IntSet :=
+  fun '(UFM m) => IntMap.keysSet m.
+
+Definition anyUFM {elt} : (elt -> bool) -> UniqFM elt -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | p, UFM m => IntMap.foldr (orb GHC.Base.∘ p) false m
+    end.
+
+Definition allUFM {elt} : (elt -> bool) -> UniqFM elt -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | p, UFM m => IntMap.foldr (andb GHC.Base.∘ p) true m
+    end.
+
+Definition nonDetEltsUFM {elt} : UniqFM elt -> list elt :=
+  fun '(UFM m) => IntMap.elems m.
+
+Definition seqEltsUFM {elt} : (list elt -> unit) -> UniqFM elt -> unit :=
+  fun seqList => seqList GHC.Base.∘ nonDetEltsUFM.
+
+Definition nonDetKeysUFM {elt} : UniqFM elt -> list Unique.Unique :=
+  fun '(UFM m) => GHC.Base.map Unique.getUnique (IntMap.keys m).
+
+Definition nonDetFoldUFM {elt} {a} : (elt -> a -> a) -> a -> UniqFM elt -> a :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | k, z, UFM m => IntMap.foldr k z m
+    end.
+
+Definition nonDetFoldUFM_Directly {elt} {a}
+   : (Unique.Unique -> elt -> a -> a) -> a -> UniqFM elt -> a :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | k, z, UFM m => IntMap.foldrWithKey (k GHC.Base.∘ Unique.getUnique) z m
+    end.
+
+Definition nonDetUFMToList {elt}
+   : UniqFM elt -> list (Unique.Unique * elt)%type :=
+  fun '(UFM m) =>
+    GHC.Base.map (fun '(pair k v) => pair (Unique.getUnique k) v) (IntMap.toList m).
+
+Definition ufmToIntMap {elt} : UniqFM elt -> IntMap.IntMap elt :=
+  fun '(UFM m) => m.
+
+(* Skipping definition `UniqFM.equalKeysUFM' *)
+
+(* Skipping definition `UniqFM.pprUniqFM' *)
+
+(* Skipping definition `UniqFM.pprUFM' *)
+
+Definition pprUFMWithKeys {a}
+   : UniqFM a ->
+     (list (Unique.Unique * a)%type -> GHC.Base.String) -> GHC.Base.String :=
+  fun ufm pp => pp (nonDetUFMToList ufm).
+
+(* Skipping definition `UniqFM.pluralUFM' *)
 
 (* External variables:
      andb bool false list nat op_zt__ option orb pair true unit Data.Foldable.foldl

--- a/examples/ghc/lib/UniqSet.v
+++ b/examples/ghc/lib/UniqSet.v
@@ -32,193 +32,6 @@ Definition getUniqSet' {a} (arg_0__ : UniqSet a) :=
 
 (* Converted value declarations: *)
 
-Definition unsafeUFMToUniqSet {a} : UniqFM.UniqFM a -> UniqSet a :=
-  Mk_UniqSet.
-
-Definition unitUniqSet {a} `{Unique.Uniquable a} : a -> UniqSet a :=
-  fun x => Mk_UniqSet (UniqFM.unitUFM x x).
-
-Definition uniqSetMinusUFM {a} {b}
-   : UniqSet a -> UniqFM.UniqFM b -> UniqSet a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_UniqSet s, t => Mk_UniqSet (UniqFM.minusUFM s t)
-    end.
-
-Definition uniqSetAny {a} : (a -> bool) -> UniqSet a -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | p, Mk_UniqSet s => UniqFM.anyUFM p s
-    end.
-
-Definition uniqSetAll {a} : (a -> bool) -> UniqSet a -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | p, Mk_UniqSet s => UniqFM.allUFM p s
-    end.
-
-Definition unionUniqSets {a} : UniqSet a -> UniqSet a -> UniqSet a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_UniqSet s, Mk_UniqSet t => Mk_UniqSet (UniqFM.plusUFM s t)
-    end.
-
-Definition sizeUniqSet {a} : UniqSet a -> nat :=
-  fun '(Mk_UniqSet s) => UniqFM.sizeUFM s.
-
-Definition restrictUniqSetToUFM {a} {b}
-   : UniqSet a -> UniqFM.UniqFM b -> UniqSet a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_UniqSet s, m => Mk_UniqSet (UniqFM.intersectUFM s m)
-    end.
-
-(* Skipping definition `UniqSet.pprUniqSet' *)
-
-Instance Unpeel_UniqSet ele
-   : GHC.Prim.Unpeel (UniqSet ele) (UniqFM.UniqFM ele) :=
-  GHC.Prim.Build_Unpeel _ _ (fun '(Mk_UniqSet y) => y) Mk_UniqSet.
-
-Definition partitionUniqSet {a}
-   : (a -> bool) -> UniqSet a -> (UniqSet a * UniqSet a)%type :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | p, Mk_UniqSet s => GHC.Prim.coerce (UniqFM.partitionUFM p s)
-    end.
-
-Definition nonDetKeysUniqSet {elt} : UniqSet elt -> list Unique.Unique :=
-  UniqFM.nonDetKeysUFM GHC.Base.∘ getUniqSet'.
-
-Definition nonDetFoldUniqSet_Directly {elt} {a}
-   : (Unique.Unique -> elt -> a -> a) -> a -> UniqSet elt -> a :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | f, n, Mk_UniqSet s => UniqFM.nonDetFoldUFM_Directly f n s
-    end.
-
-Definition nonDetFoldUniqSet {elt} {a}
-   : (elt -> a -> a) -> a -> UniqSet elt -> a :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | c, n, Mk_UniqSet s => UniqFM.nonDetFoldUFM c n s
-    end.
-
-Definition nonDetEltsUniqSet {elt} : UniqSet elt -> list elt :=
-  UniqFM.nonDetEltsUFM GHC.Base.∘ getUniqSet'.
-
-Definition minusUniqSet {a} : UniqSet a -> UniqSet a -> UniqSet a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_UniqSet s, Mk_UniqSet t => Mk_UniqSet (UniqFM.minusUFM s t)
-    end.
-
-Definition lookupUniqSet_Directly {a}
-   : UniqSet a -> Unique.Unique -> option a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_UniqSet s, k => UniqFM.lookupUFM_Directly s k
-    end.
-
-Definition lookupUniqSet {a} {b} `{Unique.Uniquable a}
-   : UniqSet b -> a -> option b :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_UniqSet s, k => UniqFM.lookupUFM s k
-    end.
-
-Definition isEmptyUniqSet {a} : UniqSet a -> bool :=
-  fun '(Mk_UniqSet s) => UniqFM.isNullUFM s.
-
-Definition intersectUniqSets {a} : UniqSet a -> UniqSet a -> UniqSet a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_UniqSet s, Mk_UniqSet t => Mk_UniqSet (UniqFM.intersectUFM s t)
-    end.
-
-Definition getUniqSet {a} : UniqSet a -> UniqFM.UniqFM a :=
-  getUniqSet'.
-
-Definition filterUniqSet_Directly {elt}
-   : (Unique.Unique -> elt -> bool) -> UniqSet elt -> UniqSet elt :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, Mk_UniqSet s => Mk_UniqSet (UniqFM.filterUFM_Directly f s)
-    end.
-
-Definition filterUniqSet {a} : (a -> bool) -> UniqSet a -> UniqSet a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | p, Mk_UniqSet s => Mk_UniqSet (UniqFM.filterUFM p s)
-    end.
-
-Definition emptyUniqSet {a} : UniqSet a :=
-  Mk_UniqSet UniqFM.emptyUFM.
-
-Definition unionManyUniqSets {a} (xs : list (UniqSet a)) : UniqSet a :=
-  match xs with
-  | nil => emptyUniqSet
-  | cons uset usets => Data.Foldable.foldr unionUniqSets uset usets
-  end.
-
-Definition elementOfUniqSet {a} `{Unique.Uniquable a}
-   : a -> UniqSet a -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | a, Mk_UniqSet s => UniqFM.elemUFM a s
-    end.
-
-Definition elemUniqSet_Directly {a} : Unique.Unique -> UniqSet a -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | a, Mk_UniqSet s => UniqFM.elemUFM_Directly a s
-    end.
-
-Definition delOneFromUniqSet_Directly {a}
-   : UniqSet a -> Unique.Unique -> UniqSet a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_UniqSet s, u => Mk_UniqSet (UniqFM.delFromUFM_Directly s u)
-    end.
-
-Definition delOneFromUniqSet {a} `{Unique.Uniquable a}
-   : UniqSet a -> a -> UniqSet a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_UniqSet s, a => Mk_UniqSet (UniqFM.delFromUFM s a)
-    end.
-
-Definition delListFromUniqSet_Directly {a}
-   : UniqSet a -> list Unique.Unique -> UniqSet a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_UniqSet s, l => Mk_UniqSet (UniqFM.delListFromUFM_Directly s l)
-    end.
-
-Definition delListFromUniqSet {a} `{Unique.Uniquable a}
-   : UniqSet a -> list a -> UniqSet a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_UniqSet s, l => Mk_UniqSet (UniqFM.delListFromUFM s l)
-    end.
-
-Definition addOneToUniqSet {a} `{Unique.Uniquable a}
-   : UniqSet a -> a -> UniqSet a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_UniqSet set, x => Mk_UniqSet (UniqFM.addToUFM set x x)
-    end.
-
-Definition mkUniqSet {a} `{Unique.Uniquable a} : list a -> UniqSet a :=
-  Data.Foldable.foldl' addOneToUniqSet emptyUniqSet.
-
-Definition mapUniqSet {b} {a} `{Unique.Uniquable b}
-   : (a -> b) -> UniqSet a -> UniqSet b :=
-  fun f => mkUniqSet GHC.Base.∘ (GHC.Base.map f GHC.Base.∘ nonDetEltsUniqSet).
-
-Definition addListToUniqSet {a} `{Unique.Uniquable a}
-   : UniqSet a -> list a -> UniqSet a :=
-  Data.Foldable.foldl' addOneToUniqSet.
-
 (* Skipping all instances of class `Data.Data.Data', including
    `UniqSet.Data__UniqSet' *)
 
@@ -229,6 +42,10 @@ Local Definition Semigroup__UniqSet_op_zlzlzgzg__ {inst_a}
 Program Instance Semigroup__UniqSet {a} : GHC.Base.Semigroup (UniqSet a) :=
   fun _ k__ =>
     k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__UniqSet_op_zlzlzgzg__ |}.
+
+Instance Unpeel_UniqSet ele
+   : GHC.Prim.Unpeel (UniqSet ele) (UniqFM.UniqFM ele) :=
+  GHC.Prim.Build_Unpeel _ _ (fun '(Mk_UniqSet y) => y) Mk_UniqSet.
 
 Local Definition Monoid__UniqSet_mappend {inst_a}
    : UniqSet inst_a -> UniqSet inst_a -> UniqSet inst_a :=
@@ -247,10 +64,193 @@ Program Instance Monoid__UniqSet {a} : GHC.Base.Monoid (UniqSet a) :=
            GHC.Base.mconcat__ := Monoid__UniqSet_mconcat ;
            GHC.Base.mempty__ := Monoid__UniqSet_mempty |}.
 
+(* Skipping instance `UniqSet.Eq___UniqSet' of class `GHC.Base.Eq_' *)
+
 (* Skipping all instances of class `Outputable.Outputable', including
    `UniqSet.Outputable__UniqSet' *)
 
-(* Skipping instance `UniqSet.Eq___UniqSet' of class `GHC.Base.Eq_' *)
+Definition emptyUniqSet {a} : UniqSet a :=
+  Mk_UniqSet UniqFM.emptyUFM.
+
+Definition unitUniqSet {a} `{Unique.Uniquable a} : a -> UniqSet a :=
+  fun x => Mk_UniqSet (UniqFM.unitUFM x x).
+
+Definition addOneToUniqSet {a} `{Unique.Uniquable a}
+   : UniqSet a -> a -> UniqSet a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_UniqSet set, x => Mk_UniqSet (UniqFM.addToUFM set x x)
+    end.
+
+Definition mkUniqSet {a} `{Unique.Uniquable a} : list a -> UniqSet a :=
+  Data.Foldable.foldl' addOneToUniqSet emptyUniqSet.
+
+Definition addListToUniqSet {a} `{Unique.Uniquable a}
+   : UniqSet a -> list a -> UniqSet a :=
+  Data.Foldable.foldl' addOneToUniqSet.
+
+Definition delOneFromUniqSet {a} `{Unique.Uniquable a}
+   : UniqSet a -> a -> UniqSet a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_UniqSet s, a => Mk_UniqSet (UniqFM.delFromUFM s a)
+    end.
+
+Definition delOneFromUniqSet_Directly {a}
+   : UniqSet a -> Unique.Unique -> UniqSet a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_UniqSet s, u => Mk_UniqSet (UniqFM.delFromUFM_Directly s u)
+    end.
+
+Definition delListFromUniqSet {a} `{Unique.Uniquable a}
+   : UniqSet a -> list a -> UniqSet a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_UniqSet s, l => Mk_UniqSet (UniqFM.delListFromUFM s l)
+    end.
+
+Definition delListFromUniqSet_Directly {a}
+   : UniqSet a -> list Unique.Unique -> UniqSet a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_UniqSet s, l => Mk_UniqSet (UniqFM.delListFromUFM_Directly s l)
+    end.
+
+Definition unionUniqSets {a} : UniqSet a -> UniqSet a -> UniqSet a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_UniqSet s, Mk_UniqSet t => Mk_UniqSet (UniqFM.plusUFM s t)
+    end.
+
+Definition unionManyUniqSets {a} (xs : list (UniqSet a)) : UniqSet a :=
+  match xs with
+  | nil => emptyUniqSet
+  | cons uset usets => Data.Foldable.foldr unionUniqSets uset usets
+  end.
+
+Definition minusUniqSet {a} : UniqSet a -> UniqSet a -> UniqSet a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_UniqSet s, Mk_UniqSet t => Mk_UniqSet (UniqFM.minusUFM s t)
+    end.
+
+Definition intersectUniqSets {a} : UniqSet a -> UniqSet a -> UniqSet a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_UniqSet s, Mk_UniqSet t => Mk_UniqSet (UniqFM.intersectUFM s t)
+    end.
+
+Definition restrictUniqSetToUFM {a} {b}
+   : UniqSet a -> UniqFM.UniqFM b -> UniqSet a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_UniqSet s, m => Mk_UniqSet (UniqFM.intersectUFM s m)
+    end.
+
+Definition uniqSetMinusUFM {a} {b}
+   : UniqSet a -> UniqFM.UniqFM b -> UniqSet a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_UniqSet s, t => Mk_UniqSet (UniqFM.minusUFM s t)
+    end.
+
+Definition elementOfUniqSet {a} `{Unique.Uniquable a}
+   : a -> UniqSet a -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | a, Mk_UniqSet s => UniqFM.elemUFM a s
+    end.
+
+Definition elemUniqSet_Directly {a} : Unique.Unique -> UniqSet a -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | a, Mk_UniqSet s => UniqFM.elemUFM_Directly a s
+    end.
+
+Definition filterUniqSet {a} : (a -> bool) -> UniqSet a -> UniqSet a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | p, Mk_UniqSet s => Mk_UniqSet (UniqFM.filterUFM p s)
+    end.
+
+Definition filterUniqSet_Directly {elt}
+   : (Unique.Unique -> elt -> bool) -> UniqSet elt -> UniqSet elt :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, Mk_UniqSet s => Mk_UniqSet (UniqFM.filterUFM_Directly f s)
+    end.
+
+Definition partitionUniqSet {a}
+   : (a -> bool) -> UniqSet a -> (UniqSet a * UniqSet a)%type :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | p, Mk_UniqSet s => GHC.Prim.coerce (UniqFM.partitionUFM p s)
+    end.
+
+Definition uniqSetAny {a} : (a -> bool) -> UniqSet a -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | p, Mk_UniqSet s => UniqFM.anyUFM p s
+    end.
+
+Definition uniqSetAll {a} : (a -> bool) -> UniqSet a -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | p, Mk_UniqSet s => UniqFM.allUFM p s
+    end.
+
+Definition sizeUniqSet {a} : UniqSet a -> nat :=
+  fun '(Mk_UniqSet s) => UniqFM.sizeUFM s.
+
+Definition isEmptyUniqSet {a} : UniqSet a -> bool :=
+  fun '(Mk_UniqSet s) => UniqFM.isNullUFM s.
+
+Definition lookupUniqSet {a} {b} `{Unique.Uniquable a}
+   : UniqSet b -> a -> option b :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_UniqSet s, k => UniqFM.lookupUFM s k
+    end.
+
+Definition lookupUniqSet_Directly {a}
+   : UniqSet a -> Unique.Unique -> option a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_UniqSet s, k => UniqFM.lookupUFM_Directly s k
+    end.
+
+Definition nonDetEltsUniqSet {elt} : UniqSet elt -> list elt :=
+  UniqFM.nonDetEltsUFM GHC.Base.∘ getUniqSet'.
+
+Definition nonDetKeysUniqSet {elt} : UniqSet elt -> list Unique.Unique :=
+  UniqFM.nonDetKeysUFM GHC.Base.∘ getUniqSet'.
+
+Definition nonDetFoldUniqSet {elt} {a}
+   : (elt -> a -> a) -> a -> UniqSet elt -> a :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | c, n, Mk_UniqSet s => UniqFM.nonDetFoldUFM c n s
+    end.
+
+Definition nonDetFoldUniqSet_Directly {elt} {a}
+   : (Unique.Unique -> elt -> a -> a) -> a -> UniqSet elt -> a :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | f, n, Mk_UniqSet s => UniqFM.nonDetFoldUFM_Directly f n s
+    end.
+
+Definition mapUniqSet {b} {a} `{Unique.Uniquable b}
+   : (a -> b) -> UniqSet a -> UniqSet b :=
+  fun f => mkUniqSet GHC.Base.∘ (GHC.Base.map f GHC.Base.∘ nonDetEltsUniqSet).
+
+Definition getUniqSet {a} : UniqSet a -> UniqFM.UniqFM a :=
+  getUniqSet'.
+
+Definition unsafeUFMToUniqSet {a} : UniqFM.UniqFM a -> UniqSet a :=
+  Mk_UniqSet.
+
+(* Skipping definition `UniqSet.pprUniqSet' *)
 
 (* External variables:
      bool cons list nat op_zt__ option Data.Foldable.foldl' Data.Foldable.foldr

--- a/examples/ghc/lib/Unique.v
+++ b/examples/ghc/lib/Unique.v
@@ -49,132 +49,21 @@ Program Instance Uniquable__Word : Uniquable GHC.Num.Word :=
 
 (* Converted value declarations: *)
 
-Definition uNIQUE_BITS : GHC.Num.Int :=
-  #56.
-
-Definition uniqueMask : GHC.Num.Int :=
-  Data.Bits.shiftL #1 uNIQUE_BITS GHC.Num.- #1.
-
-Definition unpkUnique : Unique -> GHC.Char.Char * GHC.Num.Int :=
-  fun '(MkUnique u) =>
-    let i := Coq.ZArith.BinInt.Z.land (Coq.ZArith.BinInt.Z.of_N u) uniqueMask in
-    let tag :=
-      GHC.Char.chr (Data.Bits.shiftR (Coq.ZArith.BinInt.Z.of_N u) uNIQUE_BITS) in
-    pair tag i.
-
-Definition stepUnique : Unique -> BinNums.N -> Unique :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | MkUnique i, n => MkUnique (i GHC.Num.+ n)
-    end.
-
-(* Skipping definition `Unique.showUnique' *)
-
-(* Skipping definition `Unique.pprUniqueAlways' *)
-
-Definition nonDetCmpUnique : Unique -> Unique -> comparison :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | MkUnique u1, MkUnique u2 =>
-        if u1 GHC.Base.== u2 : bool
-        then Eq
-        else if u1 GHC.Base.< u2 : bool
-             then Lt
-             else Gt
-    end.
-
-(* Skipping definition `Unique.newTagUnique' *)
-
 Definition mkUniqueGrimily : BinNums.N -> Unique :=
   MkUnique.
 
-Definition mkUnique : GHC.Char.Char -> GHC.Num.Word -> Unique :=
-  fun c i =>
-    let bits := Coq.ZArith.BinInt.Z.land (Coq.ZArith.BinInt.Z.of_N i) uniqueMask in
-    let tag := Data.Bits.shiftL (GHC.Base.ord c) uNIQUE_BITS in
-    MkUnique (Coq.ZArith.BinInt.Z.to_N (Coq.ZArith.BinInt.Z.lor tag bits)).
+Local Definition Uniquable__FastString_getUnique
+   : FastString.FastString -> Unique :=
+  fun fs => mkUniqueGrimily (FastString.uniqueOfFS fs).
 
-Definition mkVarOccUnique : FastString.FastString -> Unique :=
-  fun fs => mkUnique (GHC.Char.hs_char__ "i") (FastString.uniqueOfFS fs).
+Program Instance Uniquable__FastString : Uniquable FastString.FastString :=
+  fun _ k__ => k__ {| getUnique__ := Uniquable__FastString_getUnique |}.
 
-Definition mkTvOccUnique : FastString.FastString -> Unique :=
-  fun fs => mkUnique (GHC.Char.hs_char__ "v") (FastString.uniqueOfFS fs).
+Local Definition Uniquable__N_getUnique : BinNums.N -> Unique :=
+  fun i => mkUniqueGrimily i.
 
-Definition mkTcOccUnique : FastString.FastString -> Unique :=
-  fun fs => mkUnique (GHC.Char.hs_char__ "c") (FastString.uniqueOfFS fs).
-
-Definition mkRegSubUnique : BinNums.N -> Unique :=
-  mkUnique (GHC.Char.hs_char__ "S").
-
-Definition mkRegSingleUnique : BinNums.N -> Unique :=
-  mkUnique (GHC.Char.hs_char__ "R").
-
-Definition mkRegPairUnique : BinNums.N -> Unique :=
-  mkUnique (GHC.Char.hs_char__ "P").
-
-Definition mkRegClassUnique : BinNums.N -> Unique :=
-  mkUnique (GHC.Char.hs_char__ "L").
-
-Definition mkPseudoUniqueH : BinNums.N -> Unique :=
-  fun i => mkUnique (GHC.Char.hs_char__ "H") i.
-
-Definition mkPseudoUniqueE : BinNums.N -> Unique :=
-  fun i => mkUnique (GHC.Char.hs_char__ "E") i.
-
-Definition mkPseudoUniqueD : BinNums.N -> Unique :=
-  fun i => mkUnique (GHC.Char.hs_char__ "D") i.
-
-Definition mkPrimOpIdUnique : BinNums.N -> Unique :=
-  fun op => mkUnique (GHC.Char.hs_char__ "9") op.
-
-Definition mkPreludeTyConUnique : BinNums.N -> Unique :=
-  fun i => mkUnique (GHC.Char.hs_char__ "3") (#2 GHC.Num.* i).
-
-Definition mkPreludeMiscIdUnique : BinNums.N -> Unique :=
-  fun i => mkUnique (GHC.Char.hs_char__ "0") i.
-
-Definition mkPreludeDataConUnique : BasicTypes.Arity -> Unique :=
-  fun i => mkUnique (GHC.Char.hs_char__ "6") (#3 GHC.Num.* BinNat.N.of_nat i).
-
-Definition mkPreludeClassUnique : BinNums.N -> Unique :=
-  fun i => mkUnique (GHC.Char.hs_char__ "2") i.
-
-Definition mkPArrDataConUnique : BinNums.N -> Unique :=
-  fun a => mkUnique (GHC.Char.hs_char__ ":") (#2 GHC.Num.* a).
-
-Definition mkDataOccUnique : FastString.FastString -> Unique :=
-  fun fs => mkUnique (GHC.Char.hs_char__ "d") (FastString.uniqueOfFS fs).
-
-Definition mkCostCentreUnique : BinNums.N -> Unique :=
-  mkUnique (GHC.Char.hs_char__ "C").
-
-Definition mkCoVarUnique : BinNums.N -> Unique :=
-  fun i => mkUnique (GHC.Char.hs_char__ "g") i.
-
-Definition mkBuiltinUnique : BinNums.N -> Unique :=
-  fun i => mkUnique (GHC.Char.hs_char__ "B") i.
-
-Definition mkAlphaTyVarUnique : BinNums.N -> Unique :=
-  fun i => mkUnique (GHC.Char.hs_char__ "1") i.
-
-Definition isValidKnownKeyUnique : Unique -> bool :=
-  fun u =>
-    let 'pair c x := unpkUnique u in
-    andb (GHC.Base.ord c GHC.Base.< #255) (x GHC.Base.<= (Data.Bits.shiftL #1 #22)).
-
-Definition initTyVarUnique : Unique :=
-  mkUnique (GHC.Char.hs_char__ "t") #0.
-
-Definition initExitJoinUnique : Unique :=
-  mkUnique (GHC.Char.hs_char__ "s") #0.
-
-Definition incrUnique : Unique -> Unique :=
-  fun '(MkUnique i) => MkUnique (i GHC.Num.+ #1).
-
-Definition tyConRepNameUnique : Unique -> Unique :=
-  fun u => incrUnique u.
-
-(* Skipping definition `Unique.iToBase62' *)
+Program Instance Uniquable__N : Uniquable BinNums.N :=
+  fun _ k__ => k__ {| getUnique__ := Uniquable__N_getUnique |}.
 
 Definition eqUnique : Unique -> Unique -> bool :=
   fun arg_0__ arg_1__ =>
@@ -193,13 +82,41 @@ Program Instance Eq___Unique : GHC.Base.Eq_ Unique :=
     k__ {| GHC.Base.op_zeze____ := Eq___Unique_op_zeze__ ;
            GHC.Base.op_zsze____ := Eq___Unique_op_zsze__ |}.
 
-Definition hasKey {a} `{Uniquable a} : a -> Unique -> bool :=
-  fun x k => getUnique x GHC.Base.== k.
+Local Definition Uniquable__Unique_getUnique : Unique -> Unique :=
+  fun u => u.
+
+Program Instance Uniquable__Unique : Uniquable Unique :=
+  fun _ k__ => k__ {| getUnique__ := Uniquable__Unique_getUnique |}.
+
+(* Skipping all instances of class `Outputable.Outputable', including
+   `Unique.Outputable__Unique' *)
+
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Unique.Show__Unique' *)
+
+Definition uNIQUE_BITS : GHC.Num.Int :=
+  #56.
 
 Definition getKey : Unique -> BinNums.N :=
   fun '(MkUnique x) => x.
 
-(* Skipping definition `Unique.finish_show' *)
+Definition incrUnique : Unique -> Unique :=
+  fun '(MkUnique i) => MkUnique (i GHC.Num.+ #1).
+
+Definition stepUnique : Unique -> BinNums.N -> Unique :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | MkUnique i, n => MkUnique (i GHC.Num.+ n)
+    end.
+
+Definition uniqueMask : GHC.Num.Int :=
+  Data.Bits.shiftL #1 uNIQUE_BITS GHC.Num.- #1.
+
+Definition mkUnique : GHC.Char.Char -> GHC.Num.Word -> Unique :=
+  fun c i =>
+    let bits := Coq.ZArith.BinInt.Z.land (Coq.ZArith.BinInt.Z.of_N i) uniqueMask in
+    let tag := Data.Bits.shiftL (GHC.Base.ord c) uNIQUE_BITS in
+    MkUnique (Coq.ZArith.BinInt.Z.to_N (Coq.ZArith.BinInt.Z.lor tag bits)).
 
 Definition deriveUnique : Unique -> BinNums.N -> Unique :=
   fun arg_0__ arg_1__ =>
@@ -207,36 +124,119 @@ Definition deriveUnique : Unique -> BinNums.N -> Unique :=
     | MkUnique i, delta => mkUnique (GHC.Char.hs_char__ "X") (i GHC.Num.+ delta)
     end.
 
+(* Skipping definition `Unique.newTagUnique' *)
+
+Definition unpkUnique : Unique -> GHC.Char.Char * GHC.Num.Int :=
+  fun '(MkUnique u) =>
+    let i := Coq.ZArith.BinInt.Z.land (Coq.ZArith.BinInt.Z.of_N u) uniqueMask in
+    let tag :=
+      GHC.Char.chr (Data.Bits.shiftR (Coq.ZArith.BinInt.Z.of_N u) uNIQUE_BITS) in
+    pair tag i.
+
+Definition isValidKnownKeyUnique : Unique -> bool :=
+  fun u =>
+    let 'pair c x := unpkUnique u in
+    andb (GHC.Base.ord c GHC.Base.< #255) (x GHC.Base.<= (Data.Bits.shiftL #1 #22)).
+
+Definition hasKey {a} `{Uniquable a} : a -> Unique -> bool :=
+  fun x k => getUnique x GHC.Base.== k.
+
+Definition nonDetCmpUnique : Unique -> Unique -> comparison :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | MkUnique u1, MkUnique u2 =>
+        if u1 GHC.Base.== u2 : bool
+        then Eq
+        else if u1 GHC.Base.< u2 : bool
+             then Lt
+             else Gt
+    end.
+
+(* Skipping definition `Unique.showUnique' *)
+
+(* Skipping definition `Unique.finish_show' *)
+
+(* Skipping definition `Unique.pprUniqueAlways' *)
+
+(* Skipping definition `Unique.iToBase62' *)
+
+Definition mkAlphaTyVarUnique : BinNums.N -> Unique :=
+  fun i => mkUnique (GHC.Char.hs_char__ "1") i.
+
+Definition mkCoVarUnique : BinNums.N -> Unique :=
+  fun i => mkUnique (GHC.Char.hs_char__ "g") i.
+
+Definition mkPreludeClassUnique : BinNums.N -> Unique :=
+  fun i => mkUnique (GHC.Char.hs_char__ "2") i.
+
+Definition mkPreludeTyConUnique : BinNums.N -> Unique :=
+  fun i => mkUnique (GHC.Char.hs_char__ "3") (#2 GHC.Num.* i).
+
+Definition tyConRepNameUnique : Unique -> Unique :=
+  fun u => incrUnique u.
+
+Definition mkPreludeDataConUnique : BasicTypes.Arity -> Unique :=
+  fun i => mkUnique (GHC.Char.hs_char__ "6") (#3 GHC.Num.* BinNat.N.of_nat i).
+
 Definition dataConWorkerUnique : Unique -> Unique :=
   fun u => incrUnique u.
 
 Definition dataConRepNameUnique : Unique -> Unique :=
   fun u => stepUnique u #2.
 
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Unique.Show__Unique' *)
+Definition mkPrimOpIdUnique : BinNums.N -> Unique :=
+  fun op => mkUnique (GHC.Char.hs_char__ "9") op.
 
-(* Skipping all instances of class `Outputable.Outputable', including
-   `Unique.Outputable__Unique' *)
+Definition mkPreludeMiscIdUnique : BinNums.N -> Unique :=
+  fun i => mkUnique (GHC.Char.hs_char__ "0") i.
 
-Local Definition Uniquable__Unique_getUnique : Unique -> Unique :=
-  fun u => u.
+Definition mkPArrDataConUnique : BinNums.N -> Unique :=
+  fun a => mkUnique (GHC.Char.hs_char__ ":") (#2 GHC.Num.* a).
 
-Program Instance Uniquable__Unique : Uniquable Unique :=
-  fun _ k__ => k__ {| getUnique__ := Uniquable__Unique_getUnique |}.
+Definition initTyVarUnique : Unique :=
+  mkUnique (GHC.Char.hs_char__ "t") #0.
 
-Local Definition Uniquable__N_getUnique : BinNums.N -> Unique :=
-  fun i => mkUniqueGrimily i.
+Definition mkBuiltinUnique : BinNums.N -> Unique :=
+  fun i => mkUnique (GHC.Char.hs_char__ "B") i.
 
-Program Instance Uniquable__N : Uniquable BinNums.N :=
-  fun _ k__ => k__ {| getUnique__ := Uniquable__N_getUnique |}.
+Definition mkPseudoUniqueD : BinNums.N -> Unique :=
+  fun i => mkUnique (GHC.Char.hs_char__ "D") i.
 
-Local Definition Uniquable__FastString_getUnique
-   : FastString.FastString -> Unique :=
-  fun fs => mkUniqueGrimily (FastString.uniqueOfFS fs).
+Definition mkPseudoUniqueE : BinNums.N -> Unique :=
+  fun i => mkUnique (GHC.Char.hs_char__ "E") i.
 
-Program Instance Uniquable__FastString : Uniquable FastString.FastString :=
-  fun _ k__ => k__ {| getUnique__ := Uniquable__FastString_getUnique |}.
+Definition mkPseudoUniqueH : BinNums.N -> Unique :=
+  fun i => mkUnique (GHC.Char.hs_char__ "H") i.
+
+Definition mkRegSingleUnique : BinNums.N -> Unique :=
+  mkUnique (GHC.Char.hs_char__ "R").
+
+Definition mkRegSubUnique : BinNums.N -> Unique :=
+  mkUnique (GHC.Char.hs_char__ "S").
+
+Definition mkRegPairUnique : BinNums.N -> Unique :=
+  mkUnique (GHC.Char.hs_char__ "P").
+
+Definition mkRegClassUnique : BinNums.N -> Unique :=
+  mkUnique (GHC.Char.hs_char__ "L").
+
+Definition mkCostCentreUnique : BinNums.N -> Unique :=
+  mkUnique (GHC.Char.hs_char__ "C").
+
+Definition mkVarOccUnique : FastString.FastString -> Unique :=
+  fun fs => mkUnique (GHC.Char.hs_char__ "i") (FastString.uniqueOfFS fs).
+
+Definition mkDataOccUnique : FastString.FastString -> Unique :=
+  fun fs => mkUnique (GHC.Char.hs_char__ "d") (FastString.uniqueOfFS fs).
+
+Definition mkTvOccUnique : FastString.FastString -> Unique :=
+  fun fs => mkUnique (GHC.Char.hs_char__ "v") (FastString.uniqueOfFS fs).
+
+Definition mkTcOccUnique : FastString.FastString -> Unique :=
+  fun fs => mkUnique (GHC.Char.hs_char__ "c") (FastString.uniqueOfFS fs).
+
+Definition initExitJoinUnique : Unique :=
+  mkUnique (GHC.Char.hs_char__ "s") #0.
 
 Definition getWordKey : Unique -> GHC.Num.Word :=
   getKey.

--- a/examples/ghc/lib/Util.v
+++ b/examples/ghc/lib/Util.v
@@ -62,422 +62,35 @@ Instance Util_HasDebugCallStack : HasDebugCallStack := tt.
 
 (* Converted value declarations: *)
 
-Fixpoint zipWithLazy {a} {b} {c} (arg_0__ : (a -> b -> c)) (arg_1__ : list a)
-                     (arg_2__ : list b) : list c
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, nil, _ => nil
-              | f, cons a as_, cons b bs => cons (f a b) (zipWithLazy f as_ bs)
-              | _, _, _ => GHC.Err.patternFailure
-              end.
-
-Definition zipWithEqual {a} {b} {c}
-   : GHC.Base.String -> (a -> b -> c) -> list a -> list b -> list c :=
-  fun arg_0__ => GHC.List.zipWith.
-
-Fixpoint zipWithAndUnzip {a} {b} {c} {d} (arg_0__ : (a -> b -> (c * d)%type))
-                         (arg_1__ : list a) (arg_2__ : list b) : (list c * list d)%type
-           := match arg_0__, arg_1__, arg_2__ with
-              | f, cons a as_, cons b bs =>
-                  let 'pair rs1 rs2 := zipWithAndUnzip f as_ bs in
-                  let 'pair r1 r2 := f a b in
-                  pair (cons r1 rs1) (cons r2 rs2)
-              | _, _, _ => pair nil nil
-              end.
-
-Definition zipWith4Equal {a} {b} {c} {d} {e}
-   : GHC.Base.String ->
-     (a -> b -> c -> d -> e) -> list a -> list b -> list c -> list d -> list e :=
-  fun arg_0__ => Data.OldList.zipWith4.
-
-Fixpoint zipWith3Lazy {a} {b} {c} {d} (arg_0__ : (a -> b -> c -> d)) (arg_1__
-                        : list a) (arg_2__ : list b) (arg_3__ : list c) : list d
-           := match arg_0__, arg_1__, arg_2__, arg_3__ with
-              | _, nil, _, _ => nil
-              | f, cons a as_, cons b bs, cons c cs =>
-                  cons (f a b c) (zipWith3Lazy f as_ bs cs)
-              | _, _, _, _ => GHC.Err.patternFailure
-              end.
-
-Definition zipWith3Equal {a} {b} {c} {d}
-   : GHC.Base.String ->
-     (a -> b -> c -> d) -> list a -> list b -> list c -> list d :=
-  fun arg_0__ => GHC.List.zipWith3.
-
-Fixpoint zipLazy {a} {b} (arg_0__ : list a) (arg_1__ : list b) : list (a *
-                                                                       b)%type
-           := match arg_0__, arg_1__ with
-              | nil, _ => nil
-              | cons x xs, cons y ys => cons (pair x y) (zipLazy xs ys)
-              | _, _ => GHC.Err.patternFailure
-              end.
-
-Definition zipEqual {a} {b}
-   : GHC.Base.String -> list a -> list b -> list (a * b)%type :=
-  fun arg_0__ => GHC.List.zip.
-
-Definition unzipWith {a} {b} {c}
-   : (a -> b -> c) -> list (a * b)%type -> list c :=
-  fun f pairs => GHC.Base.map (fun '(pair a b) => f a b) pairs.
-
-Definition uncurry3 {a} {b} {c} {d}
-   : (a -> b -> c -> d) -> (a * b * c)%type -> d :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, pair (pair a b) c => f a b c
-    end.
-
-Definition transitiveClosure {a}
-   : (a -> list a) -> (a -> a -> bool) -> list a -> list a :=
-  fun succ eq xs =>
-    let fix is_in arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | _, nil => false
-                 | x, cons y ys => if eq x y : bool then true else is_in x ys
-                 end in
-    let go :=
-      GHC.DeferredFix.deferredFix2 (fun go arg_5__ arg_6__ =>
-                                      match arg_5__, arg_6__ with
-                                      | done, nil => done
-                                      | done, cons x xs =>
-                                          if is_in x done : bool then go done xs else
-                                          go (cons x done) (Coq.Init.Datatypes.app (succ x) xs)
-                                      end) in
-    go nil xs.
-
-(* Skipping definition `Util.toCmdArgs' *)
-
-(* Skipping definition `Util.toArgs' *)
-
-Definition third3 {c} {d} {a} {b}
-   : (c -> d) -> (a * b * c)%type -> (a * b * d)%type :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, pair (pair a b) c => pair (pair a b) (f c)
-    end.
-
-Definition thenCmp : comparison -> comparison -> comparison :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Eq, ordering => ordering
-    | ordering, _ => ordering
-    end.
-
-Definition thdOf3 {a} {b} {c} : (a * b * c)%type -> c :=
-  fun '(pair (pair _ _) c) => c.
-
-Fixpoint takeList {b} {a} (arg_0__ : list b) (arg_1__ : list a) : list a
-           := match arg_0__, arg_1__ with
-              | nil, _ => nil
-              | cons _ xs, ls =>
-                  match ls with
-                  | nil => nil
-                  | cons y ys => cons y (takeList xs ys)
-                  end
-              end.
-
-Fixpoint stretchZipWith {a} {b} {c} (arg_0__ : (a -> bool)) (arg_1__ : b)
-                        (arg_2__ : (a -> b -> c)) (arg_3__ : list a) (arg_4__ : list b) : list c
-           := match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__ with
-              | _, _, _, nil, _ => nil
-              | p, z, f, cons x xs, ys =>
-                  if p x : bool then cons (f x z) (stretchZipWith p z f xs ys) else
-                  match ys with
-                  | nil => nil
-                  | cons y ys => cons (f x y) (stretchZipWith p z f xs ys)
-                  end
-              end.
-
-(* Skipping definition `Util.splitLongestPrefix' *)
-
-Fixpoint splitEithers {a} {b} (arg_0__ : list (Data.Either.Either a b)) : (list
-                                                                           a *
-                                                                           list b)%type
-           := match arg_0__ with
-              | nil => pair nil nil
-              | cons e es =>
-                  let 'pair xs ys := splitEithers es in
-                  match e with
-                  | Data.Either.Left x => pair (cons x xs) ys
-                  | Data.Either.Right y => pair xs (cons y ys)
-                  end
-              end.
-
-Fixpoint splitAtList {b} {a} (arg_0__ : list b) (arg_1__ : list a) : (list a *
-                                                                      list a)%type
-           := match arg_0__, arg_1__ with
-              | nil, xs => pair nil xs
-              | _, (nil as xs) => pair xs xs
-              | cons _ xs, cons y ys =>
-                  let 'pair ys' ys'' := splitAtList xs ys in
-                  pair (cons y ys') ys''
-              end.
-
-Definition split : GHC.Char.Char -> GHC.Base.String -> list GHC.Base.String :=
-  GHC.DeferredFix.deferredFix2 (fun split
-                                (c : GHC.Char.Char)
-                                (s : GHC.Base.String) =>
-                                  let 'pair chunk rest := GHC.List.break (fun arg_0__ => arg_0__ GHC.Base.== c)
-                                                            s in
-                                  match rest with
-                                  | nil => cons chunk nil
-                                  | cons _ rest => cons chunk (split c rest)
-                                  end).
-
-Definition spanEnd {a} : (a -> bool) -> list a -> (list a * list a)%type :=
-  fun p l =>
-    let fix go arg_0__ arg_1__ arg_2__ arg_3__
-              := match arg_0__, arg_1__, arg_2__, arg_3__ with
-                 | yes, _rev_yes, rev_no, nil => pair yes (GHC.List.reverse rev_no)
-                 | yes, rev_yes, rev_no, cons x xs =>
-                     if p x : bool then go yes (cons x rev_yes) rev_no xs else
-                     go xs nil (cons x (Coq.Init.Datatypes.app rev_yes rev_no)) xs
-                 end in
-    go l nil nil l.
-
-Definition snocView {a} : list a -> option (list a * a)%type :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | nil => None
-    | xs =>
-        let fix go arg_1__ arg_2__
-                  := match arg_1__, arg_2__ with
-                     | acc, cons x nil => Some (pair (GHC.List.reverse acc) x)
-                     | acc, cons x xs => go (cons x acc) xs
-                     | _, nil => Panic.panic (GHC.Base.hs_string__ "Util: snocView")
-                     end in
-        go nil xs
-    end.
-
-Definition sndOf3 {a} {b} {c} : (a * b * c)%type -> b :=
-  fun '(pair (pair _ b) _) => b.
-
-Definition snd3 {b} {d} {a} {c}
-   : (b -> d) -> (a * b * c)%type -> (a * d * c)%type :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, pair (pair a b) c => pair (pair a (f b)) c
-    end.
-
-Definition sizedComplement {bv} `{Data.Bits.Bits bv} : bv -> bv -> bv :=
-  fun vector_mask vect => Data.Bits.xor vector_mask vect.
-
-Definition singleton {a} : a -> list a :=
-  fun x => cons x nil.
-
-(* Skipping definition `Util.sharedGlobalM' *)
-
-(* Skipping definition `Util.sharedGlobal' *)
-
-Fixpoint seqList {a} {b} (arg_0__ : list a) (arg_1__ : b) : b
-           := match arg_0__, arg_1__ with
-              | nil, b => b
-              | cons x xs, b => GHC.Prim.seq x (seqList xs b)
-              end.
-
-(* Skipping definition `Util.restrictedDamerauLevenshteinDistanceWorker' *)
-
-(* Skipping definition `Util.restrictedDamerauLevenshteinDistanceWithLengths' *)
-
-(* Skipping definition `Util.restrictedDamerauLevenshteinDistance'' *)
-
-(* Skipping definition `Util.restrictedDamerauLevenshteinDistance' *)
-
-(* Skipping definition `Util.reslash' *)
-
-(* Skipping definition `Util.removeSpaces' *)
-
-(* Skipping definition `Util.readRational__' *)
-
-(* Skipping definition `Util.readRational' *)
-
-(* Skipping definition `Util.readHexRational__' *)
-
-(* Skipping definition `Util.readHexRational' *)
-
-Fixpoint partitionWith {a} {b} {c} (arg_0__ : (a -> Data.Either.Either b c))
-                       (arg_1__ : list a) : (list b * list c)%type
-           := match arg_0__, arg_1__ with
-              | _, nil => pair nil nil
-              | f, cons x xs =>
-                  let 'pair bs cs := partitionWith f xs in
-                  match f x with
-                  | Data.Either.Left b => pair (cons b bs) cs
-                  | Data.Either.Right c => pair bs (cons c cs)
-                  end
-              end.
-
-Definition partitionByList {a}
-   : list bool -> list a -> (list a * list a)%type :=
-  let fix go arg_0__ arg_1__ arg_2__ arg_3__
-            := match arg_0__, arg_1__, arg_2__, arg_3__ with
-               | trues, falses, cons true bs, cons x xs => go (cons x trues) falses bs xs
-               | trues, falses, cons false bs, cons x xs => go trues (cons x falses) bs xs
-               | trues, falses, _, _ => pair (GHC.List.reverse trues) (GHC.List.reverse falses)
-               end in
-  go nil nil.
-
-Definition overrideWith : bool -> OverridingBool -> bool :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | b, Auto => b
-    | _, Always => true
-    | _, Never => false
-    end.
-
-Definition op_zlzbzbzg__ {f} `{GHC.Base.Applicative f}
-   : f bool -> f bool -> f bool :=
-  GHC.Base.liftA2 orb.
-
-Notation "'_<||>_'" := (op_zlzbzbzg__).
-
-Infix "<||>" := (_<||>_) (at level 99).
-
-Definition op_zlzazazg__ {f} `{GHC.Base.Applicative f}
-   : f bool -> f bool -> f bool :=
-  GHC.Base.liftA2 andb.
-
-Notation "'_<&&>_'" := (op_zlzazazg__).
-
-Infix "<&&>" := (_<&&>_) (at level 99).
-
-Definition only {a} `{GHC.Err.Default a} : list a -> a :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | cons a _ => a
-    | _ => Panic.panic (GHC.Base.hs_string__ "Util: only")
-    end.
-
-(* Skipping definition `Util.nubSort' *)
-
-Definition notNull {a} : list a -> bool :=
-  fun arg_0__ => match arg_0__ with | nil => false | _ => true end.
-
-Fixpoint neLength {a} {b} (arg_0__ : list a) (arg_1__ : list b) : bool
-           := match arg_0__, arg_1__ with
-              | nil, nil => false
-              | cons _ xs, cons _ ys => neLength xs ys
-              | _, _ => true
-              end.
-
-Definition ncgDebugIsOn : bool :=
-  false.
-
-(* Skipping definition `Util.nTimes' *)
-
-Definition nOfThem {a} : nat -> a -> list a :=
-  fun n thing => Coq.Lists.List.repeat thing n.
-
-(* Skipping definition `Util.mulHi' *)
-
-(* Skipping definition `Util.modificationTimeIfExists' *)
-
-(* Skipping definition `Util.minWith' *)
-
-(* Skipping definition `Util.maybeReadFuzzy' *)
-
-(* Skipping definition `Util.maybeRead' *)
-
-(* Skipping definition `Util.matchVectors' *)
-
-Definition mapSnd {b} {c} {a}
-   : (b -> c) -> list (a * b)%type -> list (a * c)%type :=
-  fun f xys =>
-    let cont_0__ arg_1__ := let 'pair x y := arg_1__ in cons (pair x (f y)) nil in
-    Coq.Lists.List.flat_map cont_0__ xys.
-
-Definition mapFst {a} {c} {b}
-   : (a -> c) -> list (a * b)%type -> list (c * b)%type :=
-  fun f xys =>
-    let cont_0__ arg_1__ := let 'pair x y := arg_1__ in cons (pair (f x) y) nil in
-    Coq.Lists.List.flat_map cont_0__ xys.
-
-Fixpoint mapAndUnzip3 {a} {b} {c} {d} (arg_0__ : (a -> (b * c * d)%type))
-                      (arg_1__ : list a) : (list b * list c * list d)%type
-           := match arg_0__, arg_1__ with
-              | _, nil => pair (pair nil nil) nil
-              | f, cons x xs =>
-                  let 'pair (pair rs1 rs2) rs3 := mapAndUnzip3 f xs in
-                  let 'pair (pair r1 r2) r3 := f x in
-                  pair (pair (cons r1 rs1) (cons r2 rs2)) (cons r3 rs3)
-              end.
-
-Fixpoint mapAndUnzip {a} {b} {c} (arg_0__ : (a -> (b * c)%type)) (arg_1__
-                       : list a) : (list b * list c)%type
-           := match arg_0__, arg_1__ with
-              | _, nil => pair nil nil
-              | f, cons x xs =>
-                  let 'pair rs1 rs2 := mapAndUnzip f xs in
-                  let 'pair r1 r2 := f x in
-                  pair (cons r1 rs1) (cons r2 rs2)
-              end.
-
-(* Skipping definition `Util.mapAccumL2' *)
-
-Axiom makeRelativeTo : GHC.Base.String -> GHC.Base.String -> GHC.Base.String.
-
-Axiom looksLikePackageName : GHC.Base.String -> bool.
-
-(* Skipping definition `Util.looksLikeModuleName' *)
-
-Definition liftSnd {a} {b} {c} : (a -> b) -> (c * a)%type -> (c * b)%type :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, pair c a => pair c (f a)
-    end.
-
-Definition liftFst {a} {b} {c} : (a -> b) -> (a * c)%type -> (b * c)%type :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | f, pair a c => pair (f a) c
-    end.
-
-Definition isn'tIn {a} `{GHC.Base.Eq_ a}
-   : GHC.Base.String -> a -> list a -> bool :=
-  fun _msg x ys => Data.Foldable.notElem x ys.
-
-Definition isWindowsHost : bool :=
-  false.
-
-Definition isSingleton {a} : list a -> bool :=
-  fun arg_0__ => match arg_0__ with | cons _ nil => true | _ => false end.
-
-Definition isIn {a} `{GHC.Base.Eq_ a}
-   : GHC.Base.String -> a -> list a -> bool :=
-  fun _msg x ys => Data.Foldable.elem x ys.
-
-Definition isEqual : comparison -> bool :=
-  fun arg_0__ => match arg_0__ with | Gt => false | Eq => true | Lt => false end.
-
-(* Skipping definition `Util.isDarwinHost' *)
-
-(* Skipping definition `Util.hashString' *)
-
-(* Skipping definition `Util.hashInt32' *)
-
-(* Skipping definition `Util.hSetTranslit' *)
-
-(* Skipping definition `Util.golden' *)
-
-(* Skipping definition `Util.globalM' *)
-
-(* Skipping definition `Util.global' *)
-
-Definition ghciTablesNextToCode : bool :=
-  false.
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Util.Show__OverridingBool' *)
 
 Definition ghciSupported : bool :=
   false.
 
-(* Skipping definition `Util.getModificationUTCTime' *)
+Axiom debugIsOn : bool.
 
-(* Skipping definition `Util.getCmd' *)
+Definition ncgDebugIsOn : bool :=
+  false.
 
-(* Skipping definition `Util.fuzzyMatch' *)
+Definition ghciTablesNextToCode : bool :=
+  false.
 
-(* Skipping definition `Util.fuzzyLookup' *)
+Definition isWindowsHost : bool :=
+  false.
+
+(* Skipping definition `Util.isDarwinHost' *)
+
+(* Skipping definition `Util.nTimes' *)
 
 Definition fstOf3 {a} {b} {c} : (a * b * c)%type -> a :=
   fun '(pair (pair a _) _) => a.
+
+Definition sndOf3 {a} {b} {c} : (a * b * c)%type -> b :=
+  fun '(pair (pair _ b) _) => b.
+
+Definition thdOf3 {a} {b} {c} : (a * b * c)%type -> c :=
+  fun '(pair (pair _ _) c) => c.
 
 Definition fst3 {a} {d} {b} {c}
    : (a -> d) -> (a * b * c)%type -> (d * b * c)%type :=
@@ -486,14 +99,38 @@ Definition fst3 {a} {d} {b} {c}
     | f, pair (pair a b) c => pair (pair (f a) b) c
     end.
 
-Fixpoint foldl2 {acc} {a} {b} `{GHC.Err.Default acc} (arg_0__
-                  : acc -> a -> b -> acc) (arg_1__ : acc) (arg_2__ : list a) (arg_3__ : list b)
-           : acc
-           := match arg_0__, arg_1__, arg_2__, arg_3__ with
-              | _, z, nil, nil => z
-              | k, z, cons a as_, cons b bs => foldl2 k (k z a b) as_ bs
-              | _, _, _, _ => Panic.panic (GHC.Base.hs_string__ "Util: foldl2")
-              end.
+Definition snd3 {b} {d} {a} {c}
+   : (b -> d) -> (a * b * c)%type -> (a * d * c)%type :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, pair (pair a b) c => pair (pair a (f b)) c
+    end.
+
+Definition third3 {c} {d} {a} {b}
+   : (c -> d) -> (a * b * c)%type -> (a * b * d)%type :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, pair (pair a b) c => pair (pair a b) (f c)
+    end.
+
+Definition uncurry3 {a} {b} {c} {d}
+   : (a -> b -> c -> d) -> (a * b * c)%type -> d :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, pair (pair a b) c => f a b c
+    end.
+
+Definition liftFst {a} {b} {c} : (a -> b) -> (a * c)%type -> (b * c)%type :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, pair a c => pair (f a) c
+    end.
+
+Definition liftSnd {a} {b} {c} : (a -> b) -> (c * a)%type -> (c * b)%type :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | f, pair c a => pair c (f a)
+    end.
 
 Definition firstM {m} {a} {c} {b} `{GHC.Base.Monad m}
    : (a -> m c) -> (a * b)%type -> m (c * b)%type :=
@@ -515,12 +152,77 @@ Fixpoint filterOut {a} (arg_0__ : (a -> bool)) (arg_1__ : list a) : list a
               | p, cons x xs => if p x : bool then filterOut p xs else cons x (filterOut p xs)
               end.
 
-Fixpoint filterByLists {a} (arg_0__ : list bool) (arg_1__ arg_2__ : list a)
-           : list a
+Fixpoint partitionWith {a} {b} {c} (arg_0__ : (a -> Data.Either.Either b c))
+                       (arg_1__ : list a) : (list b * list c)%type
+           := match arg_0__, arg_1__ with
+              | _, nil => pair nil nil
+              | f, cons x xs =>
+                  let 'pair bs cs := partitionWith f xs in
+                  match f x with
+                  | Data.Either.Left b => pair (cons b bs) cs
+                  | Data.Either.Right c => pair bs (cons c cs)
+                  end
+              end.
+
+Fixpoint splitEithers {a} {b} (arg_0__ : list (Data.Either.Either a b)) : (list
+                                                                           a *
+                                                                           list b)%type
+           := match arg_0__ with
+              | nil => pair nil nil
+              | cons e es =>
+                  let 'pair xs ys := splitEithers es in
+                  match e with
+                  | Data.Either.Left x => pair (cons x xs) ys
+                  | Data.Either.Right y => pair xs (cons y ys)
+                  end
+              end.
+
+Definition chkAppend {a} : list a -> list a -> list a :=
+  fun xs ys =>
+    if Data.Foldable.null ys : bool then xs else
+    Coq.Init.Datatypes.app xs ys.
+
+Definition zipEqual {a} {b}
+   : GHC.Base.String -> list a -> list b -> list (a * b)%type :=
+  fun arg_0__ => GHC.List.zip.
+
+Definition zipWithEqual {a} {b} {c}
+   : GHC.Base.String -> (a -> b -> c) -> list a -> list b -> list c :=
+  fun arg_0__ => GHC.List.zipWith.
+
+Definition zipWith3Equal {a} {b} {c} {d}
+   : GHC.Base.String ->
+     (a -> b -> c -> d) -> list a -> list b -> list c -> list d :=
+  fun arg_0__ => GHC.List.zipWith3.
+
+Definition zipWith4Equal {a} {b} {c} {d} {e}
+   : GHC.Base.String ->
+     (a -> b -> c -> d -> e) -> list a -> list b -> list c -> list d -> list e :=
+  fun arg_0__ => Data.OldList.zipWith4.
+
+Fixpoint zipLazy {a} {b} (arg_0__ : list a) (arg_1__ : list b) : list (a *
+                                                                       b)%type
+           := match arg_0__, arg_1__ with
+              | nil, _ => nil
+              | cons x xs, cons y ys => cons (pair x y) (zipLazy xs ys)
+              | _, _ => GHC.Err.patternFailure
+              end.
+
+Fixpoint zipWithLazy {a} {b} {c} (arg_0__ : (a -> b -> c)) (arg_1__ : list a)
+                     (arg_2__ : list b) : list c
            := match arg_0__, arg_1__, arg_2__ with
-              | cons true bs, cons x xs, cons _ ys => cons x (filterByLists bs xs ys)
-              | cons false bs, cons _ xs, cons y ys => cons y (filterByLists bs xs ys)
-              | _, _, _ => nil
+              | _, nil, _ => nil
+              | f, cons a as_, cons b bs => cons (f a b) (zipWithLazy f as_ bs)
+              | _, _, _ => GHC.Err.patternFailure
+              end.
+
+Fixpoint zipWith3Lazy {a} {b} {c} {d} (arg_0__ : (a -> b -> c -> d)) (arg_1__
+                        : list a) (arg_2__ : list b) (arg_3__ : list c) : list d
+           := match arg_0__, arg_1__, arg_2__, arg_3__ with
+              | _, nil, _, _ => nil
+              | f, cons a as_, cons b bs, cons c cs =>
+                  cons (f a b c) (zipWith3Lazy f as_ bs cs)
+              | _, _, _, _ => GHC.Err.patternFailure
               end.
 
 Fixpoint filterByList {a} (arg_0__ : list bool) (arg_1__ : list a) : list a
@@ -530,19 +232,129 @@ Fixpoint filterByList {a} (arg_0__ : list bool) (arg_1__ : list a) : list a
               | _, _ => nil
               end.
 
-Definition exactLog2 : GHC.Num.Integer -> option GHC.Num.Integer :=
-  fun x =>
-    let pow2 :=
-      GHC.DeferredFix.deferredFix1 (fun pow2 x =>
-                                      if x GHC.Base.== #1 : bool then #0 else
-                                      #1 GHC.Num.+ pow2 (Data.Bits.shiftR x #1)) in
-    if (orb (x GHC.Base.<= #0) (x GHC.Base.>= #2147483648)) : bool
-    then None
-    else if (x Data.Bits..&.(**) (GHC.Num.negate x)) GHC.Base./= x : bool
-         then None
-         else Some (pow2 x).
+Fixpoint filterByLists {a} (arg_0__ : list bool) (arg_1__ arg_2__ : list a)
+           : list a
+           := match arg_0__, arg_1__, arg_2__ with
+              | cons true bs, cons x xs, cons _ ys => cons x (filterByLists bs xs ys)
+              | cons false bs, cons _ xs, cons y ys => cons y (filterByLists bs xs ys)
+              | _, _, _ => nil
+              end.
 
-(* Skipping definition `Util.escapeSpaces' *)
+Definition partitionByList {a}
+   : list bool -> list a -> (list a * list a)%type :=
+  let fix go arg_0__ arg_1__ arg_2__ arg_3__
+            := match arg_0__, arg_1__, arg_2__, arg_3__ with
+               | trues, falses, cons true bs, cons x xs => go (cons x trues) falses bs xs
+               | trues, falses, cons false bs, cons x xs => go trues (cons x falses) bs xs
+               | trues, falses, _, _ => pair (GHC.List.reverse trues) (GHC.List.reverse falses)
+               end in
+  go nil nil.
+
+Fixpoint stretchZipWith {a} {b} {c} (arg_0__ : (a -> bool)) (arg_1__ : b)
+                        (arg_2__ : (a -> b -> c)) (arg_3__ : list a) (arg_4__ : list b) : list c
+           := match arg_0__, arg_1__, arg_2__, arg_3__, arg_4__ with
+              | _, _, _, nil, _ => nil
+              | p, z, f, cons x xs, ys =>
+                  if p x : bool then cons (f x z) (stretchZipWith p z f xs ys) else
+                  match ys with
+                  | nil => nil
+                  | cons y ys => cons (f x y) (stretchZipWith p z f xs ys)
+                  end
+              end.
+
+Definition mapFst {a} {c} {b}
+   : (a -> c) -> list (a * b)%type -> list (c * b)%type :=
+  fun f xys =>
+    let cont_0__ arg_1__ := let 'pair x y := arg_1__ in cons (pair (f x) y) nil in
+    Coq.Lists.List.flat_map cont_0__ xys.
+
+Definition mapSnd {b} {c} {a}
+   : (b -> c) -> list (a * b)%type -> list (a * c)%type :=
+  fun f xys =>
+    let cont_0__ arg_1__ := let 'pair x y := arg_1__ in cons (pair x (f y)) nil in
+    Coq.Lists.List.flat_map cont_0__ xys.
+
+Fixpoint mapAndUnzip {a} {b} {c} (arg_0__ : (a -> (b * c)%type)) (arg_1__
+                       : list a) : (list b * list c)%type
+           := match arg_0__, arg_1__ with
+              | _, nil => pair nil nil
+              | f, cons x xs =>
+                  let 'pair rs1 rs2 := mapAndUnzip f xs in
+                  let 'pair r1 r2 := f x in
+                  pair (cons r1 rs1) (cons r2 rs2)
+              end.
+
+Fixpoint mapAndUnzip3 {a} {b} {c} {d} (arg_0__ : (a -> (b * c * d)%type))
+                      (arg_1__ : list a) : (list b * list c * list d)%type
+           := match arg_0__, arg_1__ with
+              | _, nil => pair (pair nil nil) nil
+              | f, cons x xs =>
+                  let 'pair (pair rs1 rs2) rs3 := mapAndUnzip3 f xs in
+                  let 'pair (pair r1 r2) r3 := f x in
+                  pair (pair (cons r1 rs1) (cons r2 rs2)) (cons r3 rs3)
+              end.
+
+Fixpoint zipWithAndUnzip {a} {b} {c} {d} (arg_0__ : (a -> b -> (c * d)%type))
+                         (arg_1__ : list a) (arg_2__ : list b) : (list c * list d)%type
+           := match arg_0__, arg_1__, arg_2__ with
+              | f, cons a as_, cons b bs =>
+                  let 'pair rs1 rs2 := zipWithAndUnzip f as_ bs in
+                  let 'pair r1 r2 := f a b in
+                  pair (cons r1 rs1) (cons r2 rs2)
+              | _, _, _ => pair nil nil
+              end.
+
+(* Skipping definition `Util.mapAccumL2' *)
+
+Definition nOfThem {a} : nat -> a -> list a :=
+  fun n thing => Coq.Lists.List.repeat thing n.
+
+Definition atLength {a} {b} : (list a -> b) -> b -> list a -> nat -> b :=
+  fun atLenPred atEnd ls0 n0 =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | num_2__, ls =>
+                     if num_2__ GHC.Base.== #0 : bool then atLenPred ls else
+                     match arg_0__, arg_1__ with
+                     | _, nil => atEnd
+                     | n, cons _ xs => go (n GHC.Num.- #1) xs
+                     end
+                 end in
+    if n0 GHC.Base.< #0 : bool then atLenPred ls0 else
+    go n0 ls0.
+
+Definition notNull {a} : list a -> bool :=
+  fun arg_0__ => match arg_0__ with | nil => false | _ => true end.
+
+Definition lengthExceeds {a} : list a -> nat -> bool :=
+  fun lst n =>
+    if n GHC.Base.< #0 : bool then true else
+    atLength notNull false lst n.
+
+Definition lengthAtLeast {a} : list a -> nat -> bool :=
+  atLength (GHC.Base.const true) false.
+
+Definition lengthIs {a} : list a -> nat -> bool :=
+  fun lst n =>
+    if n GHC.Base.< #0 : bool then false else
+    atLength Data.Foldable.null false lst n.
+
+Definition lengthIsNot {a} : list a -> nat -> bool :=
+  fun lst n =>
+    if n GHC.Base.< #0 : bool then true else
+    atLength notNull true lst n.
+
+Definition lengthAtMost {a} : list a -> nat -> bool :=
+  fun lst n =>
+    if n GHC.Base.< #0 : bool then false else
+    atLength Data.Foldable.null true lst n.
+
+Definition lengthLessThan {a} : list a -> nat -> bool :=
+  atLength (GHC.Base.const false) true.
+
+Definition listLengthCmp {a} : list a -> nat -> comparison :=
+  let atLen := fun arg_0__ => match arg_0__ with | nil => Eq | _ => Gt end in
+  let atEnd := Lt in atLength atLen atEnd.
 
 Fixpoint equalLength {a} {b} (arg_0__ : list a) (arg_1__ : list b) : bool
            := match arg_0__, arg_1__ with
@@ -551,59 +363,12 @@ Fixpoint equalLength {a} {b} (arg_0__ : list a) (arg_1__ : list b) : bool
               | _, _ => false
               end.
 
-Definition eqMaybeBy {a} : (a -> a -> bool) -> option a -> option a -> bool :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | _, None, None => true
-    | eq, Some x, Some y => eq x y
-    | _, _, _ => false
-    end.
-
-Fixpoint eqListBy {a} (arg_0__ : (a -> a -> bool)) (arg_1__ arg_2__ : list a)
-           : bool
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, nil, nil => true
-              | eq, cons x xs, cons y ys => andb (eq x y) (eqListBy eq xs ys)
-              | _, _, _ => false
-              end.
-
-Definition dropWhileEndLE {a} : (a -> bool) -> list a -> list a :=
-  fun p =>
-    Data.Foldable.foldr (fun x r =>
-                           if andb (Data.Foldable.null r) (p x) : bool
-                           then nil
-                           else cons x r) nil.
-
-Definition dropTail {a} : nat -> list a -> list a :=
-  fun n xs =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | cons _ ys, cons x xs => cons x (go ys xs)
-                 | _, _ => nil
-                 end in
-    go (Coq.Lists.List.skipn n xs) xs.
-
-Fixpoint dropList {b} {a} (arg_0__ : list b) (arg_1__ : list a) : list a
+Fixpoint neLength {a} {b} (arg_0__ : list a) (arg_1__ : list b) : bool
            := match arg_0__, arg_1__ with
-              | nil, xs => xs
-              | _, (nil as xs) => xs
-              | cons _ xs, cons _ ys => dropList xs ys
+              | nil, nil => false
+              | cons _ xs, cons _ ys => neLength xs ys
+              | _, _ => true
               end.
-
-(* Skipping definition `Util.doesDirNameExist' *)
-
-Axiom debugIsOn : bool.
-
-Definition count {a} : (a -> bool) -> list a -> nat :=
-  fun p =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | n, nil => n
-                 | n, cons x xs => if p x : bool then go (n GHC.Num.+ #1) xs else go n xs
-                 end in
-    go #0.
-
-(* Skipping definition `Util.consIORef' *)
 
 Fixpoint compareLength {a} {b} (arg_0__ : list a) (arg_1__ : list b)
            : comparison
@@ -630,6 +395,192 @@ Definition ltLength {a} {b} : list a -> list b -> bool :=
     | Gt => false
     end.
 
+Definition singleton {a} : a -> list a :=
+  fun x => cons x nil.
+
+Definition isSingleton {a} : list a -> bool :=
+  fun arg_0__ => match arg_0__ with | cons _ nil => true | _ => false end.
+
+Definition only {a} `{GHC.Err.Default a} : list a -> a :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | cons a _ => a
+    | _ => Panic.panic (GHC.Base.hs_string__ "Util: only")
+    end.
+
+Definition isIn {a} `{GHC.Base.Eq_ a}
+   : GHC.Base.String -> a -> list a -> bool :=
+  fun _msg x ys => Data.Foldable.elem x ys.
+
+Definition isn'tIn {a} `{GHC.Base.Eq_ a}
+   : GHC.Base.String -> a -> list a -> bool :=
+  fun _msg x ys => Data.Foldable.notElem x ys.
+
+(* Skipping definition `Util.chunkList' *)
+
+Fixpoint changeLast {a} (arg_0__ : list a) (arg_1__ : a) : list a
+           := match arg_0__, arg_1__ with
+              | nil, _ => Panic.panic (GHC.Base.hs_string__ "changeLast")
+              | cons _ nil, x => cons x nil
+              | cons x xs, x' => cons x (changeLast xs x')
+              end.
+
+(* Skipping definition `Util.minWith' *)
+
+(* Skipping definition `Util.nubSort' *)
+
+Definition transitiveClosure {a}
+   : (a -> list a) -> (a -> a -> bool) -> list a -> list a :=
+  fun succ eq xs =>
+    let fix is_in arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | _, nil => false
+                 | x, cons y ys => if eq x y : bool then true else is_in x ys
+                 end in
+    let go :=
+      GHC.DeferredFix.deferredFix2 (fun go arg_5__ arg_6__ =>
+                                      match arg_5__, arg_6__ with
+                                      | done, nil => done
+                                      | done, cons x xs =>
+                                          if is_in x done : bool then go done xs else
+                                          go (cons x done) (Coq.Init.Datatypes.app (succ x) xs)
+                                      end) in
+    go nil xs.
+
+Fixpoint foldl2 {acc} {a} {b} `{GHC.Err.Default acc} (arg_0__
+                  : acc -> a -> b -> acc) (arg_1__ : acc) (arg_2__ : list a) (arg_3__ : list b)
+           : acc
+           := match arg_0__, arg_1__, arg_2__, arg_3__ with
+              | _, z, nil, nil => z
+              | k, z, cons a as_, cons b bs => foldl2 k (k z a b) as_ bs
+              | _, _, _, _ => Panic.panic (GHC.Base.hs_string__ "Util: foldl2")
+              end.
+
+Fixpoint all2 {a} {b} (arg_0__ : (a -> b -> bool)) (arg_1__ : list a) (arg_2__
+                : list b) : bool
+           := match arg_0__, arg_1__, arg_2__ with
+              | _, nil, nil => true
+              | p, cons x xs, cons y ys => andb (p x y) (all2 p xs ys)
+              | _, _, _ => false
+              end.
+
+Definition count {a} : (a -> bool) -> list a -> nat :=
+  fun p =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | n, nil => n
+                 | n, cons x xs => if p x : bool then go (n GHC.Num.+ #1) xs else go n xs
+                 end in
+    go #0.
+
+Fixpoint takeList {b} {a} (arg_0__ : list b) (arg_1__ : list a) : list a
+           := match arg_0__, arg_1__ with
+              | nil, _ => nil
+              | cons _ xs, ls =>
+                  match ls with
+                  | nil => nil
+                  | cons y ys => cons y (takeList xs ys)
+                  end
+              end.
+
+Fixpoint dropList {b} {a} (arg_0__ : list b) (arg_1__ : list a) : list a
+           := match arg_0__, arg_1__ with
+              | nil, xs => xs
+              | _, (nil as xs) => xs
+              | cons _ xs, cons _ ys => dropList xs ys
+              end.
+
+Fixpoint splitAtList {b} {a} (arg_0__ : list b) (arg_1__ : list a) : (list a *
+                                                                      list a)%type
+           := match arg_0__, arg_1__ with
+              | nil, xs => pair nil xs
+              | _, (nil as xs) => pair xs xs
+              | cons _ xs, cons y ys =>
+                  let 'pair ys' ys'' := splitAtList xs ys in
+                  pair (cons y ys') ys''
+              end.
+
+Definition dropTail {a} : nat -> list a -> list a :=
+  fun n xs =>
+    let fix go arg_0__ arg_1__
+              := match arg_0__, arg_1__ with
+                 | cons _ ys, cons x xs => cons x (go ys xs)
+                 | _, _ => nil
+                 end in
+    go (Coq.Lists.List.skipn n xs) xs.
+
+Definition dropWhileEndLE {a} : (a -> bool) -> list a -> list a :=
+  fun p =>
+    Data.Foldable.foldr (fun x r =>
+                           if andb (Data.Foldable.null r) (p x) : bool
+                           then nil
+                           else cons x r) nil.
+
+Definition spanEnd {a} : (a -> bool) -> list a -> (list a * list a)%type :=
+  fun p l =>
+    let fix go arg_0__ arg_1__ arg_2__ arg_3__
+              := match arg_0__, arg_1__, arg_2__, arg_3__ with
+                 | yes, _rev_yes, rev_no, nil => pair yes (GHC.List.reverse rev_no)
+                 | yes, rev_yes, rev_no, cons x xs =>
+                     if p x : bool then go yes (cons x rev_yes) rev_no xs else
+                     go xs nil (cons x (Coq.Init.Datatypes.app rev_yes rev_no)) xs
+                 end in
+    go l nil nil l.
+
+Definition snocView {a} : list a -> option (list a * a)%type :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | nil => None
+    | xs =>
+        let fix go arg_1__ arg_2__
+                  := match arg_1__, arg_2__ with
+                     | acc, cons x nil => Some (pair (GHC.List.reverse acc) x)
+                     | acc, cons x xs => go (cons x acc) xs
+                     | _, nil => Panic.panic (GHC.Base.hs_string__ "Util: snocView")
+                     end in
+        go nil xs
+    end.
+
+Definition split : GHC.Char.Char -> GHC.Base.String -> list GHC.Base.String :=
+  GHC.DeferredFix.deferredFix2 (fun split
+                                (c : GHC.Char.Char)
+                                (s : GHC.Base.String) =>
+                                  let 'pair chunk rest := GHC.List.break (fun arg_0__ => arg_0__ GHC.Base.== c)
+                                                            s in
+                                  match rest with
+                                  | nil => cons chunk nil
+                                  | cons _ rest => cons chunk (split c rest)
+                                  end).
+
+Definition capitalise : GHC.Base.String -> GHC.Base.String :=
+  fun arg_0__ => match arg_0__ with | nil => nil | cons c cs => cons c cs end.
+
+Definition isEqual : comparison -> bool :=
+  fun arg_0__ => match arg_0__ with | Gt => false | Eq => true | Lt => false end.
+
+Definition thenCmp : comparison -> comparison -> comparison :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Eq, ordering => ordering
+    | ordering, _ => ordering
+    end.
+
+Fixpoint eqListBy {a} (arg_0__ : (a -> a -> bool)) (arg_1__ arg_2__ : list a)
+           : bool
+           := match arg_0__, arg_1__, arg_2__ with
+              | _, nil, nil => true
+              | eq, cons x xs, cons y ys => andb (eq x y) (eqListBy eq xs ys)
+              | _, _, _ => false
+              end.
+
+Definition eqMaybeBy {a} : (a -> a -> bool) -> option a -> option a -> bool :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | _, None, None => true
+    | eq, Some x, Some y => eq x y
+    | _, _, _ => false
+    end.
+
 Fixpoint cmpList {a} (arg_0__ : (a -> a -> comparison)) (arg_1__ arg_2__
                    : list a) : comparison
            := match arg_0__, arg_1__, arg_2__ with
@@ -643,89 +594,138 @@ Fixpoint cmpList {a} (arg_0__ : (a -> a -> comparison)) (arg_1__ arg_2__
                   end
               end.
 
-(* Skipping definition `Util.chunkList' *)
+(* Skipping definition `Util.removeSpaces' *)
 
-Definition chkAppend {a} : list a -> list a -> list a :=
-  fun xs ys =>
-    if Data.Foldable.null ys : bool then xs else
-    Coq.Init.Datatypes.app xs ys.
+Definition op_zlzazazg__ {f} `{GHC.Base.Applicative f}
+   : f bool -> f bool -> f bool :=
+  GHC.Base.liftA2 andb.
 
-(* Skipping definition `Util.charToC' *)
+Notation "'_<&&>_'" := (op_zlzazazg__).
 
-Fixpoint changeLast {a} (arg_0__ : list a) (arg_1__ : a) : list a
+Infix "<&&>" := (_<&&>_) (at level 99).
+
+Definition op_zlzbzbzg__ {f} `{GHC.Base.Applicative f}
+   : f bool -> f bool -> f bool :=
+  GHC.Base.liftA2 orb.
+
+Notation "'_<||>_'" := (op_zlzbzbzg__).
+
+Infix "<||>" := (_<||>_) (at level 99).
+
+(* Skipping definition `Util.restrictedDamerauLevenshteinDistance' *)
+
+(* Skipping definition `Util.restrictedDamerauLevenshteinDistanceWithLengths' *)
+
+(* Skipping definition `Util.restrictedDamerauLevenshteinDistance'' *)
+
+(* Skipping definition `Util.restrictedDamerauLevenshteinDistanceWorker' *)
+
+Definition sizedComplement {bv} `{Data.Bits.Bits bv} : bv -> bv -> bv :=
+  fun vector_mask vect => Data.Bits.xor vector_mask vect.
+
+(* Skipping definition `Util.matchVectors' *)
+
+(* Skipping definition `Util.fuzzyMatch' *)
+
+(* Skipping definition `Util.fuzzyLookup' *)
+
+Definition unzipWith {a} {b} {c}
+   : (a -> b -> c) -> list (a * b)%type -> list c :=
+  fun f pairs => GHC.Base.map (fun '(pair a b) => f a b) pairs.
+
+Fixpoint seqList {a} {b} (arg_0__ : list a) (arg_1__ : b) : b
            := match arg_0__, arg_1__ with
-              | nil, _ => Panic.panic (GHC.Base.hs_string__ "changeLast")
-              | cons _ nil, x => cons x nil
-              | cons x xs, x' => cons x (changeLast xs x')
+              | nil, b => b
+              | cons x xs, b => GHC.Prim.seq x (seqList xs b)
               end.
 
-Definition capitalise : GHC.Base.String -> GHC.Base.String :=
-  fun arg_0__ => match arg_0__ with | nil => nil | cons c cs => cons c cs end.
+(* Skipping definition `Util.global' *)
 
-Definition atLength {a} {b} : (list a -> b) -> b -> list a -> nat -> b :=
-  fun atLenPred atEnd ls0 n0 =>
-    let fix go arg_0__ arg_1__
-              := match arg_0__, arg_1__ with
-                 | num_2__, ls =>
-                     if num_2__ GHC.Base.== #0 : bool then atLenPred ls else
-                     match arg_0__, arg_1__ with
-                     | _, nil => atEnd
-                     | n, cons _ xs => go (n GHC.Num.- #1) xs
-                     end
-                 end in
-    if n0 GHC.Base.< #0 : bool then atLenPred ls0 else
-    go n0 ls0.
+(* Skipping definition `Util.consIORef' *)
 
-Definition lengthAtLeast {a} : list a -> nat -> bool :=
-  atLength (GHC.Base.const true) false.
+(* Skipping definition `Util.globalM' *)
 
-Definition lengthAtMost {a} : list a -> nat -> bool :=
-  fun lst n =>
-    if n GHC.Base.< #0 : bool then false else
-    atLength Data.Foldable.null true lst n.
+(* Skipping definition `Util.sharedGlobal' *)
 
-Definition lengthExceeds {a} : list a -> nat -> bool :=
-  fun lst n =>
-    if n GHC.Base.< #0 : bool then true else
-    atLength notNull false lst n.
+(* Skipping definition `Util.sharedGlobalM' *)
 
-Definition lengthIs {a} : list a -> nat -> bool :=
-  fun lst n =>
-    if n GHC.Base.< #0 : bool then false else
-    atLength Data.Foldable.null false lst n.
+(* Skipping definition `Util.looksLikeModuleName' *)
 
-Definition lengthIsNot {a} : list a -> nat -> bool :=
-  fun lst n =>
-    if n GHC.Base.< #0 : bool then true else
-    atLength notNull true lst n.
+Axiom looksLikePackageName : GHC.Base.String -> bool.
 
-Definition lengthLessThan {a} : list a -> nat -> bool :=
-  atLength (GHC.Base.const false) true.
+(* Skipping definition `Util.getCmd' *)
 
-Definition listLengthCmp {a} : list a -> nat -> comparison :=
-  let atLen := fun arg_0__ => match arg_0__ with | nil => Eq | _ => Gt end in
-  let atEnd := Lt in atLength atLen atEnd.
+(* Skipping definition `Util.toCmdArgs' *)
 
-Fixpoint all2 {a} {b} (arg_0__ : (a -> b -> bool)) (arg_1__ : list a) (arg_2__
-                : list b) : bool
-           := match arg_0__, arg_1__, arg_2__ with
-              | _, nil, nil => true
-              | p, cons x xs, cons y ys => andb (p x y) (all2 p xs ys)
-              | _, _, _ => false
-              end.
+(* Skipping definition `Util.toArgs' *)
 
-(* Skipping definition `Util.abstractDataType' *)
+Definition exactLog2 : GHC.Num.Integer -> option GHC.Num.Integer :=
+  fun x =>
+    let pow2 :=
+      GHC.DeferredFix.deferredFix1 (fun pow2 x =>
+                                      if x GHC.Base.== #1 : bool then #0 else
+                                      #1 GHC.Num.+ pow2 (Data.Bits.shiftR x #1)) in
+    if (orb (x GHC.Base.<= #0) (x GHC.Base.>= #2147483648)) : bool
+    then None
+    else if (x Data.Bits..&.(**) (GHC.Num.negate x)) GHC.Base./= x : bool
+         then None
+         else Some (pow2 x).
+
+(* Skipping definition `Util.readRational__' *)
+
+(* Skipping definition `Util.readRational' *)
+
+(* Skipping definition `Util.readHexRational' *)
+
+(* Skipping definition `Util.readHexRational__' *)
+
+(* Skipping definition `Util.maybeRead' *)
+
+(* Skipping definition `Util.maybeReadFuzzy' *)
+
+(* Skipping definition `Util.doesDirNameExist' *)
+
+(* Skipping definition `Util.getModificationUTCTime' *)
+
+(* Skipping definition `Util.modificationTimeIfExists' *)
+
+(* Skipping definition `Util.hSetTranslit' *)
+
+(* Skipping definition `Util.splitLongestPrefix' *)
+
+(* Skipping definition `Util.escapeSpaces' *)
+
+(* Skipping definition `Util.reslash' *)
+
+Axiom makeRelativeTo : GHC.Base.String -> GHC.Base.String -> GHC.Base.String.
 
 (* Skipping definition `Util.abstractConstr' *)
 
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Util.Show__OverridingBool' *)
+(* Skipping definition `Util.abstractDataType' *)
+
+(* Skipping definition `Util.charToC' *)
+
+(* Skipping definition `Util.hashString' *)
+
+(* Skipping definition `Util.golden' *)
+
+(* Skipping definition `Util.hashInt32' *)
+
+(* Skipping definition `Util.mulHi' *)
+
+Definition overrideWith : bool -> OverridingBool -> bool :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | b, Auto => b
+    | _, Always => true
+    | _, Never => false
+    end.
 
 Module Notations.
-Notation "'_Util.<||>_'" := (op_zlzbzbzg__).
-Infix "Util.<||>" := (_<||>_) (at level 99).
 Notation "'_Util.<&&>_'" := (op_zlzazazg__).
 Infix "Util.<&&>" := (_<&&>_) (at level 99).
+Notation "'_Util.<||>_'" := (op_zlzbzbzg__).
+Infix "Util.<||>" := (_<||>_) (at level 99).
 End Notations.
 
 (* External variables:

--- a/examples/ghc/module-edits/Demand/edits
+++ b/examples/ghc/module-edits/Demand/edits
@@ -99,13 +99,8 @@ redefine Definition Core.seqStrictSig : StrictSig -> unit := fun x => tt.
 # order edits
 #
 
-order Core.Eq___JointDmd_op_zeze__ Core.Eq___JointDmd_op_zsze__ Core.Eq___JointDmd Core.Eq___DmdType_op_zeze__ Core.Eq___StrictSig_op_zeze__ Core.Eq___StrictSig_op_zsze__
-order Core.Eq___DmdType Core.Eq___StrictSig_op_zeze__
+order Core.Eq___Termination Core.Eq___CPRResult Core.Eq___DmdType_op_zeze__
+order Core.Eq___Count Core.Eq___Use_op_zeze__ Core.Eq___Use Core.Eq___UseDmd_op_zeze__ Core.Eq___UseDmd Core.Eq___DmdType_op_zeze__
+order Core.Eq___ExnStr Core.Eq___Str_op_zeze__ Core.Eq___Str Core.Eq___StrDmd_op_zeze__ Core.Eq___StrDmd Core.Eq___JointDmd Core.Eq___DmdType_op_zeze__ Core.Eq___DmdType Core.Eq___StrictSig_op_zeze__
 
-order Core.Eq___Count Core.Eq___Use_op_zeze__ Core.Eq___Use Core.Eq___UseDmd_op_zeze__ Core.Eq___UseDmd Core.mkUProd
-
-order Core.resTypeArgDmd Core.topRes Core.dmdTypeDepth Core.ensureArgs
-order Core.useTop Core.splitUseProdDmd
-
-order Core.Eq___ExnStr Core.Eq___Str_op_zeze__
-order Core.Eq___Str Core.Eq___StrDmd_op_zeze__
+order Core.Eq___TyCon Core.Ord__AltCon_compare

--- a/examples/ghc/module-edits/IdInfo/edits
+++ b/examples/ghc/module-edits/IdInfo/edits
@@ -17,3 +17,4 @@ skip Core.ppCafInfo
 ## Ordering
 order Core.Eq___CafInfo Core.Ord__CafInfo
 order Core.Eq___TyCon Core.Eq___RecSelParent_op_zeze__
+order Core.Eq___PatSyn Core.Eq___RecSelParent_op_zeze__

--- a/examples/ghc/module-edits/Module/edits
+++ b/examples/ghc/module-edits/Module/edits
@@ -15,6 +15,7 @@ skip module GHC.Fingerprint
 skip module GHC.Fingerprint.Type
 
 order Module.Uniquable__ModuleName Module.Ord__NDModule_compare Module.Ord__NDModule 
+order Module.Uniquable__ModuleName Module.Eq___ModuleName_op_zeze__
 order Module.Uniquable__UnitId Module.Ord__NDModule_compare Ord__NDModule 
 
 
@@ -65,8 +66,10 @@ skip Module.renameHoleModule'
 
 order Module.Eq___ModuleName      Module.Eq___IndefModule_op_zeze__
 order Module.Eq___ModuleName      Module.Eq___Module_op_zeze__
+order Module.Eq___ModuleName      Module.Eq___InstalledModule_op_zeze__
 order Module.Ord__ModuleName      Module.Ord__IndefModule_compare
 order Module.Ord__ModuleName      Module.Ord__Module_compare
+order Module.Ord__ModuleName      Module.Ord__InstalledModule_op_zl__
 order Module.Eq___InstalledUnitId Module.Eq___DefUnitId_op_zeze__
 order Module.Eq___InstalledUnitId Module.Eq___DefUnitId_op_zsze__
 order Module.Eq___InstalledUnitId Module.Eq___InstalledModule_op_zeze__

--- a/examples/ghc/module-edits/OccName/edits
+++ b/examples/ghc/module-edits/OccName/edits
@@ -66,7 +66,7 @@ redefine Local Definition OccName.Ord__NameSpace_op_zlze__ : NameSpace -> (NameS
             | _  => false
           end.
 
-order OccName.Eq___NameSpace OccName.Eq___OccName_op_zeze__ OccName.Eq___OccName OccName.Ord__OccName_compare OccName.Ord__OccName
+order OccName.Eq___NameSpace OccName.Ord__NameSpace OccName.Eq___OccName_op_zeze__
 
 order OccName.Eq___NameSpace OccName.nameSpacesRelated
 

--- a/examples/ghc/module-edits/SrcLoc/edits
+++ b/examples/ghc/module-edits/SrcLoc/edits
@@ -12,8 +12,7 @@ order SrcLoc.Eq___RealSrcLoc SrcLoc.Ord__RealSrcLoc_min SrcLoc.Ord__RealSrcLoc_m
 
 order SrcLoc.Ord__SrcSpan SrcLoc.rightmost SrcLoc.leftmost_smallest
 
-order SrcLoc.Eq___RealSrcSpan  SrcLoc.Eq___SrcSpan_op_zeze__ SrcLoc.Ord__RealSrcSpan SrcLoc.Ord__SrcSpan_op_zlze__ SrcLoc.Ord__SrcSpan_op_zl__ SrcLoc.Ord__SrcSpan_op_zgze__ SrcLoc.Ord__SrcSpan_op_zg__ SrcLoc.Ord__SrcSpan_compare
-order SrcLoc.Eq___RealSrcLoc  SrcLoc.Eq___SrcLoc_op_zeze__ SrcLoc.Ord__RealSrcLoc SrcLoc.Ord__SrcLoc_op_zlze__ SrcLoc.Ord__SrcLoc_op_zl__ SrcLoc.Ord__SrcLoc_op_zgze__ SrcLoc.Ord__SrcLoc_op_zg__ SrcLoc.Ord__SrcLoc_compare
+order SrcLoc.Eq___RealSrcLoc SrcLoc.Ord__RealSrcLoc SrcLoc.Eq___RealSrcSpan SrcLoc.Ord__RealSrcSpan_compare
 
 
 order SrcLoc.Eq___GenLocated SrcLoc.Ord__GenLocated

--- a/examples/ghc/module-edits/TrieMap/edits
+++ b/examples/ghc/module-edits/TrieMap/edits
@@ -31,6 +31,11 @@ order TrieMap.TrieMap__TypeMap        TrieMap.lookupTypeMap
 order TrieMap.TrieMap__CoreMap        TrieMap.lookupCoreMap
 order TrieMap.Eq___DeBruijn__Type_    TrieMap.xtBndr
 
+order TrieMap.Eq___DeBruijn__CoreExpr TrieMap.TrieMap__CoreMapX TrieMap.TrieMap__CoreMapG TrieMap.TrieMap__CoreMap_alterTM
+order TrieMap.TrieMap__TypeMapX TrieMap.TrieMap__CoercionMapX_emptyTM
+order TrieMap.Eq___DeBruijn__Coercion TrieMap.TrieMap__CoercionMapX TrieMap.TrieMap__CoercionMapG
+order TrieMap.Eq___DeBruijn__Type_ TrieMap.Eq___DeBruijn__Coercion_op_zeze__
+
 # Why do I need to specify explicit type class instances for Coq?
 in TrieMap.xtTickish                      rewrite forall, TrieMap.alterTM      = TrieMap.alterTM      (m := TrieMap.TickishMap)
 in TrieMap.lkTickish                      rewrite forall, TrieMap.lookupTM     = TrieMap.lookupTM     (m := TrieMap.TickishMap)
@@ -48,7 +53,11 @@ in TrieMap.TrieMap__CoreMap_alterTM       rewrite forall, TrieMap.alterTM      =
 in TrieMap.TrieMap__CoreMap_lookupTM      rewrite forall, TrieMap.lookupTM     = TrieMap.lookupTM     (m := TrieMap.CoreMapG)
 in TrieMap.TrieMap__LooseTypeMap_alterTM  rewrite forall, TrieMap.alterTM      = TrieMap.alterTM      (m := TrieMap.TypeMapG)
 in TrieMap.TrieMap__LooseTypeMap_lookupTM rewrite forall, TrieMap.lookupTM     = TrieMap.lookupTM     (m := TrieMap.TypeMapG)
+in TrieMap.lookupTypeMap                  rewrite forall, TrieMap.lookupTM     = TrieMap.lookupTM     (m := TrieMap.TypeMap)
 in TrieMap.extendTypeMap                  rewrite forall, TrieMap.alterTM      = TrieMap.alterTM      (m := TrieMap.TypeMap)
+in TrieMap.lookupCoreMap                  rewrite forall, TrieMap.lookupTM     = TrieMap.lookupTM     (m := TrieMap.CoreMap)
+in TrieMap.extendCoreMap                  rewrite forall, TrieMap.alterTM      = TrieMap.alterTM      (m := TrieMap.CoreMap)
+in TrieMap.xtBndr                         rewrite forall, TrieMap.xtG          = TrieMap.xtG          (m := TrieMap.TypeMapX)
 
 # Why do I need to `add` redundant instances that should be computable?
 

--- a/examples/ghc/module-edits/UniqSet/edits
+++ b/examples/ghc/module-edits/UniqSet/edits
@@ -24,3 +24,4 @@ redefine Local Definition UniqSet.Monoid__UniqSet_mempty {inst_a} : UniqSet inst
   Mk_UniqSet GHC.Base.mempty.
 
 order Unpeel_UniqSet UniqSet.partitionUniqSet
+order Unpeel_UniqSet UniqSet.Monoid__UniqSet_mappend

--- a/examples/transformers/lib/Control/Applicative/Backwards.v
+++ b/examples/transformers/lib/Control/Applicative/Backwards.v
@@ -34,40 +34,176 @@ Definition forwards {f : Type -> Type} {a : Type} (arg_0__ : Backwards f a) :=
 
 (* Converted value declarations: *)
 
-Local Definition Traversable__Backwards_traverse {inst_f}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f},
-     (a -> f b) -> (Backwards inst_f) a -> f ((Backwards inst_f) b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, Mk_Backwards t =>
-          GHC.Base.fmap Mk_Backwards (Data.Traversable.traverse f t)
+Local Definition Eq1__Backwards_liftEq {inst_f} `{(Data.Functor.Classes.Eq1
+   inst_f)}
+   : forall {a} {b},
+     (a -> b -> bool) -> (Backwards inst_f) a -> (Backwards inst_f) b -> bool :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | eq, Mk_Backwards x, Mk_Backwards y => Data.Functor.Classes.liftEq eq x y
       end.
 
-Local Definition Traversable__Backwards_mapM {inst_f}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m},
-     (a -> m b) -> (Backwards inst_f) a -> m ((Backwards inst_f) b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Backwards_traverse.
+Program Instance Eq1__Backwards {f} `{(Data.Functor.Classes.Eq1 f)}
+   : Data.Functor.Classes.Eq1 (Backwards f) :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__Backwards_liftEq |}.
 
-Local Definition Traversable__Backwards_sequenceA {inst_f}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {f} {a},
-     forall `{GHC.Base.Applicative f},
-     (Backwards inst_f) (f a) -> f ((Backwards inst_f) a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} =>
-    fun '(Mk_Backwards t) =>
-      GHC.Base.fmap Mk_Backwards (Data.Traversable.sequenceA t).
+Local Definition Ord1__Backwards_liftCompare {inst_f}
+  `{(Data.Functor.Classes.Ord1 inst_f)}
+   : forall {a} {b},
+     (a -> b -> comparison) ->
+     (Backwards inst_f) a -> (Backwards inst_f) b -> comparison :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | comp, Mk_Backwards x, Mk_Backwards y =>
+          Data.Functor.Classes.liftCompare comp x y
+      end.
 
-Local Definition Traversable__Backwards_sequence {inst_f}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {m} {a},
-     forall `{GHC.Base.Monad m},
-     (Backwards inst_f) (m a) -> m ((Backwards inst_f) a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Backwards_sequenceA.
+Program Instance Ord1__Backwards {f} `{(Data.Functor.Classes.Ord1 f)}
+   : Data.Functor.Classes.Ord1 (Backwards f) :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
+             Ord1__Backwards_liftCompare |}.
+
+(* Skipping all instances of class `Data.Functor.Classes.Read1', including
+   `Control.Applicative.Backwards.Read1__Backwards' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Show1', including
+   `Control.Applicative.Backwards.Show1__Backwards' *)
+
+Local Definition Eq___Backwards_op_zeze__ {inst_f} {inst_a}
+  `{Data.Functor.Classes.Eq1 inst_f} `{GHC.Base.Eq_ inst_a}
+   : (Backwards inst_f inst_a) -> (Backwards inst_f inst_a) -> bool :=
+  Data.Functor.Classes.eq1.
+
+Local Definition Eq___Backwards_op_zsze__ {inst_f} {inst_a}
+  `{Data.Functor.Classes.Eq1 inst_f} `{GHC.Base.Eq_ inst_a}
+   : (Backwards inst_f inst_a) -> (Backwards inst_f inst_a) -> bool :=
+  fun x y => negb (Eq___Backwards_op_zeze__ x y).
+
+Program Instance Eq___Backwards {f} {a} `{Data.Functor.Classes.Eq1 f}
+  `{GHC.Base.Eq_ a}
+   : GHC.Base.Eq_ (Backwards f a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___Backwards_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___Backwards_op_zsze__ |}.
+
+Local Definition Ord__Backwards_compare {inst_f} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
+   : (Backwards inst_f inst_a) -> (Backwards inst_f inst_a) -> comparison :=
+  Data.Functor.Classes.compare1.
+
+Local Definition Ord__Backwards_op_zl__ {inst_f} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
+   : (Backwards inst_f inst_a) -> (Backwards inst_f inst_a) -> bool :=
+  fun x y => Ord__Backwards_compare x y GHC.Base.== Lt.
+
+Local Definition Ord__Backwards_op_zlze__ {inst_f} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
+   : (Backwards inst_f inst_a) -> (Backwards inst_f inst_a) -> bool :=
+  fun x y => Ord__Backwards_compare x y GHC.Base./= Gt.
+
+Local Definition Ord__Backwards_op_zg__ {inst_f} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
+   : (Backwards inst_f inst_a) -> (Backwards inst_f inst_a) -> bool :=
+  fun x y => Ord__Backwards_compare x y GHC.Base.== Gt.
+
+Local Definition Ord__Backwards_op_zgze__ {inst_f} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
+   : (Backwards inst_f inst_a) -> (Backwards inst_f inst_a) -> bool :=
+  fun x y => Ord__Backwards_compare x y GHC.Base./= Lt.
+
+Local Definition Ord__Backwards_max {inst_f} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
+   : (Backwards inst_f inst_a) ->
+     (Backwards inst_f inst_a) -> (Backwards inst_f inst_a) :=
+  fun x y => if Ord__Backwards_op_zlze__ x y : bool then y else x.
+
+Local Definition Ord__Backwards_min {inst_f} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
+   : (Backwards inst_f inst_a) ->
+     (Backwards inst_f inst_a) -> (Backwards inst_f inst_a) :=
+  fun x y => if Ord__Backwards_op_zlze__ x y : bool then x else y.
+
+Program Instance Ord__Backwards {f} {a} `{Data.Functor.Classes.Ord1 f}
+  `{GHC.Base.Ord a}
+   : GHC.Base.Ord (Backwards f a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zl____ := Ord__Backwards_op_zl__ ;
+           GHC.Base.op_zlze____ := Ord__Backwards_op_zlze__ ;
+           GHC.Base.op_zg____ := Ord__Backwards_op_zg__ ;
+           GHC.Base.op_zgze____ := Ord__Backwards_op_zgze__ ;
+           GHC.Base.compare__ := Ord__Backwards_compare ;
+           GHC.Base.max__ := Ord__Backwards_max ;
+           GHC.Base.min__ := Ord__Backwards_min |}.
+
+(* Skipping all instances of class `GHC.Read.Read', including
+   `Control.Applicative.Backwards.Read__Backwards' *)
+
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Control.Applicative.Backwards.Show__Backwards' *)
+
+Local Definition Functor__Backwards_fmap {inst_f} `{(GHC.Base.Functor inst_f)}
+   : forall {a} {b}, (a -> b) -> (Backwards inst_f) a -> (Backwards inst_f) b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, Mk_Backwards a => Mk_Backwards (GHC.Base.fmap f a)
+      end.
+
+Local Definition Functor__Backwards_op_zlzd__ {inst_f} `{(GHC.Base.Functor
+   inst_f)}
+   : forall {a} {b}, a -> (Backwards inst_f) b -> (Backwards inst_f) a :=
+  fun {a} {b} => Functor__Backwards_fmap GHC.Base.∘ GHC.Base.const.
+
+Program Instance Functor__Backwards {f} `{(GHC.Base.Functor f)}
+   : GHC.Base.Functor (Backwards f) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Backwards_fmap ;
+           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Backwards_op_zlzd__ |}.
+
+Local Definition Applicative__Backwards_op_zlztzg__ {inst_f}
+  `{(GHC.Base.Applicative inst_f)}
+   : forall {a} {b},
+     (Backwards inst_f) (a -> b) -> (Backwards inst_f) a -> (Backwards inst_f) b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | Mk_Backwards f, Mk_Backwards a => Mk_Backwards (a GHC.Base.<**> f)
+      end.
+
+Local Definition Applicative__Backwards_liftA2 {inst_f} `{(GHC.Base.Applicative
+   inst_f)}
+   : forall {a} {b} {c},
+     (a -> b -> c) ->
+     (Backwards inst_f) a -> (Backwards inst_f) b -> (Backwards inst_f) c :=
+  fun {a} {b} {c} =>
+    fun f x => Applicative__Backwards_op_zlztzg__ (GHC.Base.fmap f x).
+
+Local Definition Applicative__Backwards_op_ztzg__ {inst_f}
+  `{(GHC.Base.Applicative inst_f)}
+   : forall {a} {b},
+     (Backwards inst_f) a -> (Backwards inst_f) b -> (Backwards inst_f) b :=
+  fun {a} {b} =>
+    fun a1 a2 => Applicative__Backwards_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
+
+Local Definition Applicative__Backwards_pure {inst_f} `{(GHC.Base.Applicative
+   inst_f)}
+   : forall {a}, a -> (Backwards inst_f) a :=
+  fun {a} => fun a => Mk_Backwards (GHC.Base.pure a).
+
+Program Instance Applicative__Backwards {f} `{(GHC.Base.Applicative f)}
+   : GHC.Base.Applicative (Backwards f) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Backwards_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Backwards_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Backwards_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__Backwards_pure |}.
+
+(* Skipping all instances of class `GHC.Base.Alternative', including
+   `Control.Applicative.Backwards.Alternative__Backwards' *)
 
 Local Definition Foldable__Backwards_foldMap {inst_f} `{(Data.Foldable.Foldable
    inst_f)}
@@ -167,24 +303,40 @@ Program Instance Foldable__Backwards {f} `{(Data.Foldable.Foldable f)}
            Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Backwards_sum ;
            Data.Foldable.toList__ := fun {a} => Foldable__Backwards_toList |}.
 
-Local Definition Functor__Backwards_fmap {inst_f} `{(GHC.Base.Functor inst_f)}
-   : forall {a} {b}, (a -> b) -> (Backwards inst_f) a -> (Backwards inst_f) b :=
-  fun {a} {b} =>
+Local Definition Traversable__Backwards_traverse {inst_f}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f},
+     (a -> f b) -> (Backwards inst_f) a -> f ((Backwards inst_f) b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
     fun arg_0__ arg_1__ =>
       match arg_0__, arg_1__ with
-      | f, Mk_Backwards a => Mk_Backwards (GHC.Base.fmap f a)
+      | f, Mk_Backwards t =>
+          GHC.Base.fmap Mk_Backwards (Data.Traversable.traverse f t)
       end.
 
-Local Definition Functor__Backwards_op_zlzd__ {inst_f} `{(GHC.Base.Functor
-   inst_f)}
-   : forall {a} {b}, a -> (Backwards inst_f) b -> (Backwards inst_f) a :=
-  fun {a} {b} => Functor__Backwards_fmap GHC.Base.∘ GHC.Base.const.
+Local Definition Traversable__Backwards_mapM {inst_f}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m},
+     (a -> m b) -> (Backwards inst_f) a -> m ((Backwards inst_f) b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Backwards_traverse.
 
-Program Instance Functor__Backwards {f} `{(GHC.Base.Functor f)}
-   : GHC.Base.Functor (Backwards f) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Backwards_fmap ;
-           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Backwards_op_zlzd__ |}.
+Local Definition Traversable__Backwards_sequenceA {inst_f}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {f} {a},
+     forall `{GHC.Base.Applicative f},
+     (Backwards inst_f) (f a) -> f ((Backwards inst_f) a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} =>
+    fun '(Mk_Backwards t) =>
+      GHC.Base.fmap Mk_Backwards (Data.Traversable.sequenceA t).
+
+Local Definition Traversable__Backwards_sequence {inst_f}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {m} {a},
+     forall `{GHC.Base.Monad m},
+     (Backwards inst_f) (m a) -> m ((Backwards inst_f) a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Backwards_sequenceA.
 
 Program Instance Traversable__Backwards {f} `{(Data.Traversable.Traversable f)}
    : Data.Traversable.Traversable (Backwards f) :=
@@ -197,158 +349,6 @@ Program Instance Traversable__Backwards {f} `{(Data.Traversable.Traversable f)}
              Traversable__Backwards_sequenceA ;
            Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
              Traversable__Backwards_traverse |}.
-
-(* Skipping all instances of class `GHC.Base.Alternative', including
-   `Control.Applicative.Backwards.Alternative__Backwards' *)
-
-Local Definition Applicative__Backwards_op_zlztzg__ {inst_f}
-  `{(GHC.Base.Applicative inst_f)}
-   : forall {a} {b},
-     (Backwards inst_f) (a -> b) -> (Backwards inst_f) a -> (Backwards inst_f) b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | Mk_Backwards f, Mk_Backwards a => Mk_Backwards (a GHC.Base.<**> f)
-      end.
-
-Local Definition Applicative__Backwards_liftA2 {inst_f} `{(GHC.Base.Applicative
-   inst_f)}
-   : forall {a} {b} {c},
-     (a -> b -> c) ->
-     (Backwards inst_f) a -> (Backwards inst_f) b -> (Backwards inst_f) c :=
-  fun {a} {b} {c} =>
-    fun f x => Applicative__Backwards_op_zlztzg__ (GHC.Base.fmap f x).
-
-Local Definition Applicative__Backwards_op_ztzg__ {inst_f}
-  `{(GHC.Base.Applicative inst_f)}
-   : forall {a} {b},
-     (Backwards inst_f) a -> (Backwards inst_f) b -> (Backwards inst_f) b :=
-  fun {a} {b} =>
-    fun a1 a2 => Applicative__Backwards_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
-
-Local Definition Applicative__Backwards_pure {inst_f} `{(GHC.Base.Applicative
-   inst_f)}
-   : forall {a}, a -> (Backwards inst_f) a :=
-  fun {a} => fun a => Mk_Backwards (GHC.Base.pure a).
-
-Program Instance Applicative__Backwards {f} `{(GHC.Base.Applicative f)}
-   : GHC.Base.Applicative (Backwards f) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Backwards_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Backwards_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Backwards_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__Backwards_pure |}.
-
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Control.Applicative.Backwards.Show__Backwards' *)
-
-(* Skipping all instances of class `GHC.Read.Read', including
-   `Control.Applicative.Backwards.Read__Backwards' *)
-
-Local Definition Ord1__Backwards_liftCompare {inst_f}
-  `{(Data.Functor.Classes.Ord1 inst_f)}
-   : forall {a} {b},
-     (a -> b -> comparison) ->
-     (Backwards inst_f) a -> (Backwards inst_f) b -> comparison :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | comp, Mk_Backwards x, Mk_Backwards y =>
-          Data.Functor.Classes.liftCompare comp x y
-      end.
-
-Local Definition Eq1__Backwards_liftEq {inst_f} `{(Data.Functor.Classes.Eq1
-   inst_f)}
-   : forall {a} {b},
-     (a -> b -> bool) -> (Backwards inst_f) a -> (Backwards inst_f) b -> bool :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | eq, Mk_Backwards x, Mk_Backwards y => Data.Functor.Classes.liftEq eq x y
-      end.
-
-Program Instance Eq1__Backwards {f} `{(Data.Functor.Classes.Eq1 f)}
-   : Data.Functor.Classes.Eq1 (Backwards f) :=
-  fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__Backwards_liftEq |}.
-
-Program Instance Ord1__Backwards {f} `{(Data.Functor.Classes.Ord1 f)}
-   : Data.Functor.Classes.Ord1 (Backwards f) :=
-  fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
-             Ord1__Backwards_liftCompare |}.
-
-Local Definition Ord__Backwards_compare {inst_f} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
-   : (Backwards inst_f inst_a) -> (Backwards inst_f inst_a) -> comparison :=
-  Data.Functor.Classes.compare1.
-
-Local Definition Ord__Backwards_op_zl__ {inst_f} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
-   : (Backwards inst_f inst_a) -> (Backwards inst_f inst_a) -> bool :=
-  fun x y => Ord__Backwards_compare x y GHC.Base.== Lt.
-
-Local Definition Ord__Backwards_op_zlze__ {inst_f} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
-   : (Backwards inst_f inst_a) -> (Backwards inst_f inst_a) -> bool :=
-  fun x y => Ord__Backwards_compare x y GHC.Base./= Gt.
-
-Local Definition Ord__Backwards_op_zg__ {inst_f} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
-   : (Backwards inst_f inst_a) -> (Backwards inst_f inst_a) -> bool :=
-  fun x y => Ord__Backwards_compare x y GHC.Base.== Gt.
-
-Local Definition Ord__Backwards_op_zgze__ {inst_f} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
-   : (Backwards inst_f inst_a) -> (Backwards inst_f inst_a) -> bool :=
-  fun x y => Ord__Backwards_compare x y GHC.Base./= Lt.
-
-Local Definition Ord__Backwards_max {inst_f} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
-   : (Backwards inst_f inst_a) ->
-     (Backwards inst_f inst_a) -> (Backwards inst_f inst_a) :=
-  fun x y => if Ord__Backwards_op_zlze__ x y : bool then y else x.
-
-Local Definition Ord__Backwards_min {inst_f} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
-   : (Backwards inst_f inst_a) ->
-     (Backwards inst_f inst_a) -> (Backwards inst_f inst_a) :=
-  fun x y => if Ord__Backwards_op_zlze__ x y : bool then x else y.
-
-Local Definition Eq___Backwards_op_zeze__ {inst_f} {inst_a}
-  `{Data.Functor.Classes.Eq1 inst_f} `{GHC.Base.Eq_ inst_a}
-   : (Backwards inst_f inst_a) -> (Backwards inst_f inst_a) -> bool :=
-  Data.Functor.Classes.eq1.
-
-Local Definition Eq___Backwards_op_zsze__ {inst_f} {inst_a}
-  `{Data.Functor.Classes.Eq1 inst_f} `{GHC.Base.Eq_ inst_a}
-   : (Backwards inst_f inst_a) -> (Backwards inst_f inst_a) -> bool :=
-  fun x y => negb (Eq___Backwards_op_zeze__ x y).
-
-Program Instance Eq___Backwards {f} {a} `{Data.Functor.Classes.Eq1 f}
-  `{GHC.Base.Eq_ a}
-   : GHC.Base.Eq_ (Backwards f a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___Backwards_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___Backwards_op_zsze__ |}.
-
-Program Instance Ord__Backwards {f} {a} `{Data.Functor.Classes.Ord1 f}
-  `{GHC.Base.Ord a}
-   : GHC.Base.Ord (Backwards f a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zl____ := Ord__Backwards_op_zl__ ;
-           GHC.Base.op_zlze____ := Ord__Backwards_op_zlze__ ;
-           GHC.Base.op_zg____ := Ord__Backwards_op_zg__ ;
-           GHC.Base.op_zgze____ := Ord__Backwards_op_zgze__ ;
-           GHC.Base.compare__ := Ord__Backwards_compare ;
-           GHC.Base.max__ := Ord__Backwards_max ;
-           GHC.Base.min__ := Ord__Backwards_min |}.
-
-(* Skipping all instances of class `Data.Functor.Classes.Show1', including
-   `Control.Applicative.Backwards.Show1__Backwards' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Read1', including
-   `Control.Applicative.Backwards.Read1__Backwards' *)
 
 (* External variables:
      Gt Lt Type bool comparison list negb Coq.Program.Basics.compose

--- a/examples/transformers/lib/Control/Applicative/Lift.v
+++ b/examples/transformers/lib/Control/Applicative/Lift.v
@@ -41,55 +41,117 @@ Arguments Other {_} {_} _.
 
 (* Converted value declarations: *)
 
-Definition unLift {f} {a} `{(GHC.Base.Applicative f)} : Lift f a -> f a :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Pure x => GHC.Base.pure x
-    | Other e => e
-    end.
+Local Definition Eq1__Lift_liftEq {inst_f} `{(Data.Functor.Classes.Eq1 inst_f)}
+   : forall {a} {b},
+     (a -> b -> bool) -> (Lift inst_f) a -> (Lift inst_f) b -> bool :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | eq, Pure x1, Pure x2 => eq x1 x2
+      | _, Pure _, Other _ => false
+      | _, Other _, Pure _ => false
+      | eq, Other y1, Other y2 => Data.Functor.Classes.liftEq eq y1 y2
+      end.
 
-Definition runErrors {e} {a} : Errors e a -> Data.Either.Either e a :=
-  fun arg_0__ =>
-    match arg_0__ with
-    | Other (Data.Functor.Constant.Mk_Constant e) => Data.Either.Left e
-    | Pure x => Data.Either.Right x
-    end.
+Program Instance Eq1__Lift {f} `{(Data.Functor.Classes.Eq1 f)}
+   : Data.Functor.Classes.Eq1 (Lift f) :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__Lift_liftEq |}.
 
-Definition mapLift {f} {a} {g} : (f a -> g a) -> Lift f a -> Lift g a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | _, Pure x => Pure x
-    | f, Other e => Other (f e)
-    end.
-
-Definition failure {e} {a} : e -> Errors e a :=
-  fun e => Other (Data.Functor.Constant.Mk_Constant e).
-
-Definition elimLift {a} {r} {f} : (a -> r) -> (f a -> r) -> Lift f a -> r :=
-  fun arg_0__ arg_1__ arg_2__ =>
-    match arg_0__, arg_1__, arg_2__ with
-    | f, _, Pure x => f x
-    | _, g, Other e => g e
-    end.
-
-Definition eitherToErrors {e} {a} : Data.Either.Either e a -> Errors e a :=
-  Data.Either.either failure Pure.
-
-(* Skipping all instances of class `GHC.Base.Alternative', including
-   `Control.Applicative.Lift.Alternative__Lift' *)
-
-Local Definition Applicative__Lift_op_zlztzg__ {inst_f} `{(GHC.Base.Applicative
+Local Definition Ord1__Lift_liftCompare {inst_f} `{(Data.Functor.Classes.Ord1
    inst_f)}
    : forall {a} {b},
-     (Lift inst_f) (a -> b) -> (Lift inst_f) a -> (Lift inst_f) b :=
+     (a -> b -> comparison) -> (Lift inst_f) a -> (Lift inst_f) b -> comparison :=
   fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | Pure f, Pure x => Pure (f x)
-      | Pure f, Other y => Other (f Data.Functor.<$> y)
-      | Other f, Pure x => Other ((fun arg_4__ => arg_4__ x) Data.Functor.<$> f)
-      | Other f, Other y => Other (f GHC.Base.<*> y)
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | comp, Pure x1, Pure x2 => comp x1 x2
+      | _, Pure _, Other _ => Lt
+      | _, Other _, Pure _ => Gt
+      | comp, Other y1, Other y2 => Data.Functor.Classes.liftCompare comp y1 y2
       end.
+
+Program Instance Ord1__Lift {f} `{(Data.Functor.Classes.Ord1 f)}
+   : Data.Functor.Classes.Ord1 (Lift f) :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
+             Ord1__Lift_liftCompare |}.
+
+(* Skipping all instances of class `Data.Functor.Classes.Read1', including
+   `Control.Applicative.Lift.Read1__Lift' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Show1', including
+   `Control.Applicative.Lift.Show1__Lift' *)
+
+Local Definition Eq___Lift_op_zeze__ {inst_f} {inst_a}
+  `{Data.Functor.Classes.Eq1 inst_f} `{GHC.Base.Eq_ inst_a}
+   : (Lift inst_f inst_a) -> (Lift inst_f inst_a) -> bool :=
+  Data.Functor.Classes.eq1.
+
+Local Definition Eq___Lift_op_zsze__ {inst_f} {inst_a}
+  `{Data.Functor.Classes.Eq1 inst_f} `{GHC.Base.Eq_ inst_a}
+   : (Lift inst_f inst_a) -> (Lift inst_f inst_a) -> bool :=
+  fun x y => negb (Eq___Lift_op_zeze__ x y).
+
+Program Instance Eq___Lift {f} {a} `{Data.Functor.Classes.Eq1 f} `{GHC.Base.Eq_
+  a}
+   : GHC.Base.Eq_ (Lift f a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___Lift_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___Lift_op_zsze__ |}.
+
+Local Definition Ord__Lift_compare {inst_f} {inst_a} `{Data.Functor.Classes.Ord1
+  inst_f} `{GHC.Base.Ord inst_a}
+   : (Lift inst_f inst_a) -> (Lift inst_f inst_a) -> comparison :=
+  Data.Functor.Classes.compare1.
+
+Local Definition Ord__Lift_op_zl__ {inst_f} {inst_a} `{Data.Functor.Classes.Ord1
+  inst_f} `{GHC.Base.Ord inst_a}
+   : (Lift inst_f inst_a) -> (Lift inst_f inst_a) -> bool :=
+  fun x y => Ord__Lift_compare x y GHC.Base.== Lt.
+
+Local Definition Ord__Lift_op_zlze__ {inst_f} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
+   : (Lift inst_f inst_a) -> (Lift inst_f inst_a) -> bool :=
+  fun x y => Ord__Lift_compare x y GHC.Base./= Gt.
+
+Local Definition Ord__Lift_op_zg__ {inst_f} {inst_a} `{Data.Functor.Classes.Ord1
+  inst_f} `{GHC.Base.Ord inst_a}
+   : (Lift inst_f inst_a) -> (Lift inst_f inst_a) -> bool :=
+  fun x y => Ord__Lift_compare x y GHC.Base.== Gt.
+
+Local Definition Ord__Lift_op_zgze__ {inst_f} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
+   : (Lift inst_f inst_a) -> (Lift inst_f inst_a) -> bool :=
+  fun x y => Ord__Lift_compare x y GHC.Base./= Lt.
+
+Local Definition Ord__Lift_max {inst_f} {inst_a} `{Data.Functor.Classes.Ord1
+  inst_f} `{GHC.Base.Ord inst_a}
+   : (Lift inst_f inst_a) -> (Lift inst_f inst_a) -> (Lift inst_f inst_a) :=
+  fun x y => if Ord__Lift_op_zlze__ x y : bool then y else x.
+
+Local Definition Ord__Lift_min {inst_f} {inst_a} `{Data.Functor.Classes.Ord1
+  inst_f} `{GHC.Base.Ord inst_a}
+   : (Lift inst_f inst_a) -> (Lift inst_f inst_a) -> (Lift inst_f inst_a) :=
+  fun x y => if Ord__Lift_op_zlze__ x y : bool then x else y.
+
+Program Instance Ord__Lift {f} {a} `{Data.Functor.Classes.Ord1 f} `{GHC.Base.Ord
+  a}
+   : GHC.Base.Ord (Lift f a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zl____ := Ord__Lift_op_zl__ ;
+           GHC.Base.op_zlze____ := Ord__Lift_op_zlze__ ;
+           GHC.Base.op_zg____ := Ord__Lift_op_zg__ ;
+           GHC.Base.op_zgze____ := Ord__Lift_op_zgze__ ;
+           GHC.Base.compare__ := Ord__Lift_compare ;
+           GHC.Base.max__ := Ord__Lift_max ;
+           GHC.Base.min__ := Ord__Lift_min |}.
+
+(* Skipping all instances of class `GHC.Read.Read', including
+   `Control.Applicative.Lift.Read__Lift' *)
+
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Control.Applicative.Lift.Show__Lift' *)
 
 Local Definition Functor__Lift_fmap {inst_f} `{(GHC.Base.Functor inst_f)}
    : forall {a} {b}, (a -> b) -> (Lift inst_f) a -> (Lift inst_f) b :=
@@ -109,62 +171,6 @@ Program Instance Functor__Lift {f} `{(GHC.Base.Functor f)}
   fun _ k__ =>
     k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Lift_fmap ;
            GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Lift_op_zlzd__ |}.
-
-Local Definition Applicative__Lift_liftA2 {inst_f} `{(GHC.Base.Applicative
-   inst_f)}
-   : forall {a} {b} {c},
-     (a -> b -> c) -> (Lift inst_f) a -> (Lift inst_f) b -> (Lift inst_f) c :=
-  fun {a} {b} {c} => fun f x => Applicative__Lift_op_zlztzg__ (GHC.Base.fmap f x).
-
-Local Definition Applicative__Lift_op_ztzg__ {inst_f} `{(GHC.Base.Applicative
-   inst_f)}
-   : forall {a} {b}, (Lift inst_f) a -> (Lift inst_f) b -> (Lift inst_f) b :=
-  fun {a} {b} =>
-    fun a1 a2 => Applicative__Lift_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
-
-Local Definition Applicative__Lift_pure {inst_f} `{(GHC.Base.Applicative
-   inst_f)}
-   : forall {a}, a -> (Lift inst_f) a :=
-  fun {a} => Pure.
-
-Program Instance Applicative__Lift {f} `{(GHC.Base.Applicative f)}
-   : GHC.Base.Applicative (Lift f) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Lift_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Lift_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Lift_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__Lift_pure |}.
-
-Local Definition Traversable__Lift_traverse {inst_f}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f},
-     (a -> f b) -> (Lift inst_f) a -> f ((Lift inst_f) b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, Pure x => Pure Data.Functor.<$> f x
-      | f, Other y => Other Data.Functor.<$> Data.Traversable.traverse f y
-      end.
-
-Local Definition Traversable__Lift_mapM {inst_f} `{(Data.Traversable.Traversable
-   inst_f)}
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m},
-     (a -> m b) -> (Lift inst_f) a -> m ((Lift inst_f) b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Lift_traverse.
-
-Local Definition Traversable__Lift_sequenceA {inst_f}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {f} {a},
-     forall `{GHC.Base.Applicative f}, (Lift inst_f) (f a) -> f ((Lift inst_f) a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} => Traversable__Lift_traverse GHC.Base.id.
-
-Local Definition Traversable__Lift_sequence {inst_f}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {m} {a},
-     forall `{GHC.Base.Monad m}, (Lift inst_f) (m a) -> m ((Lift inst_f) a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Lift_sequenceA.
 
 Local Definition Foldable__Lift_foldMap {inst_f} `{(Data.Foldable.Foldable
    inst_f)}
@@ -262,6 +268,37 @@ Program Instance Foldable__Lift {f} `{(Data.Foldable.Foldable f)}
            Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Lift_sum ;
            Data.Foldable.toList__ := fun {a} => Foldable__Lift_toList |}.
 
+Local Definition Traversable__Lift_traverse {inst_f}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f},
+     (a -> f b) -> (Lift inst_f) a -> f ((Lift inst_f) b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, Pure x => Pure Data.Functor.<$> f x
+      | f, Other y => Other Data.Functor.<$> Data.Traversable.traverse f y
+      end.
+
+Local Definition Traversable__Lift_mapM {inst_f} `{(Data.Traversable.Traversable
+   inst_f)}
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m},
+     (a -> m b) -> (Lift inst_f) a -> m ((Lift inst_f) b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Lift_traverse.
+
+Local Definition Traversable__Lift_sequenceA {inst_f}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {f} {a},
+     forall `{GHC.Base.Applicative f}, (Lift inst_f) (f a) -> f ((Lift inst_f) a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} => Traversable__Lift_traverse GHC.Base.id.
+
+Local Definition Traversable__Lift_sequence {inst_f}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {m} {a},
+     forall `{GHC.Base.Monad m}, (Lift inst_f) (m a) -> m ((Lift inst_f) a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Lift_sequenceA.
+
 Program Instance Traversable__Lift {f} `{(Data.Traversable.Traversable f)}
    : Data.Traversable.Traversable (Lift f) :=
   fun _ k__ =>
@@ -274,117 +311,80 @@ Program Instance Traversable__Lift {f} `{(Data.Traversable.Traversable f)}
            Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
              Traversable__Lift_traverse |}.
 
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Control.Applicative.Lift.Show__Lift' *)
-
-(* Skipping all instances of class `GHC.Read.Read', including
-   `Control.Applicative.Lift.Read__Lift' *)
-
-Local Definition Ord1__Lift_liftCompare {inst_f} `{(Data.Functor.Classes.Ord1
+Local Definition Applicative__Lift_op_zlztzg__ {inst_f} `{(GHC.Base.Applicative
    inst_f)}
    : forall {a} {b},
-     (a -> b -> comparison) -> (Lift inst_f) a -> (Lift inst_f) b -> comparison :=
+     (Lift inst_f) (a -> b) -> (Lift inst_f) a -> (Lift inst_f) b :=
   fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | comp, Pure x1, Pure x2 => comp x1 x2
-      | _, Pure _, Other _ => Lt
-      | _, Other _, Pure _ => Gt
-      | comp, Other y1, Other y2 => Data.Functor.Classes.liftCompare comp y1 y2
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | Pure f, Pure x => Pure (f x)
+      | Pure f, Other y => Other (f Data.Functor.<$> y)
+      | Other f, Pure x => Other ((fun arg_4__ => arg_4__ x) Data.Functor.<$> f)
+      | Other f, Other y => Other (f GHC.Base.<*> y)
       end.
 
-Local Definition Eq1__Lift_liftEq {inst_f} `{(Data.Functor.Classes.Eq1 inst_f)}
-   : forall {a} {b},
-     (a -> b -> bool) -> (Lift inst_f) a -> (Lift inst_f) b -> bool :=
+Local Definition Applicative__Lift_liftA2 {inst_f} `{(GHC.Base.Applicative
+   inst_f)}
+   : forall {a} {b} {c},
+     (a -> b -> c) -> (Lift inst_f) a -> (Lift inst_f) b -> (Lift inst_f) c :=
+  fun {a} {b} {c} => fun f x => Applicative__Lift_op_zlztzg__ (GHC.Base.fmap f x).
+
+Local Definition Applicative__Lift_op_ztzg__ {inst_f} `{(GHC.Base.Applicative
+   inst_f)}
+   : forall {a} {b}, (Lift inst_f) a -> (Lift inst_f) b -> (Lift inst_f) b :=
   fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | eq, Pure x1, Pure x2 => eq x1 x2
-      | _, Pure _, Other _ => false
-      | _, Other _, Pure _ => false
-      | eq, Other y1, Other y2 => Data.Functor.Classes.liftEq eq y1 y2
-      end.
+    fun a1 a2 => Applicative__Lift_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
 
-Program Instance Eq1__Lift {f} `{(Data.Functor.Classes.Eq1 f)}
-   : Data.Functor.Classes.Eq1 (Lift f) :=
+Local Definition Applicative__Lift_pure {inst_f} `{(GHC.Base.Applicative
+   inst_f)}
+   : forall {a}, a -> (Lift inst_f) a :=
+  fun {a} => Pure.
+
+Program Instance Applicative__Lift {f} `{(GHC.Base.Applicative f)}
+   : GHC.Base.Applicative (Lift f) :=
   fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__Lift_liftEq |}.
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Lift_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Lift_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Lift_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__Lift_pure |}.
 
-Program Instance Ord1__Lift {f} `{(Data.Functor.Classes.Ord1 f)}
-   : Data.Functor.Classes.Ord1 (Lift f) :=
-  fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
-             Ord1__Lift_liftCompare |}.
+(* Skipping all instances of class `GHC.Base.Alternative', including
+   `Control.Applicative.Lift.Alternative__Lift' *)
 
-Local Definition Ord__Lift_compare {inst_f} {inst_a} `{Data.Functor.Classes.Ord1
-  inst_f} `{GHC.Base.Ord inst_a}
-   : (Lift inst_f inst_a) -> (Lift inst_f inst_a) -> comparison :=
-  Data.Functor.Classes.compare1.
+Definition unLift {f} {a} `{(GHC.Base.Applicative f)} : Lift f a -> f a :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Pure x => GHC.Base.pure x
+    | Other e => e
+    end.
 
-Local Definition Ord__Lift_op_zl__ {inst_f} {inst_a} `{Data.Functor.Classes.Ord1
-  inst_f} `{GHC.Base.Ord inst_a}
-   : (Lift inst_f inst_a) -> (Lift inst_f inst_a) -> bool :=
-  fun x y => Ord__Lift_compare x y GHC.Base.== Lt.
+Definition mapLift {f} {a} {g} : (f a -> g a) -> Lift f a -> Lift g a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | _, Pure x => Pure x
+    | f, Other e => Other (f e)
+    end.
 
-Local Definition Ord__Lift_op_zlze__ {inst_f} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
-   : (Lift inst_f inst_a) -> (Lift inst_f inst_a) -> bool :=
-  fun x y => Ord__Lift_compare x y GHC.Base./= Gt.
+Definition elimLift {a} {r} {f} : (a -> r) -> (f a -> r) -> Lift f a -> r :=
+  fun arg_0__ arg_1__ arg_2__ =>
+    match arg_0__, arg_1__, arg_2__ with
+    | f, _, Pure x => f x
+    | _, g, Other e => g e
+    end.
 
-Local Definition Ord__Lift_op_zg__ {inst_f} {inst_a} `{Data.Functor.Classes.Ord1
-  inst_f} `{GHC.Base.Ord inst_a}
-   : (Lift inst_f inst_a) -> (Lift inst_f inst_a) -> bool :=
-  fun x y => Ord__Lift_compare x y GHC.Base.== Gt.
+Definition runErrors {e} {a} : Errors e a -> Data.Either.Either e a :=
+  fun arg_0__ =>
+    match arg_0__ with
+    | Other (Data.Functor.Constant.Mk_Constant e) => Data.Either.Left e
+    | Pure x => Data.Either.Right x
+    end.
 
-Local Definition Ord__Lift_op_zgze__ {inst_f} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
-   : (Lift inst_f inst_a) -> (Lift inst_f inst_a) -> bool :=
-  fun x y => Ord__Lift_compare x y GHC.Base./= Lt.
+Definition failure {e} {a} : e -> Errors e a :=
+  fun e => Other (Data.Functor.Constant.Mk_Constant e).
 
-Local Definition Ord__Lift_max {inst_f} {inst_a} `{Data.Functor.Classes.Ord1
-  inst_f} `{GHC.Base.Ord inst_a}
-   : (Lift inst_f inst_a) -> (Lift inst_f inst_a) -> (Lift inst_f inst_a) :=
-  fun x y => if Ord__Lift_op_zlze__ x y : bool then y else x.
-
-Local Definition Ord__Lift_min {inst_f} {inst_a} `{Data.Functor.Classes.Ord1
-  inst_f} `{GHC.Base.Ord inst_a}
-   : (Lift inst_f inst_a) -> (Lift inst_f inst_a) -> (Lift inst_f inst_a) :=
-  fun x y => if Ord__Lift_op_zlze__ x y : bool then x else y.
-
-Local Definition Eq___Lift_op_zeze__ {inst_f} {inst_a}
-  `{Data.Functor.Classes.Eq1 inst_f} `{GHC.Base.Eq_ inst_a}
-   : (Lift inst_f inst_a) -> (Lift inst_f inst_a) -> bool :=
-  Data.Functor.Classes.eq1.
-
-Local Definition Eq___Lift_op_zsze__ {inst_f} {inst_a}
-  `{Data.Functor.Classes.Eq1 inst_f} `{GHC.Base.Eq_ inst_a}
-   : (Lift inst_f inst_a) -> (Lift inst_f inst_a) -> bool :=
-  fun x y => negb (Eq___Lift_op_zeze__ x y).
-
-Program Instance Eq___Lift {f} {a} `{Data.Functor.Classes.Eq1 f} `{GHC.Base.Eq_
-  a}
-   : GHC.Base.Eq_ (Lift f a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___Lift_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___Lift_op_zsze__ |}.
-
-Program Instance Ord__Lift {f} {a} `{Data.Functor.Classes.Ord1 f} `{GHC.Base.Ord
-  a}
-   : GHC.Base.Ord (Lift f a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zl____ := Ord__Lift_op_zl__ ;
-           GHC.Base.op_zlze____ := Ord__Lift_op_zlze__ ;
-           GHC.Base.op_zg____ := Ord__Lift_op_zg__ ;
-           GHC.Base.op_zgze____ := Ord__Lift_op_zgze__ ;
-           GHC.Base.compare__ := Ord__Lift_compare ;
-           GHC.Base.max__ := Ord__Lift_max ;
-           GHC.Base.min__ := Ord__Lift_min |}.
-
-(* Skipping all instances of class `Data.Functor.Classes.Show1', including
-   `Control.Applicative.Lift.Show1__Lift' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Read1', including
-   `Control.Applicative.Lift.Read1__Lift' *)
+Definition eitherToErrors {e} {a} : Data.Either.Either e a -> Errors e a :=
+  Data.Either.either failure Pure.
 
 (* External variables:
      Gt Lt bool comparison false list negb true Coq.Program.Basics.compose

--- a/examples/transformers/lib/Control/Monad/Trans/Cont.v
+++ b/examples/transformers/lib/Control/Monad/Trans/Cont.v
@@ -34,113 +34,6 @@ Definition runContT {r : Type} {m : Type -> Type} {a} (arg_0__ : ContT r m a) :=
 
 (* Converted value declarations: *)
 
-Definition withContT {b} {m} {r} {a}
-   : ((b -> m r) -> (a -> m r)) -> ContT r m a -> ContT r m b :=
-  fun f m => Mk_ContT (runContT m GHC.Base.∘ f).
-
-Definition withCont {b} {r} {a}
-   : ((b -> r) -> (a -> r)) -> Cont r a -> Cont r b :=
-  fun f =>
-    withContT ((fun arg_0__ => Data.Functor.Identity.Mk_Identity GHC.Base.∘ arg_0__)
-               GHC.Base.∘
-               (f GHC.Base.∘
-                (fun arg_1__ => Data.Functor.Identity.runIdentity GHC.Base.∘ arg_1__))).
-
-Definition runCont {r} {a} : Cont r a -> (a -> r) -> r :=
-  fun m k =>
-    Data.Functor.Identity.runIdentity (runContT m (Data.Functor.Identity.Mk_Identity
-                                                   GHC.Base.∘
-                                                   k)).
-
-Definition mapContT {m} {r} {a} : (m r -> m r) -> ContT r m a -> ContT r m a :=
-  fun f m => Mk_ContT (f GHC.Base.∘ runContT m).
-
-Definition mapCont {r} {a} : (r -> r) -> Cont r a -> Cont r a :=
-  fun f =>
-    mapContT (Data.Functor.Identity.Mk_Identity GHC.Base.∘
-              (f GHC.Base.∘ Data.Functor.Identity.runIdentity)).
-
-Definition liftLocal {m} {r'} {r} {a} `{(GHC.Base.Monad m)}
-   : m r' ->
-     ((r' -> r') -> m r -> m r) -> (r' -> r') -> ContT r m a -> ContT r m a :=
-  fun ask local f m =>
-    Mk_ContT (fun c =>
-                ask GHC.Base.>>=
-                (fun r => local f (runContT m (local (GHC.Base.const r) GHC.Base.∘ c)))).
-
-Definition evalContT {m} {r} `{(GHC.Base.Monad m)} : ContT r m r -> m r :=
-  fun m => runContT m GHC.Base.return_.
-
-Local Definition MonadTrans__ContT_lift {inst_r}
-   : forall {m} {a}, forall `{(GHC.Base.Monad m)}, m a -> (ContT inst_r) m a :=
-  fun {m} {a} `{(GHC.Base.Monad m)} =>
-    fun m => Mk_ContT (fun arg_0__ => m GHC.Base.>>= arg_0__).
-
-Program Instance MonadTrans__ContT {r}
-   : Control.Monad.Trans.Class.MonadTrans (ContT r) :=
-  fun _ k__ =>
-    k__ {| Control.Monad.Trans.Class.lift__ := fun {m} {a} `{(GHC.Base.Monad m)} =>
-             MonadTrans__ContT_lift |}.
-
-Definition resetT {m} {r} {r'} `{(GHC.Base.Monad m)}
-   : ContT r m r -> ContT r' m r :=
-  Control.Monad.Trans.Class.lift GHC.Base.∘ evalContT.
-
-Definition reset {r} {r'} : Cont r r -> Cont r' r :=
-  resetT.
-
-Definition shiftT {m} {a} {r} `{(GHC.Base.Monad m)}
-   : ((a -> m r) -> ContT r m r) -> ContT r m a :=
-  fun f => Mk_ContT (evalContT GHC.Base.∘ f).
-
-Definition shift {a} {r} : ((a -> r) -> Cont r r) -> Cont r a :=
-  fun f =>
-    shiftT (f GHC.Base.∘
-            (fun arg_0__ => Data.Functor.Identity.runIdentity GHC.Base.∘ arg_0__)).
-
-Definition evalCont {r} : Cont r r -> r :=
-  fun m => Data.Functor.Identity.runIdentity (evalContT m).
-
-Definition cont {a} {r} : ((a -> r) -> r) -> Cont r a :=
-  fun f =>
-    Mk_ContT (fun c =>
-                Data.Functor.Identity.Mk_Identity (f (Data.Functor.Identity.runIdentity
-                                                      GHC.Base.∘
-                                                      c))).
-
-Definition callCC {a} {r} {m} {b}
-   : ((a -> ContT r m b) -> ContT r m a) -> ContT r m a :=
-  fun f =>
-    Mk_ContT (fun c => runContT (f (fun x => Mk_ContT (fun arg_0__ => c x))) c).
-
-(* Skipping all instances of class `Control.Monad.IO.Class.MonadIO', including
-   `Control.Monad.Trans.Cont.MonadIO__ContT' *)
-
-Local Definition MonadFail__ContT_fail {inst_m} {inst_r}
-  `{(Control.Monad.Fail.MonadFail inst_m)}
-   : forall {a}, GHC.Base.String -> (ContT inst_r inst_m) a :=
-  fun {a} => fun msg => Mk_ContT (fun arg_0__ => Control.Monad.Fail.fail msg).
-
-Local Definition Monad__ContT_op_zgzgze__ {inst_r} {inst_m}
-   : forall {a} {b},
-     (ContT inst_r inst_m) a ->
-     (a -> (ContT inst_r inst_m) b) -> (ContT inst_r inst_m) b :=
-  fun {a} {b} =>
-    fun m k => Mk_ContT (fun c => runContT m (fun x => runContT (k x) c)).
-
-Local Definition Monad__ContT_op_zgzg__ {inst_r} {inst_m}
-   : forall {a} {b},
-     (ContT inst_r inst_m) a -> (ContT inst_r inst_m) b -> (ContT inst_r inst_m) b :=
-  fun {a} {b} => fun m k => Monad__ContT_op_zgzgze__ m (fun arg_0__ => k).
-
-Local Definition Applicative__ContT_op_zlztzg__ {inst_r} {inst_m}
-   : forall {a} {b},
-     (ContT inst_r inst_m) (a -> b) ->
-     (ContT inst_r inst_m) a -> (ContT inst_r inst_m) b :=
-  fun {a} {b} =>
-    fun f v =>
-      Mk_ContT (fun c => runContT f (fun g => runContT v (c GHC.Base.∘ g))).
-
 Local Definition Functor__ContT_fmap {inst_r} {inst_m}
    : forall {a} {b},
      (a -> b) -> (ContT inst_r inst_m) a -> (ContT inst_r inst_m) b :=
@@ -154,6 +47,14 @@ Program Instance Functor__ContT {r} {m} : GHC.Base.Functor (ContT r m) :=
   fun _ k__ =>
     k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__ContT_fmap ;
            GHC.Base.op_zlzd____ := fun {a} {b} => Functor__ContT_op_zlzd__ |}.
+
+Local Definition Applicative__ContT_op_zlztzg__ {inst_r} {inst_m}
+   : forall {a} {b},
+     (ContT inst_r inst_m) (a -> b) ->
+     (ContT inst_r inst_m) a -> (ContT inst_r inst_m) b :=
+  fun {a} {b} =>
+    fun f v =>
+      Mk_ContT (fun c => runContT f (fun g => runContT v (c GHC.Base.∘ g))).
 
 Local Definition Applicative__ContT_liftA2 {inst_r} {inst_m}
    : forall {a} {b} {c},
@@ -182,6 +83,18 @@ Program Instance Applicative__ContT {r} {m}
            GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__ContT_op_ztzg__ ;
            GHC.Base.pure__ := fun {a} => Applicative__ContT_pure |}.
 
+Local Definition Monad__ContT_op_zgzgze__ {inst_r} {inst_m}
+   : forall {a} {b},
+     (ContT inst_r inst_m) a ->
+     (a -> (ContT inst_r inst_m) b) -> (ContT inst_r inst_m) b :=
+  fun {a} {b} =>
+    fun m k => Mk_ContT (fun c => runContT m (fun x => runContT (k x) c)).
+
+Local Definition Monad__ContT_op_zgzg__ {inst_r} {inst_m}
+   : forall {a} {b},
+     (ContT inst_r inst_m) a -> (ContT inst_r inst_m) b -> (ContT inst_r inst_m) b :=
+  fun {a} {b} => fun m k => Monad__ContT_op_zgzgze__ m (fun arg_0__ => k).
+
 Local Definition Monad__ContT_return_ {inst_r} {inst_m}
    : forall {a}, a -> (ContT inst_r inst_m) a :=
   fun {a} => GHC.Base.pure.
@@ -192,10 +105,97 @@ Program Instance Monad__ContT {r} {m} : GHC.Base.Monad (ContT r m) :=
            GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__ContT_op_zgzgze__ ;
            GHC.Base.return___ := fun {a} => Monad__ContT_return_ |}.
 
+Local Definition MonadFail__ContT_fail {inst_m} {inst_r}
+  `{(Control.Monad.Fail.MonadFail inst_m)}
+   : forall {a}, GHC.Base.String -> (ContT inst_r inst_m) a :=
+  fun {a} => fun msg => Mk_ContT (fun arg_0__ => Control.Monad.Fail.fail msg).
+
 Program Instance MonadFail__ContT {m} {r} `{(Control.Monad.Fail.MonadFail m)}
    : Control.Monad.Fail.MonadFail (ContT r m) :=
   fun _ k__ =>
     k__ {| Control.Monad.Fail.fail__ := fun {a} => MonadFail__ContT_fail |}.
+
+Local Definition MonadTrans__ContT_lift {inst_r}
+   : forall {m} {a}, forall `{(GHC.Base.Monad m)}, m a -> (ContT inst_r) m a :=
+  fun {m} {a} `{(GHC.Base.Monad m)} =>
+    fun m => Mk_ContT (fun arg_0__ => m GHC.Base.>>= arg_0__).
+
+Program Instance MonadTrans__ContT {r}
+   : Control.Monad.Trans.Class.MonadTrans (ContT r) :=
+  fun _ k__ =>
+    k__ {| Control.Monad.Trans.Class.lift__ := fun {m} {a} `{(GHC.Base.Monad m)} =>
+             MonadTrans__ContT_lift |}.
+
+(* Skipping all instances of class `Control.Monad.IO.Class.MonadIO', including
+   `Control.Monad.Trans.Cont.MonadIO__ContT' *)
+
+Definition cont {a} {r} : ((a -> r) -> r) -> Cont r a :=
+  fun f =>
+    Mk_ContT (fun c =>
+                Data.Functor.Identity.Mk_Identity (f (Data.Functor.Identity.runIdentity
+                                                      GHC.Base.∘
+                                                      c))).
+
+Definition runCont {r} {a} : Cont r a -> (a -> r) -> r :=
+  fun m k =>
+    Data.Functor.Identity.runIdentity (runContT m (Data.Functor.Identity.Mk_Identity
+                                                   GHC.Base.∘
+                                                   k)).
+
+Definition evalContT {m} {r} `{(GHC.Base.Monad m)} : ContT r m r -> m r :=
+  fun m => runContT m GHC.Base.return_.
+
+Definition evalCont {r} : Cont r r -> r :=
+  fun m => Data.Functor.Identity.runIdentity (evalContT m).
+
+Definition mapContT {m} {r} {a} : (m r -> m r) -> ContT r m a -> ContT r m a :=
+  fun f m => Mk_ContT (f GHC.Base.∘ runContT m).
+
+Definition mapCont {r} {a} : (r -> r) -> Cont r a -> Cont r a :=
+  fun f =>
+    mapContT (Data.Functor.Identity.Mk_Identity GHC.Base.∘
+              (f GHC.Base.∘ Data.Functor.Identity.runIdentity)).
+
+Definition withContT {b} {m} {r} {a}
+   : ((b -> m r) -> (a -> m r)) -> ContT r m a -> ContT r m b :=
+  fun f m => Mk_ContT (runContT m GHC.Base.∘ f).
+
+Definition withCont {b} {r} {a}
+   : ((b -> r) -> (a -> r)) -> Cont r a -> Cont r b :=
+  fun f =>
+    withContT ((fun arg_0__ => Data.Functor.Identity.Mk_Identity GHC.Base.∘ arg_0__)
+               GHC.Base.∘
+               (f GHC.Base.∘
+                (fun arg_1__ => Data.Functor.Identity.runIdentity GHC.Base.∘ arg_1__))).
+
+Definition resetT {m} {r} {r'} `{(GHC.Base.Monad m)}
+   : ContT r m r -> ContT r' m r :=
+  Control.Monad.Trans.Class.lift GHC.Base.∘ evalContT.
+
+Definition reset {r} {r'} : Cont r r -> Cont r' r :=
+  resetT.
+
+Definition shiftT {m} {a} {r} `{(GHC.Base.Monad m)}
+   : ((a -> m r) -> ContT r m r) -> ContT r m a :=
+  fun f => Mk_ContT (evalContT GHC.Base.∘ f).
+
+Definition shift {a} {r} : ((a -> r) -> Cont r r) -> Cont r a :=
+  fun f =>
+    shiftT (f GHC.Base.∘
+            (fun arg_0__ => Data.Functor.Identity.runIdentity GHC.Base.∘ arg_0__)).
+
+Definition callCC {a} {r} {m} {b}
+   : ((a -> ContT r m b) -> ContT r m a) -> ContT r m a :=
+  fun f =>
+    Mk_ContT (fun c => runContT (f (fun x => Mk_ContT (fun arg_0__ => c x))) c).
+
+Definition liftLocal {m} {r'} {r} {a} `{(GHC.Base.Monad m)}
+   : m r' ->
+     ((r' -> r') -> m r -> m r) -> (r' -> r') -> ContT r m a -> ContT r m a :=
+  fun ask local f m =>
+    Mk_ContT (fun c =>
+                ask GHC.Base.>>=
+                (fun r => local f (runContT m (local (GHC.Base.const r) GHC.Base.∘ c)))).
 
 (* External variables:
      Type Control.Monad.Fail.MonadFail Control.Monad.Fail.fail

--- a/examples/transformers/lib/Control/Monad/Trans/Except.v
+++ b/examples/transformers/lib/Control/Monad/Trans/Except.v
@@ -41,146 +41,128 @@ Arguments Mk_ExceptT {_} {_} {_} _.
 
 (* Converted value declarations: *)
 
-Definition throwE {m} {e} {a} `{(GHC.Base.Monad m)} : e -> ExceptT e m a :=
-  Mk_ExceptT GHC.Base.∘ (GHC.Base.return_ GHC.Base.∘ Data.Either.Left).
+Local Definition Eq1__ExceptT_liftEq {inst_e} {inst_m} `{GHC.Base.Eq_ inst_e}
+  `{Data.Functor.Classes.Eq1 inst_m}
+   : forall {a} {b},
+     (a -> b -> bool) ->
+     (ExceptT inst_e inst_m) a -> (ExceptT inst_e inst_m) b -> bool :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | eq, Mk_ExceptT x, Mk_ExceptT y =>
+          (@Data.Functor.Classes.liftEq inst_m _ _ _ (Data.Functor.Classes.liftEq eq)) x y
+      end.
+
+Program Instance Eq1__ExceptT {e} {m} `{GHC.Base.Eq_ e}
+  `{Data.Functor.Classes.Eq1 m}
+   : Data.Functor.Classes.Eq1 (ExceptT e m) :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__ExceptT_liftEq |}.
+
+Local Definition Ord1__ExceptT_liftCompare {inst_e} {inst_m} `{GHC.Base.Ord
+  inst_e} `{Data.Functor.Classes.Ord1 inst_m}
+   : forall {a} {b},
+     (a -> b -> comparison) ->
+     (ExceptT inst_e inst_m) a -> (ExceptT inst_e inst_m) b -> comparison :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | comp, Mk_ExceptT x, Mk_ExceptT y =>
+          (@Data.Functor.Classes.liftCompare inst_m _ _ _ _
+           (Data.Functor.Classes.liftCompare comp)) x y
+      end.
+
+Program Instance Ord1__ExceptT {e} {m} `{GHC.Base.Ord e}
+  `{Data.Functor.Classes.Ord1 m}
+   : Data.Functor.Classes.Ord1 (ExceptT e m) :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
+             Ord1__ExceptT_liftCompare |}.
+
+(* Skipping all instances of class `Data.Functor.Classes.Read1', including
+   `Control.Monad.Trans.Except.Read1__ExceptT' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Show1', including
+   `Control.Monad.Trans.Except.Show1__ExceptT' *)
+
+Local Definition Eq___ExceptT_op_zeze__ {inst_e} {inst_m} {inst_a}
+  `{GHC.Base.Eq_ inst_e} `{Data.Functor.Classes.Eq1 inst_m} `{GHC.Base.Eq_ inst_a}
+   : (ExceptT inst_e inst_m inst_a) -> (ExceptT inst_e inst_m inst_a) -> bool :=
+  Data.Functor.Classes.eq1.
+
+Local Definition Eq___ExceptT_op_zsze__ {inst_e} {inst_m} {inst_a}
+  `{GHC.Base.Eq_ inst_e} `{Data.Functor.Classes.Eq1 inst_m} `{GHC.Base.Eq_ inst_a}
+   : (ExceptT inst_e inst_m inst_a) -> (ExceptT inst_e inst_m inst_a) -> bool :=
+  fun x y => negb (Eq___ExceptT_op_zeze__ x y).
+
+Program Instance Eq___ExceptT {e} {m} {a} `{GHC.Base.Eq_ e}
+  `{Data.Functor.Classes.Eq1 m} `{GHC.Base.Eq_ a}
+   : GHC.Base.Eq_ (ExceptT e m a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___ExceptT_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___ExceptT_op_zsze__ |}.
+
+Local Definition Ord__ExceptT_compare {inst_e} {inst_m} {inst_a} `{GHC.Base.Ord
+  inst_e} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
+   : (ExceptT inst_e inst_m inst_a) ->
+     (ExceptT inst_e inst_m inst_a) -> comparison :=
+  Data.Functor.Classes.compare1.
+
+Local Definition Ord__ExceptT_op_zl__ {inst_e} {inst_m} {inst_a} `{GHC.Base.Ord
+  inst_e} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
+   : (ExceptT inst_e inst_m inst_a) -> (ExceptT inst_e inst_m inst_a) -> bool :=
+  fun x y => Ord__ExceptT_compare x y GHC.Base.== Lt.
+
+Local Definition Ord__ExceptT_op_zlze__ {inst_e} {inst_m} {inst_a}
+  `{GHC.Base.Ord inst_e} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord
+  inst_a}
+   : (ExceptT inst_e inst_m inst_a) -> (ExceptT inst_e inst_m inst_a) -> bool :=
+  fun x y => Ord__ExceptT_compare x y GHC.Base./= Gt.
+
+Local Definition Ord__ExceptT_op_zg__ {inst_e} {inst_m} {inst_a} `{GHC.Base.Ord
+  inst_e} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
+   : (ExceptT inst_e inst_m inst_a) -> (ExceptT inst_e inst_m inst_a) -> bool :=
+  fun x y => Ord__ExceptT_compare x y GHC.Base.== Gt.
+
+Local Definition Ord__ExceptT_op_zgze__ {inst_e} {inst_m} {inst_a}
+  `{GHC.Base.Ord inst_e} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord
+  inst_a}
+   : (ExceptT inst_e inst_m inst_a) -> (ExceptT inst_e inst_m inst_a) -> bool :=
+  fun x y => Ord__ExceptT_compare x y GHC.Base./= Lt.
+
+Local Definition Ord__ExceptT_max {inst_e} {inst_m} {inst_a} `{GHC.Base.Ord
+  inst_e} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
+   : (ExceptT inst_e inst_m inst_a) ->
+     (ExceptT inst_e inst_m inst_a) -> (ExceptT inst_e inst_m inst_a) :=
+  fun x y => if Ord__ExceptT_op_zlze__ x y : bool then y else x.
+
+Local Definition Ord__ExceptT_min {inst_e} {inst_m} {inst_a} `{GHC.Base.Ord
+  inst_e} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
+   : (ExceptT inst_e inst_m inst_a) ->
+     (ExceptT inst_e inst_m inst_a) -> (ExceptT inst_e inst_m inst_a) :=
+  fun x y => if Ord__ExceptT_op_zlze__ x y : bool then x else y.
+
+Program Instance Ord__ExceptT {e} {m} {a} `{GHC.Base.Ord e}
+  `{Data.Functor.Classes.Ord1 m} `{GHC.Base.Ord a}
+   : GHC.Base.Ord (ExceptT e m a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zl____ := Ord__ExceptT_op_zl__ ;
+           GHC.Base.op_zlze____ := Ord__ExceptT_op_zlze__ ;
+           GHC.Base.op_zg____ := Ord__ExceptT_op_zg__ ;
+           GHC.Base.op_zgze____ := Ord__ExceptT_op_zgze__ ;
+           GHC.Base.compare__ := Ord__ExceptT_compare ;
+           GHC.Base.max__ := Ord__ExceptT_max ;
+           GHC.Base.min__ := Ord__ExceptT_min |}.
+
+(* Skipping all instances of class `GHC.Read.Read', including
+   `Control.Monad.Trans.Except.Read__ExceptT' *)
+
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Control.Monad.Trans.Except.Show__ExceptT' *)
 
 Definition runExceptT {e} {m} {a}
    : ExceptT e m a -> m (Data.Either.Either e a) :=
   fun '(Mk_ExceptT m) => m.
-
-Definition runExcept {e} {a} : Except e a -> Data.Either.Either e a :=
-  fun '(Mk_ExceptT m) => Data.Functor.Identity.runIdentity m.
-
-Definition mapExceptT {m} {e} {a} {n} {e'} {b}
-   : (m (Data.Either.Either e a) -> n (Data.Either.Either e' b)) ->
-     ExceptT e m a -> ExceptT e' n b :=
-  fun f m => Mk_ExceptT (f (runExceptT m)).
-
-Definition withExceptT {m} {e} {e'} {a} `{(GHC.Base.Functor m)}
-   : (e -> e') -> ExceptT e m a -> ExceptT e' m a :=
-  fun f =>
-    mapExceptT (GHC.Base.fmap (Data.Either.either (Data.Either.Left GHC.Base.∘ f)
-                                                  Data.Either.Right)).
-
-Definition withExcept {e} {e'} {a} : (e -> e') -> Except e a -> Except e' a :=
-  withExceptT.
-
-Definition mapExcept {e} {a} {e'} {b}
-   : (Data.Either.Either e a -> Data.Either.Either e' b) ->
-     Except e a -> Except e' b :=
-  fun f =>
-    mapExceptT (Data.Functor.Identity.Mk_Identity GHC.Base.∘
-                (f GHC.Base.∘ Data.Functor.Identity.runIdentity)).
-
-Definition liftPass {m} {w} {e} {a} `{(GHC.Base.Monad m)}
-   : Control.Monad.Signatures.Pass w m (Data.Either.Either e a) ->
-     Control.Monad.Signatures.Pass w (ExceptT e m) a :=
-  fun pass =>
-    mapExceptT (fun m =>
-                  pass (m GHC.Base.>>=
-                        (fun a =>
-                           GHC.Base.return_ (match a with
-                                             | Data.Either.Left l => pair (Data.Either.Left l) GHC.Base.id
-                                             | Data.Either.Right (pair r f) => pair (Data.Either.Right r) f
-                                             end)))).
-
-Definition liftListen {m} {w} {e} {a} `{(GHC.Base.Monad m)}
-   : Control.Monad.Signatures.Listen w m (Data.Either.Either e a) ->
-     Control.Monad.Signatures.Listen w (ExceptT e m) a :=
-  fun listen =>
-    mapExceptT (fun m =>
-                  let cont_0__ arg_1__ :=
-                    let 'pair a w := arg_1__ in
-                    GHC.Base.return_ (GHC.Base.fmap (fun r => pair r w) a) in
-                  listen m GHC.Base.>>= cont_0__).
-
-Definition liftCallCC {m} {e} {a} {b}
-   : Control.Monad.Signatures.CallCC m (Data.Either.Either e a)
-     (Data.Either.Either e b) ->
-     Control.Monad.Signatures.CallCC (ExceptT e m) a b :=
-  fun callCC f =>
-    Mk_ExceptT (callCC (fun c =>
-                          runExceptT (f (fun a => Mk_ExceptT (c (Data.Either.Right a)))))).
-
-Definition except {e} {a} : Data.Either.Either e a -> Except e a :=
-  fun m => Mk_ExceptT (Data.Functor.Identity.Mk_Identity m).
-
-Definition catchE {m} {e} {a} {e'} `{(GHC.Base.Monad m)}
-   : ExceptT e m a -> (e -> ExceptT e' m a) -> ExceptT e' m a :=
-  fun m h =>
-    Mk_ExceptT (runExceptT m GHC.Base.>>=
-                (fun a =>
-                   match a with
-                   | Data.Either.Left l => runExceptT (h l)
-                   | Data.Either.Right r => GHC.Base.return_ (Data.Either.Right r)
-                   end)).
-
-(* Skipping all instances of class `Control.Monad.Zip.MonadZip', including
-   `Control.Monad.Trans.Except.MonadZip__ExceptT' *)
-
-(* Skipping all instances of class `Control.Monad.IO.Class.MonadIO', including
-   `Control.Monad.Trans.Except.MonadIO__ExceptT' *)
-
-Local Definition MonadTrans__ExceptT_lift {inst_e}
-   : forall {m} {a}, forall `{(GHC.Base.Monad m)}, m a -> (ExceptT inst_e) m a :=
-  fun {m} {a} `{(GHC.Base.Monad m)} =>
-    Mk_ExceptT GHC.Base.∘ GHC.Base.liftM Data.Either.Right.
-
-Program Instance MonadTrans__ExceptT {e}
-   : Control.Monad.Trans.Class.MonadTrans (ExceptT e) :=
-  fun _ k__ =>
-    k__ {| Control.Monad.Trans.Class.lift__ := fun {m} {a} `{(GHC.Base.Monad m)} =>
-             MonadTrans__ExceptT_lift |}.
-
-(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
-   `Control.Monad.Trans.Except.MonadFix__ExceptT' *)
-
-(* Skipping all instances of class `GHC.Base.MonadPlus', including
-   `Control.Monad.Trans.Except.MonadPlus__ExceptT' *)
-
-Definition Monad__ExceptT_op_zgzgze__ {inst_m} {inst_e} `{_
-   : GHC.Base.Monad inst_m}
-   : forall {a} {b},
-     ExceptT inst_e inst_m a ->
-     (a -> ExceptT inst_e inst_m b) -> ExceptT inst_e inst_m b :=
-  fun {a} {b} =>
-    fun m k =>
-      Mk_ExceptT (runExceptT m GHC.Base.>>=
-                  (fun a =>
-                     match a with
-                     | Data.Either.Left e => GHC.Base.return_ (Data.Either.Left e)
-                     | Data.Either.Right x => runExceptT (k x)
-                     end)).
-
-Local Definition Monad__ExceptT_op_zgzg__ {inst_m} {inst_e} `{(GHC.Base.Monad
-   inst_m)}
-   : forall {a} {b},
-     (ExceptT inst_e inst_m) a ->
-     (ExceptT inst_e inst_m) b -> (ExceptT inst_e inst_m) b :=
-  fun {a} {b} => fun m k => Monad__ExceptT_op_zgzgze__ m (fun arg_0__ => k).
-
-Local Definition Applicative__ExceptT_op_zlztzg__ {inst_m} {inst_e}
-  `{GHC.Base.Functor inst_m} `{GHC.Base.Monad inst_m}
-   : forall {a} {b},
-     (ExceptT inst_e inst_m) (a -> b) ->
-     (ExceptT inst_e inst_m) a -> (ExceptT inst_e inst_m) b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | Mk_ExceptT f, Mk_ExceptT v =>
-          Mk_ExceptT (f GHC.Base.>>=
-                      (fun mf =>
-                         match mf with
-                         | Data.Either.Left e => GHC.Base.return_ (Data.Either.Left e)
-                         | Data.Either.Right k =>
-                             v GHC.Base.>>=
-                             (fun mv =>
-                                match mv with
-                                | Data.Either.Left e => GHC.Base.return_ (Data.Either.Left e)
-                                | Data.Either.Right x => GHC.Base.return_ (Data.Either.Right (k x))
-                                end)
-                         end))
-      end.
 
 Local Definition Functor__ExceptT_fmap {inst_m} {inst_e} `{(GHC.Base.Functor
    inst_m)}
@@ -201,100 +183,6 @@ Program Instance Functor__ExceptT {m} {e} `{(GHC.Base.Functor m)}
   fun _ k__ =>
     k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__ExceptT_fmap ;
            GHC.Base.op_zlzd____ := fun {a} {b} => Functor__ExceptT_op_zlzd__ |}.
-
-Local Definition Applicative__ExceptT_liftA2 {inst_m} {inst_e}
-  `{GHC.Base.Functor inst_m} `{GHC.Base.Monad inst_m}
-   : forall {a} {b} {c},
-     (a -> b -> c) ->
-     (ExceptT inst_e inst_m) a ->
-     (ExceptT inst_e inst_m) b -> (ExceptT inst_e inst_m) c :=
-  fun {a} {b} {c} =>
-    fun f x => Applicative__ExceptT_op_zlztzg__ (GHC.Base.fmap f x).
-
-Local Definition Applicative__ExceptT_pure {inst_m} {inst_e} `{GHC.Base.Functor
-  inst_m} `{GHC.Base.Monad inst_m}
-   : forall {a}, a -> (ExceptT inst_e inst_m) a :=
-  fun {a} => fun a => Mk_ExceptT (GHC.Base.return_ (Data.Either.Right a)).
-
-Definition Applicative__ExceptT_op_ztzg__ {inst_m} {inst_s} `{_
-   : GHC.Base.Monad inst_m}
-   : forall {a} {b},
-     ExceptT inst_s inst_m a -> ExceptT inst_s inst_m b -> ExceptT inst_s inst_m b :=
-  fun {a} {b} =>
-    fun m k =>
-      Applicative__ExceptT_op_zlztzg__ (Applicative__ExceptT_op_zlztzg__
-                                        (Applicative__ExceptT_pure (fun x y => x)) k) m.
-
-Program Instance Applicative__ExceptT {m} {e} `{GHC.Base.Functor m}
-  `{GHC.Base.Monad m}
-   : GHC.Base.Applicative (ExceptT e m) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__ExceptT_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__ExceptT_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__ExceptT_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__ExceptT_pure |}.
-
-Local Definition Monad__ExceptT_return_ {inst_m} {inst_e} `{(GHC.Base.Monad
-   inst_m)}
-   : forall {a}, a -> (ExceptT inst_e inst_m) a :=
-  fun {a} => GHC.Base.pure.
-
-Program Instance Monad__ExceptT {m} {e} `{(GHC.Base.Monad m)}
-   : GHC.Base.Monad (ExceptT e m) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__ExceptT_op_zgzg__ ;
-           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__ExceptT_op_zgzgze__ ;
-           GHC.Base.return___ := fun {a} => Monad__ExceptT_return_ |}.
-
-Local Definition MonadFail__ExceptT_fail {inst_m} {inst_e}
-  `{(Control.Monad.Fail.MonadFail inst_m)}
-   : forall {a}, GHC.Base.String -> (ExceptT inst_e inst_m) a :=
-  fun {a} => Mk_ExceptT GHC.Base.∘ Control.Monad.Fail.fail.
-
-Program Instance MonadFail__ExceptT {m} {e} `{(Control.Monad.Fail.MonadFail m)}
-   : Control.Monad.Fail.MonadFail (ExceptT e m) :=
-  fun _ k__ =>
-    k__ {| Control.Monad.Fail.fail__ := fun {a} => MonadFail__ExceptT_fail |}.
-
-(* Skipping all instances of class `GHC.Base.Alternative', including
-   `Control.Monad.Trans.Except.Alternative__ExceptT' *)
-
-Local Definition Traversable__ExceptT_traverse {inst_f} {inst_e}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f},
-     (a -> f b) -> (ExceptT inst_e inst_f) a -> f ((ExceptT inst_e inst_f) b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, Mk_ExceptT a =>
-          Mk_ExceptT Data.Functor.<$>
-          Data.Traversable.traverse (Data.Either.either (GHC.Base.pure GHC.Base.∘
-                                                         Data.Either.Left) (GHC.Base.fmap Data.Either.Right GHC.Base.∘
-                                                                            f)) a
-      end.
-
-Local Definition Traversable__ExceptT_mapM {inst_f} {inst_e}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m},
-     (a -> m b) -> (ExceptT inst_e inst_f) a -> m ((ExceptT inst_e inst_f) b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__ExceptT_traverse.
-
-Local Definition Traversable__ExceptT_sequenceA {inst_f} {inst_e}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {f} {a},
-     forall `{GHC.Base.Applicative f},
-     (ExceptT inst_e inst_f) (f a) -> f ((ExceptT inst_e inst_f) a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} =>
-    Traversable__ExceptT_traverse GHC.Base.id.
-
-Local Definition Traversable__ExceptT_sequence {inst_f} {inst_e}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {m} {a},
-     forall `{GHC.Base.Monad m},
-     (ExceptT inst_e inst_f) (m a) -> m ((ExceptT inst_e inst_f) a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__ExceptT_sequenceA.
 
 Local Definition Foldable__ExceptT_foldMap {inst_f} {inst_e}
   `{(Data.Foldable.Foldable inst_f)}
@@ -398,6 +286,43 @@ Program Instance Foldable__ExceptT {f} {e} `{(Data.Foldable.Foldable f)}
            Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__ExceptT_sum ;
            Data.Foldable.toList__ := fun {a} => Foldable__ExceptT_toList |}.
 
+Local Definition Traversable__ExceptT_traverse {inst_f} {inst_e}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f},
+     (a -> f b) -> (ExceptT inst_e inst_f) a -> f ((ExceptT inst_e inst_f) b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, Mk_ExceptT a =>
+          Mk_ExceptT Data.Functor.<$>
+          Data.Traversable.traverse (Data.Either.either (GHC.Base.pure GHC.Base.∘
+                                                         Data.Either.Left) (GHC.Base.fmap Data.Either.Right GHC.Base.∘
+                                                                            f)) a
+      end.
+
+Local Definition Traversable__ExceptT_mapM {inst_f} {inst_e}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m},
+     (a -> m b) -> (ExceptT inst_e inst_f) a -> m ((ExceptT inst_e inst_f) b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__ExceptT_traverse.
+
+Local Definition Traversable__ExceptT_sequenceA {inst_f} {inst_e}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {f} {a},
+     forall `{GHC.Base.Applicative f},
+     (ExceptT inst_e inst_f) (f a) -> f ((ExceptT inst_e inst_f) a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} =>
+    Traversable__ExceptT_traverse GHC.Base.id.
+
+Local Definition Traversable__ExceptT_sequence {inst_f} {inst_e}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {m} {a},
+     forall `{GHC.Base.Monad m},
+     (ExceptT inst_e inst_f) (m a) -> m ((ExceptT inst_e inst_f) a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__ExceptT_sequenceA.
+
 Program Instance Traversable__ExceptT {f} {e} `{(Data.Traversable.Traversable
    f)}
    : Data.Traversable.Traversable (ExceptT e f) :=
@@ -411,124 +336,199 @@ Program Instance Traversable__ExceptT {f} {e} `{(Data.Traversable.Traversable
            Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
              Traversable__ExceptT_traverse |}.
 
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Control.Monad.Trans.Except.Show__ExceptT' *)
-
-(* Skipping all instances of class `GHC.Read.Read', including
-   `Control.Monad.Trans.Except.Read__ExceptT' *)
-
-Local Definition Ord1__ExceptT_liftCompare {inst_e} {inst_m} `{GHC.Base.Ord
-  inst_e} `{Data.Functor.Classes.Ord1 inst_m}
+Local Definition Applicative__ExceptT_op_zlztzg__ {inst_m} {inst_e}
+  `{GHC.Base.Functor inst_m} `{GHC.Base.Monad inst_m}
    : forall {a} {b},
-     (a -> b -> comparison) ->
-     (ExceptT inst_e inst_m) a -> (ExceptT inst_e inst_m) b -> comparison :=
+     (ExceptT inst_e inst_m) (a -> b) ->
+     (ExceptT inst_e inst_m) a -> (ExceptT inst_e inst_m) b :=
   fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | comp, Mk_ExceptT x, Mk_ExceptT y =>
-          (@Data.Functor.Classes.liftCompare inst_m _ _ _ _
-           (Data.Functor.Classes.liftCompare comp)) x y
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | Mk_ExceptT f, Mk_ExceptT v =>
+          Mk_ExceptT (f GHC.Base.>>=
+                      (fun mf =>
+                         match mf with
+                         | Data.Either.Left e => GHC.Base.return_ (Data.Either.Left e)
+                         | Data.Either.Right k =>
+                             v GHC.Base.>>=
+                             (fun mv =>
+                                match mv with
+                                | Data.Either.Left e => GHC.Base.return_ (Data.Either.Left e)
+                                | Data.Either.Right x => GHC.Base.return_ (Data.Either.Right (k x))
+                                end)
+                         end))
       end.
 
-Local Definition Eq1__ExceptT_liftEq {inst_e} {inst_m} `{GHC.Base.Eq_ inst_e}
-  `{Data.Functor.Classes.Eq1 inst_m}
+Local Definition Applicative__ExceptT_liftA2 {inst_m} {inst_e}
+  `{GHC.Base.Functor inst_m} `{GHC.Base.Monad inst_m}
+   : forall {a} {b} {c},
+     (a -> b -> c) ->
+     (ExceptT inst_e inst_m) a ->
+     (ExceptT inst_e inst_m) b -> (ExceptT inst_e inst_m) c :=
+  fun {a} {b} {c} =>
+    fun f x => Applicative__ExceptT_op_zlztzg__ (GHC.Base.fmap f x).
+
+Local Definition Applicative__ExceptT_pure {inst_m} {inst_e} `{GHC.Base.Functor
+  inst_m} `{GHC.Base.Monad inst_m}
+   : forall {a}, a -> (ExceptT inst_e inst_m) a :=
+  fun {a} => fun a => Mk_ExceptT (GHC.Base.return_ (Data.Either.Right a)).
+
+Definition Applicative__ExceptT_op_ztzg__ {inst_m} {inst_s} `{_
+   : GHC.Base.Monad inst_m}
    : forall {a} {b},
-     (a -> b -> bool) ->
-     (ExceptT inst_e inst_m) a -> (ExceptT inst_e inst_m) b -> bool :=
+     ExceptT inst_s inst_m a -> ExceptT inst_s inst_m b -> ExceptT inst_s inst_m b :=
   fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | eq, Mk_ExceptT x, Mk_ExceptT y =>
-          (@Data.Functor.Classes.liftEq inst_m _ _ _ (Data.Functor.Classes.liftEq eq)) x y
-      end.
+    fun m k =>
+      Applicative__ExceptT_op_zlztzg__ (Applicative__ExceptT_op_zlztzg__
+                                        (Applicative__ExceptT_pure (fun x y => x)) k) m.
 
-Program Instance Eq1__ExceptT {e} {m} `{GHC.Base.Eq_ e}
-  `{Data.Functor.Classes.Eq1 m}
-   : Data.Functor.Classes.Eq1 (ExceptT e m) :=
+Program Instance Applicative__ExceptT {m} {e} `{GHC.Base.Functor m}
+  `{GHC.Base.Monad m}
+   : GHC.Base.Applicative (ExceptT e m) :=
   fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__ExceptT_liftEq |}.
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__ExceptT_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__ExceptT_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__ExceptT_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__ExceptT_pure |}.
 
-Program Instance Ord1__ExceptT {e} {m} `{GHC.Base.Ord e}
-  `{Data.Functor.Classes.Ord1 m}
-   : Data.Functor.Classes.Ord1 (ExceptT e m) :=
+(* Skipping all instances of class `GHC.Base.Alternative', including
+   `Control.Monad.Trans.Except.Alternative__ExceptT' *)
+
+Definition Monad__ExceptT_op_zgzgze__ {inst_m} {inst_e} `{_
+   : GHC.Base.Monad inst_m}
+   : forall {a} {b},
+     ExceptT inst_e inst_m a ->
+     (a -> ExceptT inst_e inst_m b) -> ExceptT inst_e inst_m b :=
+  fun {a} {b} =>
+    fun m k =>
+      Mk_ExceptT (runExceptT m GHC.Base.>>=
+                  (fun a =>
+                     match a with
+                     | Data.Either.Left e => GHC.Base.return_ (Data.Either.Left e)
+                     | Data.Either.Right x => runExceptT (k x)
+                     end)).
+
+Local Definition Monad__ExceptT_op_zgzg__ {inst_m} {inst_e} `{(GHC.Base.Monad
+   inst_m)}
+   : forall {a} {b},
+     (ExceptT inst_e inst_m) a ->
+     (ExceptT inst_e inst_m) b -> (ExceptT inst_e inst_m) b :=
+  fun {a} {b} => fun m k => Monad__ExceptT_op_zgzgze__ m (fun arg_0__ => k).
+
+Local Definition Monad__ExceptT_return_ {inst_m} {inst_e} `{(GHC.Base.Monad
+   inst_m)}
+   : forall {a}, a -> (ExceptT inst_e inst_m) a :=
+  fun {a} => GHC.Base.pure.
+
+Program Instance Monad__ExceptT {m} {e} `{(GHC.Base.Monad m)}
+   : GHC.Base.Monad (ExceptT e m) :=
   fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
-             Ord1__ExceptT_liftCompare |}.
+    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__ExceptT_op_zgzg__ ;
+           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__ExceptT_op_zgzgze__ ;
+           GHC.Base.return___ := fun {a} => Monad__ExceptT_return_ |}.
 
-Local Definition Ord__ExceptT_compare {inst_e} {inst_m} {inst_a} `{GHC.Base.Ord
-  inst_e} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
-   : (ExceptT inst_e inst_m inst_a) ->
-     (ExceptT inst_e inst_m inst_a) -> comparison :=
-  Data.Functor.Classes.compare1.
+Local Definition MonadTrans__ExceptT_lift {inst_e}
+   : forall {m} {a}, forall `{(GHC.Base.Monad m)}, m a -> (ExceptT inst_e) m a :=
+  fun {m} {a} `{(GHC.Base.Monad m)} =>
+    Mk_ExceptT GHC.Base.∘ GHC.Base.liftM Data.Either.Right.
 
-Local Definition Ord__ExceptT_op_zl__ {inst_e} {inst_m} {inst_a} `{GHC.Base.Ord
-  inst_e} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
-   : (ExceptT inst_e inst_m inst_a) -> (ExceptT inst_e inst_m inst_a) -> bool :=
-  fun x y => Ord__ExceptT_compare x y GHC.Base.== Lt.
-
-Local Definition Ord__ExceptT_op_zlze__ {inst_e} {inst_m} {inst_a}
-  `{GHC.Base.Ord inst_e} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord
-  inst_a}
-   : (ExceptT inst_e inst_m inst_a) -> (ExceptT inst_e inst_m inst_a) -> bool :=
-  fun x y => Ord__ExceptT_compare x y GHC.Base./= Gt.
-
-Local Definition Ord__ExceptT_op_zg__ {inst_e} {inst_m} {inst_a} `{GHC.Base.Ord
-  inst_e} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
-   : (ExceptT inst_e inst_m inst_a) -> (ExceptT inst_e inst_m inst_a) -> bool :=
-  fun x y => Ord__ExceptT_compare x y GHC.Base.== Gt.
-
-Local Definition Ord__ExceptT_op_zgze__ {inst_e} {inst_m} {inst_a}
-  `{GHC.Base.Ord inst_e} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord
-  inst_a}
-   : (ExceptT inst_e inst_m inst_a) -> (ExceptT inst_e inst_m inst_a) -> bool :=
-  fun x y => Ord__ExceptT_compare x y GHC.Base./= Lt.
-
-Local Definition Ord__ExceptT_max {inst_e} {inst_m} {inst_a} `{GHC.Base.Ord
-  inst_e} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
-   : (ExceptT inst_e inst_m inst_a) ->
-     (ExceptT inst_e inst_m inst_a) -> (ExceptT inst_e inst_m inst_a) :=
-  fun x y => if Ord__ExceptT_op_zlze__ x y : bool then y else x.
-
-Local Definition Ord__ExceptT_min {inst_e} {inst_m} {inst_a} `{GHC.Base.Ord
-  inst_e} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
-   : (ExceptT inst_e inst_m inst_a) ->
-     (ExceptT inst_e inst_m inst_a) -> (ExceptT inst_e inst_m inst_a) :=
-  fun x y => if Ord__ExceptT_op_zlze__ x y : bool then x else y.
-
-Local Definition Eq___ExceptT_op_zeze__ {inst_e} {inst_m} {inst_a}
-  `{GHC.Base.Eq_ inst_e} `{Data.Functor.Classes.Eq1 inst_m} `{GHC.Base.Eq_ inst_a}
-   : (ExceptT inst_e inst_m inst_a) -> (ExceptT inst_e inst_m inst_a) -> bool :=
-  Data.Functor.Classes.eq1.
-
-Local Definition Eq___ExceptT_op_zsze__ {inst_e} {inst_m} {inst_a}
-  `{GHC.Base.Eq_ inst_e} `{Data.Functor.Classes.Eq1 inst_m} `{GHC.Base.Eq_ inst_a}
-   : (ExceptT inst_e inst_m inst_a) -> (ExceptT inst_e inst_m inst_a) -> bool :=
-  fun x y => negb (Eq___ExceptT_op_zeze__ x y).
-
-Program Instance Eq___ExceptT {e} {m} {a} `{GHC.Base.Eq_ e}
-  `{Data.Functor.Classes.Eq1 m} `{GHC.Base.Eq_ a}
-   : GHC.Base.Eq_ (ExceptT e m a) :=
+Program Instance MonadTrans__ExceptT {e}
+   : Control.Monad.Trans.Class.MonadTrans (ExceptT e) :=
   fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___ExceptT_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___ExceptT_op_zsze__ |}.
+    k__ {| Control.Monad.Trans.Class.lift__ := fun {m} {a} `{(GHC.Base.Monad m)} =>
+             MonadTrans__ExceptT_lift |}.
 
-Program Instance Ord__ExceptT {e} {m} {a} `{GHC.Base.Ord e}
-  `{Data.Functor.Classes.Ord1 m} `{GHC.Base.Ord a}
-   : GHC.Base.Ord (ExceptT e m a) :=
+Local Definition MonadFail__ExceptT_fail {inst_m} {inst_e}
+  `{(Control.Monad.Fail.MonadFail inst_m)}
+   : forall {a}, GHC.Base.String -> (ExceptT inst_e inst_m) a :=
+  fun {a} => Mk_ExceptT GHC.Base.∘ Control.Monad.Fail.fail.
+
+Program Instance MonadFail__ExceptT {m} {e} `{(Control.Monad.Fail.MonadFail m)}
+   : Control.Monad.Fail.MonadFail (ExceptT e m) :=
   fun _ k__ =>
-    k__ {| GHC.Base.op_zl____ := Ord__ExceptT_op_zl__ ;
-           GHC.Base.op_zlze____ := Ord__ExceptT_op_zlze__ ;
-           GHC.Base.op_zg____ := Ord__ExceptT_op_zg__ ;
-           GHC.Base.op_zgze____ := Ord__ExceptT_op_zgze__ ;
-           GHC.Base.compare__ := Ord__ExceptT_compare ;
-           GHC.Base.max__ := Ord__ExceptT_max ;
-           GHC.Base.min__ := Ord__ExceptT_min |}.
+    k__ {| Control.Monad.Fail.fail__ := fun {a} => MonadFail__ExceptT_fail |}.
 
-(* Skipping all instances of class `Data.Functor.Classes.Show1', including
-   `Control.Monad.Trans.Except.Show1__ExceptT' *)
+(* Skipping all instances of class `GHC.Base.MonadPlus', including
+   `Control.Monad.Trans.Except.MonadPlus__ExceptT' *)
 
-(* Skipping all instances of class `Data.Functor.Classes.Read1', including
-   `Control.Monad.Trans.Except.Read1__ExceptT' *)
+(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
+   `Control.Monad.Trans.Except.MonadFix__ExceptT' *)
+
+(* Skipping all instances of class `Control.Monad.IO.Class.MonadIO', including
+   `Control.Monad.Trans.Except.MonadIO__ExceptT' *)
+
+(* Skipping all instances of class `Control.Monad.Zip.MonadZip', including
+   `Control.Monad.Trans.Except.MonadZip__ExceptT' *)
+
+Definition except {e} {a} : Data.Either.Either e a -> Except e a :=
+  fun m => Mk_ExceptT (Data.Functor.Identity.Mk_Identity m).
+
+Definition runExcept {e} {a} : Except e a -> Data.Either.Either e a :=
+  fun '(Mk_ExceptT m) => Data.Functor.Identity.runIdentity m.
+
+Definition mapExceptT {m} {e} {a} {n} {e'} {b}
+   : (m (Data.Either.Either e a) -> n (Data.Either.Either e' b)) ->
+     ExceptT e m a -> ExceptT e' n b :=
+  fun f m => Mk_ExceptT (f (runExceptT m)).
+
+Definition mapExcept {e} {a} {e'} {b}
+   : (Data.Either.Either e a -> Data.Either.Either e' b) ->
+     Except e a -> Except e' b :=
+  fun f =>
+    mapExceptT (Data.Functor.Identity.Mk_Identity GHC.Base.∘
+                (f GHC.Base.∘ Data.Functor.Identity.runIdentity)).
+
+Definition withExceptT {m} {e} {e'} {a} `{(GHC.Base.Functor m)}
+   : (e -> e') -> ExceptT e m a -> ExceptT e' m a :=
+  fun f =>
+    mapExceptT (GHC.Base.fmap (Data.Either.either (Data.Either.Left GHC.Base.∘ f)
+                                                  Data.Either.Right)).
+
+Definition withExcept {e} {e'} {a} : (e -> e') -> Except e a -> Except e' a :=
+  withExceptT.
+
+Definition throwE {m} {e} {a} `{(GHC.Base.Monad m)} : e -> ExceptT e m a :=
+  Mk_ExceptT GHC.Base.∘ (GHC.Base.return_ GHC.Base.∘ Data.Either.Left).
+
+Definition catchE {m} {e} {a} {e'} `{(GHC.Base.Monad m)}
+   : ExceptT e m a -> (e -> ExceptT e' m a) -> ExceptT e' m a :=
+  fun m h =>
+    Mk_ExceptT (runExceptT m GHC.Base.>>=
+                (fun a =>
+                   match a with
+                   | Data.Either.Left l => runExceptT (h l)
+                   | Data.Either.Right r => GHC.Base.return_ (Data.Either.Right r)
+                   end)).
+
+Definition liftCallCC {m} {e} {a} {b}
+   : Control.Monad.Signatures.CallCC m (Data.Either.Either e a)
+     (Data.Either.Either e b) ->
+     Control.Monad.Signatures.CallCC (ExceptT e m) a b :=
+  fun callCC f =>
+    Mk_ExceptT (callCC (fun c =>
+                          runExceptT (f (fun a => Mk_ExceptT (c (Data.Either.Right a)))))).
+
+Definition liftListen {m} {w} {e} {a} `{(GHC.Base.Monad m)}
+   : Control.Monad.Signatures.Listen w m (Data.Either.Either e a) ->
+     Control.Monad.Signatures.Listen w (ExceptT e m) a :=
+  fun listen =>
+    mapExceptT (fun m =>
+                  let cont_0__ arg_1__ :=
+                    let 'pair a w := arg_1__ in
+                    GHC.Base.return_ (GHC.Base.fmap (fun r => pair r w) a) in
+                  listen m GHC.Base.>>= cont_0__).
+
+Definition liftPass {m} {w} {e} {a} `{(GHC.Base.Monad m)}
+   : Control.Monad.Signatures.Pass w m (Data.Either.Either e a) ->
+     Control.Monad.Signatures.Pass w (ExceptT e m) a :=
+  fun pass =>
+    mapExceptT (fun m =>
+                  pass (m GHC.Base.>>=
+                        (fun a =>
+                           GHC.Base.return_ (match a with
+                                             | Data.Either.Left l => pair (Data.Either.Left l) GHC.Base.id
+                                             | Data.Either.Right (pair r f) => pair (Data.Either.Right r) f
+                                             end)))).
 
 (* External variables:
      Gt Lt bool comparison false list negb pair true Control.Monad.Fail.MonadFail

--- a/examples/transformers/lib/Control/Monad/Trans/Identity.v
+++ b/examples/transformers/lib/Control/Monad/Trans/Identity.v
@@ -39,62 +39,120 @@ Definition runIdentityT {f : Type -> Type} {a} (arg_0__ : IdentityT f a) :=
 
 (* Converted value declarations: *)
 
+Local Definition Eq1__IdentityT_liftEq {inst_f} `{(Data.Functor.Classes.Eq1
+   inst_f)}
+   : forall {a} {b},
+     (a -> b -> bool) -> (IdentityT inst_f) a -> (IdentityT inst_f) b -> bool :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | eq, Mk_IdentityT x, Mk_IdentityT y => Data.Functor.Classes.liftEq eq x y
+      end.
+
+Program Instance Eq1__IdentityT {f} `{(Data.Functor.Classes.Eq1 f)}
+   : Data.Functor.Classes.Eq1 (IdentityT f) :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__IdentityT_liftEq |}.
+
+Local Definition Ord1__IdentityT_liftCompare {inst_f}
+  `{(Data.Functor.Classes.Ord1 inst_f)}
+   : forall {a} {b},
+     (a -> b -> comparison) ->
+     (IdentityT inst_f) a -> (IdentityT inst_f) b -> comparison :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | comp, Mk_IdentityT x, Mk_IdentityT y =>
+          Data.Functor.Classes.liftCompare comp x y
+      end.
+
+Program Instance Ord1__IdentityT {f} `{(Data.Functor.Classes.Ord1 f)}
+   : Data.Functor.Classes.Ord1 (IdentityT f) :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
+             Ord1__IdentityT_liftCompare |}.
+
+(* Skipping all instances of class `Data.Functor.Classes.Read1', including
+   `Control.Monad.Trans.Identity.Read1__IdentityT' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Show1', including
+   `Control.Monad.Trans.Identity.Show1__IdentityT' *)
+
+Local Definition Eq___IdentityT_op_zeze__ {inst_f} {inst_a}
+  `{Data.Functor.Classes.Eq1 inst_f} `{GHC.Base.Eq_ inst_a}
+   : (IdentityT inst_f inst_a) -> (IdentityT inst_f inst_a) -> bool :=
+  Data.Functor.Classes.eq1.
+
+Local Definition Eq___IdentityT_op_zsze__ {inst_f} {inst_a}
+  `{Data.Functor.Classes.Eq1 inst_f} `{GHC.Base.Eq_ inst_a}
+   : (IdentityT inst_f inst_a) -> (IdentityT inst_f inst_a) -> bool :=
+  fun x y => negb (Eq___IdentityT_op_zeze__ x y).
+
+Program Instance Eq___IdentityT {f} {a} `{Data.Functor.Classes.Eq1 f}
+  `{GHC.Base.Eq_ a}
+   : GHC.Base.Eq_ (IdentityT f a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___IdentityT_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___IdentityT_op_zsze__ |}.
+
+Local Definition Ord__IdentityT_compare {inst_f} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
+   : (IdentityT inst_f inst_a) -> (IdentityT inst_f inst_a) -> comparison :=
+  Data.Functor.Classes.compare1.
+
+Local Definition Ord__IdentityT_op_zl__ {inst_f} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
+   : (IdentityT inst_f inst_a) -> (IdentityT inst_f inst_a) -> bool :=
+  fun x y => Ord__IdentityT_compare x y GHC.Base.== Lt.
+
+Local Definition Ord__IdentityT_op_zlze__ {inst_f} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
+   : (IdentityT inst_f inst_a) -> (IdentityT inst_f inst_a) -> bool :=
+  fun x y => Ord__IdentityT_compare x y GHC.Base./= Gt.
+
+Local Definition Ord__IdentityT_op_zg__ {inst_f} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
+   : (IdentityT inst_f inst_a) -> (IdentityT inst_f inst_a) -> bool :=
+  fun x y => Ord__IdentityT_compare x y GHC.Base.== Gt.
+
+Local Definition Ord__IdentityT_op_zgze__ {inst_f} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
+   : (IdentityT inst_f inst_a) -> (IdentityT inst_f inst_a) -> bool :=
+  fun x y => Ord__IdentityT_compare x y GHC.Base./= Lt.
+
+Local Definition Ord__IdentityT_max {inst_f} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
+   : (IdentityT inst_f inst_a) ->
+     (IdentityT inst_f inst_a) -> (IdentityT inst_f inst_a) :=
+  fun x y => if Ord__IdentityT_op_zlze__ x y : bool then y else x.
+
+Local Definition Ord__IdentityT_min {inst_f} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
+   : (IdentityT inst_f inst_a) ->
+     (IdentityT inst_f inst_a) -> (IdentityT inst_f inst_a) :=
+  fun x y => if Ord__IdentityT_op_zlze__ x y : bool then x else y.
+
+Program Instance Ord__IdentityT {f} {a} `{Data.Functor.Classes.Ord1 f}
+  `{GHC.Base.Ord a}
+   : GHC.Base.Ord (IdentityT f a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zl____ := Ord__IdentityT_op_zl__ ;
+           GHC.Base.op_zlze____ := Ord__IdentityT_op_zlze__ ;
+           GHC.Base.op_zg____ := Ord__IdentityT_op_zg__ ;
+           GHC.Base.op_zgze____ := Ord__IdentityT_op_zgze__ ;
+           GHC.Base.compare__ := Ord__IdentityT_compare ;
+           GHC.Base.max__ := Ord__IdentityT_max ;
+           GHC.Base.min__ := Ord__IdentityT_min |}.
+
+(* Skipping all instances of class `GHC.Read.Read', including
+   `Control.Monad.Trans.Identity.Read__IdentityT' *)
+
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Control.Monad.Trans.Identity.Show__IdentityT' *)
+
 Definition mapIdentityT {m} {a} {n} {b}
    : (m a -> n b) -> IdentityT m a -> IdentityT n b :=
   fun f => Mk_IdentityT GHC.Base.∘ (f GHC.Base.∘ runIdentityT).
-
-(* Skipping definition `Control.Monad.Trans.Identity.liftCatch' *)
-
-Definition liftCallCC {m} {a} {b}
-   : Control.Monad.Signatures.CallCC m a b ->
-     Control.Monad.Signatures.CallCC (IdentityT m) a b :=
-  fun callCC f =>
-    Mk_IdentityT (callCC (fun c => runIdentityT (f (Mk_IdentityT GHC.Base.∘ c)))).
-
-Definition lift2IdentityT {m} {a} {n} {b} {p} {c}
-   : (m a -> n b -> p c) -> IdentityT m a -> IdentityT n b -> IdentityT p c :=
-  fun f a b => Mk_IdentityT (f (runIdentityT a) (runIdentityT b)).
-
-Local Definition MonadTrans__IdentityT_lift
-   : forall {m} {a}, forall `{(GHC.Base.Monad m)}, m a -> IdentityT m a :=
-  fun {m} {a} `{(GHC.Base.Monad m)} => Mk_IdentityT.
-
-Program Instance MonadTrans__IdentityT
-   : Control.Monad.Trans.Class.MonadTrans IdentityT :=
-  fun _ k__ =>
-    k__ {| Control.Monad.Trans.Class.lift__ := fun {m} {a} `{(GHC.Base.Monad m)} =>
-             MonadTrans__IdentityT_lift |}.
-
-(* Skipping all instances of class `Control.Monad.Zip.MonadZip', including
-   `Control.Monad.Trans.Identity.MonadZip__IdentityT' *)
-
-(* Skipping all instances of class `Control.Monad.IO.Class.MonadIO', including
-   `Control.Monad.Trans.Identity.MonadIO__IdentityT' *)
-
-(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
-   `Control.Monad.Trans.Identity.MonadFix__IdentityT' *)
-
-(* Skipping all instances of class `GHC.Base.MonadPlus', including
-   `Control.Monad.Trans.Identity.MonadPlus__IdentityT' *)
-
-Local Definition MonadFail__IdentityT_fail {inst_m}
-  `{(Control.Monad.Fail.MonadFail inst_m)}
-   : forall {a}, GHC.Base.String -> (IdentityT inst_m) a :=
-  fun {a} => fun msg => Mk_IdentityT (Control.Monad.Fail.fail msg).
-
-Local Definition Monad__IdentityT_op_zgzgze__ {inst_m} `{(GHC.Base.Monad
-   inst_m)}
-   : forall {a} {b},
-     (IdentityT inst_m) a -> (a -> (IdentityT inst_m) b) -> (IdentityT inst_m) b :=
-  fun {a} {b} =>
-    fun m k =>
-      Mk_IdentityT ((runIdentityT GHC.Base.∘ k) GHC.Base.=<< runIdentityT m).
-
-Local Definition Applicative__IdentityT_op_zlztzg__ {inst_m}
-  `{(GHC.Base.Applicative inst_m)}
-   : forall {a} {b},
-     (IdentityT inst_m) (a -> b) -> (IdentityT inst_m) a -> (IdentityT inst_m) b :=
-  fun {a} {b} => lift2IdentityT _GHC.Base.<*>_.
 
 Local Definition Functor__IdentityT_fmap {inst_m} `{(GHC.Base.Functor inst_m)}
    : forall {a} {b}, (a -> b) -> (IdentityT inst_m) a -> (IdentityT inst_m) b :=
@@ -110,91 +168,6 @@ Program Instance Functor__IdentityT {m} `{(GHC.Base.Functor m)}
   fun _ k__ =>
     k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__IdentityT_fmap ;
            GHC.Base.op_zlzd____ := fun {a} {b} => Functor__IdentityT_op_zlzd__ |}.
-
-Local Definition Applicative__IdentityT_liftA2 {inst_m} `{(GHC.Base.Applicative
-   inst_m)}
-   : forall {a} {b} {c},
-     (a -> b -> c) ->
-     (IdentityT inst_m) a -> (IdentityT inst_m) b -> (IdentityT inst_m) c :=
-  fun {a} {b} {c} =>
-    fun f x => Applicative__IdentityT_op_zlztzg__ (GHC.Base.fmap f x).
-
-Local Definition Applicative__IdentityT_op_ztzg__ {inst_m}
-  `{(GHC.Base.Applicative inst_m)}
-   : forall {a} {b},
-     (IdentityT inst_m) a -> (IdentityT inst_m) b -> (IdentityT inst_m) b :=
-  fun {a} {b} => lift2IdentityT _GHC.Base.*>_.
-
-Local Definition Applicative__IdentityT_pure {inst_m} `{(GHC.Base.Applicative
-   inst_m)}
-   : forall {a}, a -> (IdentityT inst_m) a :=
-  fun {a} => fun x => Mk_IdentityT (GHC.Base.pure x).
-
-Program Instance Applicative__IdentityT {m} `{(GHC.Base.Applicative m)}
-   : GHC.Base.Applicative (IdentityT m) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__IdentityT_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__IdentityT_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__IdentityT_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__IdentityT_pure |}.
-
-Local Definition Monad__IdentityT_op_zgzg__ {inst_m} `{(GHC.Base.Monad inst_m)}
-   : forall {a} {b},
-     (IdentityT inst_m) a -> (IdentityT inst_m) b -> (IdentityT inst_m) b :=
-  fun {a} {b} => fun m k => Monad__IdentityT_op_zgzgze__ m (fun arg_0__ => k).
-
-Local Definition Monad__IdentityT_return_ {inst_m} `{(GHC.Base.Monad inst_m)}
-   : forall {a}, a -> (IdentityT inst_m) a :=
-  fun {a} => GHC.Base.pure.
-
-Program Instance Monad__IdentityT {m} `{(GHC.Base.Monad m)}
-   : GHC.Base.Monad (IdentityT m) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__IdentityT_op_zgzg__ ;
-           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__IdentityT_op_zgzgze__ ;
-           GHC.Base.return___ := fun {a} => Monad__IdentityT_return_ |}.
-
-Program Instance MonadFail__IdentityT {m} `{(Control.Monad.Fail.MonadFail m)}
-   : Control.Monad.Fail.MonadFail (IdentityT m) :=
-  fun _ k__ =>
-    k__ {| Control.Monad.Fail.fail__ := fun {a} => MonadFail__IdentityT_fail |}.
-
-(* Skipping all instances of class `GHC.Base.Alternative', including
-   `Control.Monad.Trans.Identity.Alternative__IdentityT' *)
-
-Local Definition Traversable__IdentityT_traverse {inst_f}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f},
-     (a -> f b) -> (IdentityT inst_f) a -> f ((IdentityT inst_f) b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, Mk_IdentityT a =>
-          Mk_IdentityT Data.Functor.<$> Data.Traversable.traverse f a
-      end.
-
-Local Definition Traversable__IdentityT_mapM {inst_f}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m},
-     (a -> m b) -> (IdentityT inst_f) a -> m ((IdentityT inst_f) b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__IdentityT_traverse.
-
-Local Definition Traversable__IdentityT_sequenceA {inst_f}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {f} {a},
-     forall `{GHC.Base.Applicative f},
-     (IdentityT inst_f) (f a) -> f ((IdentityT inst_f) a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} =>
-    Traversable__IdentityT_traverse GHC.Base.id.
-
-Local Definition Traversable__IdentityT_sequence {inst_f}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {m} {a},
-     forall `{GHC.Base.Monad m},
-     (IdentityT inst_f) (m a) -> m ((IdentityT inst_f) a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__IdentityT_sequenceA.
 
 Local Definition Foldable__IdentityT_foldMap {inst_f} `{(Data.Foldable.Foldable
    inst_f)}
@@ -294,6 +267,40 @@ Program Instance Foldable__IdentityT {f} `{(Data.Foldable.Foldable f)}
            Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__IdentityT_sum ;
            Data.Foldable.toList__ := fun {a} => Foldable__IdentityT_toList |}.
 
+Local Definition Traversable__IdentityT_traverse {inst_f}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f},
+     (a -> f b) -> (IdentityT inst_f) a -> f ((IdentityT inst_f) b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, Mk_IdentityT a =>
+          Mk_IdentityT Data.Functor.<$> Data.Traversable.traverse f a
+      end.
+
+Local Definition Traversable__IdentityT_mapM {inst_f}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m},
+     (a -> m b) -> (IdentityT inst_f) a -> m ((IdentityT inst_f) b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__IdentityT_traverse.
+
+Local Definition Traversable__IdentityT_sequenceA {inst_f}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {f} {a},
+     forall `{GHC.Base.Applicative f},
+     (IdentityT inst_f) (f a) -> f ((IdentityT inst_f) a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} =>
+    Traversable__IdentityT_traverse GHC.Base.id.
+
+Local Definition Traversable__IdentityT_sequence {inst_f}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {m} {a},
+     forall `{GHC.Base.Monad m},
+     (IdentityT inst_f) (m a) -> m ((IdentityT inst_f) a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__IdentityT_sequenceA.
+
 Program Instance Traversable__IdentityT {f} `{(Data.Traversable.Traversable f)}
    : Data.Traversable.Traversable (IdentityT f) :=
   fun _ k__ =>
@@ -306,116 +313,109 @@ Program Instance Traversable__IdentityT {f} `{(Data.Traversable.Traversable f)}
            Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
              Traversable__IdentityT_traverse |}.
 
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Control.Monad.Trans.Identity.Show__IdentityT' *)
+Definition lift2IdentityT {m} {a} {n} {b} {p} {c}
+   : (m a -> n b -> p c) -> IdentityT m a -> IdentityT n b -> IdentityT p c :=
+  fun f a b => Mk_IdentityT (f (runIdentityT a) (runIdentityT b)).
 
-(* Skipping all instances of class `GHC.Read.Read', including
-   `Control.Monad.Trans.Identity.Read__IdentityT' *)
-
-Local Definition Ord1__IdentityT_liftCompare {inst_f}
-  `{(Data.Functor.Classes.Ord1 inst_f)}
+Local Definition Applicative__IdentityT_op_zlztzg__ {inst_m}
+  `{(GHC.Base.Applicative inst_m)}
    : forall {a} {b},
-     (a -> b -> comparison) ->
-     (IdentityT inst_f) a -> (IdentityT inst_f) b -> comparison :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | comp, Mk_IdentityT x, Mk_IdentityT y =>
-          Data.Functor.Classes.liftCompare comp x y
-      end.
+     (IdentityT inst_m) (a -> b) -> (IdentityT inst_m) a -> (IdentityT inst_m) b :=
+  fun {a} {b} => lift2IdentityT _GHC.Base.<*>_.
 
-Local Definition Eq1__IdentityT_liftEq {inst_f} `{(Data.Functor.Classes.Eq1
-   inst_f)}
+Local Definition Applicative__IdentityT_liftA2 {inst_m} `{(GHC.Base.Applicative
+   inst_m)}
+   : forall {a} {b} {c},
+     (a -> b -> c) ->
+     (IdentityT inst_m) a -> (IdentityT inst_m) b -> (IdentityT inst_m) c :=
+  fun {a} {b} {c} =>
+    fun f x => Applicative__IdentityT_op_zlztzg__ (GHC.Base.fmap f x).
+
+Local Definition Applicative__IdentityT_op_ztzg__ {inst_m}
+  `{(GHC.Base.Applicative inst_m)}
    : forall {a} {b},
-     (a -> b -> bool) -> (IdentityT inst_f) a -> (IdentityT inst_f) b -> bool :=
+     (IdentityT inst_m) a -> (IdentityT inst_m) b -> (IdentityT inst_m) b :=
+  fun {a} {b} => lift2IdentityT _GHC.Base.*>_.
+
+Local Definition Applicative__IdentityT_pure {inst_m} `{(GHC.Base.Applicative
+   inst_m)}
+   : forall {a}, a -> (IdentityT inst_m) a :=
+  fun {a} => fun x => Mk_IdentityT (GHC.Base.pure x).
+
+Program Instance Applicative__IdentityT {m} `{(GHC.Base.Applicative m)}
+   : GHC.Base.Applicative (IdentityT m) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__IdentityT_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__IdentityT_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__IdentityT_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__IdentityT_pure |}.
+
+(* Skipping all instances of class `GHC.Base.Alternative', including
+   `Control.Monad.Trans.Identity.Alternative__IdentityT' *)
+
+Local Definition Monad__IdentityT_op_zgzgze__ {inst_m} `{(GHC.Base.Monad
+   inst_m)}
+   : forall {a} {b},
+     (IdentityT inst_m) a -> (a -> (IdentityT inst_m) b) -> (IdentityT inst_m) b :=
   fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | eq, Mk_IdentityT x, Mk_IdentityT y => Data.Functor.Classes.liftEq eq x y
-      end.
+    fun m k =>
+      Mk_IdentityT ((runIdentityT GHC.Base.∘ k) GHC.Base.=<< runIdentityT m).
 
-Program Instance Eq1__IdentityT {f} `{(Data.Functor.Classes.Eq1 f)}
-   : Data.Functor.Classes.Eq1 (IdentityT f) :=
+Local Definition Monad__IdentityT_op_zgzg__ {inst_m} `{(GHC.Base.Monad inst_m)}
+   : forall {a} {b},
+     (IdentityT inst_m) a -> (IdentityT inst_m) b -> (IdentityT inst_m) b :=
+  fun {a} {b} => fun m k => Monad__IdentityT_op_zgzgze__ m (fun arg_0__ => k).
+
+Local Definition Monad__IdentityT_return_ {inst_m} `{(GHC.Base.Monad inst_m)}
+   : forall {a}, a -> (IdentityT inst_m) a :=
+  fun {a} => GHC.Base.pure.
+
+Program Instance Monad__IdentityT {m} `{(GHC.Base.Monad m)}
+   : GHC.Base.Monad (IdentityT m) :=
   fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__IdentityT_liftEq |}.
+    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__IdentityT_op_zgzg__ ;
+           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__IdentityT_op_zgzgze__ ;
+           GHC.Base.return___ := fun {a} => Monad__IdentityT_return_ |}.
 
-Program Instance Ord1__IdentityT {f} `{(Data.Functor.Classes.Ord1 f)}
-   : Data.Functor.Classes.Ord1 (IdentityT f) :=
+Local Definition MonadFail__IdentityT_fail {inst_m}
+  `{(Control.Monad.Fail.MonadFail inst_m)}
+   : forall {a}, GHC.Base.String -> (IdentityT inst_m) a :=
+  fun {a} => fun msg => Mk_IdentityT (Control.Monad.Fail.fail msg).
+
+Program Instance MonadFail__IdentityT {m} `{(Control.Monad.Fail.MonadFail m)}
+   : Control.Monad.Fail.MonadFail (IdentityT m) :=
   fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
-             Ord1__IdentityT_liftCompare |}.
+    k__ {| Control.Monad.Fail.fail__ := fun {a} => MonadFail__IdentityT_fail |}.
 
-Local Definition Ord__IdentityT_compare {inst_f} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
-   : (IdentityT inst_f inst_a) -> (IdentityT inst_f inst_a) -> comparison :=
-  Data.Functor.Classes.compare1.
+(* Skipping all instances of class `GHC.Base.MonadPlus', including
+   `Control.Monad.Trans.Identity.MonadPlus__IdentityT' *)
 
-Local Definition Ord__IdentityT_op_zl__ {inst_f} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
-   : (IdentityT inst_f inst_a) -> (IdentityT inst_f inst_a) -> bool :=
-  fun x y => Ord__IdentityT_compare x y GHC.Base.== Lt.
+(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
+   `Control.Monad.Trans.Identity.MonadFix__IdentityT' *)
 
-Local Definition Ord__IdentityT_op_zlze__ {inst_f} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
-   : (IdentityT inst_f inst_a) -> (IdentityT inst_f inst_a) -> bool :=
-  fun x y => Ord__IdentityT_compare x y GHC.Base./= Gt.
+(* Skipping all instances of class `Control.Monad.IO.Class.MonadIO', including
+   `Control.Monad.Trans.Identity.MonadIO__IdentityT' *)
 
-Local Definition Ord__IdentityT_op_zg__ {inst_f} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
-   : (IdentityT inst_f inst_a) -> (IdentityT inst_f inst_a) -> bool :=
-  fun x y => Ord__IdentityT_compare x y GHC.Base.== Gt.
+(* Skipping all instances of class `Control.Monad.Zip.MonadZip', including
+   `Control.Monad.Trans.Identity.MonadZip__IdentityT' *)
 
-Local Definition Ord__IdentityT_op_zgze__ {inst_f} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
-   : (IdentityT inst_f inst_a) -> (IdentityT inst_f inst_a) -> bool :=
-  fun x y => Ord__IdentityT_compare x y GHC.Base./= Lt.
+Local Definition MonadTrans__IdentityT_lift
+   : forall {m} {a}, forall `{(GHC.Base.Monad m)}, m a -> IdentityT m a :=
+  fun {m} {a} `{(GHC.Base.Monad m)} => Mk_IdentityT.
 
-Local Definition Ord__IdentityT_max {inst_f} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
-   : (IdentityT inst_f inst_a) ->
-     (IdentityT inst_f inst_a) -> (IdentityT inst_f inst_a) :=
-  fun x y => if Ord__IdentityT_op_zlze__ x y : bool then y else x.
-
-Local Definition Ord__IdentityT_min {inst_f} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
-   : (IdentityT inst_f inst_a) ->
-     (IdentityT inst_f inst_a) -> (IdentityT inst_f inst_a) :=
-  fun x y => if Ord__IdentityT_op_zlze__ x y : bool then x else y.
-
-Local Definition Eq___IdentityT_op_zeze__ {inst_f} {inst_a}
-  `{Data.Functor.Classes.Eq1 inst_f} `{GHC.Base.Eq_ inst_a}
-   : (IdentityT inst_f inst_a) -> (IdentityT inst_f inst_a) -> bool :=
-  Data.Functor.Classes.eq1.
-
-Local Definition Eq___IdentityT_op_zsze__ {inst_f} {inst_a}
-  `{Data.Functor.Classes.Eq1 inst_f} `{GHC.Base.Eq_ inst_a}
-   : (IdentityT inst_f inst_a) -> (IdentityT inst_f inst_a) -> bool :=
-  fun x y => negb (Eq___IdentityT_op_zeze__ x y).
-
-Program Instance Eq___IdentityT {f} {a} `{Data.Functor.Classes.Eq1 f}
-  `{GHC.Base.Eq_ a}
-   : GHC.Base.Eq_ (IdentityT f a) :=
+Program Instance MonadTrans__IdentityT
+   : Control.Monad.Trans.Class.MonadTrans IdentityT :=
   fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___IdentityT_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___IdentityT_op_zsze__ |}.
+    k__ {| Control.Monad.Trans.Class.lift__ := fun {m} {a} `{(GHC.Base.Monad m)} =>
+             MonadTrans__IdentityT_lift |}.
 
-Program Instance Ord__IdentityT {f} {a} `{Data.Functor.Classes.Ord1 f}
-  `{GHC.Base.Ord a}
-   : GHC.Base.Ord (IdentityT f a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zl____ := Ord__IdentityT_op_zl__ ;
-           GHC.Base.op_zlze____ := Ord__IdentityT_op_zlze__ ;
-           GHC.Base.op_zg____ := Ord__IdentityT_op_zg__ ;
-           GHC.Base.op_zgze____ := Ord__IdentityT_op_zgze__ ;
-           GHC.Base.compare__ := Ord__IdentityT_compare ;
-           GHC.Base.max__ := Ord__IdentityT_max ;
-           GHC.Base.min__ := Ord__IdentityT_min |}.
+Definition liftCallCC {m} {a} {b}
+   : Control.Monad.Signatures.CallCC m a b ->
+     Control.Monad.Signatures.CallCC (IdentityT m) a b :=
+  fun callCC f =>
+    Mk_IdentityT (callCC (fun c => runIdentityT (f (Mk_IdentityT GHC.Base.∘ c)))).
 
-(* Skipping all instances of class `Data.Functor.Classes.Show1', including
-   `Control.Monad.Trans.Identity.Show1__IdentityT' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Read1', including
-   `Control.Monad.Trans.Identity.Read1__IdentityT' *)
+(* Skipping definition `Control.Monad.Trans.Identity.liftCatch' *)
 
 (* External variables:
      Gt Lt Type bool comparison list negb Control.Monad.Fail.MonadFail

--- a/examples/transformers/lib/Control/Monad/Trans/Maybe.v
+++ b/examples/transformers/lib/Control/Monad/Trans/Maybe.v
@@ -57,103 +57,119 @@ Local Definition Monad_tmp {inst_m} `{(GHC.Base.Monad inst_m)}
 
 (* Converted value declarations: *)
 
-Definition maybeToExceptT {m} {e} {a} `{(GHC.Base.Functor m)}
-   : e -> MaybeT m a -> Control.Monad.Trans.Except.ExceptT e m a :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | e, Mk_MaybeT m =>
-        Control.Monad.Trans.Except.Mk_ExceptT (GHC.Base.fmap (Data.Maybe.maybe
-                                                              (Data.Either.Left e) Data.Either.Right) m)
-    end.
+Local Definition Eq1__MaybeT_liftEq {inst_m} `{(Data.Functor.Classes.Eq1
+   inst_m)}
+   : forall {a} {b},
+     (a -> b -> bool) -> (MaybeT inst_m) a -> (MaybeT inst_m) b -> bool :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | eq, Mk_MaybeT x, Mk_MaybeT y =>
+          Data.Functor.Classes.liftEq (Data.Functor.Classes.liftEq eq) x y
+      end.
+
+Program Instance Eq1__MaybeT {m} `{(Data.Functor.Classes.Eq1 m)}
+   : Data.Functor.Classes.Eq1 (MaybeT m) :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__MaybeT_liftEq |}.
+
+Local Definition Ord1__MaybeT_liftCompare {inst_m} `{(Data.Functor.Classes.Ord1
+   inst_m)}
+   : forall {a} {b},
+     (a -> b -> comparison) ->
+     (MaybeT inst_m) a -> (MaybeT inst_m) b -> comparison :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | comp, Mk_MaybeT x, Mk_MaybeT y =>
+          Data.Functor.Classes.liftCompare (Data.Functor.Classes.liftCompare comp) x y
+      end.
+
+Program Instance Ord1__MaybeT {m} `{(Data.Functor.Classes.Ord1 m)}
+   : Data.Functor.Classes.Ord1 (MaybeT m) :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
+             Ord1__MaybeT_liftCompare |}.
+
+(* Skipping all instances of class `Data.Functor.Classes.Read1', including
+   `Control.Monad.Trans.Maybe.Read1__MaybeT' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Show1', including
+   `Control.Monad.Trans.Maybe.Show1__MaybeT' *)
+
+Local Definition Eq___MaybeT_op_zeze__ {inst_m} {inst_a}
+  `{Data.Functor.Classes.Eq1 inst_m} `{GHC.Base.Eq_ inst_a}
+   : (MaybeT inst_m inst_a) -> (MaybeT inst_m inst_a) -> bool :=
+  Data.Functor.Classes.eq1.
+
+Local Definition Eq___MaybeT_op_zsze__ {inst_m} {inst_a}
+  `{Data.Functor.Classes.Eq1 inst_m} `{GHC.Base.Eq_ inst_a}
+   : (MaybeT inst_m inst_a) -> (MaybeT inst_m inst_a) -> bool :=
+  fun x y => negb (Eq___MaybeT_op_zeze__ x y).
+
+Program Instance Eq___MaybeT {m} {a} `{Data.Functor.Classes.Eq1 m}
+  `{GHC.Base.Eq_ a}
+   : GHC.Base.Eq_ (MaybeT m a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___MaybeT_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___MaybeT_op_zsze__ |}.
+
+Local Definition Ord__MaybeT_compare {inst_m} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
+   : (MaybeT inst_m inst_a) -> (MaybeT inst_m inst_a) -> comparison :=
+  Data.Functor.Classes.compare1.
+
+Local Definition Ord__MaybeT_op_zl__ {inst_m} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
+   : (MaybeT inst_m inst_a) -> (MaybeT inst_m inst_a) -> bool :=
+  fun x y => Ord__MaybeT_compare x y GHC.Base.== Lt.
+
+Local Definition Ord__MaybeT_op_zlze__ {inst_m} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
+   : (MaybeT inst_m inst_a) -> (MaybeT inst_m inst_a) -> bool :=
+  fun x y => Ord__MaybeT_compare x y GHC.Base./= Gt.
+
+Local Definition Ord__MaybeT_op_zg__ {inst_m} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
+   : (MaybeT inst_m inst_a) -> (MaybeT inst_m inst_a) -> bool :=
+  fun x y => Ord__MaybeT_compare x y GHC.Base.== Gt.
+
+Local Definition Ord__MaybeT_op_zgze__ {inst_m} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
+   : (MaybeT inst_m inst_a) -> (MaybeT inst_m inst_a) -> bool :=
+  fun x y => Ord__MaybeT_compare x y GHC.Base./= Lt.
+
+Local Definition Ord__MaybeT_max {inst_m} {inst_a} `{Data.Functor.Classes.Ord1
+  inst_m} `{GHC.Base.Ord inst_a}
+   : (MaybeT inst_m inst_a) -> (MaybeT inst_m inst_a) -> (MaybeT inst_m inst_a) :=
+  fun x y => if Ord__MaybeT_op_zlze__ x y : bool then y else x.
+
+Local Definition Ord__MaybeT_min {inst_m} {inst_a} `{Data.Functor.Classes.Ord1
+  inst_m} `{GHC.Base.Ord inst_a}
+   : (MaybeT inst_m inst_a) -> (MaybeT inst_m inst_a) -> (MaybeT inst_m inst_a) :=
+  fun x y => if Ord__MaybeT_op_zlze__ x y : bool then x else y.
+
+Program Instance Ord__MaybeT {m} {a} `{Data.Functor.Classes.Ord1 m}
+  `{GHC.Base.Ord a}
+   : GHC.Base.Ord (MaybeT m a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zl____ := Ord__MaybeT_op_zl__ ;
+           GHC.Base.op_zlze____ := Ord__MaybeT_op_zlze__ ;
+           GHC.Base.op_zg____ := Ord__MaybeT_op_zg__ ;
+           GHC.Base.op_zgze____ := Ord__MaybeT_op_zgze__ ;
+           GHC.Base.compare__ := Ord__MaybeT_compare ;
+           GHC.Base.max__ := Ord__MaybeT_max ;
+           GHC.Base.min__ := Ord__MaybeT_min |}.
+
+(* Skipping all instances of class `GHC.Read.Read', including
+   `Control.Monad.Trans.Maybe.Read__MaybeT' *)
+
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Control.Monad.Trans.Maybe.Show__MaybeT' *)
 
 Definition mapMaybeT {m} {a} {n} {b}
    : (m (option a) -> n (option b)) -> MaybeT m a -> MaybeT n b :=
   fun f => Mk_MaybeT GHC.Base.∘ (f GHC.Base.∘ runMaybeT).
-
-Definition liftPass {m} {w} {a} `{(GHC.Base.Monad m)}
-   : Control.Monad.Signatures.Pass w m (option a) ->
-     Control.Monad.Signatures.Pass w (MaybeT m) a :=
-  fun pass =>
-    mapMaybeT (fun m =>
-                 pass (m GHC.Base.>>=
-                       (fun a =>
-                          GHC.Base.return_ (match a with
-                                            | None => pair None GHC.Base.id
-                                            | Some (pair v f) => pair (Some v) f
-                                            end)))).
-
-Definition liftListen {m} {w} {a} `{(GHC.Base.Monad m)}
-   : Control.Monad.Signatures.Listen w m (option a) ->
-     Control.Monad.Signatures.Listen w (MaybeT m) a :=
-  fun listen =>
-    mapMaybeT (fun m =>
-                 let cont_0__ arg_1__ :=
-                   let 'pair a w := arg_1__ in
-                   GHC.Base.return_ (GHC.Base.fmap (fun r => pair r w) a) in
-                 listen m GHC.Base.>>= cont_0__).
-
-(* Skipping definition `Control.Monad.Trans.Maybe.liftCatch' *)
-
-Definition liftCallCC {m} {a} {b}
-   : Control.Monad.Signatures.CallCC m (option a) (option b) ->
-     Control.Monad.Signatures.CallCC (MaybeT m) a b :=
-  fun callCC f =>
-    Mk_MaybeT (callCC (fun c =>
-                         runMaybeT (f (Mk_MaybeT GHC.Base.∘ (c GHC.Base.∘ Some))))).
-
-Definition exceptToMaybeT {m} {e} {a} `{(GHC.Base.Functor m)}
-   : Control.Monad.Trans.Except.ExceptT e m a -> MaybeT m a :=
-  fun '(Control.Monad.Trans.Except.Mk_ExceptT m) =>
-    Mk_MaybeT (GHC.Base.fmap (Data.Either.either (GHC.Base.const None) Some) m).
-
-(* Skipping all instances of class `Control.Monad.Zip.MonadZip', including
-   `Control.Monad.Trans.Maybe.MonadZip__MaybeT' *)
-
-(* Skipping all instances of class `Control.Monad.IO.Class.MonadIO', including
-   `Control.Monad.Trans.Maybe.MonadIO__MaybeT' *)
-
-Local Definition MonadTrans__MaybeT_lift
-   : forall {m} {a}, forall `{(GHC.Base.Monad m)}, m a -> MaybeT m a :=
-  fun {m} {a} `{(GHC.Base.Monad m)} => Mk_MaybeT GHC.Base.∘ GHC.Base.liftM Some.
-
-Program Instance MonadTrans__MaybeT
-   : Control.Monad.Trans.Class.MonadTrans MaybeT :=
-  fun _ k__ =>
-    k__ {| Control.Monad.Trans.Class.lift__ := fun {m} {a} `{(GHC.Base.Monad m)} =>
-             MonadTrans__MaybeT_lift |}.
-
-(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
-   `Control.Monad.Trans.Maybe.MonadFix__MaybeT' *)
-
-(* Skipping all instances of class `GHC.Base.MonadPlus', including
-   `Control.Monad.Trans.Maybe.MonadPlus__MaybeT' *)
-
-Definition Monad__MaybeT_op_zgzgze__ {inst_m} `{_ : GHC.Base.Monad inst_m} :=
-  fun {a} {b} => (@Monad_tmp inst_m _ _ _ a b).
-
-Local Definition Monad__MaybeT_op_zgzg__ {inst_m} `{(GHC.Base.Monad inst_m)}
-   : forall {a} {b},
-     (MaybeT inst_m) a -> (MaybeT inst_m) b -> (MaybeT inst_m) b :=
-  fun {a} {b} => fun m k => Monad__MaybeT_op_zgzgze__ m (fun arg_0__ => k).
-
-Local Definition Applicative__MaybeT_op_zlztzg__ {inst_m} `{GHC.Base.Functor
-  inst_m} `{GHC.Base.Monad inst_m}
-   : forall {a} {b},
-     (MaybeT inst_m) (a -> b) -> (MaybeT inst_m) a -> (MaybeT inst_m) b :=
-  fun {a} {b} =>
-    fun mf mx =>
-      Mk_MaybeT (runMaybeT mf GHC.Base.>>=
-                 (fun mb_f =>
-                    match mb_f with
-                    | None => GHC.Base.return_ None
-                    | Some f =>
-                        runMaybeT mx GHC.Base.>>=
-                        (fun mb_x =>
-                           match mb_x with
-                           | None => GHC.Base.return_ None
-                           | Some x => GHC.Base.return_ (Some (f x))
-                           end)
-                    end)).
 
 Local Definition Functor__MaybeT_fmap {inst_m} `{(GHC.Base.Functor inst_m)}
    : forall {a} {b}, (a -> b) -> (MaybeT inst_m) a -> (MaybeT inst_m) b :=
@@ -168,88 +184,6 @@ Program Instance Functor__MaybeT {m} `{(GHC.Base.Functor m)}
   fun _ k__ =>
     k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__MaybeT_fmap ;
            GHC.Base.op_zlzd____ := fun {a} {b} => Functor__MaybeT_op_zlzd__ |}.
-
-Local Definition Applicative__MaybeT_liftA2 {inst_m} `{GHC.Base.Functor inst_m}
-  `{GHC.Base.Monad inst_m}
-   : forall {a} {b} {c},
-     (a -> b -> c) -> (MaybeT inst_m) a -> (MaybeT inst_m) b -> (MaybeT inst_m) c :=
-  fun {a} {b} {c} =>
-    fun f x => Applicative__MaybeT_op_zlztzg__ (GHC.Base.fmap f x).
-
-Local Definition Applicative__MaybeT_pure {inst_m} `{GHC.Base.Functor inst_m}
-  `{GHC.Base.Monad inst_m}
-   : forall {a}, a -> (MaybeT inst_m) a :=
-  fun {a} => Mk_MaybeT GHC.Base.∘ (GHC.Base.return_ GHC.Base.∘ Some).
-
-Local Definition Applicative__MaybeT_op_ztzg__ {inst_m} `{GHC.Base.Monad inst_m}
-   : forall {a} {b}, MaybeT inst_m a -> MaybeT inst_m b -> MaybeT inst_m b :=
-  fun {a} {b} => fun m k => Monad_tmp m (fun arg_0__ => k).
-
-Program Instance Applicative__MaybeT {m} `{GHC.Base.Functor m} `{GHC.Base.Monad
-  m}
-   : GHC.Base.Applicative (MaybeT m) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__MaybeT_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__MaybeT_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__MaybeT_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__MaybeT_pure |}.
-
-Local Definition Monad__MaybeT_return_ {inst_m} `{(GHC.Base.Monad inst_m)}
-   : forall {a}, a -> (MaybeT inst_m) a :=
-  fun {a} => GHC.Base.pure.
-
-Program Instance Monad__MaybeT {m} `{(GHC.Base.Monad m)}
-   : GHC.Base.Monad (MaybeT m) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__MaybeT_op_zgzg__ ;
-           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__MaybeT_op_zgzgze__ ;
-           GHC.Base.return___ := fun {a} => Monad__MaybeT_return_ |}.
-
-Local Definition MonadFail__MaybeT_fail {inst_m} `{(GHC.Base.Monad inst_m)}
-   : forall {a}, GHC.Base.String -> (MaybeT inst_m) a :=
-  fun {a} => fun arg_0__ => Mk_MaybeT (GHC.Base.return_ None).
-
-Program Instance MonadFail__MaybeT {m} `{(GHC.Base.Monad m)}
-   : Control.Monad.Fail.MonadFail (MaybeT m) :=
-  fun _ k__ =>
-    k__ {| Control.Monad.Fail.fail__ := fun {a} => MonadFail__MaybeT_fail |}.
-
-(* Skipping all instances of class `GHC.Base.Alternative', including
-   `Control.Monad.Trans.Maybe.Alternative__MaybeT' *)
-
-Local Definition Traversable__MaybeT_traverse {inst_f}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f},
-     (a -> f b) -> (MaybeT inst_f) a -> f ((MaybeT inst_f) b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, Mk_MaybeT a =>
-          Mk_MaybeT Data.Functor.<$>
-          Data.Traversable.traverse (Data.Traversable.traverse f) a
-      end.
-
-Local Definition Traversable__MaybeT_mapM {inst_f}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m},
-     (a -> m b) -> (MaybeT inst_f) a -> m ((MaybeT inst_f) b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__MaybeT_traverse.
-
-Local Definition Traversable__MaybeT_sequenceA {inst_f}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {f} {a},
-     forall `{GHC.Base.Applicative f},
-     (MaybeT inst_f) (f a) -> f ((MaybeT inst_f) a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} =>
-    Traversable__MaybeT_traverse GHC.Base.id.
-
-Local Definition Traversable__MaybeT_sequence {inst_f}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {m} {a},
-     forall `{GHC.Base.Monad m}, (MaybeT inst_f) (m a) -> m ((MaybeT inst_f) a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__MaybeT_sequenceA.
 
 Local Definition Foldable__MaybeT_foldMap {inst_f} `{(Data.Foldable.Foldable
    inst_f)}
@@ -351,6 +285,40 @@ Program Instance Foldable__MaybeT {f} `{(Data.Foldable.Foldable f)}
            Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__MaybeT_sum ;
            Data.Foldable.toList__ := fun {a} => Foldable__MaybeT_toList |}.
 
+Local Definition Traversable__MaybeT_traverse {inst_f}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f},
+     (a -> f b) -> (MaybeT inst_f) a -> f ((MaybeT inst_f) b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, Mk_MaybeT a =>
+          Mk_MaybeT Data.Functor.<$>
+          Data.Traversable.traverse (Data.Traversable.traverse f) a
+      end.
+
+Local Definition Traversable__MaybeT_mapM {inst_f}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m},
+     (a -> m b) -> (MaybeT inst_f) a -> m ((MaybeT inst_f) b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__MaybeT_traverse.
+
+Local Definition Traversable__MaybeT_sequenceA {inst_f}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {f} {a},
+     forall `{GHC.Base.Applicative f},
+     (MaybeT inst_f) (f a) -> f ((MaybeT inst_f) a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} =>
+    Traversable__MaybeT_traverse GHC.Base.id.
+
+Local Definition Traversable__MaybeT_sequence {inst_f}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {m} {a},
+     forall `{GHC.Base.Monad m}, (MaybeT inst_f) (m a) -> m ((MaybeT inst_f) a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__MaybeT_sequenceA.
+
 Program Instance Traversable__MaybeT {f} `{(Data.Traversable.Traversable f)}
    : Data.Traversable.Traversable (MaybeT f) :=
   fun _ k__ =>
@@ -363,115 +331,147 @@ Program Instance Traversable__MaybeT {f} `{(Data.Traversable.Traversable f)}
            Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
              Traversable__MaybeT_traverse |}.
 
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Control.Monad.Trans.Maybe.Show__MaybeT' *)
-
-(* Skipping all instances of class `GHC.Read.Read', including
-   `Control.Monad.Trans.Maybe.Read__MaybeT' *)
-
-Local Definition Ord1__MaybeT_liftCompare {inst_m} `{(Data.Functor.Classes.Ord1
-   inst_m)}
+Local Definition Applicative__MaybeT_op_zlztzg__ {inst_m} `{GHC.Base.Functor
+  inst_m} `{GHC.Base.Monad inst_m}
    : forall {a} {b},
-     (a -> b -> comparison) ->
-     (MaybeT inst_m) a -> (MaybeT inst_m) b -> comparison :=
+     (MaybeT inst_m) (a -> b) -> (MaybeT inst_m) a -> (MaybeT inst_m) b :=
   fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | comp, Mk_MaybeT x, Mk_MaybeT y =>
-          Data.Functor.Classes.liftCompare (Data.Functor.Classes.liftCompare comp) x y
-      end.
+    fun mf mx =>
+      Mk_MaybeT (runMaybeT mf GHC.Base.>>=
+                 (fun mb_f =>
+                    match mb_f with
+                    | None => GHC.Base.return_ None
+                    | Some f =>
+                        runMaybeT mx GHC.Base.>>=
+                        (fun mb_x =>
+                           match mb_x with
+                           | None => GHC.Base.return_ None
+                           | Some x => GHC.Base.return_ (Some (f x))
+                           end)
+                    end)).
 
-Local Definition Eq1__MaybeT_liftEq {inst_m} `{(Data.Functor.Classes.Eq1
-   inst_m)}
+Local Definition Applicative__MaybeT_liftA2 {inst_m} `{GHC.Base.Functor inst_m}
+  `{GHC.Base.Monad inst_m}
+   : forall {a} {b} {c},
+     (a -> b -> c) -> (MaybeT inst_m) a -> (MaybeT inst_m) b -> (MaybeT inst_m) c :=
+  fun {a} {b} {c} =>
+    fun f x => Applicative__MaybeT_op_zlztzg__ (GHC.Base.fmap f x).
+
+Local Definition Applicative__MaybeT_pure {inst_m} `{GHC.Base.Functor inst_m}
+  `{GHC.Base.Monad inst_m}
+   : forall {a}, a -> (MaybeT inst_m) a :=
+  fun {a} => Mk_MaybeT GHC.Base.∘ (GHC.Base.return_ GHC.Base.∘ Some).
+
+Local Definition Applicative__MaybeT_op_ztzg__ {inst_m} `{GHC.Base.Monad inst_m}
+   : forall {a} {b}, MaybeT inst_m a -> MaybeT inst_m b -> MaybeT inst_m b :=
+  fun {a} {b} => fun m k => Monad_tmp m (fun arg_0__ => k).
+
+Program Instance Applicative__MaybeT {m} `{GHC.Base.Functor m} `{GHC.Base.Monad
+  m}
+   : GHC.Base.Applicative (MaybeT m) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__MaybeT_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__MaybeT_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__MaybeT_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__MaybeT_pure |}.
+
+(* Skipping all instances of class `GHC.Base.Alternative', including
+   `Control.Monad.Trans.Maybe.Alternative__MaybeT' *)
+
+Definition Monad__MaybeT_op_zgzgze__ {inst_m} `{_ : GHC.Base.Monad inst_m} :=
+  fun {a} {b} => (@Monad_tmp inst_m _ _ _ a b).
+
+Local Definition Monad__MaybeT_op_zgzg__ {inst_m} `{(GHC.Base.Monad inst_m)}
    : forall {a} {b},
-     (a -> b -> bool) -> (MaybeT inst_m) a -> (MaybeT inst_m) b -> bool :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | eq, Mk_MaybeT x, Mk_MaybeT y =>
-          Data.Functor.Classes.liftEq (Data.Functor.Classes.liftEq eq) x y
-      end.
+     (MaybeT inst_m) a -> (MaybeT inst_m) b -> (MaybeT inst_m) b :=
+  fun {a} {b} => fun m k => Monad__MaybeT_op_zgzgze__ m (fun arg_0__ => k).
 
-Program Instance Eq1__MaybeT {m} `{(Data.Functor.Classes.Eq1 m)}
-   : Data.Functor.Classes.Eq1 (MaybeT m) :=
+Local Definition Monad__MaybeT_return_ {inst_m} `{(GHC.Base.Monad inst_m)}
+   : forall {a}, a -> (MaybeT inst_m) a :=
+  fun {a} => GHC.Base.pure.
+
+Program Instance Monad__MaybeT {m} `{(GHC.Base.Monad m)}
+   : GHC.Base.Monad (MaybeT m) :=
   fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__MaybeT_liftEq |}.
+    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__MaybeT_op_zgzg__ ;
+           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__MaybeT_op_zgzgze__ ;
+           GHC.Base.return___ := fun {a} => Monad__MaybeT_return_ |}.
 
-Program Instance Ord1__MaybeT {m} `{(Data.Functor.Classes.Ord1 m)}
-   : Data.Functor.Classes.Ord1 (MaybeT m) :=
+Local Definition MonadTrans__MaybeT_lift
+   : forall {m} {a}, forall `{(GHC.Base.Monad m)}, m a -> MaybeT m a :=
+  fun {m} {a} `{(GHC.Base.Monad m)} => Mk_MaybeT GHC.Base.∘ GHC.Base.liftM Some.
+
+Program Instance MonadTrans__MaybeT
+   : Control.Monad.Trans.Class.MonadTrans MaybeT :=
   fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
-             Ord1__MaybeT_liftCompare |}.
+    k__ {| Control.Monad.Trans.Class.lift__ := fun {m} {a} `{(GHC.Base.Monad m)} =>
+             MonadTrans__MaybeT_lift |}.
 
-Local Definition Ord__MaybeT_compare {inst_m} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
-   : (MaybeT inst_m inst_a) -> (MaybeT inst_m inst_a) -> comparison :=
-  Data.Functor.Classes.compare1.
+Local Definition MonadFail__MaybeT_fail {inst_m} `{(GHC.Base.Monad inst_m)}
+   : forall {a}, GHC.Base.String -> (MaybeT inst_m) a :=
+  fun {a} => fun arg_0__ => Mk_MaybeT (GHC.Base.return_ None).
 
-Local Definition Ord__MaybeT_op_zl__ {inst_m} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
-   : (MaybeT inst_m inst_a) -> (MaybeT inst_m inst_a) -> bool :=
-  fun x y => Ord__MaybeT_compare x y GHC.Base.== Lt.
-
-Local Definition Ord__MaybeT_op_zlze__ {inst_m} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
-   : (MaybeT inst_m inst_a) -> (MaybeT inst_m inst_a) -> bool :=
-  fun x y => Ord__MaybeT_compare x y GHC.Base./= Gt.
-
-Local Definition Ord__MaybeT_op_zg__ {inst_m} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
-   : (MaybeT inst_m inst_a) -> (MaybeT inst_m inst_a) -> bool :=
-  fun x y => Ord__MaybeT_compare x y GHC.Base.== Gt.
-
-Local Definition Ord__MaybeT_op_zgze__ {inst_m} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
-   : (MaybeT inst_m inst_a) -> (MaybeT inst_m inst_a) -> bool :=
-  fun x y => Ord__MaybeT_compare x y GHC.Base./= Lt.
-
-Local Definition Ord__MaybeT_max {inst_m} {inst_a} `{Data.Functor.Classes.Ord1
-  inst_m} `{GHC.Base.Ord inst_a}
-   : (MaybeT inst_m inst_a) -> (MaybeT inst_m inst_a) -> (MaybeT inst_m inst_a) :=
-  fun x y => if Ord__MaybeT_op_zlze__ x y : bool then y else x.
-
-Local Definition Ord__MaybeT_min {inst_m} {inst_a} `{Data.Functor.Classes.Ord1
-  inst_m} `{GHC.Base.Ord inst_a}
-   : (MaybeT inst_m inst_a) -> (MaybeT inst_m inst_a) -> (MaybeT inst_m inst_a) :=
-  fun x y => if Ord__MaybeT_op_zlze__ x y : bool then x else y.
-
-Local Definition Eq___MaybeT_op_zeze__ {inst_m} {inst_a}
-  `{Data.Functor.Classes.Eq1 inst_m} `{GHC.Base.Eq_ inst_a}
-   : (MaybeT inst_m inst_a) -> (MaybeT inst_m inst_a) -> bool :=
-  Data.Functor.Classes.eq1.
-
-Local Definition Eq___MaybeT_op_zsze__ {inst_m} {inst_a}
-  `{Data.Functor.Classes.Eq1 inst_m} `{GHC.Base.Eq_ inst_a}
-   : (MaybeT inst_m inst_a) -> (MaybeT inst_m inst_a) -> bool :=
-  fun x y => negb (Eq___MaybeT_op_zeze__ x y).
-
-Program Instance Eq___MaybeT {m} {a} `{Data.Functor.Classes.Eq1 m}
-  `{GHC.Base.Eq_ a}
-   : GHC.Base.Eq_ (MaybeT m a) :=
+Program Instance MonadFail__MaybeT {m} `{(GHC.Base.Monad m)}
+   : Control.Monad.Fail.MonadFail (MaybeT m) :=
   fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___MaybeT_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___MaybeT_op_zsze__ |}.
+    k__ {| Control.Monad.Fail.fail__ := fun {a} => MonadFail__MaybeT_fail |}.
 
-Program Instance Ord__MaybeT {m} {a} `{Data.Functor.Classes.Ord1 m}
-  `{GHC.Base.Ord a}
-   : GHC.Base.Ord (MaybeT m a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zl____ := Ord__MaybeT_op_zl__ ;
-           GHC.Base.op_zlze____ := Ord__MaybeT_op_zlze__ ;
-           GHC.Base.op_zg____ := Ord__MaybeT_op_zg__ ;
-           GHC.Base.op_zgze____ := Ord__MaybeT_op_zgze__ ;
-           GHC.Base.compare__ := Ord__MaybeT_compare ;
-           GHC.Base.max__ := Ord__MaybeT_max ;
-           GHC.Base.min__ := Ord__MaybeT_min |}.
+(* Skipping all instances of class `GHC.Base.MonadPlus', including
+   `Control.Monad.Trans.Maybe.MonadPlus__MaybeT' *)
 
-(* Skipping all instances of class `Data.Functor.Classes.Show1', including
-   `Control.Monad.Trans.Maybe.Show1__MaybeT' *)
+(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
+   `Control.Monad.Trans.Maybe.MonadFix__MaybeT' *)
 
-(* Skipping all instances of class `Data.Functor.Classes.Read1', including
-   `Control.Monad.Trans.Maybe.Read1__MaybeT' *)
+(* Skipping all instances of class `Control.Monad.IO.Class.MonadIO', including
+   `Control.Monad.Trans.Maybe.MonadIO__MaybeT' *)
+
+(* Skipping all instances of class `Control.Monad.Zip.MonadZip', including
+   `Control.Monad.Trans.Maybe.MonadZip__MaybeT' *)
+
+Definition maybeToExceptT {m} {e} {a} `{(GHC.Base.Functor m)}
+   : e -> MaybeT m a -> Control.Monad.Trans.Except.ExceptT e m a :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | e, Mk_MaybeT m =>
+        Control.Monad.Trans.Except.Mk_ExceptT (GHC.Base.fmap (Data.Maybe.maybe
+                                                              (Data.Either.Left e) Data.Either.Right) m)
+    end.
+
+Definition exceptToMaybeT {m} {e} {a} `{(GHC.Base.Functor m)}
+   : Control.Monad.Trans.Except.ExceptT e m a -> MaybeT m a :=
+  fun '(Control.Monad.Trans.Except.Mk_ExceptT m) =>
+    Mk_MaybeT (GHC.Base.fmap (Data.Either.either (GHC.Base.const None) Some) m).
+
+Definition liftCallCC {m} {a} {b}
+   : Control.Monad.Signatures.CallCC m (option a) (option b) ->
+     Control.Monad.Signatures.CallCC (MaybeT m) a b :=
+  fun callCC f =>
+    Mk_MaybeT (callCC (fun c =>
+                         runMaybeT (f (Mk_MaybeT GHC.Base.∘ (c GHC.Base.∘ Some))))).
+
+(* Skipping definition `Control.Monad.Trans.Maybe.liftCatch' *)
+
+Definition liftListen {m} {w} {a} `{(GHC.Base.Monad m)}
+   : Control.Monad.Signatures.Listen w m (option a) ->
+     Control.Monad.Signatures.Listen w (MaybeT m) a :=
+  fun listen =>
+    mapMaybeT (fun m =>
+                 let cont_0__ arg_1__ :=
+                   let 'pair a w := arg_1__ in
+                   GHC.Base.return_ (GHC.Base.fmap (fun r => pair r w) a) in
+                 listen m GHC.Base.>>= cont_0__).
+
+Definition liftPass {m} {w} {a} `{(GHC.Base.Monad m)}
+   : Control.Monad.Signatures.Pass w m (option a) ->
+     Control.Monad.Signatures.Pass w (MaybeT m) a :=
+  fun pass =>
+    mapMaybeT (fun m =>
+                 pass (m GHC.Base.>>=
+                       (fun a =>
+                          GHC.Base.return_ (match a with
+                                            | None => pair None GHC.Base.id
+                                            | Some (pair v f) => pair (Some v) f
+                                            end)))).
 
 (* External variables:
      Gt Lt Monad_tmp None Some bool comparison false list negb option pair true

--- a/examples/transformers/lib/Control/Monad/Trans/RWS/Lazy.v
+++ b/examples/transformers/lib/Control/Monad/Trans/RWS/Lazy.v
@@ -55,246 +55,6 @@ Local Definition Monad__RWST_tmp {inst_w} {inst_m} {inst_r} {inst_s}
 
 (* Converted value declarations: *)
 
-Definition writer {m} {a} {w} {r} {s} `{(GHC.Base.Monad m)}
-   : (a * w)%type -> RWST r w s m a :=
-  fun '(pair a w) =>
-    Mk_RWST (fun arg_1__ arg_2__ =>
-               match arg_1__, arg_2__ with
-               | _, s => GHC.Base.return_ (pair (pair a s) w)
-               end).
-
-Definition withRWST {r'} {s} {r} {w} {m} {a}
-   : (r' -> s -> (r * s)%type) -> RWST r w s m a -> RWST r' w s m a :=
-  fun f m => Mk_RWST (fun r s => Data.Tuple.uncurry (runRWST m) (f r s)).
-
-Definition withRWS {r'} {s} {r} {w} {a}
-   : (r' -> s -> (r * s)%type) -> RWS r w s a -> RWS r' w s a :=
-  withRWST.
-
-Definition tell {m} {w} {r} {s} `{(GHC.Base.Monad m)}
-   : w -> RWST r w s m unit :=
-  fun w =>
-    Mk_RWST (fun arg_0__ arg_1__ =>
-               match arg_0__, arg_1__ with
-               | _, s => GHC.Base.return_ (pair (pair tt s) w)
-               end).
-
-Definition state {w} {m} {s} {a} {r} `{GHC.Base.Monoid w} `{GHC.Base.Monad m}
-   : (s -> (a * s)%type) -> RWST r w s m a :=
-  fun f =>
-    Mk_RWST (fun arg_0__ arg_1__ =>
-               match arg_0__, arg_1__ with
-               | _, s =>
-                   let 'pair a s' := f s in
-                   GHC.Base.return_ (pair (pair a s') GHC.Base.mempty)
-               end).
-
-Definition rws {r} {s} {a} {w} : (r -> s -> (a * s * w)%type) -> RWS r w s a :=
-  fun f => Mk_RWST (fun r s => Data.Functor.Identity.Mk_Identity (f r s)).
-
-Definition runRWS {r} {w} {s} {a} : RWS r w s a -> r -> s -> (a * s * w)%type :=
-  fun m r s => Data.Functor.Identity.runIdentity (runRWST m r s).
-
-Definition put {w} {m} {s} {r} `{GHC.Base.Monoid w} `{GHC.Base.Monad m}
-   : s -> RWST r w s m unit :=
-  fun s =>
-    Mk_RWST (fun arg_0__ arg_1__ =>
-               GHC.Base.return_ (pair (pair tt s) GHC.Base.mempty)).
-
-Definition pass {m} {r} {w} {s} {a} `{(GHC.Base.Monad m)}
-   : RWST r w s m (a * (w -> w))%type -> RWST r w s m a :=
-  fun m =>
-    Mk_RWST (fun r s =>
-               let cont_0__ arg_1__ :=
-                 let 'pair (pair (pair a f) s') w := arg_1__ in
-                 GHC.Base.return_ (pair (pair a s') (f w)) in
-               runRWST m r s GHC.Base.>>= cont_0__).
-
-Definition modify {w} {m} {s} {r} `{GHC.Base.Monoid w} `{GHC.Base.Monad m}
-   : (s -> s) -> RWST r w s m unit :=
-  fun f =>
-    Mk_RWST (fun arg_0__ arg_1__ =>
-               match arg_0__, arg_1__ with
-               | _, s => GHC.Base.return_ (pair (pair tt (f s)) GHC.Base.mempty)
-               end).
-
-Definition mapRWST {m} {a} {s} {w} {n} {b} {w'} {r}
-   : (m (a * s * w)%type -> n (b * s * w')%type) ->
-     RWST r w s m a -> RWST r w' s n b :=
-  fun f m => Mk_RWST (fun r s => f (runRWST m r s)).
-
-Definition mapRWS {a} {s} {w} {b} {w'} {r}
-   : ((a * s * w)%type -> (b * s * w')%type) -> RWS r w s a -> RWS r w' s b :=
-  fun f =>
-    mapRWST (Data.Functor.Identity.Mk_Identity GHC.Base.∘
-             (f GHC.Base.∘ Data.Functor.Identity.runIdentity)).
-
-Definition local {r} {w} {s} {m} {a}
-   : (r -> r) -> RWST r w s m a -> RWST r w s m a :=
-  fun f m => Mk_RWST (fun r s => runRWST m (f r) s).
-
-Definition listens {m} {w} {b} {r} {s} {a} `{(GHC.Base.Monad m)}
-   : (w -> b) -> RWST r w s m a -> RWST r w s m (a * b)%type :=
-  fun f m =>
-    Mk_RWST (fun r s =>
-               let cont_0__ arg_1__ :=
-                 let 'pair (pair a s') w := arg_1__ in
-                 GHC.Base.return_ (pair (pair (pair a (f w)) s') w) in
-               runRWST m r s GHC.Base.>>= cont_0__).
-
-Definition listen {m} {r} {w} {s} {a} `{(GHC.Base.Monad m)}
-   : RWST r w s m a -> RWST r w s m (a * w)%type :=
-  fun m =>
-    Mk_RWST (fun r s =>
-               let cont_0__ arg_1__ :=
-                 let 'pair (pair a s') w := arg_1__ in
-                 GHC.Base.return_ (pair (pair (pair a w) s') w) in
-               runRWST m r s GHC.Base.>>= cont_0__).
-
-(* Skipping definition `Control.Monad.Trans.RWS.Lazy.liftCatch' *)
-
-Definition liftCallCC' {w} {m} {a} {s} {b} {r} `{(GHC.Base.Monoid w)}
-   : Control.Monad.Signatures.CallCC m (a * s * w)%type (b * s * w)%type ->
-     Control.Monad.Signatures.CallCC (RWST r w s m) a b :=
-  fun callCC f =>
-    Mk_RWST (fun r s =>
-               callCC (fun c =>
-                         runRWST (f (fun a =>
-                                       Mk_RWST (fun arg_0__ arg_1__ =>
-                                                  match arg_0__, arg_1__ with
-                                                  | _, s' => c (pair (pair a s') GHC.Base.mempty)
-                                                  end))) r s)).
-
-Definition liftCallCC {w} {m} {a} {s} {b} {r} `{(GHC.Base.Monoid w)}
-   : Control.Monad.Signatures.CallCC m (a * s * w)%type (b * s * w)%type ->
-     Control.Monad.Signatures.CallCC (RWST r w s m) a b :=
-  fun callCC f =>
-    Mk_RWST (fun r s =>
-               callCC (fun c =>
-                         runRWST (f (fun a =>
-                                       Mk_RWST (fun arg_0__ arg_1__ => c (pair (pair a s) GHC.Base.mempty)))) r s)).
-
-Definition gets {w} {m} {s} {a} {r} `{GHC.Base.Monoid w} `{GHC.Base.Monad m}
-   : (s -> a) -> RWST r w s m a :=
-  fun f =>
-    Mk_RWST (fun arg_0__ arg_1__ =>
-               match arg_0__, arg_1__ with
-               | _, s => GHC.Base.return_ (pair (pair (f s) s) GHC.Base.mempty)
-               end).
-
-Definition get {w} {m} {r} {s} `{GHC.Base.Monoid w} `{GHC.Base.Monad m}
-   : RWST r w s m s :=
-  Mk_RWST (fun arg_0__ arg_1__ =>
-             match arg_0__, arg_1__ with
-             | _, s => GHC.Base.return_ (pair (pair s s) GHC.Base.mempty)
-             end).
-
-Definition execRWST {m} {r} {w} {s} {a} `{(GHC.Base.Monad m)}
-   : RWST r w s m a -> r -> s -> m (s * w)%type :=
-  fun m r s =>
-    let cont_0__ arg_1__ :=
-      let 'pair (pair _ s') w := arg_1__ in
-      GHC.Base.return_ (pair s' w) in
-    runRWST m r s GHC.Base.>>= cont_0__.
-
-Definition execRWS {r} {w} {s} {a} : RWS r w s a -> r -> s -> (s * w)%type :=
-  fun m r s => let 'pair (pair _ s') w := runRWS m r s in pair s' w.
-
-Definition evalRWST {m} {r} {w} {s} {a} `{(GHC.Base.Monad m)}
-   : RWST r w s m a -> r -> s -> m (a * w)%type :=
-  fun m r s =>
-    let cont_0__ arg_1__ :=
-      let 'pair (pair a _) w := arg_1__ in
-      GHC.Base.return_ (pair a w) in
-    runRWST m r s GHC.Base.>>= cont_0__.
-
-Definition evalRWS {r} {w} {s} {a} : RWS r w s a -> r -> s -> (a * w)%type :=
-  fun m r s => let 'pair (pair a _) w := runRWS m r s in pair a w.
-
-Definition censor {m} {w} {r} {s} {a} `{(GHC.Base.Monad m)}
-   : (w -> w) -> RWST r w s m a -> RWST r w s m a :=
-  fun f m =>
-    Mk_RWST (fun r s =>
-               let cont_0__ arg_1__ :=
-                 let 'pair (pair a s') w := arg_1__ in
-                 GHC.Base.return_ (pair (pair a s') (f w)) in
-               runRWST m r s GHC.Base.>>= cont_0__).
-
-Definition asks {w} {m} {r} {a} {s} `{GHC.Base.Monoid w} `{GHC.Base.Monad m}
-   : (r -> a) -> RWST r w s m a :=
-  fun f =>
-    Mk_RWST (fun r s => GHC.Base.return_ (pair (pair (f r) s) GHC.Base.mempty)).
-
-Definition reader {w} {m} {r} {a} {s} `{GHC.Base.Monoid w} `{GHC.Base.Monad m}
-   : (r -> a) -> RWST r w s m a :=
-  asks.
-
-Definition ask {w} {m} {r} {s} `{GHC.Base.Monoid w} `{GHC.Base.Monad m}
-   : RWST r w s m r :=
-  Mk_RWST (fun r s => GHC.Base.return_ (pair (pair r s) GHC.Base.mempty)).
-
-(* Skipping all instances of class `Control.Monad.IO.Class.MonadIO', including
-   `Control.Monad.Trans.RWS.Lazy.MonadIO__RWST' *)
-
-Local Definition MonadTrans__RWST_lift {inst_w} {inst_r} {inst_s}
-  `{(GHC.Base.Monoid inst_w)}
-   : forall {m} {a},
-     forall `{(GHC.Base.Monad m)}, m a -> (RWST inst_r inst_w inst_s) m a :=
-  fun {m} {a} `{(GHC.Base.Monad m)} =>
-    fun m =>
-      Mk_RWST (fun arg_0__ arg_1__ =>
-                 match arg_0__, arg_1__ with
-                 | _, s =>
-                     m GHC.Base.>>= (fun a => GHC.Base.return_ (pair (pair a s) GHC.Base.mempty))
-                 end).
-
-Program Instance MonadTrans__RWST {w} {r} {s} `{(GHC.Base.Monoid w)}
-   : Control.Monad.Trans.Class.MonadTrans (RWST r w s) :=
-  fun _ k__ =>
-    k__ {| Control.Monad.Trans.Class.lift__ := fun {m} {a} `{(GHC.Base.Monad m)} =>
-             MonadTrans__RWST_lift |}.
-
-(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
-   `Control.Monad.Trans.RWS.Lazy.MonadFix__RWST' *)
-
-(* Skipping all instances of class `GHC.Base.MonadPlus', including
-   `Control.Monad.Trans.RWS.Lazy.MonadPlus__RWST' *)
-
-Definition Monad__RWST_op_zgzgze__ {inst_w} {inst_m} {inst_r} {inst_s} `{_
-   : GHC.Base.Monoid inst_w} `{_ : GHC.Base.Monad inst_m}
-   : forall {a} {b},
-     RWST inst_r inst_w inst_s inst_m a ->
-     (a -> RWST inst_r inst_w inst_s inst_m b) ->
-     RWST inst_r inst_w inst_s inst_m b :=
-  fun {a} {b} => Monad__RWST_tmp.
-
-Local Definition Monad__RWST_op_zgzg__ {inst_w} {inst_m} {inst_r} {inst_s}
-  `{GHC.Base.Monoid inst_w} `{GHC.Base.Monad inst_m}
-   : forall {a} {b},
-     (RWST inst_r inst_w inst_s inst_m) a ->
-     (RWST inst_r inst_w inst_s inst_m) b -> (RWST inst_r inst_w inst_s inst_m) b :=
-  fun {a} {b} => fun m k => Monad__RWST_op_zgzgze__ m (fun arg_0__ => k).
-
-Local Definition Applicative__RWST_op_zlztzg__ {inst_w} {inst_m} {inst_r}
-  {inst_s} `{GHC.Base.Monoid inst_w} `{GHC.Base.Functor inst_m} `{GHC.Base.Monad
-  inst_m}
-   : forall {a} {b},
-     (RWST inst_r inst_w inst_s inst_m) (a -> b) ->
-     (RWST inst_r inst_w inst_s inst_m) a -> (RWST inst_r inst_w inst_s inst_m) b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | Mk_RWST mf, Mk_RWST mx =>
-          Mk_RWST (fun r s =>
-                     let cont_2__ arg_3__ :=
-                       let 'pair (pair f s') w := arg_3__ in
-                       let cont_4__ arg_5__ :=
-                         let 'pair (pair x s'') w' := arg_5__ in
-                         GHC.Base.return_ (pair (pair (f x) s'') (GHC.Base.mappend w w')) in
-                       mx r s' GHC.Base.>>= cont_4__ in
-                     mf r s GHC.Base.>>= cont_2__)
-      end.
-
 Local Definition Functor__RWST_fmap {inst_m} {inst_r} {inst_w} {inst_s}
   `{(GHC.Base.Functor inst_m)}
    : forall {a} {b},
@@ -318,6 +78,26 @@ Program Instance Functor__RWST {m} {r} {w} {s} `{(GHC.Base.Functor m)}
   fun _ k__ =>
     k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__RWST_fmap ;
            GHC.Base.op_zlzd____ := fun {a} {b} => Functor__RWST_op_zlzd__ |}.
+
+Local Definition Applicative__RWST_op_zlztzg__ {inst_w} {inst_m} {inst_r}
+  {inst_s} `{GHC.Base.Monoid inst_w} `{GHC.Base.Functor inst_m} `{GHC.Base.Monad
+  inst_m}
+   : forall {a} {b},
+     (RWST inst_r inst_w inst_s inst_m) (a -> b) ->
+     (RWST inst_r inst_w inst_s inst_m) a -> (RWST inst_r inst_w inst_s inst_m) b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | Mk_RWST mf, Mk_RWST mx =>
+          Mk_RWST (fun r s =>
+                     let cont_2__ arg_3__ :=
+                       let 'pair (pair f s') w := arg_3__ in
+                       let cont_4__ arg_5__ :=
+                         let 'pair (pair x s'') w' := arg_5__ in
+                         GHC.Base.return_ (pair (pair (f x) s'') (GHC.Base.mappend w w')) in
+                       mx r s' GHC.Base.>>= cont_4__ in
+                     mf r s GHC.Base.>>= cont_2__)
+      end.
 
 Local Definition Applicative__RWST_liftA2 {inst_w} {inst_m} {inst_r} {inst_s}
   `{GHC.Base.Monoid inst_w} `{GHC.Base.Functor inst_m} `{GHC.Base.Monad inst_m}
@@ -354,6 +134,24 @@ Program Instance Applicative__RWST {w} {m} {r} {s} `{GHC.Base.Monoid w}
            GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__RWST_op_ztzg__ ;
            GHC.Base.pure__ := fun {a} => Applicative__RWST_pure |}.
 
+(* Skipping all instances of class `GHC.Base.Alternative', including
+   `Control.Monad.Trans.RWS.Lazy.Alternative__RWST' *)
+
+Definition Monad__RWST_op_zgzgze__ {inst_w} {inst_m} {inst_r} {inst_s} `{_
+   : GHC.Base.Monoid inst_w} `{_ : GHC.Base.Monad inst_m}
+   : forall {a} {b},
+     RWST inst_r inst_w inst_s inst_m a ->
+     (a -> RWST inst_r inst_w inst_s inst_m b) ->
+     RWST inst_r inst_w inst_s inst_m b :=
+  fun {a} {b} => Monad__RWST_tmp.
+
+Local Definition Monad__RWST_op_zgzg__ {inst_w} {inst_m} {inst_r} {inst_s}
+  `{GHC.Base.Monoid inst_w} `{GHC.Base.Monad inst_m}
+   : forall {a} {b},
+     (RWST inst_r inst_w inst_s inst_m) a ->
+     (RWST inst_r inst_w inst_s inst_m) b -> (RWST inst_r inst_w inst_s inst_m) b :=
+  fun {a} {b} => fun m k => Monad__RWST_op_zgzgze__ m (fun arg_0__ => k).
+
 Local Definition Monad__RWST_return_ {inst_w} {inst_m} {inst_r} {inst_s}
   `{GHC.Base.Monoid inst_w} `{GHC.Base.Monad inst_m}
    : forall {a}, a -> (RWST inst_r inst_w inst_s inst_m) a :=
@@ -367,6 +165,24 @@ Program Instance Monad__RWST {w} {m} {r} {s} `{GHC.Base.Monoid w}
            GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__RWST_op_zgzgze__ ;
            GHC.Base.return___ := fun {a} => Monad__RWST_return_ |}.
 
+Local Definition MonadTrans__RWST_lift {inst_w} {inst_r} {inst_s}
+  `{(GHC.Base.Monoid inst_w)}
+   : forall {m} {a},
+     forall `{(GHC.Base.Monad m)}, m a -> (RWST inst_r inst_w inst_s) m a :=
+  fun {m} {a} `{(GHC.Base.Monad m)} =>
+    fun m =>
+      Mk_RWST (fun arg_0__ arg_1__ =>
+                 match arg_0__, arg_1__ with
+                 | _, s =>
+                     m GHC.Base.>>= (fun a => GHC.Base.return_ (pair (pair a s) GHC.Base.mempty))
+                 end).
+
+Program Instance MonadTrans__RWST {w} {r} {s} `{(GHC.Base.Monoid w)}
+   : Control.Monad.Trans.Class.MonadTrans (RWST r w s) :=
+  fun _ k__ =>
+    k__ {| Control.Monad.Trans.Class.lift__ := fun {m} {a} `{(GHC.Base.Monad m)} =>
+             MonadTrans__RWST_lift |}.
+
 Local Definition MonadFail__RWST_fail {inst_w} {inst_m} {inst_r} {inst_s}
   `{GHC.Base.Monoid inst_w} `{Control.Monad.Fail.MonadFail inst_m}
    : forall {a}, GHC.Base.String -> (RWST inst_r inst_w inst_s inst_m) a :=
@@ -379,8 +195,192 @@ Program Instance MonadFail__RWST {w} {m} {r} {s} `{GHC.Base.Monoid w}
   fun _ k__ =>
     k__ {| Control.Monad.Fail.fail__ := fun {a} => MonadFail__RWST_fail |}.
 
-(* Skipping all instances of class `GHC.Base.Alternative', including
-   `Control.Monad.Trans.RWS.Lazy.Alternative__RWST' *)
+(* Skipping all instances of class `GHC.Base.MonadPlus', including
+   `Control.Monad.Trans.RWS.Lazy.MonadPlus__RWST' *)
+
+(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
+   `Control.Monad.Trans.RWS.Lazy.MonadFix__RWST' *)
+
+(* Skipping all instances of class `Control.Monad.IO.Class.MonadIO', including
+   `Control.Monad.Trans.RWS.Lazy.MonadIO__RWST' *)
+
+Definition rws {r} {s} {a} {w} : (r -> s -> (a * s * w)%type) -> RWS r w s a :=
+  fun f => Mk_RWST (fun r s => Data.Functor.Identity.Mk_Identity (f r s)).
+
+Definition runRWS {r} {w} {s} {a} : RWS r w s a -> r -> s -> (a * s * w)%type :=
+  fun m r s => Data.Functor.Identity.runIdentity (runRWST m r s).
+
+Definition evalRWS {r} {w} {s} {a} : RWS r w s a -> r -> s -> (a * w)%type :=
+  fun m r s => let 'pair (pair a _) w := runRWS m r s in pair a w.
+
+Definition execRWS {r} {w} {s} {a} : RWS r w s a -> r -> s -> (s * w)%type :=
+  fun m r s => let 'pair (pair _ s') w := runRWS m r s in pair s' w.
+
+Definition mapRWST {m} {a} {s} {w} {n} {b} {w'} {r}
+   : (m (a * s * w)%type -> n (b * s * w')%type) ->
+     RWST r w s m a -> RWST r w' s n b :=
+  fun f m => Mk_RWST (fun r s => f (runRWST m r s)).
+
+Definition mapRWS {a} {s} {w} {b} {w'} {r}
+   : ((a * s * w)%type -> (b * s * w')%type) -> RWS r w s a -> RWS r w' s b :=
+  fun f =>
+    mapRWST (Data.Functor.Identity.Mk_Identity GHC.Base.∘
+             (f GHC.Base.∘ Data.Functor.Identity.runIdentity)).
+
+Definition withRWST {r'} {s} {r} {w} {m} {a}
+   : (r' -> s -> (r * s)%type) -> RWST r w s m a -> RWST r' w s m a :=
+  fun f m => Mk_RWST (fun r s => Data.Tuple.uncurry (runRWST m) (f r s)).
+
+Definition withRWS {r'} {s} {r} {w} {a}
+   : (r' -> s -> (r * s)%type) -> RWS r w s a -> RWS r' w s a :=
+  withRWST.
+
+Definition evalRWST {m} {r} {w} {s} {a} `{(GHC.Base.Monad m)}
+   : RWST r w s m a -> r -> s -> m (a * w)%type :=
+  fun m r s =>
+    let cont_0__ arg_1__ :=
+      let 'pair (pair a _) w := arg_1__ in
+      GHC.Base.return_ (pair a w) in
+    runRWST m r s GHC.Base.>>= cont_0__.
+
+Definition execRWST {m} {r} {w} {s} {a} `{(GHC.Base.Monad m)}
+   : RWST r w s m a -> r -> s -> m (s * w)%type :=
+  fun m r s =>
+    let cont_0__ arg_1__ :=
+      let 'pair (pair _ s') w := arg_1__ in
+      GHC.Base.return_ (pair s' w) in
+    runRWST m r s GHC.Base.>>= cont_0__.
+
+Definition asks {w} {m} {r} {a} {s} `{GHC.Base.Monoid w} `{GHC.Base.Monad m}
+   : (r -> a) -> RWST r w s m a :=
+  fun f =>
+    Mk_RWST (fun r s => GHC.Base.return_ (pair (pair (f r) s) GHC.Base.mempty)).
+
+Definition reader {w} {m} {r} {a} {s} `{GHC.Base.Monoid w} `{GHC.Base.Monad m}
+   : (r -> a) -> RWST r w s m a :=
+  asks.
+
+Definition ask {w} {m} {r} {s} `{GHC.Base.Monoid w} `{GHC.Base.Monad m}
+   : RWST r w s m r :=
+  Mk_RWST (fun r s => GHC.Base.return_ (pair (pair r s) GHC.Base.mempty)).
+
+Definition local {r} {w} {s} {m} {a}
+   : (r -> r) -> RWST r w s m a -> RWST r w s m a :=
+  fun f m => Mk_RWST (fun r s => runRWST m (f r) s).
+
+Definition writer {m} {a} {w} {r} {s} `{(GHC.Base.Monad m)}
+   : (a * w)%type -> RWST r w s m a :=
+  fun '(pair a w) =>
+    Mk_RWST (fun arg_1__ arg_2__ =>
+               match arg_1__, arg_2__ with
+               | _, s => GHC.Base.return_ (pair (pair a s) w)
+               end).
+
+Definition tell {m} {w} {r} {s} `{(GHC.Base.Monad m)}
+   : w -> RWST r w s m unit :=
+  fun w =>
+    Mk_RWST (fun arg_0__ arg_1__ =>
+               match arg_0__, arg_1__ with
+               | _, s => GHC.Base.return_ (pair (pair tt s) w)
+               end).
+
+Definition listen {m} {r} {w} {s} {a} `{(GHC.Base.Monad m)}
+   : RWST r w s m a -> RWST r w s m (a * w)%type :=
+  fun m =>
+    Mk_RWST (fun r s =>
+               let cont_0__ arg_1__ :=
+                 let 'pair (pair a s') w := arg_1__ in
+                 GHC.Base.return_ (pair (pair (pair a w) s') w) in
+               runRWST m r s GHC.Base.>>= cont_0__).
+
+Definition listens {m} {w} {b} {r} {s} {a} `{(GHC.Base.Monad m)}
+   : (w -> b) -> RWST r w s m a -> RWST r w s m (a * b)%type :=
+  fun f m =>
+    Mk_RWST (fun r s =>
+               let cont_0__ arg_1__ :=
+                 let 'pair (pair a s') w := arg_1__ in
+                 GHC.Base.return_ (pair (pair (pair a (f w)) s') w) in
+               runRWST m r s GHC.Base.>>= cont_0__).
+
+Definition pass {m} {r} {w} {s} {a} `{(GHC.Base.Monad m)}
+   : RWST r w s m (a * (w -> w))%type -> RWST r w s m a :=
+  fun m =>
+    Mk_RWST (fun r s =>
+               let cont_0__ arg_1__ :=
+                 let 'pair (pair (pair a f) s') w := arg_1__ in
+                 GHC.Base.return_ (pair (pair a s') (f w)) in
+               runRWST m r s GHC.Base.>>= cont_0__).
+
+Definition censor {m} {w} {r} {s} {a} `{(GHC.Base.Monad m)}
+   : (w -> w) -> RWST r w s m a -> RWST r w s m a :=
+  fun f m =>
+    Mk_RWST (fun r s =>
+               let cont_0__ arg_1__ :=
+                 let 'pair (pair a s') w := arg_1__ in
+                 GHC.Base.return_ (pair (pair a s') (f w)) in
+               runRWST m r s GHC.Base.>>= cont_0__).
+
+Definition state {w} {m} {s} {a} {r} `{GHC.Base.Monoid w} `{GHC.Base.Monad m}
+   : (s -> (a * s)%type) -> RWST r w s m a :=
+  fun f =>
+    Mk_RWST (fun arg_0__ arg_1__ =>
+               match arg_0__, arg_1__ with
+               | _, s =>
+                   let 'pair a s' := f s in
+                   GHC.Base.return_ (pair (pair a s') GHC.Base.mempty)
+               end).
+
+Definition get {w} {m} {r} {s} `{GHC.Base.Monoid w} `{GHC.Base.Monad m}
+   : RWST r w s m s :=
+  Mk_RWST (fun arg_0__ arg_1__ =>
+             match arg_0__, arg_1__ with
+             | _, s => GHC.Base.return_ (pair (pair s s) GHC.Base.mempty)
+             end).
+
+Definition put {w} {m} {s} {r} `{GHC.Base.Monoid w} `{GHC.Base.Monad m}
+   : s -> RWST r w s m unit :=
+  fun s =>
+    Mk_RWST (fun arg_0__ arg_1__ =>
+               GHC.Base.return_ (pair (pair tt s) GHC.Base.mempty)).
+
+Definition modify {w} {m} {s} {r} `{GHC.Base.Monoid w} `{GHC.Base.Monad m}
+   : (s -> s) -> RWST r w s m unit :=
+  fun f =>
+    Mk_RWST (fun arg_0__ arg_1__ =>
+               match arg_0__, arg_1__ with
+               | _, s => GHC.Base.return_ (pair (pair tt (f s)) GHC.Base.mempty)
+               end).
+
+Definition gets {w} {m} {s} {a} {r} `{GHC.Base.Monoid w} `{GHC.Base.Monad m}
+   : (s -> a) -> RWST r w s m a :=
+  fun f =>
+    Mk_RWST (fun arg_0__ arg_1__ =>
+               match arg_0__, arg_1__ with
+               | _, s => GHC.Base.return_ (pair (pair (f s) s) GHC.Base.mempty)
+               end).
+
+Definition liftCallCC {w} {m} {a} {s} {b} {r} `{(GHC.Base.Monoid w)}
+   : Control.Monad.Signatures.CallCC m (a * s * w)%type (b * s * w)%type ->
+     Control.Monad.Signatures.CallCC (RWST r w s m) a b :=
+  fun callCC f =>
+    Mk_RWST (fun r s =>
+               callCC (fun c =>
+                         runRWST (f (fun a =>
+                                       Mk_RWST (fun arg_0__ arg_1__ => c (pair (pair a s) GHC.Base.mempty)))) r s)).
+
+Definition liftCallCC' {w} {m} {a} {s} {b} {r} `{(GHC.Base.Monoid w)}
+   : Control.Monad.Signatures.CallCC m (a * s * w)%type (b * s * w)%type ->
+     Control.Monad.Signatures.CallCC (RWST r w s m) a b :=
+  fun callCC f =>
+    Mk_RWST (fun r s =>
+               callCC (fun c =>
+                         runRWST (f (fun a =>
+                                       Mk_RWST (fun arg_0__ arg_1__ =>
+                                                  match arg_0__, arg_1__ with
+                                                  | _, s' => c (pair (pair a s') GHC.Base.mempty)
+                                                  end))) r s)).
+
+(* Skipping definition `Control.Monad.Trans.RWS.Lazy.liftCatch' *)
 
 (* External variables:
      Monad__RWST_tmp op_zt__ pair tt unit Control.Monad.Fail.MonadFail

--- a/examples/transformers/lib/Control/Monad/Trans/Reader.v
+++ b/examples/transformers/lib/Control/Monad/Trans/Reader.v
@@ -36,80 +36,9 @@ Definition runReaderT {r : Type} {m : Type -> Type} {a} (arg_0__
 
 (* Converted value declarations: *)
 
-Definition withReaderT {r'} {r} {m} {a}
-   : (r' -> r) -> ReaderT r m a -> ReaderT r' m a :=
-  fun f m => Mk_ReaderT (runReaderT m GHC.Base.∘ f).
-
-Definition withReader {r'} {r} {a} : (r' -> r) -> Reader r a -> Reader r' a :=
-  withReaderT.
-
-Definition runReader {r} {a} : Reader r a -> r -> a :=
-  fun m => Data.Functor.Identity.runIdentity GHC.Base.∘ runReaderT m.
-
-Definition reader {m} {r} {a} `{(GHC.Base.Monad m)}
-   : (r -> a) -> ReaderT r m a :=
-  fun f => Mk_ReaderT (GHC.Base.return_ GHC.Base.∘ f).
-
 Definition mapReaderT {m} {a} {n} {b} {r}
    : (m a -> n b) -> ReaderT r m a -> ReaderT r n b :=
   fun f m => Mk_ReaderT (f GHC.Base.∘ runReaderT m).
-
-Definition mapReader {a} {b} {r} : (a -> b) -> Reader r a -> Reader r b :=
-  fun f =>
-    mapReaderT (Data.Functor.Identity.Mk_Identity GHC.Base.∘
-                (f GHC.Base.∘ Data.Functor.Identity.runIdentity)).
-
-Definition local {r} {m} {a} : (r -> r) -> ReaderT r m a -> ReaderT r m a :=
-  withReaderT.
-
-Definition liftReaderT {m} {a} {r} : m a -> ReaderT r m a :=
-  fun m => Mk_ReaderT (GHC.Base.const m).
-
-(* Skipping definition `Control.Monad.Trans.Reader.liftCatch' *)
-
-Definition liftCallCC {m} {a} {b} {r}
-   : Control.Monad.Signatures.CallCC m a b ->
-     Control.Monad.Signatures.CallCC (ReaderT r m) a b :=
-  fun callCC f =>
-    Mk_ReaderT (fun r =>
-                  callCC (fun c =>
-                            runReaderT (f (Mk_ReaderT GHC.Base.∘ (GHC.Base.const GHC.Base.∘ c))) r)).
-
-Definition asks {m} {r} {a} `{(GHC.Base.Monad m)} : (r -> a) -> ReaderT r m a :=
-  fun f => Mk_ReaderT (GHC.Base.return_ GHC.Base.∘ f).
-
-Definition ask {m} {r} `{(GHC.Base.Monad m)} : ReaderT r m r :=
-  Mk_ReaderT GHC.Base.return_.
-
-(* Skipping all instances of class `Control.Monad.Zip.MonadZip', including
-   `Control.Monad.Trans.Reader.MonadZip__ReaderT' *)
-
-(* Skipping all instances of class `Control.Monad.IO.Class.MonadIO', including
-   `Control.Monad.Trans.Reader.MonadIO__ReaderT' *)
-
-Local Definition MonadTrans__ReaderT_lift {inst_r}
-   : forall {m} {a}, forall `{(GHC.Base.Monad m)}, m a -> (ReaderT inst_r) m a :=
-  fun {m} {a} `{(GHC.Base.Monad m)} => liftReaderT.
-
-Program Instance MonadTrans__ReaderT {r}
-   : Control.Monad.Trans.Class.MonadTrans (ReaderT r) :=
-  fun _ k__ =>
-    k__ {| Control.Monad.Trans.Class.lift__ := fun {m} {a} `{(GHC.Base.Monad m)} =>
-             MonadTrans__ReaderT_lift |}.
-
-(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
-   `Control.Monad.Trans.Reader.MonadFix__ReaderT' *)
-
-(* Skipping all instances of class `GHC.Base.MonadPlus', including
-   `Control.Monad.Trans.Reader.MonadPlus__ReaderT' *)
-
-Local Definition Applicative__ReaderT_op_zlztzg__ {inst_m} {inst_r}
-  `{(GHC.Base.Applicative inst_m)}
-   : forall {a} {b},
-     (ReaderT inst_r inst_m) (a -> b) ->
-     (ReaderT inst_r inst_m) a -> (ReaderT inst_r inst_m) b :=
-  fun {a} {b} =>
-    fun f v => Mk_ReaderT (fun r => runReaderT f r GHC.Base.<*> runReaderT v r).
 
 Local Definition Functor__ReaderT_fmap {inst_m} {inst_r} `{(GHC.Base.Functor
    inst_m)}
@@ -129,6 +58,14 @@ Program Instance Functor__ReaderT {m} {r} `{(GHC.Base.Functor m)}
     k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__ReaderT_fmap ;
            GHC.Base.op_zlzd____ := fun {a} {b} => Functor__ReaderT_op_zlzd__ |}.
 
+Local Definition Applicative__ReaderT_op_zlztzg__ {inst_m} {inst_r}
+  `{(GHC.Base.Applicative inst_m)}
+   : forall {a} {b},
+     (ReaderT inst_r inst_m) (a -> b) ->
+     (ReaderT inst_r inst_m) a -> (ReaderT inst_r inst_m) b :=
+  fun {a} {b} =>
+    fun f v => Mk_ReaderT (fun r => runReaderT f r GHC.Base.<*> runReaderT v r).
+
 Local Definition Applicative__ReaderT_liftA2 {inst_m} {inst_r}
   `{(GHC.Base.Applicative inst_m)}
    : forall {a} {b} {c},
@@ -146,6 +83,9 @@ Local Definition Applicative__ReaderT_op_ztzg__ {inst_m} {inst_r}
   fun {a} {b} =>
     fun u v => Mk_ReaderT (fun r => runReaderT u r GHC.Base.*> runReaderT v r).
 
+Definition liftReaderT {m} {a} {r} : m a -> ReaderT r m a :=
+  fun m => Mk_ReaderT (GHC.Base.const m).
+
 Local Definition Applicative__ReaderT_pure {inst_m} {inst_r}
   `{(GHC.Base.Applicative inst_m)}
    : forall {a}, a -> (ReaderT inst_r inst_m) a :=
@@ -158,6 +98,9 @@ Program Instance Applicative__ReaderT {m} {r} `{(GHC.Base.Applicative m)}
            GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__ReaderT_op_zlztzg__ ;
            GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__ReaderT_op_ztzg__ ;
            GHC.Base.pure__ := fun {a} => Applicative__ReaderT_pure |}.
+
+(* Skipping all instances of class `GHC.Base.Alternative', including
+   `Control.Monad.Trans.Reader.Alternative__ReaderT' *)
 
 Local Definition Monad__ReaderT_op_zgzg__ {inst_m} {inst_r} `{(GHC.Base.Monad
    inst_m)}
@@ -187,6 +130,16 @@ Program Instance Monad__ReaderT {m} {r} `{(GHC.Base.Monad m)}
            GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__ReaderT_op_zgzgze__ ;
            GHC.Base.return___ := fun {a} => Monad__ReaderT_return_ |}.
 
+Local Definition MonadTrans__ReaderT_lift {inst_r}
+   : forall {m} {a}, forall `{(GHC.Base.Monad m)}, m a -> (ReaderT inst_r) m a :=
+  fun {m} {a} `{(GHC.Base.Monad m)} => liftReaderT.
+
+Program Instance MonadTrans__ReaderT {r}
+   : Control.Monad.Trans.Class.MonadTrans (ReaderT r) :=
+  fun _ k__ =>
+    k__ {| Control.Monad.Trans.Class.lift__ := fun {m} {a} `{(GHC.Base.Monad m)} =>
+             MonadTrans__ReaderT_lift |}.
+
 Local Definition MonadFail__ReaderT_fail {inst_m} {inst_r}
   `{(Control.Monad.Fail.MonadFail inst_m)}
    : forall {a}, GHC.Base.String -> (ReaderT inst_r inst_m) a :=
@@ -198,8 +151,55 @@ Program Instance MonadFail__ReaderT {m} {r} `{(Control.Monad.Fail.MonadFail m)}
   fun _ k__ =>
     k__ {| Control.Monad.Fail.fail__ := fun {a} => MonadFail__ReaderT_fail |}.
 
-(* Skipping all instances of class `GHC.Base.Alternative', including
-   `Control.Monad.Trans.Reader.Alternative__ReaderT' *)
+(* Skipping all instances of class `GHC.Base.MonadPlus', including
+   `Control.Monad.Trans.Reader.MonadPlus__ReaderT' *)
+
+(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
+   `Control.Monad.Trans.Reader.MonadFix__ReaderT' *)
+
+(* Skipping all instances of class `Control.Monad.IO.Class.MonadIO', including
+   `Control.Monad.Trans.Reader.MonadIO__ReaderT' *)
+
+(* Skipping all instances of class `Control.Monad.Zip.MonadZip', including
+   `Control.Monad.Trans.Reader.MonadZip__ReaderT' *)
+
+Definition reader {m} {r} {a} `{(GHC.Base.Monad m)}
+   : (r -> a) -> ReaderT r m a :=
+  fun f => Mk_ReaderT (GHC.Base.return_ GHC.Base.∘ f).
+
+Definition runReader {r} {a} : Reader r a -> r -> a :=
+  fun m => Data.Functor.Identity.runIdentity GHC.Base.∘ runReaderT m.
+
+Definition mapReader {a} {b} {r} : (a -> b) -> Reader r a -> Reader r b :=
+  fun f =>
+    mapReaderT (Data.Functor.Identity.Mk_Identity GHC.Base.∘
+                (f GHC.Base.∘ Data.Functor.Identity.runIdentity)).
+
+Definition withReaderT {r'} {r} {m} {a}
+   : (r' -> r) -> ReaderT r m a -> ReaderT r' m a :=
+  fun f m => Mk_ReaderT (runReaderT m GHC.Base.∘ f).
+
+Definition withReader {r'} {r} {a} : (r' -> r) -> Reader r a -> Reader r' a :=
+  withReaderT.
+
+Definition ask {m} {r} `{(GHC.Base.Monad m)} : ReaderT r m r :=
+  Mk_ReaderT GHC.Base.return_.
+
+Definition local {r} {m} {a} : (r -> r) -> ReaderT r m a -> ReaderT r m a :=
+  withReaderT.
+
+Definition asks {m} {r} {a} `{(GHC.Base.Monad m)} : (r -> a) -> ReaderT r m a :=
+  fun f => Mk_ReaderT (GHC.Base.return_ GHC.Base.∘ f).
+
+Definition liftCallCC {m} {a} {b} {r}
+   : Control.Monad.Signatures.CallCC m a b ->
+     Control.Monad.Signatures.CallCC (ReaderT r m) a b :=
+  fun callCC f =>
+    Mk_ReaderT (fun r =>
+                  callCC (fun c =>
+                            runReaderT (f (Mk_ReaderT GHC.Base.∘ (GHC.Base.const GHC.Base.∘ c))) r)).
+
+(* Skipping definition `Control.Monad.Trans.Reader.liftCatch' *)
 
 (* External variables:
      Type Control.Monad.Fail.MonadFail Control.Monad.Fail.fail

--- a/examples/transformers/lib/Control/Monad/Trans/State/Lazy.v
+++ b/examples/transformers/lib/Control/Monad/Trans/State/Lazy.v
@@ -36,116 +36,6 @@ Definition runStateT {s} {m} {a} (arg_0__ : StateT s m a) :=
 
 (* Converted value declarations: *)
 
-Definition withStateT {s} {m} {a} : (s -> s) -> StateT s m a -> StateT s m a :=
-  fun f m => Mk_StateT (runStateT m GHC.Base.∘ f).
-
-Definition withState {s} {a} : (s -> s) -> State s a -> State s a :=
-  withStateT.
-
-Definition state {m} {s} {a} `{(GHC.Base.Monad m)}
-   : (s -> (a * s)%type) -> StateT s m a :=
-  fun f => Mk_StateT (GHC.Base.return_ GHC.Base.∘ f).
-
-Definition runState {s} {a} : State s a -> s -> (a * s)%type :=
-  fun m => Data.Functor.Identity.runIdentity GHC.Base.∘ runStateT m.
-
-Definition put {m} {s} `{(GHC.Base.Monad m)} : s -> StateT s m unit :=
-  fun s => state (fun arg_0__ => pair tt s).
-
-Definition modify {m} {s} `{(GHC.Base.Monad m)} : (s -> s) -> StateT s m unit :=
-  fun f => state (fun s => pair tt (f s)).
-
-Definition mapStateT {m} {a} {s} {n} {b}
-   : (m (a * s)%type -> n (b * s)%type) -> StateT s m a -> StateT s n b :=
-  fun f m => Mk_StateT (f GHC.Base.∘ runStateT m).
-
-Definition mapState {a} {s} {b}
-   : ((a * s)%type -> (b * s)%type) -> State s a -> State s b :=
-  fun f =>
-    mapStateT (Data.Functor.Identity.Mk_Identity GHC.Base.∘
-               (f GHC.Base.∘ Data.Functor.Identity.runIdentity)).
-
-Definition liftPass {m} {w} {a} {s} `{(GHC.Base.Monad m)}
-   : Control.Monad.Signatures.Pass w m (a * s)%type ->
-     Control.Monad.Signatures.Pass w (StateT s m) a :=
-  fun pass m =>
-    Mk_StateT (fun s =>
-                 pass (let cont_0__ arg_1__ :=
-                         let 'pair (pair a f) s' := arg_1__ in
-                         GHC.Base.return_ (pair (pair a s') f) in
-                       runStateT m s GHC.Base.>>= cont_0__)).
-
-Definition liftListen {m} {w} {a} {s} `{(GHC.Base.Monad m)}
-   : Control.Monad.Signatures.Listen w m (a * s)%type ->
-     Control.Monad.Signatures.Listen w (StateT s m) a :=
-  fun listen m =>
-    Mk_StateT (fun s =>
-                 let cont_0__ arg_1__ :=
-                   let 'pair (pair a s') w := arg_1__ in
-                   GHC.Base.return_ (pair (pair a w) s') in
-                 listen (runStateT m s) GHC.Base.>>= cont_0__).
-
-(* Skipping definition `Control.Monad.Trans.State.Lazy.liftCatch' *)
-
-Definition liftCallCC' {m} {a} {s} {b}
-   : Control.Monad.Signatures.CallCC m (a * s)%type (b * s)%type ->
-     Control.Monad.Signatures.CallCC (StateT s m) a b :=
-  fun callCC f =>
-    Mk_StateT (fun s =>
-                 callCC (fun c =>
-                           runStateT (f (fun a => Mk_StateT (fun s' => c (pair a s')))) s)).
-
-Definition liftCallCC {m} {a} {s} {b}
-   : Control.Monad.Signatures.CallCC m (a * s)%type (b * s)%type ->
-     Control.Monad.Signatures.CallCC (StateT s m) a b :=
-  fun callCC f =>
-    Mk_StateT (fun s =>
-                 callCC (fun c =>
-                           runStateT (f (fun a => Mk_StateT (fun arg_0__ => c (pair a s)))) s)).
-
-Definition gets {m} {s} {a} `{(GHC.Base.Monad m)} : (s -> a) -> StateT s m a :=
-  fun f => state (fun s => pair (f s) s).
-
-Definition get {m} {s} `{(GHC.Base.Monad m)} : StateT s m s :=
-  state (fun s => pair s s).
-
-Local Definition Monad__StateT_op_zgzgze__ {inst_m} {inst_s} `{(GHC.Base.Monad
-   inst_m)}
-   : forall {a} {b},
-     (StateT inst_s inst_m) a ->
-     (a -> (StateT inst_s inst_m) b) -> (StateT inst_s inst_m) b :=
-  fun {a} {b} =>
-    fun m k =>
-      Mk_StateT (fun s =>
-                   let cont_0__ arg_1__ := let 'pair a s' := arg_1__ in runStateT (k a) s' in
-                   runStateT m s GHC.Base.>>= cont_0__).
-
-Local Definition Monad__StateT_op_zgzg__ {inst_m} {inst_s} `{(GHC.Base.Monad
-   inst_m)}
-   : forall {a} {b},
-     (StateT inst_s inst_m) a ->
-     (StateT inst_s inst_m) b -> (StateT inst_s inst_m) b :=
-  fun {a} {b} => fun m k => Monad__StateT_op_zgzgze__ m (fun arg_0__ => k).
-
-Local Definition Applicative__StateT_op_zlztzg__ {inst_m} {inst_s}
-  `{GHC.Base.Functor inst_m} `{GHC.Base.Monad inst_m}
-   : forall {a} {b},
-     (StateT inst_s inst_m) (a -> b) ->
-     (StateT inst_s inst_m) a -> (StateT inst_s inst_m) b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | Mk_StateT mf, Mk_StateT mx =>
-          Mk_StateT (fun s =>
-                       let cont_2__ arg_3__ :=
-                         let 'pair f s' := arg_3__ in
-                         let cont_4__ arg_5__ :=
-                           let 'pair x s'' := arg_5__ in
-                           GHC.Base.return_ (pair (f x) s'') in
-                         mx s' GHC.Base.>>= cont_4__ in
-                       mf s GHC.Base.>>= cont_2__)
-      end.
-
 Local Definition Functor__StateT_fmap {inst_m} {inst_s} `{(GHC.Base.Functor
    inst_m)}
    : forall {a} {b},
@@ -165,6 +55,25 @@ Program Instance Functor__StateT {m} {s} `{(GHC.Base.Functor m)}
   fun _ k__ =>
     k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__StateT_fmap ;
            GHC.Base.op_zlzd____ := fun {a} {b} => Functor__StateT_op_zlzd__ |}.
+
+Local Definition Applicative__StateT_op_zlztzg__ {inst_m} {inst_s}
+  `{GHC.Base.Functor inst_m} `{GHC.Base.Monad inst_m}
+   : forall {a} {b},
+     (StateT inst_s inst_m) (a -> b) ->
+     (StateT inst_s inst_m) a -> (StateT inst_s inst_m) b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | Mk_StateT mf, Mk_StateT mx =>
+          Mk_StateT (fun s =>
+                       let cont_2__ arg_3__ :=
+                         let 'pair f s' := arg_3__ in
+                         let cont_4__ arg_5__ :=
+                           let 'pair x s'' := arg_5__ in
+                           GHC.Base.return_ (pair (f x) s'') in
+                         mx s' GHC.Base.>>= cont_4__ in
+                       mf s GHC.Base.>>= cont_2__)
+      end.
 
 Local Definition Applicative__StateT_liftA2 {inst_m} {inst_s} `{GHC.Base.Functor
   inst_m} `{GHC.Base.Monad inst_m}
@@ -198,6 +107,27 @@ Program Instance Applicative__StateT {m} {s} `{GHC.Base.Functor m}
            GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__StateT_op_ztzg__ ;
            GHC.Base.pure__ := fun {a} => Applicative__StateT_pure |}.
 
+(* Skipping all instances of class `GHC.Base.Alternative', including
+   `Control.Monad.Trans.State.Lazy.Alternative__StateT' *)
+
+Local Definition Monad__StateT_op_zgzgze__ {inst_m} {inst_s} `{(GHC.Base.Monad
+   inst_m)}
+   : forall {a} {b},
+     (StateT inst_s inst_m) a ->
+     (a -> (StateT inst_s inst_m) b) -> (StateT inst_s inst_m) b :=
+  fun {a} {b} =>
+    fun m k =>
+      Mk_StateT (fun s =>
+                   let cont_0__ arg_1__ := let 'pair a s' := arg_1__ in runStateT (k a) s' in
+                   runStateT m s GHC.Base.>>= cont_0__).
+
+Local Definition Monad__StateT_op_zgzg__ {inst_m} {inst_s} `{(GHC.Base.Monad
+   inst_m)}
+   : forall {a} {b},
+     (StateT inst_s inst_m) a ->
+     (StateT inst_s inst_m) b -> (StateT inst_s inst_m) b :=
+  fun {a} {b} => fun m k => Monad__StateT_op_zgzgze__ m (fun arg_0__ => k).
+
 Local Definition Monad__StateT_return_ {inst_m} {inst_s} `{(GHC.Base.Monad
    inst_m)}
    : forall {a}, a -> (StateT inst_s inst_m) a :=
@@ -210,30 +140,21 @@ Program Instance Monad__StateT {m} {s} `{(GHC.Base.Monad m)}
            GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__StateT_op_zgzgze__ ;
            GHC.Base.return___ := fun {a} => Monad__StateT_return_ |}.
 
-Definition modify' {m} {s} `{(GHC.Base.Monad m)}
-   : (s -> s) -> StateT s m unit :=
-  fun f => get GHC.Base.>>= (fun s => put (f s)).
+Local Definition MonadFail__StateT_fail {inst_m} {inst_s}
+  `{(Control.Monad.Fail.MonadFail inst_m)}
+   : forall {a}, GHC.Base.String -> (StateT inst_s inst_m) a :=
+  fun {a} => fun str => Mk_StateT (fun arg_0__ => Control.Monad.Fail.fail str).
 
-Definition execStateT {m} {s} {a} `{(GHC.Base.Monad m)}
-   : StateT s m a -> s -> m s :=
-  fun m s =>
-    let cont_0__ arg_1__ := let 'pair _ s' := arg_1__ in GHC.Base.return_ s' in
-    runStateT m s GHC.Base.>>= cont_0__.
+Program Instance MonadFail__StateT {m} {s} `{(Control.Monad.Fail.MonadFail m)}
+   : Control.Monad.Fail.MonadFail (StateT s m) :=
+  fun _ k__ =>
+    k__ {| Control.Monad.Fail.fail__ := fun {a} => MonadFail__StateT_fail |}.
 
-Definition execState {s} {a} : State s a -> s -> s :=
-  fun m s => Data.Tuple.snd (runState m s).
+(* Skipping all instances of class `GHC.Base.MonadPlus', including
+   `Control.Monad.Trans.State.Lazy.MonadPlus__StateT' *)
 
-Definition evalStateT {m} {s} {a} `{(GHC.Base.Monad m)}
-   : StateT s m a -> s -> m a :=
-  fun m s =>
-    let cont_0__ arg_1__ := let 'pair a _ := arg_1__ in GHC.Base.return_ a in
-    runStateT m s GHC.Base.>>= cont_0__.
-
-Definition evalState {s} {a} : State s a -> s -> a :=
-  fun m s => Data.Tuple.fst (runState m s).
-
-(* Skipping all instances of class `Control.Monad.IO.Class.MonadIO', including
-   `Control.Monad.Trans.State.Lazy.MonadIO__StateT' *)
+(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
+   `Control.Monad.Trans.State.Lazy.MonadFix__StateT' *)
 
 Local Definition MonadTrans__StateT_lift {inst_s}
    : forall {m} {a}, forall `{(GHC.Base.Monad m)}, m a -> (StateT inst_s) m a :=
@@ -247,24 +168,103 @@ Program Instance MonadTrans__StateT {s}
     k__ {| Control.Monad.Trans.Class.lift__ := fun {m} {a} `{(GHC.Base.Monad m)} =>
              MonadTrans__StateT_lift |}.
 
-(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
-   `Control.Monad.Trans.State.Lazy.MonadFix__StateT' *)
+(* Skipping all instances of class `Control.Monad.IO.Class.MonadIO', including
+   `Control.Monad.Trans.State.Lazy.MonadIO__StateT' *)
 
-(* Skipping all instances of class `GHC.Base.MonadPlus', including
-   `Control.Monad.Trans.State.Lazy.MonadPlus__StateT' *)
+Definition state {m} {s} {a} `{(GHC.Base.Monad m)}
+   : (s -> (a * s)%type) -> StateT s m a :=
+  fun f => Mk_StateT (GHC.Base.return_ GHC.Base.∘ f).
 
-Local Definition MonadFail__StateT_fail {inst_m} {inst_s}
-  `{(Control.Monad.Fail.MonadFail inst_m)}
-   : forall {a}, GHC.Base.String -> (StateT inst_s inst_m) a :=
-  fun {a} => fun str => Mk_StateT (fun arg_0__ => Control.Monad.Fail.fail str).
+Definition runState {s} {a} : State s a -> s -> (a * s)%type :=
+  fun m => Data.Functor.Identity.runIdentity GHC.Base.∘ runStateT m.
 
-Program Instance MonadFail__StateT {m} {s} `{(Control.Monad.Fail.MonadFail m)}
-   : Control.Monad.Fail.MonadFail (StateT s m) :=
-  fun _ k__ =>
-    k__ {| Control.Monad.Fail.fail__ := fun {a} => MonadFail__StateT_fail |}.
+Definition evalState {s} {a} : State s a -> s -> a :=
+  fun m s => Data.Tuple.fst (runState m s).
 
-(* Skipping all instances of class `GHC.Base.Alternative', including
-   `Control.Monad.Trans.State.Lazy.Alternative__StateT' *)
+Definition execState {s} {a} : State s a -> s -> s :=
+  fun m s => Data.Tuple.snd (runState m s).
+
+Definition mapStateT {m} {a} {s} {n} {b}
+   : (m (a * s)%type -> n (b * s)%type) -> StateT s m a -> StateT s n b :=
+  fun f m => Mk_StateT (f GHC.Base.∘ runStateT m).
+
+Definition mapState {a} {s} {b}
+   : ((a * s)%type -> (b * s)%type) -> State s a -> State s b :=
+  fun f =>
+    mapStateT (Data.Functor.Identity.Mk_Identity GHC.Base.∘
+               (f GHC.Base.∘ Data.Functor.Identity.runIdentity)).
+
+Definition withStateT {s} {m} {a} : (s -> s) -> StateT s m a -> StateT s m a :=
+  fun f m => Mk_StateT (runStateT m GHC.Base.∘ f).
+
+Definition withState {s} {a} : (s -> s) -> State s a -> State s a :=
+  withStateT.
+
+Definition evalStateT {m} {s} {a} `{(GHC.Base.Monad m)}
+   : StateT s m a -> s -> m a :=
+  fun m s =>
+    let cont_0__ arg_1__ := let 'pair a _ := arg_1__ in GHC.Base.return_ a in
+    runStateT m s GHC.Base.>>= cont_0__.
+
+Definition execStateT {m} {s} {a} `{(GHC.Base.Monad m)}
+   : StateT s m a -> s -> m s :=
+  fun m s =>
+    let cont_0__ arg_1__ := let 'pair _ s' := arg_1__ in GHC.Base.return_ s' in
+    runStateT m s GHC.Base.>>= cont_0__.
+
+Definition get {m} {s} `{(GHC.Base.Monad m)} : StateT s m s :=
+  state (fun s => pair s s).
+
+Definition put {m} {s} `{(GHC.Base.Monad m)} : s -> StateT s m unit :=
+  fun s => state (fun arg_0__ => pair tt s).
+
+Definition modify {m} {s} `{(GHC.Base.Monad m)} : (s -> s) -> StateT s m unit :=
+  fun f => state (fun s => pair tt (f s)).
+
+Definition modify' {m} {s} `{(GHC.Base.Monad m)}
+   : (s -> s) -> StateT s m unit :=
+  fun f => get GHC.Base.>>= (fun s => put (f s)).
+
+Definition gets {m} {s} {a} `{(GHC.Base.Monad m)} : (s -> a) -> StateT s m a :=
+  fun f => state (fun s => pair (f s) s).
+
+Definition liftCallCC {m} {a} {s} {b}
+   : Control.Monad.Signatures.CallCC m (a * s)%type (b * s)%type ->
+     Control.Monad.Signatures.CallCC (StateT s m) a b :=
+  fun callCC f =>
+    Mk_StateT (fun s =>
+                 callCC (fun c =>
+                           runStateT (f (fun a => Mk_StateT (fun arg_0__ => c (pair a s)))) s)).
+
+Definition liftCallCC' {m} {a} {s} {b}
+   : Control.Monad.Signatures.CallCC m (a * s)%type (b * s)%type ->
+     Control.Monad.Signatures.CallCC (StateT s m) a b :=
+  fun callCC f =>
+    Mk_StateT (fun s =>
+                 callCC (fun c =>
+                           runStateT (f (fun a => Mk_StateT (fun s' => c (pair a s')))) s)).
+
+(* Skipping definition `Control.Monad.Trans.State.Lazy.liftCatch' *)
+
+Definition liftListen {m} {w} {a} {s} `{(GHC.Base.Monad m)}
+   : Control.Monad.Signatures.Listen w m (a * s)%type ->
+     Control.Monad.Signatures.Listen w (StateT s m) a :=
+  fun listen m =>
+    Mk_StateT (fun s =>
+                 let cont_0__ arg_1__ :=
+                   let 'pair (pair a s') w := arg_1__ in
+                   GHC.Base.return_ (pair (pair a w) s') in
+                 listen (runStateT m s) GHC.Base.>>= cont_0__).
+
+Definition liftPass {m} {w} {a} {s} `{(GHC.Base.Monad m)}
+   : Control.Monad.Signatures.Pass w m (a * s)%type ->
+     Control.Monad.Signatures.Pass w (StateT s m) a :=
+  fun pass m =>
+    Mk_StateT (fun s =>
+                 pass (let cont_0__ arg_1__ :=
+                         let 'pair (pair a f) s' := arg_1__ in
+                         GHC.Base.return_ (pair (pair a s') f) in
+                       runStateT m s GHC.Base.>>= cont_0__)).
 
 (* External variables:
      op_zt__ pair tt unit Control.Monad.Fail.MonadFail Control.Monad.Fail.fail

--- a/examples/transformers/lib/Control/Monad/Trans/Writer/Lazy.v
+++ b/examples/transformers/lib/Control/Monad/Trans/Writer/Lazy.v
@@ -62,121 +62,129 @@ Local Definition Monad__WriterT_tmp {inst_w} {inst_m} `{GHC.Base.Monoid
 
 (* Converted value declarations: *)
 
-Definition writer {m} {a} {w} `{(GHC.Base.Monad m)}
-   : (a * w)%type -> WriterT w m a :=
-  Mk_WriterT GHC.Base.∘ GHC.Base.return_.
+Local Definition Eq1__WriterT_liftEq {inst_w} {inst_m} `{GHC.Base.Eq_ inst_w}
+  `{Data.Functor.Classes.Eq1 inst_m}
+   : forall {a} {b},
+     (a -> b -> bool) ->
+     (WriterT inst_w inst_m) a -> (WriterT inst_w inst_m) b -> bool :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | eq, Mk_WriterT m1, Mk_WriterT m2 =>
+          Data.Functor.Classes.liftEq (Data.Functor.Classes.liftEq2 eq _GHC.Base.==_) m1
+          m2
+      end.
 
-Definition tell {m} {w} `{(GHC.Base.Monad m)} : w -> WriterT w m unit :=
-  fun w => writer (pair tt w).
+Program Instance Eq1__WriterT {w} {m} `{GHC.Base.Eq_ w}
+  `{Data.Functor.Classes.Eq1 m}
+   : Data.Functor.Classes.Eq1 (WriterT w m) :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__WriterT_liftEq |}.
 
-Definition runWriter {w} {a} : Writer w a -> (a * w)%type :=
-  Data.Functor.Identity.runIdentity GHC.Base.∘ runWriterT.
+Local Definition Ord1__WriterT_liftCompare {inst_w} {inst_m} `{GHC.Base.Ord
+  inst_w} `{Data.Functor.Classes.Ord1 inst_m}
+   : forall {a} {b},
+     (a -> b -> comparison) ->
+     (WriterT inst_w inst_m) a -> (WriterT inst_w inst_m) b -> comparison :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | comp, Mk_WriterT m1, Mk_WriterT m2 =>
+          Data.Functor.Classes.liftCompare (Data.Functor.Classes.liftCompare2 comp
+                                            GHC.Base.compare) m1 m2
+      end.
 
-Definition pass {m} {w} {a} `{(GHC.Base.Monad m)}
-   : WriterT w m (a * (w -> w))%type -> WriterT w m a :=
-  fun m =>
-    Mk_WriterT (let cont_0__ arg_1__ :=
-                  let 'pair (pair a f) w := arg_1__ in
-                  GHC.Base.return_ (pair a (f w)) in
-                runWriterT m GHC.Base.>>= cont_0__).
+Program Instance Ord1__WriterT {w} {m} `{GHC.Base.Ord w}
+  `{Data.Functor.Classes.Ord1 m}
+   : Data.Functor.Classes.Ord1 (WriterT w m) :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
+             Ord1__WriterT_liftCompare |}.
+
+(* Skipping all instances of class `Data.Functor.Classes.Read1', including
+   `Control.Monad.Trans.Writer.Lazy.Read1__WriterT' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Show1', including
+   `Control.Monad.Trans.Writer.Lazy.Show1__WriterT' *)
+
+Local Definition Eq___WriterT_op_zeze__ {inst_w} {inst_m} {inst_a}
+  `{GHC.Base.Eq_ inst_w} `{Data.Functor.Classes.Eq1 inst_m} `{GHC.Base.Eq_ inst_a}
+   : (WriterT inst_w inst_m inst_a) -> (WriterT inst_w inst_m inst_a) -> bool :=
+  Data.Functor.Classes.eq1.
+
+Local Definition Eq___WriterT_op_zsze__ {inst_w} {inst_m} {inst_a}
+  `{GHC.Base.Eq_ inst_w} `{Data.Functor.Classes.Eq1 inst_m} `{GHC.Base.Eq_ inst_a}
+   : (WriterT inst_w inst_m inst_a) -> (WriterT inst_w inst_m inst_a) -> bool :=
+  fun x y => negb (Eq___WriterT_op_zeze__ x y).
+
+Program Instance Eq___WriterT {w} {m} {a} `{GHC.Base.Eq_ w}
+  `{Data.Functor.Classes.Eq1 m} `{GHC.Base.Eq_ a}
+   : GHC.Base.Eq_ (WriterT w m a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___WriterT_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___WriterT_op_zsze__ |}.
+
+Local Definition Ord__WriterT_compare {inst_w} {inst_m} {inst_a} `{GHC.Base.Ord
+  inst_w} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
+   : (WriterT inst_w inst_m inst_a) ->
+     (WriterT inst_w inst_m inst_a) -> comparison :=
+  Data.Functor.Classes.compare1.
+
+Local Definition Ord__WriterT_op_zl__ {inst_w} {inst_m} {inst_a} `{GHC.Base.Ord
+  inst_w} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
+   : (WriterT inst_w inst_m inst_a) -> (WriterT inst_w inst_m inst_a) -> bool :=
+  fun x y => Ord__WriterT_compare x y GHC.Base.== Lt.
+
+Local Definition Ord__WriterT_op_zlze__ {inst_w} {inst_m} {inst_a}
+  `{GHC.Base.Ord inst_w} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord
+  inst_a}
+   : (WriterT inst_w inst_m inst_a) -> (WriterT inst_w inst_m inst_a) -> bool :=
+  fun x y => Ord__WriterT_compare x y GHC.Base./= Gt.
+
+Local Definition Ord__WriterT_op_zg__ {inst_w} {inst_m} {inst_a} `{GHC.Base.Ord
+  inst_w} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
+   : (WriterT inst_w inst_m inst_a) -> (WriterT inst_w inst_m inst_a) -> bool :=
+  fun x y => Ord__WriterT_compare x y GHC.Base.== Gt.
+
+Local Definition Ord__WriterT_op_zgze__ {inst_w} {inst_m} {inst_a}
+  `{GHC.Base.Ord inst_w} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord
+  inst_a}
+   : (WriterT inst_w inst_m inst_a) -> (WriterT inst_w inst_m inst_a) -> bool :=
+  fun x y => Ord__WriterT_compare x y GHC.Base./= Lt.
+
+Local Definition Ord__WriterT_max {inst_w} {inst_m} {inst_a} `{GHC.Base.Ord
+  inst_w} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
+   : (WriterT inst_w inst_m inst_a) ->
+     (WriterT inst_w inst_m inst_a) -> (WriterT inst_w inst_m inst_a) :=
+  fun x y => if Ord__WriterT_op_zlze__ x y : bool then y else x.
+
+Local Definition Ord__WriterT_min {inst_w} {inst_m} {inst_a} `{GHC.Base.Ord
+  inst_w} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
+   : (WriterT inst_w inst_m inst_a) ->
+     (WriterT inst_w inst_m inst_a) -> (WriterT inst_w inst_m inst_a) :=
+  fun x y => if Ord__WriterT_op_zlze__ x y : bool then x else y.
+
+Program Instance Ord__WriterT {w} {m} {a} `{GHC.Base.Ord w}
+  `{Data.Functor.Classes.Ord1 m} `{GHC.Base.Ord a}
+   : GHC.Base.Ord (WriterT w m a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zl____ := Ord__WriterT_op_zl__ ;
+           GHC.Base.op_zlze____ := Ord__WriterT_op_zlze__ ;
+           GHC.Base.op_zg____ := Ord__WriterT_op_zg__ ;
+           GHC.Base.op_zgze____ := Ord__WriterT_op_zgze__ ;
+           GHC.Base.compare__ := Ord__WriterT_compare ;
+           GHC.Base.max__ := Ord__WriterT_max ;
+           GHC.Base.min__ := Ord__WriterT_min |}.
+
+(* Skipping all instances of class `GHC.Read.Read', including
+   `Control.Monad.Trans.Writer.Lazy.Read__WriterT' *)
+
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Control.Monad.Trans.Writer.Lazy.Show__WriterT' *)
 
 Definition mapWriterT {m} {a} {w} {n} {b} {w'}
    : (m (a * w)%type -> n (b * w')%type) -> WriterT w m a -> WriterT w' n b :=
   fun f m => Mk_WriterT (f (runWriterT m)).
-
-Definition mapWriter {a} {w} {b} {w'}
-   : ((a * w)%type -> (b * w')%type) -> Writer w a -> Writer w' b :=
-  fun f =>
-    mapWriterT (Data.Functor.Identity.Mk_Identity GHC.Base.∘
-                (f GHC.Base.∘ Data.Functor.Identity.runIdentity)).
-
-Definition listens {m} {w} {b} {a} `{(GHC.Base.Monad m)}
-   : (w -> b) -> WriterT w m a -> WriterT w m (a * b)%type :=
-  fun f m =>
-    Mk_WriterT (let cont_0__ arg_1__ :=
-                  let 'pair a w := arg_1__ in
-                  GHC.Base.return_ (pair (pair a (f w)) w) in
-                runWriterT m GHC.Base.>>= cont_0__).
-
-Definition listen {m} {w} {a} `{(GHC.Base.Monad m)}
-   : WriterT w m a -> WriterT w m (a * w)%type :=
-  fun m =>
-    Mk_WriterT (let cont_0__ arg_1__ :=
-                  let 'pair a w := arg_1__ in
-                  GHC.Base.return_ (pair (pair a w) w) in
-                runWriterT m GHC.Base.>>= cont_0__).
-
-(* Skipping definition `Control.Monad.Trans.Writer.Lazy.liftCatch' *)
-
-Definition liftCallCC {w} {m} {a} {b} `{(GHC.Base.Monoid w)}
-   : Control.Monad.Signatures.CallCC m (a * w)%type (b * w)%type ->
-     Control.Monad.Signatures.CallCC (WriterT w m) a b :=
-  fun callCC f =>
-    Mk_WriterT (callCC (fun c =>
-                          runWriterT (f (fun a => Mk_WriterT (c (pair a GHC.Base.mempty)))))).
-
-Definition execWriterT {m} {w} {a} `{(GHC.Base.Monad m)}
-   : WriterT w m a -> m w :=
-  fun m =>
-    let cont_0__ arg_1__ := let 'pair _ w := arg_1__ in GHC.Base.return_ w in
-    runWriterT m GHC.Base.>>= cont_0__.
-
-Definition execWriter {w} {a} : Writer w a -> w :=
-  fun m => Data.Tuple.snd (runWriter m).
-
-Definition censor {m} {w} {a} `{(GHC.Base.Monad m)}
-   : (w -> w) -> WriterT w m a -> WriterT w m a :=
-  fun f m =>
-    Mk_WriterT (let cont_0__ arg_1__ :=
-                  let 'pair a w := arg_1__ in
-                  GHC.Base.return_ (pair a (f w)) in
-                runWriterT m GHC.Base.>>= cont_0__).
-
-(* Skipping all instances of class `Control.Monad.Zip.MonadZip', including
-   `Control.Monad.Trans.Writer.Lazy.MonadZip__WriterT' *)
-
-(* Skipping all instances of class `Control.Monad.IO.Class.MonadIO', including
-   `Control.Monad.Trans.Writer.Lazy.MonadIO__WriterT' *)
-
-Local Definition MonadTrans__WriterT_lift {inst_w} `{(GHC.Base.Monoid inst_w)}
-   : forall {m} {a}, forall `{(GHC.Base.Monad m)}, m a -> (WriterT inst_w) m a :=
-  fun {m} {a} `{(GHC.Base.Monad m)} =>
-    fun m =>
-      Mk_WriterT (m GHC.Base.>>=
-                  (fun a => GHC.Base.return_ (pair a GHC.Base.mempty))).
-
-Program Instance MonadTrans__WriterT {w} `{(GHC.Base.Monoid w)}
-   : Control.Monad.Trans.Class.MonadTrans (WriterT w) :=
-  fun _ k__ =>
-    k__ {| Control.Monad.Trans.Class.lift__ := fun {m} {a} `{(GHC.Base.Monad m)} =>
-             MonadTrans__WriterT_lift |}.
-
-(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
-   `Control.Monad.Trans.Writer.Lazy.MonadFix__WriterT' *)
-
-(* Skipping all instances of class `GHC.Base.MonadPlus', including
-   `Control.Monad.Trans.Writer.Lazy.MonadPlus__WriterT' *)
-
-Definition Monad__WriterT_op_zgzgze__ {inst_w} {inst_m} `{_
-   : GHC.Base.Monoid inst_w} `{_ : GHC.Base.Monad inst_m}
-   : forall {a} {b},
-     WriterT inst_w inst_m a ->
-     (a -> WriterT inst_w inst_m b) -> WriterT inst_w inst_m b :=
-  fun {a} {b} => Monad__WriterT_tmp.
-
-Local Definition Applicative__WriterT_op_zlztzg__ {inst_w} {inst_m}
-  `{GHC.Base.Monoid inst_w} `{GHC.Base.Applicative inst_m}
-   : forall {a} {b},
-     (WriterT inst_w inst_m) (a -> b) ->
-     (WriterT inst_w inst_m) a -> (WriterT inst_w inst_m) b :=
-  fun {a} {b} =>
-    fun f v =>
-      let k :=
-        fun arg_0__ arg_1__ =>
-          match arg_0__, arg_1__ with
-          | pair a w, pair b w' => pair (a b) (GHC.Base.mappend w w')
-          end in
-      Mk_WriterT (GHC.Base.liftA2 k (runWriterT f) (runWriterT v)).
 
 Local Definition Functor__WriterT_fmap {inst_m} {inst_w} `{(GHC.Base.Functor
    inst_m)}
@@ -196,103 +204,6 @@ Program Instance Functor__WriterT {m} {w} `{(GHC.Base.Functor m)}
   fun _ k__ =>
     k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__WriterT_fmap ;
            GHC.Base.op_zlzd____ := fun {a} {b} => Functor__WriterT_op_zlzd__ |}.
-
-Local Definition Applicative__WriterT_liftA2 {inst_w} {inst_m} `{GHC.Base.Monoid
-  inst_w} `{GHC.Base.Applicative inst_m}
-   : forall {a} {b} {c},
-     (a -> b -> c) ->
-     (WriterT inst_w inst_m) a ->
-     (WriterT inst_w inst_m) b -> (WriterT inst_w inst_m) c :=
-  fun {a} {b} {c} =>
-    fun f x => Applicative__WriterT_op_zlztzg__ (GHC.Base.fmap f x).
-
-Local Definition Applicative__WriterT_pure {inst_w} {inst_m} `{GHC.Base.Monoid
-  inst_w} `{GHC.Base.Applicative inst_m}
-   : forall {a}, a -> (WriterT inst_w inst_m) a :=
-  fun {a} => fun a => Mk_WriterT (GHC.Base.pure (pair a GHC.Base.mempty)).
-
-Local Definition Applicative__WriterT_op_ztzg__ {inst_w} {inst_m}
-  `{GHC.Base.Monoid inst_w} `{GHC.Base.Applicative inst_m}
-   : forall {a} {b},
-     (WriterT inst_w inst_m) a ->
-     (WriterT inst_w inst_m) b -> (WriterT inst_w inst_m) b :=
-  fun {a} {b} =>
-    fun a1 a2 => Applicative__WriterT_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
-
-Program Instance Applicative__WriterT {w} {m} `{GHC.Base.Monoid w}
-  `{GHC.Base.Applicative m}
-   : GHC.Base.Applicative (WriterT w m) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__WriterT_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__WriterT_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__WriterT_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__WriterT_pure |}.
-
-Local Definition Monad__WriterT_op_zgzg__ {inst_w} {inst_m} `{GHC.Base.Monoid
-  inst_w} `{GHC.Base.Monad inst_m}
-   : forall {a} {b},
-     (WriterT inst_w inst_m) a ->
-     (WriterT inst_w inst_m) b -> (WriterT inst_w inst_m) b :=
-  fun {a} {b} => fun m k => Monad__WriterT_op_zgzgze__ m (fun arg_0__ => k).
-
-Local Definition Monad__WriterT_return_ {inst_w} {inst_m} `{GHC.Base.Monoid
-  inst_w} `{GHC.Base.Monad inst_m}
-   : forall {a}, a -> (WriterT inst_w inst_m) a :=
-  fun {a} => GHC.Base.pure.
-
-Program Instance Monad__WriterT {w} {m} `{GHC.Base.Monoid w} `{GHC.Base.Monad m}
-   : GHC.Base.Monad (WriterT w m) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__WriterT_op_zgzg__ ;
-           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__WriterT_op_zgzgze__ ;
-           GHC.Base.return___ := fun {a} => Monad__WriterT_return_ |}.
-
-Local Definition MonadFail__WriterT_fail {inst_w} {inst_m} `{GHC.Base.Monoid
-  inst_w} `{Control.Monad.Fail.MonadFail inst_m}
-   : forall {a}, GHC.Base.String -> (WriterT inst_w inst_m) a :=
-  fun {a} => fun msg => Mk_WriterT (Control.Monad.Fail.fail msg).
-
-Program Instance MonadFail__WriterT {w} {m} `{GHC.Base.Monoid w}
-  `{Control.Monad.Fail.MonadFail m}
-   : Control.Monad.Fail.MonadFail (WriterT w m) :=
-  fun _ k__ =>
-    k__ {| Control.Monad.Fail.fail__ := fun {a} => MonadFail__WriterT_fail |}.
-
-(* Skipping all instances of class `GHC.Base.Alternative', including
-   `Control.Monad.Trans.Writer.Lazy.Alternative__WriterT' *)
-
-Local Definition Traversable__WriterT_traverse {inst_f} {inst_w}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f},
-     (a -> f b) -> (WriterT inst_w inst_f) a -> f ((WriterT inst_w inst_f) b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun f =>
-      let f' := fun '(pair a b) => GHC.Base.fmap (fun c => pair c b) (f a) in
-      GHC.Base.fmap Mk_WriterT GHC.Base.∘
-      (Data.Traversable.traverse f' GHC.Base.∘ runWriterT).
-
-Local Definition Traversable__WriterT_mapM {inst_f} {inst_w}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m},
-     (a -> m b) -> (WriterT inst_w inst_f) a -> m ((WriterT inst_w inst_f) b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__WriterT_traverse.
-
-Local Definition Traversable__WriterT_sequenceA {inst_f} {inst_w}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {f} {a},
-     forall `{GHC.Base.Applicative f},
-     (WriterT inst_w inst_f) (f a) -> f ((WriterT inst_w inst_f) a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} =>
-    Traversable__WriterT_traverse GHC.Base.id.
-
-Local Definition Traversable__WriterT_sequence {inst_f} {inst_w}
-  `{(Data.Traversable.Traversable inst_f)}
-   : forall {m} {a},
-     forall `{GHC.Base.Monad m},
-     (WriterT inst_w inst_f) (m a) -> m ((WriterT inst_w inst_f) a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__WriterT_sequenceA.
 
 Local Definition Foldable__WriterT_foldMap {inst_f} {inst_w}
   `{(Data.Foldable.Foldable inst_f)}
@@ -389,6 +300,39 @@ Program Instance Foldable__WriterT {f} {w} `{(Data.Foldable.Foldable f)}
            Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__WriterT_sum ;
            Data.Foldable.toList__ := fun {a} => Foldable__WriterT_toList |}.
 
+Local Definition Traversable__WriterT_traverse {inst_f} {inst_w}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f},
+     (a -> f b) -> (WriterT inst_w inst_f) a -> f ((WriterT inst_w inst_f) b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+    fun f =>
+      let f' := fun '(pair a b) => GHC.Base.fmap (fun c => pair c b) (f a) in
+      GHC.Base.fmap Mk_WriterT GHC.Base.∘
+      (Data.Traversable.traverse f' GHC.Base.∘ runWriterT).
+
+Local Definition Traversable__WriterT_mapM {inst_f} {inst_w}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m},
+     (a -> m b) -> (WriterT inst_w inst_f) a -> m ((WriterT inst_w inst_f) b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__WriterT_traverse.
+
+Local Definition Traversable__WriterT_sequenceA {inst_f} {inst_w}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {f} {a},
+     forall `{GHC.Base.Applicative f},
+     (WriterT inst_w inst_f) (f a) -> f ((WriterT inst_w inst_f) a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} =>
+    Traversable__WriterT_traverse GHC.Base.id.
+
+Local Definition Traversable__WriterT_sequence {inst_f} {inst_w}
+  `{(Data.Traversable.Traversable inst_f)}
+   : forall {m} {a},
+     forall `{GHC.Base.Monad m},
+     (WriterT inst_w inst_f) (m a) -> m ((WriterT inst_w inst_f) a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__WriterT_sequenceA.
+
 Program Instance Traversable__WriterT {f} {w} `{(Data.Traversable.Traversable
    f)}
    : Data.Traversable.Traversable (WriterT w f) :=
@@ -402,125 +346,181 @@ Program Instance Traversable__WriterT {f} {w} `{(Data.Traversable.Traversable
            Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
              Traversable__WriterT_traverse |}.
 
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Control.Monad.Trans.Writer.Lazy.Show__WriterT' *)
-
-(* Skipping all instances of class `GHC.Read.Read', including
-   `Control.Monad.Trans.Writer.Lazy.Read__WriterT' *)
-
-Local Definition Ord1__WriterT_liftCompare {inst_w} {inst_m} `{GHC.Base.Ord
-  inst_w} `{Data.Functor.Classes.Ord1 inst_m}
+Local Definition Applicative__WriterT_op_zlztzg__ {inst_w} {inst_m}
+  `{GHC.Base.Monoid inst_w} `{GHC.Base.Applicative inst_m}
    : forall {a} {b},
-     (a -> b -> comparison) ->
-     (WriterT inst_w inst_m) a -> (WriterT inst_w inst_m) b -> comparison :=
+     (WriterT inst_w inst_m) (a -> b) ->
+     (WriterT inst_w inst_m) a -> (WriterT inst_w inst_m) b :=
   fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | comp, Mk_WriterT m1, Mk_WriterT m2 =>
-          Data.Functor.Classes.liftCompare (Data.Functor.Classes.liftCompare2 comp
-                                            GHC.Base.compare) m1 m2
-      end.
+    fun f v =>
+      let k :=
+        fun arg_0__ arg_1__ =>
+          match arg_0__, arg_1__ with
+          | pair a w, pair b w' => pair (a b) (GHC.Base.mappend w w')
+          end in
+      Mk_WriterT (GHC.Base.liftA2 k (runWriterT f) (runWriterT v)).
 
-Local Definition Eq1__WriterT_liftEq {inst_w} {inst_m} `{GHC.Base.Eq_ inst_w}
-  `{Data.Functor.Classes.Eq1 inst_m}
+Local Definition Applicative__WriterT_liftA2 {inst_w} {inst_m} `{GHC.Base.Monoid
+  inst_w} `{GHC.Base.Applicative inst_m}
+   : forall {a} {b} {c},
+     (a -> b -> c) ->
+     (WriterT inst_w inst_m) a ->
+     (WriterT inst_w inst_m) b -> (WriterT inst_w inst_m) c :=
+  fun {a} {b} {c} =>
+    fun f x => Applicative__WriterT_op_zlztzg__ (GHC.Base.fmap f x).
+
+Local Definition Applicative__WriterT_pure {inst_w} {inst_m} `{GHC.Base.Monoid
+  inst_w} `{GHC.Base.Applicative inst_m}
+   : forall {a}, a -> (WriterT inst_w inst_m) a :=
+  fun {a} => fun a => Mk_WriterT (GHC.Base.pure (pair a GHC.Base.mempty)).
+
+Local Definition Applicative__WriterT_op_ztzg__ {inst_w} {inst_m}
+  `{GHC.Base.Monoid inst_w} `{GHC.Base.Applicative inst_m}
    : forall {a} {b},
-     (a -> b -> bool) ->
-     (WriterT inst_w inst_m) a -> (WriterT inst_w inst_m) b -> bool :=
+     (WriterT inst_w inst_m) a ->
+     (WriterT inst_w inst_m) b -> (WriterT inst_w inst_m) b :=
   fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | eq, Mk_WriterT m1, Mk_WriterT m2 =>
-          Data.Functor.Classes.liftEq (Data.Functor.Classes.liftEq2 eq _GHC.Base.==_) m1
-          m2
-      end.
+    fun a1 a2 => Applicative__WriterT_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
 
-Program Instance Eq1__WriterT {w} {m} `{GHC.Base.Eq_ w}
-  `{Data.Functor.Classes.Eq1 m}
-   : Data.Functor.Classes.Eq1 (WriterT w m) :=
+Program Instance Applicative__WriterT {w} {m} `{GHC.Base.Monoid w}
+  `{GHC.Base.Applicative m}
+   : GHC.Base.Applicative (WriterT w m) :=
   fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__WriterT_liftEq |}.
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__WriterT_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__WriterT_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__WriterT_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__WriterT_pure |}.
 
-Program Instance Ord1__WriterT {w} {m} `{GHC.Base.Ord w}
-  `{Data.Functor.Classes.Ord1 m}
-   : Data.Functor.Classes.Ord1 (WriterT w m) :=
+(* Skipping all instances of class `GHC.Base.Alternative', including
+   `Control.Monad.Trans.Writer.Lazy.Alternative__WriterT' *)
+
+Definition Monad__WriterT_op_zgzgze__ {inst_w} {inst_m} `{_
+   : GHC.Base.Monoid inst_w} `{_ : GHC.Base.Monad inst_m}
+   : forall {a} {b},
+     WriterT inst_w inst_m a ->
+     (a -> WriterT inst_w inst_m b) -> WriterT inst_w inst_m b :=
+  fun {a} {b} => Monad__WriterT_tmp.
+
+Local Definition Monad__WriterT_op_zgzg__ {inst_w} {inst_m} `{GHC.Base.Monoid
+  inst_w} `{GHC.Base.Monad inst_m}
+   : forall {a} {b},
+     (WriterT inst_w inst_m) a ->
+     (WriterT inst_w inst_m) b -> (WriterT inst_w inst_m) b :=
+  fun {a} {b} => fun m k => Monad__WriterT_op_zgzgze__ m (fun arg_0__ => k).
+
+Local Definition Monad__WriterT_return_ {inst_w} {inst_m} `{GHC.Base.Monoid
+  inst_w} `{GHC.Base.Monad inst_m}
+   : forall {a}, a -> (WriterT inst_w inst_m) a :=
+  fun {a} => GHC.Base.pure.
+
+Program Instance Monad__WriterT {w} {m} `{GHC.Base.Monoid w} `{GHC.Base.Monad m}
+   : GHC.Base.Monad (WriterT w m) :=
   fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
-             Ord1__WriterT_liftCompare |}.
+    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__WriterT_op_zgzg__ ;
+           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__WriterT_op_zgzgze__ ;
+           GHC.Base.return___ := fun {a} => Monad__WriterT_return_ |}.
 
-Local Definition Ord__WriterT_compare {inst_w} {inst_m} {inst_a} `{GHC.Base.Ord
-  inst_w} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
-   : (WriterT inst_w inst_m inst_a) ->
-     (WriterT inst_w inst_m inst_a) -> comparison :=
-  Data.Functor.Classes.compare1.
+Local Definition MonadTrans__WriterT_lift {inst_w} `{(GHC.Base.Monoid inst_w)}
+   : forall {m} {a}, forall `{(GHC.Base.Monad m)}, m a -> (WriterT inst_w) m a :=
+  fun {m} {a} `{(GHC.Base.Monad m)} =>
+    fun m =>
+      Mk_WriterT (m GHC.Base.>>=
+                  (fun a => GHC.Base.return_ (pair a GHC.Base.mempty))).
 
-Local Definition Ord__WriterT_op_zl__ {inst_w} {inst_m} {inst_a} `{GHC.Base.Ord
-  inst_w} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
-   : (WriterT inst_w inst_m inst_a) -> (WriterT inst_w inst_m inst_a) -> bool :=
-  fun x y => Ord__WriterT_compare x y GHC.Base.== Lt.
-
-Local Definition Ord__WriterT_op_zlze__ {inst_w} {inst_m} {inst_a}
-  `{GHC.Base.Ord inst_w} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord
-  inst_a}
-   : (WriterT inst_w inst_m inst_a) -> (WriterT inst_w inst_m inst_a) -> bool :=
-  fun x y => Ord__WriterT_compare x y GHC.Base./= Gt.
-
-Local Definition Ord__WriterT_op_zg__ {inst_w} {inst_m} {inst_a} `{GHC.Base.Ord
-  inst_w} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
-   : (WriterT inst_w inst_m inst_a) -> (WriterT inst_w inst_m inst_a) -> bool :=
-  fun x y => Ord__WriterT_compare x y GHC.Base.== Gt.
-
-Local Definition Ord__WriterT_op_zgze__ {inst_w} {inst_m} {inst_a}
-  `{GHC.Base.Ord inst_w} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord
-  inst_a}
-   : (WriterT inst_w inst_m inst_a) -> (WriterT inst_w inst_m inst_a) -> bool :=
-  fun x y => Ord__WriterT_compare x y GHC.Base./= Lt.
-
-Local Definition Ord__WriterT_max {inst_w} {inst_m} {inst_a} `{GHC.Base.Ord
-  inst_w} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
-   : (WriterT inst_w inst_m inst_a) ->
-     (WriterT inst_w inst_m inst_a) -> (WriterT inst_w inst_m inst_a) :=
-  fun x y => if Ord__WriterT_op_zlze__ x y : bool then y else x.
-
-Local Definition Ord__WriterT_min {inst_w} {inst_m} {inst_a} `{GHC.Base.Ord
-  inst_w} `{Data.Functor.Classes.Ord1 inst_m} `{GHC.Base.Ord inst_a}
-   : (WriterT inst_w inst_m inst_a) ->
-     (WriterT inst_w inst_m inst_a) -> (WriterT inst_w inst_m inst_a) :=
-  fun x y => if Ord__WriterT_op_zlze__ x y : bool then x else y.
-
-Local Definition Eq___WriterT_op_zeze__ {inst_w} {inst_m} {inst_a}
-  `{GHC.Base.Eq_ inst_w} `{Data.Functor.Classes.Eq1 inst_m} `{GHC.Base.Eq_ inst_a}
-   : (WriterT inst_w inst_m inst_a) -> (WriterT inst_w inst_m inst_a) -> bool :=
-  Data.Functor.Classes.eq1.
-
-Local Definition Eq___WriterT_op_zsze__ {inst_w} {inst_m} {inst_a}
-  `{GHC.Base.Eq_ inst_w} `{Data.Functor.Classes.Eq1 inst_m} `{GHC.Base.Eq_ inst_a}
-   : (WriterT inst_w inst_m inst_a) -> (WriterT inst_w inst_m inst_a) -> bool :=
-  fun x y => negb (Eq___WriterT_op_zeze__ x y).
-
-Program Instance Eq___WriterT {w} {m} {a} `{GHC.Base.Eq_ w}
-  `{Data.Functor.Classes.Eq1 m} `{GHC.Base.Eq_ a}
-   : GHC.Base.Eq_ (WriterT w m a) :=
+Program Instance MonadTrans__WriterT {w} `{(GHC.Base.Monoid w)}
+   : Control.Monad.Trans.Class.MonadTrans (WriterT w) :=
   fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___WriterT_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___WriterT_op_zsze__ |}.
+    k__ {| Control.Monad.Trans.Class.lift__ := fun {m} {a} `{(GHC.Base.Monad m)} =>
+             MonadTrans__WriterT_lift |}.
 
-Program Instance Ord__WriterT {w} {m} {a} `{GHC.Base.Ord w}
-  `{Data.Functor.Classes.Ord1 m} `{GHC.Base.Ord a}
-   : GHC.Base.Ord (WriterT w m a) :=
+Local Definition MonadFail__WriterT_fail {inst_w} {inst_m} `{GHC.Base.Monoid
+  inst_w} `{Control.Monad.Fail.MonadFail inst_m}
+   : forall {a}, GHC.Base.String -> (WriterT inst_w inst_m) a :=
+  fun {a} => fun msg => Mk_WriterT (Control.Monad.Fail.fail msg).
+
+Program Instance MonadFail__WriterT {w} {m} `{GHC.Base.Monoid w}
+  `{Control.Monad.Fail.MonadFail m}
+   : Control.Monad.Fail.MonadFail (WriterT w m) :=
   fun _ k__ =>
-    k__ {| GHC.Base.op_zl____ := Ord__WriterT_op_zl__ ;
-           GHC.Base.op_zlze____ := Ord__WriterT_op_zlze__ ;
-           GHC.Base.op_zg____ := Ord__WriterT_op_zg__ ;
-           GHC.Base.op_zgze____ := Ord__WriterT_op_zgze__ ;
-           GHC.Base.compare__ := Ord__WriterT_compare ;
-           GHC.Base.max__ := Ord__WriterT_max ;
-           GHC.Base.min__ := Ord__WriterT_min |}.
+    k__ {| Control.Monad.Fail.fail__ := fun {a} => MonadFail__WriterT_fail |}.
 
-(* Skipping all instances of class `Data.Functor.Classes.Show1', including
-   `Control.Monad.Trans.Writer.Lazy.Show1__WriterT' *)
+(* Skipping all instances of class `GHC.Base.MonadPlus', including
+   `Control.Monad.Trans.Writer.Lazy.MonadPlus__WriterT' *)
 
-(* Skipping all instances of class `Data.Functor.Classes.Read1', including
-   `Control.Monad.Trans.Writer.Lazy.Read1__WriterT' *)
+(* Skipping all instances of class `Control.Monad.Fix.MonadFix', including
+   `Control.Monad.Trans.Writer.Lazy.MonadFix__WriterT' *)
+
+(* Skipping all instances of class `Control.Monad.IO.Class.MonadIO', including
+   `Control.Monad.Trans.Writer.Lazy.MonadIO__WriterT' *)
+
+(* Skipping all instances of class `Control.Monad.Zip.MonadZip', including
+   `Control.Monad.Trans.Writer.Lazy.MonadZip__WriterT' *)
+
+Definition writer {m} {a} {w} `{(GHC.Base.Monad m)}
+   : (a * w)%type -> WriterT w m a :=
+  Mk_WriterT GHC.Base.∘ GHC.Base.return_.
+
+Definition runWriter {w} {a} : Writer w a -> (a * w)%type :=
+  Data.Functor.Identity.runIdentity GHC.Base.∘ runWriterT.
+
+Definition execWriter {w} {a} : Writer w a -> w :=
+  fun m => Data.Tuple.snd (runWriter m).
+
+Definition mapWriter {a} {w} {b} {w'}
+   : ((a * w)%type -> (b * w')%type) -> Writer w a -> Writer w' b :=
+  fun f =>
+    mapWriterT (Data.Functor.Identity.Mk_Identity GHC.Base.∘
+                (f GHC.Base.∘ Data.Functor.Identity.runIdentity)).
+
+Definition execWriterT {m} {w} {a} `{(GHC.Base.Monad m)}
+   : WriterT w m a -> m w :=
+  fun m =>
+    let cont_0__ arg_1__ := let 'pair _ w := arg_1__ in GHC.Base.return_ w in
+    runWriterT m GHC.Base.>>= cont_0__.
+
+Definition tell {m} {w} `{(GHC.Base.Monad m)} : w -> WriterT w m unit :=
+  fun w => writer (pair tt w).
+
+Definition listen {m} {w} {a} `{(GHC.Base.Monad m)}
+   : WriterT w m a -> WriterT w m (a * w)%type :=
+  fun m =>
+    Mk_WriterT (let cont_0__ arg_1__ :=
+                  let 'pair a w := arg_1__ in
+                  GHC.Base.return_ (pair (pair a w) w) in
+                runWriterT m GHC.Base.>>= cont_0__).
+
+Definition listens {m} {w} {b} {a} `{(GHC.Base.Monad m)}
+   : (w -> b) -> WriterT w m a -> WriterT w m (a * b)%type :=
+  fun f m =>
+    Mk_WriterT (let cont_0__ arg_1__ :=
+                  let 'pair a w := arg_1__ in
+                  GHC.Base.return_ (pair (pair a (f w)) w) in
+                runWriterT m GHC.Base.>>= cont_0__).
+
+Definition pass {m} {w} {a} `{(GHC.Base.Monad m)}
+   : WriterT w m (a * (w -> w))%type -> WriterT w m a :=
+  fun m =>
+    Mk_WriterT (let cont_0__ arg_1__ :=
+                  let 'pair (pair a f) w := arg_1__ in
+                  GHC.Base.return_ (pair a (f w)) in
+                runWriterT m GHC.Base.>>= cont_0__).
+
+Definition censor {m} {w} {a} `{(GHC.Base.Monad m)}
+   : (w -> w) -> WriterT w m a -> WriterT w m a :=
+  fun f m =>
+    Mk_WriterT (let cont_0__ arg_1__ :=
+                  let 'pair a w := arg_1__ in
+                  GHC.Base.return_ (pair a (f w)) in
+                runWriterT m GHC.Base.>>= cont_0__).
+
+Definition liftCallCC {w} {m} {a} {b} `{(GHC.Base.Monoid w)}
+   : Control.Monad.Signatures.CallCC m (a * w)%type (b * w)%type ->
+     Control.Monad.Signatures.CallCC (WriterT w m) a b :=
+  fun callCC f =>
+    Mk_WriterT (callCC (fun c =>
+                          runWriterT (f (fun a => Mk_WriterT (c (pair a GHC.Base.mempty)))))).
+
+(* Skipping definition `Control.Monad.Trans.Writer.Lazy.liftCatch' *)
 
 (* External variables:
      Gt Lt Monad__WriterT_tmp Type bool comparison list negb op_zt__ pair tt unit

--- a/examples/transformers/lib/Data/Functor/Constant.v
+++ b/examples/transformers/lib/Data/Functor/Constant.v
@@ -119,146 +119,74 @@ Program Instance Ord__Constant {a} {b} `{GHC.Base.Ord a}
            GHC.Base.max__ := Ord__Constant_max ;
            GHC.Base.min__ := Ord__Constant_min |}.
 
-Local Definition Bitraversable__Constant_bitraverse
-   : forall {f} {a} {c} {b} {d},
-     forall `{GHC.Base.Applicative f},
-     (a -> f c) -> (b -> f d) -> Constant a b -> f (Constant c d) :=
-  fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | f, _, Mk_Constant a => Mk_Constant Data.Functor.<$> f a
-      end.
+(* Skipping all instances of class `GHC.Read.Read', including
+   `Data.Functor.Constant.Read__Constant' *)
 
-Local Definition Bifoldable__Constant_bifoldMap
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monoid m}, (a -> m) -> (b -> m) -> Constant a b -> m :=
-  fun {m} {a} {b} `{GHC.Base.Monoid m} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | f, _, Mk_Constant a => f a
-      end.
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Data.Functor.Constant.Show__Constant' *)
 
-Local Definition Bifoldable__Constant_bifold
-   : forall {m}, forall `{GHC.Base.Monoid m}, Constant m m -> m :=
-  fun {m} `{GHC.Base.Monoid m} =>
-    Bifoldable__Constant_bifoldMap GHC.Base.id GHC.Base.id.
-
-Local Definition Bifoldable__Constant_bifoldl
-   : forall {c} {a} {b},
-     (c -> a -> c) -> (c -> b -> c) -> c -> Constant a b -> c :=
-  fun {c} {a} {b} =>
-    fun f g z t =>
-      Data.SemigroupInternal.appEndo (Data.SemigroupInternal.getDual
-                                      (Bifoldable__Constant_bifoldMap (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
-                                                                       (Data.SemigroupInternal.Mk_Endo GHC.Base.∘
-                                                                        GHC.Base.flip f))
-                                       (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
-                                        (Data.SemigroupInternal.Mk_Endo GHC.Base.∘ GHC.Base.flip g)) t)) z.
-
-Local Definition Bifoldable__Constant_bifoldr
-   : forall {a} {c} {b},
-     (a -> c -> c) -> (b -> c -> c) -> c -> Constant a b -> c :=
-  fun {a} {c} {b} =>
-    fun f g z t =>
-      Data.SemigroupInternal.appEndo (Bifoldable__Constant_bifoldMap
-                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo f)
-                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo g) t) z.
-
-Program Instance Bifoldable__Constant : Data.Bifoldable.Bifoldable Constant :=
-  fun _ k__ =>
-    k__ {| Data.Bifoldable.bifold__ := fun {m} `{GHC.Base.Monoid m} =>
-             Bifoldable__Constant_bifold ;
-           Data.Bifoldable.bifoldMap__ := fun {m} {a} {b} `{GHC.Base.Monoid m} =>
-             Bifoldable__Constant_bifoldMap ;
-           Data.Bifoldable.bifoldl__ := fun {c} {a} {b} => Bifoldable__Constant_bifoldl ;
-           Data.Bifoldable.bifoldr__ := fun {a} {c} {b} => Bifoldable__Constant_bifoldr |}.
-
-Local Definition Bifunctor__Constant_first
-   : forall {a} {b} {c}, (a -> b) -> Constant a c -> Constant b c :=
-  fun {a} {b} {c} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, Mk_Constant x => Mk_Constant (f x)
-      end.
-
-Local Definition Bifunctor__Constant_second
-   : forall {b} {c} {a}, (b -> c) -> Constant a b -> Constant a c :=
-  fun {b} {c} {a} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | _, Mk_Constant x => Mk_Constant x
-      end.
-
-Local Definition Bifunctor__Constant_bimap
+Local Definition Eq2__Constant_liftEq2
    : forall {a} {b} {c} {d},
-     (a -> b) -> (c -> d) -> Constant a c -> Constant b d :=
+     (a -> b -> bool) -> (c -> d -> bool) -> Constant a c -> Constant b d -> bool :=
   fun {a} {b} {c} {d} =>
-    fun f g => Bifunctor__Constant_first f GHC.Base.∘ Bifunctor__Constant_second g.
-
-Program Instance Bifunctor__Constant : Data.Bifunctor.Bifunctor Constant :=
-  fun _ k__ =>
-    k__ {| Data.Bifunctor.bimap__ := fun {a} {b} {c} {d} =>
-             Bifunctor__Constant_bimap ;
-           Data.Bifunctor.first__ := fun {a} {b} {c} => Bifunctor__Constant_first ;
-           Data.Bifunctor.second__ := fun {b} {c} {a} => Bifunctor__Constant_second |}.
-
-Program Instance Bitraversable__Constant
-   : Data.Bitraversable.Bitraversable Constant :=
-  fun _ k__ =>
-    k__ {| Data.Bitraversable.bitraverse__ := fun {f}
-           {a}
-           {c}
-           {b}
-           {d}
-           `{GHC.Base.Applicative f} =>
-             Bitraversable__Constant_bitraverse |}.
-
-Local Definition Semigroup__Constant_op_zlzlzgzg__ {inst_a} {inst_b}
-  `{(GHC.Base.Semigroup inst_a)}
-   : (Constant inst_a inst_b) ->
-     (Constant inst_a inst_b) -> (Constant inst_a inst_b) :=
-  fun arg_0__ arg_1__ =>
-    match arg_0__, arg_1__ with
-    | Mk_Constant x, Mk_Constant y => Mk_Constant (x GHC.Base.<<>> y)
-    end.
-
-Program Instance Semigroup__Constant {a} {b} `{(GHC.Base.Semigroup a)}
-   : GHC.Base.Semigroup (Constant a b) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__Constant_op_zlzlzgzg__ |}.
-
-Local Definition Monoid__Constant_mappend {inst_a} {inst_b} `{(GHC.Base.Monoid
-   inst_a)}
-   : (Constant inst_a inst_b) ->
-     (Constant inst_a inst_b) -> (Constant inst_a inst_b) :=
-  _GHC.Base.<<>>_.
-
-Local Definition Monoid__Constant_mempty {inst_a} {inst_b} `{(GHC.Base.Monoid
-   inst_a)}
-   : (Constant inst_a inst_b) :=
-  Mk_Constant GHC.Base.mempty.
-
-Local Definition Monoid__Constant_mconcat {inst_a} {inst_b} `{(GHC.Base.Monoid
-   inst_a)}
-   : list (Constant inst_a inst_b) -> (Constant inst_a inst_b) :=
-  GHC.Base.foldr Monoid__Constant_mappend Monoid__Constant_mempty.
-
-Program Instance Monoid__Constant {a} {b} `{(GHC.Base.Monoid a)}
-   : GHC.Base.Monoid (Constant a b) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.mappend__ := Monoid__Constant_mappend ;
-           GHC.Base.mconcat__ := Monoid__Constant_mconcat ;
-           GHC.Base.mempty__ := Monoid__Constant_mempty |}.
-
-Local Definition Applicative__Constant_op_zlztzg__ {inst_a} `{(GHC.Base.Monoid
-   inst_a)}
-   : forall {a} {b},
-     (Constant inst_a) (a -> b) -> (Constant inst_a) a -> (Constant inst_a) b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | Mk_Constant x, Mk_Constant y => Mk_Constant (GHC.Base.mappend x y)
+    fun arg_0__ arg_1__ arg_2__ arg_3__ =>
+      match arg_0__, arg_1__, arg_2__, arg_3__ with
+      | eq, _, Mk_Constant x, Mk_Constant y => eq x y
       end.
+
+Program Instance Eq2__Constant : Data.Functor.Classes.Eq2 Constant :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftEq2__ := fun {a} {b} {c} {d} =>
+             Eq2__Constant_liftEq2 |}.
+
+Local Definition Ord2__Constant_liftCompare2
+   : forall {a} {b} {c} {d},
+     (a -> b -> comparison) ->
+     (c -> d -> comparison) -> Constant a c -> Constant b d -> comparison :=
+  fun {a} {b} {c} {d} =>
+    fun arg_0__ arg_1__ arg_2__ arg_3__ =>
+      match arg_0__, arg_1__, arg_2__, arg_3__ with
+      | comp, _, Mk_Constant x, Mk_Constant y => comp x y
+      end.
+
+Program Instance Ord2__Constant : Data.Functor.Classes.Ord2 Constant :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftCompare2__ := fun {a} {b} {c} {d} =>
+             Ord2__Constant_liftCompare2 |}.
+
+(* Skipping all instances of class `Data.Functor.Classes.Read2', including
+   `Data.Functor.Constant.Read2__Constant' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Show2', including
+   `Data.Functor.Constant.Show2__Constant' *)
+
+Local Definition Eq1__Constant_liftEq {inst_a} `{(GHC.Base.Eq_ inst_a)}
+   : forall {a} {b},
+     (a -> b -> bool) -> (Constant inst_a) a -> (Constant inst_a) b -> bool :=
+  fun {a} {b} => Data.Functor.Classes.liftEq2 _GHC.Base.==_.
+
+Program Instance Eq1__Constant {a} `{(GHC.Base.Eq_ a)}
+   : Data.Functor.Classes.Eq1 (Constant a) :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__Constant_liftEq |}.
+
+Local Definition Ord1__Constant_liftCompare {inst_a} `{(GHC.Base.Ord inst_a)}
+   : forall {a} {b},
+     (a -> b -> comparison) ->
+     (Constant inst_a) a -> (Constant inst_a) b -> comparison :=
+  fun {a} {b} => Data.Functor.Classes.liftCompare2 GHC.Base.compare.
+
+Program Instance Ord1__Constant {a} `{(GHC.Base.Ord a)}
+   : Data.Functor.Classes.Ord1 (Constant a) :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
+             Ord1__Constant_liftCompare |}.
+
+(* Skipping all instances of class `Data.Functor.Classes.Read1', including
+   `Data.Functor.Constant.Read1__Constant' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Show1', including
+   `Data.Functor.Constant.Show1__Constant' *)
 
 Local Definition Functor__Constant_fmap {inst_a}
    : forall {a} {b}, (a -> b) -> (Constant inst_a) a -> (Constant inst_a) b :=
@@ -276,62 +204,6 @@ Program Instance Functor__Constant {a} : GHC.Base.Functor (Constant a) :=
   fun _ k__ =>
     k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Constant_fmap ;
            GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Constant_op_zlzd__ |}.
-
-Local Definition Applicative__Constant_liftA2 {inst_a} `{(GHC.Base.Monoid
-   inst_a)}
-   : forall {a} {b} {c},
-     (a -> b -> c) ->
-     (Constant inst_a) a -> (Constant inst_a) b -> (Constant inst_a) c :=
-  fun {a} {b} {c} =>
-    fun f x => Applicative__Constant_op_zlztzg__ (GHC.Base.fmap f x).
-
-Local Definition Applicative__Constant_op_ztzg__ {inst_a} `{(GHC.Base.Monoid
-   inst_a)}
-   : forall {a} {b},
-     (Constant inst_a) a -> (Constant inst_a) b -> (Constant inst_a) b :=
-  fun {a} {b} =>
-    fun a1 a2 => Applicative__Constant_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
-
-Local Definition Applicative__Constant_pure {inst_a} `{(GHC.Base.Monoid inst_a)}
-   : forall {a}, a -> (Constant inst_a) a :=
-  fun {a} => fun arg_0__ => Mk_Constant GHC.Base.mempty.
-
-Program Instance Applicative__Constant {a} `{(GHC.Base.Monoid a)}
-   : GHC.Base.Applicative (Constant a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Constant_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Constant_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Constant_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__Constant_pure |}.
-
-Local Definition Traversable__Constant_traverse {inst_a}
-   : forall {f} {a} {b},
-     forall `{GHC.Base.Applicative f},
-     (a -> f b) -> (Constant inst_a) a -> f ((Constant inst_a) b) :=
-  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | _, Mk_Constant x => GHC.Base.pure (Mk_Constant x)
-      end.
-
-Local Definition Traversable__Constant_mapM {inst_a}
-   : forall {m} {a} {b},
-     forall `{GHC.Base.Monad m},
-     (a -> m b) -> (Constant inst_a) a -> m ((Constant inst_a) b) :=
-  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Constant_traverse.
-
-Local Definition Traversable__Constant_sequenceA {inst_a}
-   : forall {f} {a},
-     forall `{GHC.Base.Applicative f},
-     (Constant inst_a) (f a) -> f ((Constant inst_a) a) :=
-  fun {f} {a} `{GHC.Base.Applicative f} =>
-    Traversable__Constant_traverse GHC.Base.id.
-
-Local Definition Traversable__Constant_sequence {inst_a}
-   : forall {m} {a},
-     forall `{GHC.Base.Monad m},
-     (Constant inst_a) (m a) -> m ((Constant inst_a) a) :=
-  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Constant_sequenceA.
 
 Local Definition Foldable__Constant_foldMap {inst_a}
    : forall {m} {a},
@@ -418,6 +290,35 @@ Program Instance Foldable__Constant {a} : Data.Foldable.Foldable (Constant a) :=
            Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Constant_sum ;
            Data.Foldable.toList__ := fun {a} => Foldable__Constant_toList |}.
 
+Local Definition Traversable__Constant_traverse {inst_a}
+   : forall {f} {a} {b},
+     forall `{GHC.Base.Applicative f},
+     (a -> f b) -> (Constant inst_a) a -> f ((Constant inst_a) b) :=
+  fun {f} {a} {b} `{GHC.Base.Applicative f} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | _, Mk_Constant x => GHC.Base.pure (Mk_Constant x)
+      end.
+
+Local Definition Traversable__Constant_mapM {inst_a}
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monad m},
+     (a -> m b) -> (Constant inst_a) a -> m ((Constant inst_a) b) :=
+  fun {m} {a} {b} `{GHC.Base.Monad m} => Traversable__Constant_traverse.
+
+Local Definition Traversable__Constant_sequenceA {inst_a}
+   : forall {f} {a},
+     forall `{GHC.Base.Applicative f},
+     (Constant inst_a) (f a) -> f ((Constant inst_a) a) :=
+  fun {f} {a} `{GHC.Base.Applicative f} =>
+    Traversable__Constant_traverse GHC.Base.id.
+
+Local Definition Traversable__Constant_sequence {inst_a}
+   : forall {m} {a},
+     forall `{GHC.Base.Monad m},
+     (Constant inst_a) (m a) -> m ((Constant inst_a) a) :=
+  fun {m} {a} `{GHC.Base.Monad m} => Traversable__Constant_sequenceA.
+
 Program Instance Traversable__Constant {a}
    : Data.Traversable.Traversable (Constant a) :=
   fun _ k__ =>
@@ -430,74 +331,173 @@ Program Instance Traversable__Constant {a}
            Data.Traversable.traverse__ := fun {f} {a} {b} `{GHC.Base.Applicative f} =>
              Traversable__Constant_traverse |}.
 
-(* Skipping all instances of class `Data.Functor.Classes.Show1', including
-   `Data.Functor.Constant.Show1__Constant' *)
+Local Definition Semigroup__Constant_op_zlzlzgzg__ {inst_a} {inst_b}
+  `{(GHC.Base.Semigroup inst_a)}
+   : (Constant inst_a inst_b) ->
+     (Constant inst_a inst_b) -> (Constant inst_a inst_b) :=
+  fun arg_0__ arg_1__ =>
+    match arg_0__, arg_1__ with
+    | Mk_Constant x, Mk_Constant y => Mk_Constant (x GHC.Base.<<>> y)
+    end.
 
-(* Skipping all instances of class `Data.Functor.Classes.Read1', including
-   `Data.Functor.Constant.Read1__Constant' *)
+Program Instance Semigroup__Constant {a} {b} `{(GHC.Base.Semigroup a)}
+   : GHC.Base.Semigroup (Constant a b) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zlzlzgzg____ := Semigroup__Constant_op_zlzlzgzg__ |}.
 
-Local Definition Ord2__Constant_liftCompare2
-   : forall {a} {b} {c} {d},
-     (a -> b -> comparison) ->
-     (c -> d -> comparison) -> Constant a c -> Constant b d -> comparison :=
-  fun {a} {b} {c} {d} =>
-    fun arg_0__ arg_1__ arg_2__ arg_3__ =>
-      match arg_0__, arg_1__, arg_2__, arg_3__ with
-      | comp, _, Mk_Constant x, Mk_Constant y => comp x y
+Local Definition Applicative__Constant_op_zlztzg__ {inst_a} `{(GHC.Base.Monoid
+   inst_a)}
+   : forall {a} {b},
+     (Constant inst_a) (a -> b) -> (Constant inst_a) a -> (Constant inst_a) b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | Mk_Constant x, Mk_Constant y => Mk_Constant (GHC.Base.mappend x y)
       end.
 
-Local Definition Eq2__Constant_liftEq2
-   : forall {a} {b} {c} {d},
-     (a -> b -> bool) -> (c -> d -> bool) -> Constant a c -> Constant b d -> bool :=
-  fun {a} {b} {c} {d} =>
-    fun arg_0__ arg_1__ arg_2__ arg_3__ =>
-      match arg_0__, arg_1__, arg_2__, arg_3__ with
-      | eq, _, Mk_Constant x, Mk_Constant y => eq x y
+Local Definition Applicative__Constant_liftA2 {inst_a} `{(GHC.Base.Monoid
+   inst_a)}
+   : forall {a} {b} {c},
+     (a -> b -> c) ->
+     (Constant inst_a) a -> (Constant inst_a) b -> (Constant inst_a) c :=
+  fun {a} {b} {c} =>
+    fun f x => Applicative__Constant_op_zlztzg__ (GHC.Base.fmap f x).
+
+Local Definition Applicative__Constant_op_ztzg__ {inst_a} `{(GHC.Base.Monoid
+   inst_a)}
+   : forall {a} {b},
+     (Constant inst_a) a -> (Constant inst_a) b -> (Constant inst_a) b :=
+  fun {a} {b} =>
+    fun a1 a2 => Applicative__Constant_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
+
+Local Definition Applicative__Constant_pure {inst_a} `{(GHC.Base.Monoid inst_a)}
+   : forall {a}, a -> (Constant inst_a) a :=
+  fun {a} => fun arg_0__ => Mk_Constant GHC.Base.mempty.
+
+Program Instance Applicative__Constant {a} `{(GHC.Base.Monoid a)}
+   : GHC.Base.Applicative (Constant a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Constant_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Constant_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Constant_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__Constant_pure |}.
+
+Local Definition Monoid__Constant_mappend {inst_a} {inst_b} `{(GHC.Base.Monoid
+   inst_a)}
+   : (Constant inst_a inst_b) ->
+     (Constant inst_a inst_b) -> (Constant inst_a inst_b) :=
+  _GHC.Base.<<>>_.
+
+Local Definition Monoid__Constant_mempty {inst_a} {inst_b} `{(GHC.Base.Monoid
+   inst_a)}
+   : (Constant inst_a inst_b) :=
+  Mk_Constant GHC.Base.mempty.
+
+Local Definition Monoid__Constant_mconcat {inst_a} {inst_b} `{(GHC.Base.Monoid
+   inst_a)}
+   : list (Constant inst_a inst_b) -> (Constant inst_a inst_b) :=
+  GHC.Base.foldr Monoid__Constant_mappend Monoid__Constant_mempty.
+
+Program Instance Monoid__Constant {a} {b} `{(GHC.Base.Monoid a)}
+   : GHC.Base.Monoid (Constant a b) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.mappend__ := Monoid__Constant_mappend ;
+           GHC.Base.mconcat__ := Monoid__Constant_mconcat ;
+           GHC.Base.mempty__ := Monoid__Constant_mempty |}.
+
+Local Definition Bifunctor__Constant_first
+   : forall {a} {b} {c}, (a -> b) -> Constant a c -> Constant b c :=
+  fun {a} {b} {c} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, Mk_Constant x => Mk_Constant (f x)
       end.
 
-Program Instance Eq2__Constant : Data.Functor.Classes.Eq2 Constant :=
+Local Definition Bifunctor__Constant_second
+   : forall {b} {c} {a}, (b -> c) -> Constant a b -> Constant a c :=
+  fun {b} {c} {a} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | _, Mk_Constant x => Mk_Constant x
+      end.
+
+Local Definition Bifunctor__Constant_bimap
+   : forall {a} {b} {c} {d},
+     (a -> b) -> (c -> d) -> Constant a c -> Constant b d :=
+  fun {a} {b} {c} {d} =>
+    fun f g => Bifunctor__Constant_first f GHC.Base.∘ Bifunctor__Constant_second g.
+
+Program Instance Bifunctor__Constant : Data.Bifunctor.Bifunctor Constant :=
   fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftEq2__ := fun {a} {b} {c} {d} =>
-             Eq2__Constant_liftEq2 |}.
+    k__ {| Data.Bifunctor.bimap__ := fun {a} {b} {c} {d} =>
+             Bifunctor__Constant_bimap ;
+           Data.Bifunctor.first__ := fun {a} {b} {c} => Bifunctor__Constant_first ;
+           Data.Bifunctor.second__ := fun {b} {c} {a} => Bifunctor__Constant_second |}.
 
-Program Instance Ord2__Constant : Data.Functor.Classes.Ord2 Constant :=
+Local Definition Bifoldable__Constant_bifoldMap
+   : forall {m} {a} {b},
+     forall `{GHC.Base.Monoid m}, (a -> m) -> (b -> m) -> Constant a b -> m :=
+  fun {m} {a} {b} `{GHC.Base.Monoid m} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | f, _, Mk_Constant a => f a
+      end.
+
+Local Definition Bifoldable__Constant_bifold
+   : forall {m}, forall `{GHC.Base.Monoid m}, Constant m m -> m :=
+  fun {m} `{GHC.Base.Monoid m} =>
+    Bifoldable__Constant_bifoldMap GHC.Base.id GHC.Base.id.
+
+Local Definition Bifoldable__Constant_bifoldl
+   : forall {c} {a} {b},
+     (c -> a -> c) -> (c -> b -> c) -> c -> Constant a b -> c :=
+  fun {c} {a} {b} =>
+    fun f g z t =>
+      Data.SemigroupInternal.appEndo (Data.SemigroupInternal.getDual
+                                      (Bifoldable__Constant_bifoldMap (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
+                                                                       (Data.SemigroupInternal.Mk_Endo GHC.Base.∘
+                                                                        GHC.Base.flip f))
+                                       (Data.SemigroupInternal.Mk_Dual GHC.Base.∘
+                                        (Data.SemigroupInternal.Mk_Endo GHC.Base.∘ GHC.Base.flip g)) t)) z.
+
+Local Definition Bifoldable__Constant_bifoldr
+   : forall {a} {c} {b},
+     (a -> c -> c) -> (b -> c -> c) -> c -> Constant a b -> c :=
+  fun {a} {c} {b} =>
+    fun f g z t =>
+      Data.SemigroupInternal.appEndo (Bifoldable__Constant_bifoldMap
+                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo f)
+                                      (Coq.Program.Basics.compose Data.SemigroupInternal.Mk_Endo g) t) z.
+
+Program Instance Bifoldable__Constant : Data.Bifoldable.Bifoldable Constant :=
   fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftCompare2__ := fun {a} {b} {c} {d} =>
-             Ord2__Constant_liftCompare2 |}.
+    k__ {| Data.Bifoldable.bifold__ := fun {m} `{GHC.Base.Monoid m} =>
+             Bifoldable__Constant_bifold ;
+           Data.Bifoldable.bifoldMap__ := fun {m} {a} {b} `{GHC.Base.Monoid m} =>
+             Bifoldable__Constant_bifoldMap ;
+           Data.Bifoldable.bifoldl__ := fun {c} {a} {b} => Bifoldable__Constant_bifoldl ;
+           Data.Bifoldable.bifoldr__ := fun {a} {c} {b} => Bifoldable__Constant_bifoldr |}.
 
-Local Definition Ord1__Constant_liftCompare {inst_a} `{(GHC.Base.Ord inst_a)}
-   : forall {a} {b},
-     (a -> b -> comparison) ->
-     (Constant inst_a) a -> (Constant inst_a) b -> comparison :=
-  fun {a} {b} => Data.Functor.Classes.liftCompare2 GHC.Base.compare.
+Local Definition Bitraversable__Constant_bitraverse
+   : forall {f} {a} {c} {b} {d},
+     forall `{GHC.Base.Applicative f},
+     (a -> f c) -> (b -> f d) -> Constant a b -> f (Constant c d) :=
+  fun {f} {a} {c} {b} {d} `{GHC.Base.Applicative f} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | f, _, Mk_Constant a => Mk_Constant Data.Functor.<$> f a
+      end.
 
-Local Definition Eq1__Constant_liftEq {inst_a} `{(GHC.Base.Eq_ inst_a)}
-   : forall {a} {b},
-     (a -> b -> bool) -> (Constant inst_a) a -> (Constant inst_a) b -> bool :=
-  fun {a} {b} => Data.Functor.Classes.liftEq2 _GHC.Base.==_.
-
-Program Instance Eq1__Constant {a} `{(GHC.Base.Eq_ a)}
-   : Data.Functor.Classes.Eq1 (Constant a) :=
+Program Instance Bitraversable__Constant
+   : Data.Bitraversable.Bitraversable Constant :=
   fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__Constant_liftEq |}.
-
-Program Instance Ord1__Constant {a} `{(GHC.Base.Ord a)}
-   : Data.Functor.Classes.Ord1 (Constant a) :=
-  fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
-             Ord1__Constant_liftCompare |}.
-
-(* Skipping all instances of class `Data.Functor.Classes.Show2', including
-   `Data.Functor.Constant.Show2__Constant' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Read2', including
-   `Data.Functor.Constant.Read2__Constant' *)
-
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Data.Functor.Constant.Show__Constant' *)
-
-(* Skipping all instances of class `GHC.Read.Read', including
-   `Data.Functor.Constant.Read__Constant' *)
+    k__ {| Data.Bitraversable.bitraverse__ := fun {f}
+           {a}
+           {c}
+           {b}
+           {d}
+           `{GHC.Base.Applicative f} =>
+             Bitraversable__Constant_bitraverse |}.
 
 (* External variables:
      Type bool comparison list true Coq.Program.Basics.compose

--- a/examples/transformers/lib/Data/Functor/Reverse.v
+++ b/examples/transformers/lib/Data/Functor/Reverse.v
@@ -34,8 +34,210 @@ Definition getReverse {f : Type -> Type} {a : Type} (arg_0__ : Reverse f a) :=
 
 (* Converted value declarations: *)
 
-(* Skipping instance `Data.Functor.Reverse.Traversable__Reverse' of class
-   `Data.Traversable.Traversable' *)
+Local Definition Eq1__Reverse_liftEq {inst_f} `{(Data.Functor.Classes.Eq1
+   inst_f)}
+   : forall {a} {b},
+     (a -> b -> bool) -> (Reverse inst_f) a -> (Reverse inst_f) b -> bool :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | eq, Mk_Reverse x, Mk_Reverse y => Data.Functor.Classes.liftEq eq x y
+      end.
+
+Program Instance Eq1__Reverse {f} `{(Data.Functor.Classes.Eq1 f)}
+   : Data.Functor.Classes.Eq1 (Reverse f) :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__Reverse_liftEq |}.
+
+Local Definition Ord1__Reverse_liftCompare {inst_f} `{(Data.Functor.Classes.Ord1
+   inst_f)}
+   : forall {a} {b},
+     (a -> b -> comparison) ->
+     (Reverse inst_f) a -> (Reverse inst_f) b -> comparison :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ arg_2__ =>
+      match arg_0__, arg_1__, arg_2__ with
+      | comp, Mk_Reverse x, Mk_Reverse y => Data.Functor.Classes.liftCompare comp x y
+      end.
+
+Program Instance Ord1__Reverse {f} `{(Data.Functor.Classes.Ord1 f)}
+   : Data.Functor.Classes.Ord1 (Reverse f) :=
+  fun _ k__ =>
+    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
+             Ord1__Reverse_liftCompare |}.
+
+(* Skipping all instances of class `Data.Functor.Classes.Read1', including
+   `Data.Functor.Reverse.Read1__Reverse' *)
+
+(* Skipping all instances of class `Data.Functor.Classes.Show1', including
+   `Data.Functor.Reverse.Show1__Reverse' *)
+
+Local Definition Eq___Reverse_op_zeze__ {inst_f} {inst_a}
+  `{Data.Functor.Classes.Eq1 inst_f} `{GHC.Base.Eq_ inst_a}
+   : (Reverse inst_f inst_a) -> (Reverse inst_f inst_a) -> bool :=
+  Data.Functor.Classes.eq1.
+
+Local Definition Eq___Reverse_op_zsze__ {inst_f} {inst_a}
+  `{Data.Functor.Classes.Eq1 inst_f} `{GHC.Base.Eq_ inst_a}
+   : (Reverse inst_f inst_a) -> (Reverse inst_f inst_a) -> bool :=
+  fun x y => negb (Eq___Reverse_op_zeze__ x y).
+
+Program Instance Eq___Reverse {f} {a} `{Data.Functor.Classes.Eq1 f}
+  `{GHC.Base.Eq_ a}
+   : GHC.Base.Eq_ (Reverse f a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zeze____ := Eq___Reverse_op_zeze__ ;
+           GHC.Base.op_zsze____ := Eq___Reverse_op_zsze__ |}.
+
+Local Definition Ord__Reverse_compare {inst_f} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
+   : (Reverse inst_f inst_a) -> (Reverse inst_f inst_a) -> comparison :=
+  Data.Functor.Classes.compare1.
+
+Local Definition Ord__Reverse_op_zl__ {inst_f} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
+   : (Reverse inst_f inst_a) -> (Reverse inst_f inst_a) -> bool :=
+  fun x y => Ord__Reverse_compare x y GHC.Base.== Lt.
+
+Local Definition Ord__Reverse_op_zlze__ {inst_f} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
+   : (Reverse inst_f inst_a) -> (Reverse inst_f inst_a) -> bool :=
+  fun x y => Ord__Reverse_compare x y GHC.Base./= Gt.
+
+Local Definition Ord__Reverse_op_zg__ {inst_f} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
+   : (Reverse inst_f inst_a) -> (Reverse inst_f inst_a) -> bool :=
+  fun x y => Ord__Reverse_compare x y GHC.Base.== Gt.
+
+Local Definition Ord__Reverse_op_zgze__ {inst_f} {inst_a}
+  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
+   : (Reverse inst_f inst_a) -> (Reverse inst_f inst_a) -> bool :=
+  fun x y => Ord__Reverse_compare x y GHC.Base./= Lt.
+
+Local Definition Ord__Reverse_max {inst_f} {inst_a} `{Data.Functor.Classes.Ord1
+  inst_f} `{GHC.Base.Ord inst_a}
+   : (Reverse inst_f inst_a) ->
+     (Reverse inst_f inst_a) -> (Reverse inst_f inst_a) :=
+  fun x y => if Ord__Reverse_op_zlze__ x y : bool then y else x.
+
+Local Definition Ord__Reverse_min {inst_f} {inst_a} `{Data.Functor.Classes.Ord1
+  inst_f} `{GHC.Base.Ord inst_a}
+   : (Reverse inst_f inst_a) ->
+     (Reverse inst_f inst_a) -> (Reverse inst_f inst_a) :=
+  fun x y => if Ord__Reverse_op_zlze__ x y : bool then x else y.
+
+Program Instance Ord__Reverse {f} {a} `{Data.Functor.Classes.Ord1 f}
+  `{GHC.Base.Ord a}
+   : GHC.Base.Ord (Reverse f a) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zl____ := Ord__Reverse_op_zl__ ;
+           GHC.Base.op_zlze____ := Ord__Reverse_op_zlze__ ;
+           GHC.Base.op_zg____ := Ord__Reverse_op_zg__ ;
+           GHC.Base.op_zgze____ := Ord__Reverse_op_zgze__ ;
+           GHC.Base.compare__ := Ord__Reverse_compare ;
+           GHC.Base.max__ := Ord__Reverse_max ;
+           GHC.Base.min__ := Ord__Reverse_min |}.
+
+(* Skipping all instances of class `GHC.Read.Read', including
+   `Data.Functor.Reverse.Read__Reverse' *)
+
+(* Skipping all instances of class `GHC.Show.Show', including
+   `Data.Functor.Reverse.Show__Reverse' *)
+
+Local Definition Functor__Reverse_fmap {inst_f} `{(GHC.Base.Functor inst_f)}
+   : forall {a} {b}, (a -> b) -> (Reverse inst_f) a -> (Reverse inst_f) b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | f, Mk_Reverse a => Mk_Reverse (GHC.Base.fmap f a)
+      end.
+
+Local Definition Functor__Reverse_op_zlzd__ {inst_f} `{(GHC.Base.Functor
+   inst_f)}
+   : forall {a} {b}, a -> (Reverse inst_f) b -> (Reverse inst_f) a :=
+  fun {a} {b} => Functor__Reverse_fmap GHC.Base.∘ GHC.Base.const.
+
+Program Instance Functor__Reverse {f} `{(GHC.Base.Functor f)}
+   : GHC.Base.Functor (Reverse f) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Reverse_fmap ;
+           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Reverse_op_zlzd__ |}.
+
+Local Definition Applicative__Reverse_op_zlztzg__ {inst_f}
+  `{(GHC.Base.Applicative inst_f)}
+   : forall {a} {b},
+     (Reverse inst_f) (a -> b) -> (Reverse inst_f) a -> (Reverse inst_f) b :=
+  fun {a} {b} =>
+    fun arg_0__ arg_1__ =>
+      match arg_0__, arg_1__ with
+      | Mk_Reverse f, Mk_Reverse a => Mk_Reverse (f GHC.Base.<*> a)
+      end.
+
+Local Definition Applicative__Reverse_liftA2 {inst_f} `{(GHC.Base.Applicative
+   inst_f)}
+   : forall {a} {b} {c},
+     (a -> b -> c) ->
+     (Reverse inst_f) a -> (Reverse inst_f) b -> (Reverse inst_f) c :=
+  fun {a} {b} {c} =>
+    fun f x => Applicative__Reverse_op_zlztzg__ (GHC.Base.fmap f x).
+
+Local Definition Applicative__Reverse_op_ztzg__ {inst_f} `{(GHC.Base.Applicative
+   inst_f)}
+   : forall {a} {b},
+     (Reverse inst_f) a -> (Reverse inst_f) b -> (Reverse inst_f) b :=
+  fun {a} {b} =>
+    fun a1 a2 => Applicative__Reverse_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
+
+Local Definition Applicative__Reverse_pure {inst_f} `{(GHC.Base.Applicative
+   inst_f)}
+   : forall {a}, a -> (Reverse inst_f) a :=
+  fun {a} => fun a => Mk_Reverse (GHC.Base.pure a).
+
+Program Instance Applicative__Reverse {f} `{(GHC.Base.Applicative f)}
+   : GHC.Base.Applicative (Reverse f) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Reverse_liftA2 ;
+           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Reverse_op_zlztzg__ ;
+           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Reverse_op_ztzg__ ;
+           GHC.Base.pure__ := fun {a} => Applicative__Reverse_pure |}.
+
+(* Skipping all instances of class `GHC.Base.Alternative', including
+   `Data.Functor.Reverse.Alternative__Reverse' *)
+
+Local Definition Monad__Reverse_op_zgzgze__ {inst_m} `{(GHC.Base.Monad inst_m)}
+   : forall {a} {b},
+     (Reverse inst_m) a -> (a -> (Reverse inst_m) b) -> (Reverse inst_m) b :=
+  fun {a} {b} =>
+    fun m f => Mk_Reverse (getReverse m GHC.Base.>>= (getReverse GHC.Base.∘ f)).
+
+Local Definition Monad__Reverse_op_zgzg__ {inst_m} `{(GHC.Base.Monad inst_m)}
+   : forall {a} {b},
+     (Reverse inst_m) a -> (Reverse inst_m) b -> (Reverse inst_m) b :=
+  fun {a} {b} => fun m k => Monad__Reverse_op_zgzgze__ m (fun arg_0__ => k).
+
+Local Definition Monad__Reverse_return_ {inst_m} `{(GHC.Base.Monad inst_m)}
+   : forall {a}, a -> (Reverse inst_m) a :=
+  fun {a} => GHC.Base.pure.
+
+Program Instance Monad__Reverse {m} `{(GHC.Base.Monad m)}
+   : GHC.Base.Monad (Reverse m) :=
+  fun _ k__ =>
+    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Reverse_op_zgzg__ ;
+           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Reverse_op_zgzgze__ ;
+           GHC.Base.return___ := fun {a} => Monad__Reverse_return_ |}.
+
+Local Definition MonadFail__Reverse_fail {inst_m}
+  `{(Control.Monad.Fail.MonadFail inst_m)}
+   : forall {a}, GHC.Base.String -> (Reverse inst_m) a :=
+  fun {a} => fun msg => Mk_Reverse (Control.Monad.Fail.fail msg).
+
+Program Instance MonadFail__Reverse {m} `{(Control.Monad.Fail.MonadFail m)}
+   : Control.Monad.Fail.MonadFail (Reverse m) :=
+  fun _ k__ =>
+    k__ {| Control.Monad.Fail.fail__ := fun {a} => MonadFail__Reverse_fail |}.
+
+(* Skipping all instances of class `GHC.Base.MonadPlus', including
+   `Data.Functor.Reverse.MonadPlus__Reverse' *)
 
 Local Definition Foldable__Reverse_foldMap {inst_f} `{(Data.Foldable.Foldable
    inst_f)}
@@ -136,210 +338,8 @@ Program Instance Foldable__Reverse {f} `{(Data.Foldable.Foldable f)}
            Data.Foldable.sum__ := fun {a} `{GHC.Num.Num a} => Foldable__Reverse_sum ;
            Data.Foldable.toList__ := fun {a} => Foldable__Reverse_toList |}.
 
-(* Skipping all instances of class `GHC.Base.MonadPlus', including
-   `Data.Functor.Reverse.MonadPlus__Reverse' *)
-
-Local Definition MonadFail__Reverse_fail {inst_m}
-  `{(Control.Monad.Fail.MonadFail inst_m)}
-   : forall {a}, GHC.Base.String -> (Reverse inst_m) a :=
-  fun {a} => fun msg => Mk_Reverse (Control.Monad.Fail.fail msg).
-
-Local Definition Monad__Reverse_op_zgzgze__ {inst_m} `{(GHC.Base.Monad inst_m)}
-   : forall {a} {b},
-     (Reverse inst_m) a -> (a -> (Reverse inst_m) b) -> (Reverse inst_m) b :=
-  fun {a} {b} =>
-    fun m f => Mk_Reverse (getReverse m GHC.Base.>>= (getReverse GHC.Base.∘ f)).
-
-Local Definition Applicative__Reverse_op_zlztzg__ {inst_f}
-  `{(GHC.Base.Applicative inst_f)}
-   : forall {a} {b},
-     (Reverse inst_f) (a -> b) -> (Reverse inst_f) a -> (Reverse inst_f) b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | Mk_Reverse f, Mk_Reverse a => Mk_Reverse (f GHC.Base.<*> a)
-      end.
-
-Local Definition Functor__Reverse_fmap {inst_f} `{(GHC.Base.Functor inst_f)}
-   : forall {a} {b}, (a -> b) -> (Reverse inst_f) a -> (Reverse inst_f) b :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ =>
-      match arg_0__, arg_1__ with
-      | f, Mk_Reverse a => Mk_Reverse (GHC.Base.fmap f a)
-      end.
-
-Local Definition Functor__Reverse_op_zlzd__ {inst_f} `{(GHC.Base.Functor
-   inst_f)}
-   : forall {a} {b}, a -> (Reverse inst_f) b -> (Reverse inst_f) a :=
-  fun {a} {b} => Functor__Reverse_fmap GHC.Base.∘ GHC.Base.const.
-
-Program Instance Functor__Reverse {f} `{(GHC.Base.Functor f)}
-   : GHC.Base.Functor (Reverse f) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.fmap__ := fun {a} {b} => Functor__Reverse_fmap ;
-           GHC.Base.op_zlzd____ := fun {a} {b} => Functor__Reverse_op_zlzd__ |}.
-
-Local Definition Applicative__Reverse_liftA2 {inst_f} `{(GHC.Base.Applicative
-   inst_f)}
-   : forall {a} {b} {c},
-     (a -> b -> c) ->
-     (Reverse inst_f) a -> (Reverse inst_f) b -> (Reverse inst_f) c :=
-  fun {a} {b} {c} =>
-    fun f x => Applicative__Reverse_op_zlztzg__ (GHC.Base.fmap f x).
-
-Local Definition Applicative__Reverse_op_ztzg__ {inst_f} `{(GHC.Base.Applicative
-   inst_f)}
-   : forall {a} {b},
-     (Reverse inst_f) a -> (Reverse inst_f) b -> (Reverse inst_f) b :=
-  fun {a} {b} =>
-    fun a1 a2 => Applicative__Reverse_op_zlztzg__ (GHC.Base.id GHC.Base.<$ a1) a2.
-
-Local Definition Applicative__Reverse_pure {inst_f} `{(GHC.Base.Applicative
-   inst_f)}
-   : forall {a}, a -> (Reverse inst_f) a :=
-  fun {a} => fun a => Mk_Reverse (GHC.Base.pure a).
-
-Program Instance Applicative__Reverse {f} `{(GHC.Base.Applicative f)}
-   : GHC.Base.Applicative (Reverse f) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.liftA2__ := fun {a} {b} {c} => Applicative__Reverse_liftA2 ;
-           GHC.Base.op_zlztzg____ := fun {a} {b} => Applicative__Reverse_op_zlztzg__ ;
-           GHC.Base.op_ztzg____ := fun {a} {b} => Applicative__Reverse_op_ztzg__ ;
-           GHC.Base.pure__ := fun {a} => Applicative__Reverse_pure |}.
-
-Local Definition Monad__Reverse_op_zgzg__ {inst_m} `{(GHC.Base.Monad inst_m)}
-   : forall {a} {b},
-     (Reverse inst_m) a -> (Reverse inst_m) b -> (Reverse inst_m) b :=
-  fun {a} {b} => fun m k => Monad__Reverse_op_zgzgze__ m (fun arg_0__ => k).
-
-Local Definition Monad__Reverse_return_ {inst_m} `{(GHC.Base.Monad inst_m)}
-   : forall {a}, a -> (Reverse inst_m) a :=
-  fun {a} => GHC.Base.pure.
-
-Program Instance Monad__Reverse {m} `{(GHC.Base.Monad m)}
-   : GHC.Base.Monad (Reverse m) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zgzg____ := fun {a} {b} => Monad__Reverse_op_zgzg__ ;
-           GHC.Base.op_zgzgze____ := fun {a} {b} => Monad__Reverse_op_zgzgze__ ;
-           GHC.Base.return___ := fun {a} => Monad__Reverse_return_ |}.
-
-Program Instance MonadFail__Reverse {m} `{(Control.Monad.Fail.MonadFail m)}
-   : Control.Monad.Fail.MonadFail (Reverse m) :=
-  fun _ k__ =>
-    k__ {| Control.Monad.Fail.fail__ := fun {a} => MonadFail__Reverse_fail |}.
-
-(* Skipping all instances of class `GHC.Base.Alternative', including
-   `Data.Functor.Reverse.Alternative__Reverse' *)
-
-(* Skipping all instances of class `GHC.Show.Show', including
-   `Data.Functor.Reverse.Show__Reverse' *)
-
-(* Skipping all instances of class `GHC.Read.Read', including
-   `Data.Functor.Reverse.Read__Reverse' *)
-
-Local Definition Ord1__Reverse_liftCompare {inst_f} `{(Data.Functor.Classes.Ord1
-   inst_f)}
-   : forall {a} {b},
-     (a -> b -> comparison) ->
-     (Reverse inst_f) a -> (Reverse inst_f) b -> comparison :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | comp, Mk_Reverse x, Mk_Reverse y => Data.Functor.Classes.liftCompare comp x y
-      end.
-
-Local Definition Eq1__Reverse_liftEq {inst_f} `{(Data.Functor.Classes.Eq1
-   inst_f)}
-   : forall {a} {b},
-     (a -> b -> bool) -> (Reverse inst_f) a -> (Reverse inst_f) b -> bool :=
-  fun {a} {b} =>
-    fun arg_0__ arg_1__ arg_2__ =>
-      match arg_0__, arg_1__, arg_2__ with
-      | eq, Mk_Reverse x, Mk_Reverse y => Data.Functor.Classes.liftEq eq x y
-      end.
-
-Program Instance Eq1__Reverse {f} `{(Data.Functor.Classes.Eq1 f)}
-   : Data.Functor.Classes.Eq1 (Reverse f) :=
-  fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftEq__ := fun {a} {b} => Eq1__Reverse_liftEq |}.
-
-Program Instance Ord1__Reverse {f} `{(Data.Functor.Classes.Ord1 f)}
-   : Data.Functor.Classes.Ord1 (Reverse f) :=
-  fun _ k__ =>
-    k__ {| Data.Functor.Classes.liftCompare__ := fun {a} {b} =>
-             Ord1__Reverse_liftCompare |}.
-
-Local Definition Ord__Reverse_compare {inst_f} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
-   : (Reverse inst_f inst_a) -> (Reverse inst_f inst_a) -> comparison :=
-  Data.Functor.Classes.compare1.
-
-Local Definition Ord__Reverse_op_zl__ {inst_f} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
-   : (Reverse inst_f inst_a) -> (Reverse inst_f inst_a) -> bool :=
-  fun x y => Ord__Reverse_compare x y GHC.Base.== Lt.
-
-Local Definition Ord__Reverse_op_zlze__ {inst_f} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
-   : (Reverse inst_f inst_a) -> (Reverse inst_f inst_a) -> bool :=
-  fun x y => Ord__Reverse_compare x y GHC.Base./= Gt.
-
-Local Definition Ord__Reverse_op_zg__ {inst_f} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
-   : (Reverse inst_f inst_a) -> (Reverse inst_f inst_a) -> bool :=
-  fun x y => Ord__Reverse_compare x y GHC.Base.== Gt.
-
-Local Definition Ord__Reverse_op_zgze__ {inst_f} {inst_a}
-  `{Data.Functor.Classes.Ord1 inst_f} `{GHC.Base.Ord inst_a}
-   : (Reverse inst_f inst_a) -> (Reverse inst_f inst_a) -> bool :=
-  fun x y => Ord__Reverse_compare x y GHC.Base./= Lt.
-
-Local Definition Ord__Reverse_max {inst_f} {inst_a} `{Data.Functor.Classes.Ord1
-  inst_f} `{GHC.Base.Ord inst_a}
-   : (Reverse inst_f inst_a) ->
-     (Reverse inst_f inst_a) -> (Reverse inst_f inst_a) :=
-  fun x y => if Ord__Reverse_op_zlze__ x y : bool then y else x.
-
-Local Definition Ord__Reverse_min {inst_f} {inst_a} `{Data.Functor.Classes.Ord1
-  inst_f} `{GHC.Base.Ord inst_a}
-   : (Reverse inst_f inst_a) ->
-     (Reverse inst_f inst_a) -> (Reverse inst_f inst_a) :=
-  fun x y => if Ord__Reverse_op_zlze__ x y : bool then x else y.
-
-Local Definition Eq___Reverse_op_zeze__ {inst_f} {inst_a}
-  `{Data.Functor.Classes.Eq1 inst_f} `{GHC.Base.Eq_ inst_a}
-   : (Reverse inst_f inst_a) -> (Reverse inst_f inst_a) -> bool :=
-  Data.Functor.Classes.eq1.
-
-Local Definition Eq___Reverse_op_zsze__ {inst_f} {inst_a}
-  `{Data.Functor.Classes.Eq1 inst_f} `{GHC.Base.Eq_ inst_a}
-   : (Reverse inst_f inst_a) -> (Reverse inst_f inst_a) -> bool :=
-  fun x y => negb (Eq___Reverse_op_zeze__ x y).
-
-Program Instance Eq___Reverse {f} {a} `{Data.Functor.Classes.Eq1 f}
-  `{GHC.Base.Eq_ a}
-   : GHC.Base.Eq_ (Reverse f a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zeze____ := Eq___Reverse_op_zeze__ ;
-           GHC.Base.op_zsze____ := Eq___Reverse_op_zsze__ |}.
-
-Program Instance Ord__Reverse {f} {a} `{Data.Functor.Classes.Ord1 f}
-  `{GHC.Base.Ord a}
-   : GHC.Base.Ord (Reverse f a) :=
-  fun _ k__ =>
-    k__ {| GHC.Base.op_zl____ := Ord__Reverse_op_zl__ ;
-           GHC.Base.op_zlze____ := Ord__Reverse_op_zlze__ ;
-           GHC.Base.op_zg____ := Ord__Reverse_op_zg__ ;
-           GHC.Base.op_zgze____ := Ord__Reverse_op_zgze__ ;
-           GHC.Base.compare__ := Ord__Reverse_compare ;
-           GHC.Base.max__ := Ord__Reverse_max ;
-           GHC.Base.min__ := Ord__Reverse_min |}.
-
-(* Skipping all instances of class `Data.Functor.Classes.Show1', including
-   `Data.Functor.Reverse.Show1__Reverse' *)
-
-(* Skipping all instances of class `Data.Functor.Classes.Read1', including
-   `Data.Functor.Reverse.Read1__Reverse' *)
+(* Skipping instance `Data.Functor.Reverse.Traversable__Reverse' of class
+   `Data.Traversable.Traversable' *)
 
 (* External variables:
      Gt Lt Type bool comparison list negb Control.Monad.Fail.MonadFail

--- a/examples/transformers/module-edits/Control/Monad/Trans/State/Lazy/edits
+++ b/examples/transformers/module-edits/Control/Monad/Trans/State/Lazy/edits
@@ -1,3 +1,4 @@
+order Control.Monad.Trans.State.Lazy.Monad__StateT Control.Monad.Trans.State.Lazy.MonadFail__StateT
 order Control.Monad.Trans.State.Lazy.Monad__StateT            Control.Monad.Trans.State.Lazy.modify'
 order Control.Monad.Trans.State.Lazy.Functor__StateT          Control.Monad.Trans.State.Lazy.Applicative__StateT_liftA2
 order Control.Monad.Trans.State.Lazy.Applicative__StateT      Control.Monad.Trans.State.Lazy.Monad__StateT_return_

--- a/src/lib/HsToCoq/ConvertHaskell/Module.hs
+++ b/src/lib/HsToCoq/ConvertHaskell/Module.hs
@@ -21,11 +21,11 @@ import HsToCoq.Util.Monad
 import Data.Function
 import Data.Maybe
 import Data.List.NonEmpty (NonEmpty (..), fromList)
-import Data.List (partition)
+import Data.List (partition, sortBy)
 import HsToCoq.Util.List
 import HsToCoq.Util.Containers
 
-import Data.Generics
+import Data.Generics (Data, everywhere, mkT)
 
 import Control.Monad.Reader
 
@@ -156,9 +156,7 @@ convertHsGroup HsGroup{..} = do
 #endif
         sigs  <- convertLSigs lsigs `catchIfAxiomatizing` const @_ @SomeException (pure M.empty)
         let convertBinding' !b = (,) (convertedBindingName b) <$> convertBinding sigs b
-        defns <- (convertTypedModuleBindings
-                   (map unLoc $ concatMap (bagToList . snd) binds)
-                   sigs
+        defns <- (convertTypedModuleBindings (concatMap (bagToList . snd) binds) sigs
                    ??
                    handler)
                  convertBinding'
@@ -181,7 +179,14 @@ convertHsGroup HsGroup{..} = do
         pure $ (unnamedSentences ++ (concat (snd <$> namedSentences')),
                 concat (snd <$> promotedSentences))
 
-  convertedClsInstDecls <- convertClsInstDecls [cid | grp <- hs_tyclds, L _ (ClsInstD NOEXTP cid) <- group_instds grp]
+  -- Derived instances have an UnhelpfulSpan, we put those to the top because
+  -- they tend to be self-contained and everything else depends on them.
+  let compareSpan (UnhelpfulSpan _) (UnhelpfulSpan _) = EQ
+      compareSpan (UnhelpfulSpan _) (RealSrcSpan _) = LT
+      compareSpan (RealSrcSpan _) (UnhelpfulSpan _) = GT
+      compareSpan (RealSrcSpan p) (RealSrcSpan q) = compare p q
+  convertedClsInstDecls <- convertClsInstDecls . map unLoc $ sortBy (compareSpan `on` getLoc)
+    [L l cid | grp <- hs_tyclds, L l (ClsInstD NOEXTP cid) <- group_instds grp]
 
   (convertedAddedTyCls,convertedAddedDecls) <- view (edits.additions.at mod.non ([],[]))
 
@@ -362,7 +367,7 @@ moduleDeclarations ConvertedModule{..} = do
 
   orders <- view $ edits.orders
   let sortedDecls = topoSortByVariablesBy bvWithInfix orders $
-        convModValDecls ++ convModClsInstDecls ++ convModAddedDecls
+        convModClsInstDecls ++ convModValDecls ++ convModAddedDecls
   let ax_decls = usedAxioms sortedDecls
   let sortedTyCls = topoSortByVariablesBy bvWithInfix orders $
         convModTyClDecls ++ convModAddedTyCls ++ ax_decls


### PR DESCRIPTION
- Put instances before other definitions
- Fixed a "bug" where definitions were provided in reverse order (because that's how they come out of the renamer).