### PR TITLE
Make edits parser recognize more Coq syntax

### DIFF
--- a/examples/base-src/module-edits/Data/Foldable/edits
+++ b/examples/base-src/module-edits/Data/Foldable/edits
@@ -8,7 +8,7 @@ skip Data.Foldable.maximumBy
 # The default implementation of elem is hard to translate
 # (it recurses through the non-method any)
 # So we remove the method and make the default method simply code
-add Data.Foldable Definition Data.Foldable.elem {f} `{(Foldable f)} {a} `{(GHC.Base.Eq_ a)} :
+add Data.Foldable Definition Data.Foldable.elem {f} `{Foldable f} {a} `{GHC.Base.Eq_ a} :
   a -> ((f a) -> bool) :=
   fun x xs => Data.Foldable.any (fun y => x GHC.Base.== y) xs.
 
@@ -31,7 +31,7 @@ redefine Local Definition Data.Foldable.Foldable__NonEmpty_elem
 
 # Coq’s type class inference does not find the right instance
 # Why?
-redefine Definition Data.Foldable.concat {t} {a} `{(Foldable t)} : (t (list a)) -> (list a) :=
+redefine Definition Data.Foldable.concat {t} {a} `{Foldable t} : (t (list a)) -> (list a) :=
   fun xs =>
     GHC.Base.build' (fun _ => (fun c n => foldr (fun x y => @foldr _ Foldable__list _ _  c y x) n xs)).
 

--- a/examples/base-src/module-edits/Data/Functor/Const/edits
+++ b/examples/base-src/module-edits/Data/Functor/Const/edits
@@ -2,7 +2,7 @@ add Data.Functor.Const Instance Unpeel_Const a b : GHC.Prim.Unpeel (Const a b) a
 
 # Avoid wrong type variable names in argument to coerce
 # TODO: ScopedTypeVariables
-redefine Local Definition Data.Functor.Const.Applicative__Const_op_zlztzg__ {inst_m} `{(GHC.Base.Monoid inst_m)}
+redefine Local Definition Data.Functor.Const.Applicative__Const_op_zlztzg__ {inst_m} `{GHC.Base.Monoid inst_m}
    : forall {a} {b}, (Const inst_m (a -> b)) -> ((Const inst_m a) -> (Const inst_m b)) :=
   fun {a} {b} => GHC.Prim.coerce (GHC.Base.mappend).
 

--- a/examples/base-src/module-edits/Data/Semigroup/Internal/edits
+++ b/examples/base-src/module-edits/Data/Semigroup/Internal/edits
@@ -70,14 +70,14 @@ delete unused type variables Data.SemigroupInternal.Ord__Alt
 
 # hs-to-coq uses the wrong type variable names in a type annotation to the argument of `coerce`
 redefine Local Definition Data.SemigroupInternal.Semigroup__Alt_op_zlzlzgzg__ {inst_f} {inst_a}
-  `{(GHC.Base.Alternative inst_f)} : (Alt inst_f inst_a) -> ((Alt inst_f inst_a) -> (Alt inst_f inst_a)) :=
+  `{GHC.Base.Alternative inst_f} : (Alt inst_f inst_a) -> ((Alt inst_f inst_a) -> (Alt inst_f inst_a)) :=
   GHC.Prim.coerce (GHC.Base.op_zlzbzg__).
 
-redefine Local Definition Data.SemigroupInternal.Semigroup__Product_op_zlzlzgzg__ {inst_a} `{(GHC.Num.Num inst_a)}
+redefine Local Definition Data.SemigroupInternal.Semigroup__Product_op_zlzlzgzg__ {inst_a} `{GHC.Num.Num inst_a}
    : (Product inst_a) -> ((Product inst_a) -> (Product inst_a)) :=
   GHC.Prim.coerce (GHC.Num.*).
 
-redefine Local Definition Data.SemigroupInternal.Semigroup__Sum_op_zlzlzgzg__ {inst_a} `{(GHC.Num.Num inst_a)}
+redefine Local Definition Data.SemigroupInternal.Semigroup__Sum_op_zlzlzgzg__ {inst_a} `{GHC.Num.Num inst_a}
    : (Sum inst_a) -> ((Sum inst_a) -> (Sum inst_a)) :=
   GHC.Prim.coerce (GHC.Num.+).
 

--- a/examples/ghc/module-edits/CoreSyn/edits
+++ b/examples/ghc/module-edits/CoreSyn/edits
@@ -74,7 +74,7 @@ skip Core.collectNAnnBndrs
 # ISSUE: unfortunately our termination edits don't work in the presence 
 # of a default constraint because the type changes.
 #
-# set type Core.collectNAnnBndrs : forall {bndr} {annot} `{(GHC.Err.Default annot)}, nat -> (Core.AnnExpr bndr annot -> (list bndr * Core.AnnExpr bndr annot))
+# set type Core.collectNAnnBndrs : forall {bndr} {annot} `{GHC.Err.Default annot}, nat -> (Core.AnnExpr bndr annot -> (list bndr * Core.AnnExpr bndr annot))
 # in Core.collectNAnnBndrs termination collect { measure arg_0__ }
 #
 

--- a/examples/ghc/module-edits/EnumSet/edits
+++ b/examples/ghc/module-edits/EnumSet/edits
@@ -5,5 +5,5 @@ data kinds EnumSet.EnumSet Type
 rename value GHC.Enum.fromEnum = EnumSet.fromEnumN
 rename value GHC.Enum.toEnum = EnumSet.toEnumN
 
-add EnumSet Definition EnumSet.toEnumN  {a} `{(GHC.Enum.Enum a)} n : a := GHC.Enum.toEnum (Coq.ZArith.BinInt.Z.of_N n).
-add EnumSet Definition EnumSet.fromEnumN {a} `{(GHC.Enum.Enum a)} (e : a) := Coq.ZArith.BinInt.Z.to_N (GHC.Enum.fromEnum e).
+add EnumSet Definition EnumSet.toEnumN  {a} `{GHC.Enum.Enum a} n : a := GHC.Enum.toEnum (Coq.ZArith.BinInt.Z.of_N n).
+add EnumSet Definition EnumSet.fromEnumN {a} `{GHC.Enum.Enum a} (e : a) := Coq.ZArith.BinInt.Z.to_N (GHC.Enum.fromEnum e).

--- a/examples/ghc/module-edits/ListSetOps/edits
+++ b/examples/ghc/module-edits/ListSetOps/edits
@@ -11,6 +11,6 @@ axiomatize definition ListSetOps.equivClasses
 #
 # Added Default constraint
 #
-set type ListSetOps.assocUsing : forall {a} {b} `{(GHC.Err.Default b)}, (a -> (a -> bool)) -> (GHC.Base.String -> (Assoc a b -> (a -> b)))
-set type ListSetOps.assoc : forall {a} {b} `{(GHC.Base.Eq_ a)}`{(GHC.Err.Default b)} , (GHC.Base.String -> (ListSetOps.Assoc a b -> (a -> b)))
-set type ListSetOps.unionLists : forall {a} `{(GHC.Base.Eq_ a)}, list a -> (list a -> list a)
+set type ListSetOps.assocUsing : forall {a} {b} `{GHC.Err.Default b}, (a -> (a -> bool)) -> (GHC.Base.String -> (Assoc a b -> (a -> b)))
+set type ListSetOps.assoc : forall {a} {b} `{GHC.Base.Eq_ a}`{GHC.Err.Default b} , (GHC.Base.String -> (ListSetOps.Assoc a b -> (a -> b)))
+set type ListSetOps.unionLists : forall {a} `{GHC.Base.Eq_ a}, list a -> (list a -> list a)

--- a/examples/ghc/module-edits/Maybes/edits
+++ b/examples/ghc/module-edits/Maybes/edits
@@ -8,7 +8,7 @@ skip Maybes.tryMaybeT
 #
 # add Default constraint to partial function
 #
-set type Maybes.expectJust : forall {a} `{(GHC.Err.Default a)}, GHC.Base.String -> ((option a) -> a)
+set type Maybes.expectJust : forall {a} `{GHC.Err.Default a}, GHC.Base.String -> ((option a) -> a)
 
 #
 # fmap and <*> defined in terms of liftM and ap

--- a/examples/ghc/module-edits/Panic/edits
+++ b/examples/ghc/module-edits/Panic/edits
@@ -2,15 +2,15 @@ axiomatize module Panic
 
 add Panic Axiom Panic.someSDoc : GHC.Base.String.
 add Panic Axiom Panic.noString : forall {a}, a -> GHC.Base.String.
-add Panic Axiom Panic.panicStr : forall {a} `{(GHC.Err.Default a)}, GHC.Base.String -> (GHC.Base.String -> a).
-add Panic Axiom Panic.assertPprPanic : forall {a} `{(GHC.Err.Default a)}, GHC.Base.String -> (GHC.Num.Integer -> (GHC.Base.String -> (GHC.Base.String -> a))).
-add Panic Definition Panic.warnPprTrace : forall {a}`{(GHC.Err.Default a)}, bool -> (GHC.Base.String -> (GHC.Num.Integer -> (GHC.Base.String -> (a -> a))))
+add Panic Axiom Panic.panicStr : forall {a} `{GHC.Err.Default a}, GHC.Base.String -> (GHC.Base.String -> a).
+add Panic Axiom Panic.assertPprPanic : forall {a} `{GHC.Err.Default a}, GHC.Base.String -> (GHC.Num.Integer -> (GHC.Base.String -> (GHC.Base.String -> a))).
+add Panic Definition Panic.warnPprTrace : forall {a}`{GHC.Err.Default a}, bool -> (GHC.Base.String -> (GHC.Num.Integer -> (GHC.Base.String -> (a -> a))))
 := fun {a} {_} b msg i msg2 x => if b then (pgmError msg: a) else x.
 
 
 add Panic Inductive Panic.panicked {a} : a -> Prop :=
- | PlainPanic `{(GHC.Err.Default a)} {s}     : panicked (Panic.panic s)
- | StrPanic   `{(GHC.Err.Default a)} {s} {d} : panicked (Panic.panicStr s d).
+ | PlainPanic `{GHC.Err.Default a} {s}     : panicked (Panic.panic s)
+ | StrPanic   `{GHC.Err.Default a} {s} {d} : panicked (Panic.panicStr s d).
 
 skip Panic.withSignalHandlers
 skip Panic.tryMost
@@ -21,18 +21,18 @@ skip Panic.handleGhcException
 skip Panic.throwGhcExceptionIO
 skip Panic.showGhcException
 
-set type Panic.throwGhcException: forall {a}`{(GHC.Err.Default a)}, GhcException -> a
+set type Panic.throwGhcException: forall {a}`{GHC.Err.Default a}, GhcException -> a
 
-set type Panic.sorryDoc : forall {a}`{(GHC.Err.Default a)}, GHC.Base.String -> (GHC.Base.String -> a)
+set type Panic.sorryDoc : forall {a}`{GHC.Err.Default a}, GHC.Base.String -> (GHC.Base.String -> a)
 
-set type Panic.sorry : forall {a}`{(GHC.Err.Default a)}, GHC.Base.String -> a
+set type Panic.sorry : forall {a}`{GHC.Err.Default a}, GHC.Base.String -> a
 
-set type Panic.pgmErrorDoc : forall {a}`{(GHC.Err.Default a)}, GHC.Base.String -> (GHC.Base.String -> a)
+set type Panic.pgmErrorDoc : forall {a}`{GHC.Err.Default a}, GHC.Base.String -> (GHC.Base.String -> a)
 
-set type Panic.pgmError : forall {a}`{(GHC.Err.Default a)}, GHC.Base.String -> a
+set type Panic.pgmError : forall {a}`{GHC.Err.Default a}, GHC.Base.String -> a
 
-set type Panic.panicDoc : forall {a}`{(GHC.Err.Default a)}, GHC.Base.String -> (GHC.Base.String -> a)
+set type Panic.panicDoc : forall {a}`{GHC.Err.Default a}, GHC.Base.String -> (GHC.Base.String -> a)
 
-set type Panic.panic : forall {a}`{(GHC.Err.Default a)}, GHC.Base.String -> a
+set type Panic.panic : forall {a}`{GHC.Err.Default a}, GHC.Base.String -> a
 
-set type Panic.assertPanic : forall {a}`{(GHC.Err.Default a)}, GHC.Base.String -> (GHC.Num.Int -> a)
+set type Panic.assertPanic : forall {a}`{GHC.Err.Default a}, GHC.Base.String -> (GHC.Num.Int -> a)

--- a/examples/ghc/module-edits/TrieMap/edits
+++ b/examples/ghc/module-edits/TrieMap/edits
@@ -101,7 +101,7 @@ axiomatize definition TrieMap.Eq___DeBruijn__CoreAlt
 # This both recurses through itself and doesn't expose that, and is naturally
 # recursive on a subterm of its arguments, not the whole thing.
 redefine Definition TrieMap.Eq___DeBruijn__list_op_zeze__
-                      {a} `{(GHC.Base.Eq_ (TrieMap.DeBruijn a))}
+                      {a} `{GHC.Base.Eq_ (TrieMap.DeBruijn a)}
                       (dbl_xs dbl_ys : TrieMap.DeBruijn (list a)) : bool :=
            match dbl_xs , dbl_ys with
            | TrieMap.D env_xs xs0 , TrieMap.D env_ys ys0 =>
@@ -135,7 +135,7 @@ axiomatize definition TrieMap.xtList
 axiomatize definition TrieMap.lkList
 axiomatize definition TrieMap.fdList
 redefine Axiom TrieMap.TrieMap__ListMap_emptyTM :
-           forall {m} {a} `{(TrieMap.TrieMap m)}, TrieMap.ListMap m a.
+           forall {m} {a} `{TrieMap.TrieMap m}, TrieMap.ListMap m a.
   # We can't use `axiomatize definition` because the type signature isn't
   # available.
 
@@ -148,14 +148,14 @@ axiomatize definition TrieMap.fdG
 # `Key` in the type signature is swapped.  Eventually we'll need a more general
 # solution to this.
 redefine Axiom TrieMap.xtG :
-           forall {m} {a} `{(TrieMap.TrieMap m)} `{(GHC.Base.Eq_ (TrieMap.Key m))},
+           forall {m} {a} `{TrieMap.TrieMap m} `{GHC.Base.Eq_ (TrieMap.Key m)},
            (TrieMap.Key m) -> ((TrieMap.XT a) -> ((TrieMap.GenMap m a) -> (TrieMap.GenMap m a))).
 redefine Axiom TrieMap.lkG :
-           forall {m} {a}  `{(TrieMap.TrieMap m)} `{(GHC.Base.Eq_ (TrieMap.Key m))},
+           forall {m} {a}  `{TrieMap.TrieMap m} `{GHC.Base.Eq_ (TrieMap.Key m)},
            (TrieMap.Key m) -> ((TrieMap.GenMap m a) -> (option a)).
 # Again, solves the parameter order problem, the solution is just uglier.  It
 # also solves something about the `Key` type, but i'm not 100% sure what, tbh.
-redefine Instance TrieMap.TrieMap__GenMap {m} `{(TrieMap.TrieMap m)} `{(GHC.Base.Eq_ (TrieMap.Key m))}
+redefine Instance TrieMap.TrieMap__GenMap {m} `{TrieMap.TrieMap m} `{GHC.Base.Eq_ (TrieMap.Key m)}
     : TrieMap.TrieMap (TrieMap.GenMap m) :=
   Build_TrieMap (TrieMap.GenMap m)
                 (TrieMap.Key m)

--- a/examples/ghc/module-edits/Util/edits
+++ b/examples/ghc/module-edits/Util/edits
@@ -18,8 +18,8 @@ redefine Definition Util.HasDebugCallStack := unit.
 rewrite forall x, GHC.Unicode.toUpper x = x
 
 ## partial
-set type Util.only : forall {a}`{(GHC.Err.Default a)}, (list a) -> a
-set type Util.foldl2 : forall {acc} {a} {b} `{(GHC.Err.Default acc)}, (acc -> (a -> (b -> acc))) -> (acc -> ((list a) -> ((list b) -> acc)))
+set type Util.only : forall {a}`{GHC.Err.Default a}, (list a) -> a
+set type Util.foldl2 : forall {acc} {a} {b} `{GHC.Err.Default acc}, (acc -> (a -> (b -> acc))) -> (acc -> ((list a) -> ((list b) -> acc)))
 
 ## termination
 skip Util.nTimes

--- a/examples/graph/module-edits/Data/Graph/Inductive/Graph/edits
+++ b/examples/graph/module-edits/Data/Graph/Inductive/Graph/edits
@@ -11,16 +11,16 @@ skip class GHC.Base.Eq_
 redefine Definition Data.Graph.Inductive.Graph.Node := Coq.Numbers.BinNums.N.
 
 #termination for ufold
-set type Data.Graph.Inductive.Graph.ufold : forall {gr} {a} {b} {c} `{(Graph gr)} `{(LawfulGraph gr)}, (((Context a b) -> (c -> c))) -> (c -> ((gr a b) -> c))
+set type Data.Graph.Inductive.Graph.ufold : forall {gr} {a} {b} {c} `{Graph gr} `{LawfulGraph gr}, (((Context a b) -> (c -> c))) -> (c -> ((gr a b) -> c))
 termination Data.Graph.Inductive.Graph.ufold        {measure (BinInt.Z.abs_nat(noNodes g))}
 obligations Data.Graph.Inductive.Graph.ufold        (Tactics.program_simpl; eapply matchAny_decr_size; try(apply Heq_anonymous); auto)
 
 #other functions that use ufold and thus need a lawful graph
-set type Data.Graph.Inductive.Graph.gmap : forall {gr} {a} {b} {c} {d} `{(DynGraph gr)} `{(LawfulGraph gr)}, ((Context a b) -> (Context c d)) -> ((gr a b) -> (gr c d))
-set type Data.Graph.Inductive.Graph.nemap : forall {gr} {a} {c} {b} {d} `{(DynGraph gr)} `{(LawfulGraph gr)}, (a -> c) -> ((b -> d) -> ((gr a b) -> (gr c d)))
-set type Data.Graph.Inductive.Graph.nmap : forall {gr} {a} {c} {b} `{(DynGraph gr)} `{(LawfulGraph gr)}, (a -> c) -> ((gr a b) -> (gr c b))
-set type Data.Graph.Inductive.Graph.gfiltermap: forall {gr} {a} {b} {c} {d} `{(DynGraph gr)} `{(LawfulGraph gr)}, (Context a b -> MContext c d) -> ((gr a b) -> (gr c d))
-set type Data.Graph.Inductive.Graph.emap: forall {gr} {b} {c} {a} `{(DynGraph gr)} `{(LawfulGraph gr)}, (b -> c) -> ((gr a b) -> (gr a c))
+set type Data.Graph.Inductive.Graph.gmap : forall {gr} {a} {b} {c} {d} `{DynGraph gr} `{LawfulGraph gr}, ((Context a b) -> (Context c d)) -> ((gr a b) -> (gr c d))
+set type Data.Graph.Inductive.Graph.nemap : forall {gr} {a} {c} {b} {d} `{DynGraph gr} `{LawfulGraph gr}, (a -> c) -> ((b -> d) -> ((gr a b) -> (gr c d)))
+set type Data.Graph.Inductive.Graph.nmap : forall {gr} {a} {c} {b} `{DynGraph gr} `{LawfulGraph gr}, (a -> c) -> ((gr a b) -> (gr c b))
+set type Data.Graph.Inductive.Graph.gfiltermap: forall {gr} {a} {b} {c} {d} `{DynGraph gr} `{LawfulGraph gr}, (Context a b -> MContext c d) -> ((gr a b) -> (gr c d))
+set type Data.Graph.Inductive.Graph.emap: forall {gr} {b} {c} {a} `{DynGraph gr} `{LawfulGraph gr}, (b -> c) -> ((gr a b) -> (gr a c))
 
 #coq cannot infer all of the type arguments correctly
 in Data.Graph.Inductive.Graph.lab rewrite forall, GHC.Base.fmap = (@GHC.Base.fmap option _ _ _)
@@ -29,10 +29,10 @@ in Data.Graph.Inductive.Graph.lab rewrite forall, GHC.Base.fmap = (@GHC.Base.fma
 rewrite forall s, (GHC.Show.show s) = (GHC.Base.hs_string__ String.EmptyString)
 
 #need some Default constraints
-set type Data.Graph.Inductive.Graph.insEdge : forall {gr} {b} {a} `{(DynGraph gr)} `{(Err.Default (Context a b))}, (LEdge b) -> ((gr a b) -> (gr a b))
-set type Data.Graph.Inductive.Graph.insEdges : forall {gr} {b} {a} `{(DynGraph gr)} `{(Err.Default (Context a b))}, list (LEdge b) -> ((gr a b) -> (gr a b))
-set type Data.Graph.Inductive.Graph.context: forall {gr} {a} {b} `{(Graph gr)} `{(Err.Default (Context a b))}, (gr a b) -> (Node -> (Context a b))
-set type Data.Graph.Inductive.Graph.deg: forall {gr} {a} {b} `{(Graph gr)} `{(Err.Default (Context a b))}, (gr a b) -> (Node -> GHC.Num.Int)
+set type Data.Graph.Inductive.Graph.insEdge : forall {gr} {b} {a} `{DynGraph gr} `{Err.Default (Context a b)}, (LEdge b) -> ((gr a b) -> (gr a b))
+set type Data.Graph.Inductive.Graph.insEdges : forall {gr} {b} {a} `{DynGraph gr} `{Err.Default (Context a b)}, list (LEdge b) -> ((gr a b) -> (gr a b))
+set type Data.Graph.Inductive.Graph.context: forall {gr} {a} {b} `{Graph gr} `{Err.Default (Context a b)}, (gr a b) -> (Node -> (Context a b))
+set type Data.Graph.Inductive.Graph.deg: forall {gr} {a} {b} `{Graph gr} `{Err.Default (Context a b)}, (gr a b) -> (Node -> GHC.Num.Int)
 
 #Coq gets confused about some polymorphic definitions
 in Data.Graph.Inductive.Graph.hasNeighborAdj rewrite forall, Data.Foldable.elem = GHC.List.elem

--- a/examples/graph/module-edits/Data/Graph/Inductive/Internal/Heap/edits
+++ b/examples/graph/module-edits/Data/Graph/Inductive/Internal/Heap/edits
@@ -2,8 +2,8 @@ skip Data.Graph.Inductive.Internal.Heap.prettyHeap
 skip Data.Graph.Inductive.Internal.Heap.printPrettyHeap
 
 #needs default as well for some reason
-set type Data.Graph.Inductive.Internal.Heap.splitMin: forall {a} {b} `{(GHC.Base.Ord a)} `{(Err.Default ((a * b) * (Heap a b)))}, (Heap a b) -> ((a * b) * (Heap a b))
-set type Data.Graph.Inductive.Internal.Heap.findMin: forall {a} {b} `{(Err.Default (a * b))}, (Heap a b) -> (a * b)
+set type Data.Graph.Inductive.Internal.Heap.splitMin: forall {a} {b} `{GHC.Base.Ord a} `{Err.Default ((a * b) * (Heap a b))}, (Heap a b) -> ((a * b) * (Heap a b))
+set type Data.Graph.Inductive.Internal.Heap.findMin: forall {a} {b} `{Err.Default (a * b)}, (Heap a b) -> (a * b)
 
 #need to prove that toList terminates - we need a function for the size of a heap
 add Data.Graph.Inductive.Internal.Heap Fixpoint Data.Graph.Inductive.Internal.Heap.size {a} {b} (h: Heap a b) :=
@@ -14,14 +14,14 @@ end.
 order Data.Graph.Inductive.Internal.Heap.size Data.Graph.Inductive.Internal.Heap.toList
 
 #need several lemmas and tactics to prove termination:
-add Data.Graph.Inductive.Internal.Heap Lemma merge_size {a} {b} `{(GHC.Base.Ord a)} (h1 h2: Heap a b) : (size (merge h1 h2) = Nat.add (size h1) (size h2)). 
+add Data.Graph.Inductive.Internal.Heap Lemma merge_size {a} {b} `{GHC.Base.Ord a} (h1 h2: Heap a b) : (size (merge h1 h2) = Nat.add (size h1) (size h2)).
 Proof.
 intros. generalize dependent h2. induction h1; intros; simpl.
   - destruct h2; reflexivity.
   - destruct h2; simpl. omega. destruct (_GHC.Base.<_ a0 a1 ) eqn : ?; simpl; omega.
  Qed.
 
- add Data.Graph.Inductive.Internal.Heap Lemma mergeAll_size {a} {b} `{(GHC.Base.Ord a)} (l: list (Heap a b)) :
+ add Data.Graph.Inductive.Internal.Heap Lemma mergeAll_size {a} {b} `{GHC.Base.Ord a} (l: list (Heap a b)) :
   size (mergeAll l) = List.fold_right plus 0 (List.map (fun x => size x) l).
 Proof.
   intros. induction l using (well_founded_induction
@@ -34,7 +34,7 @@ Proof.
     + simpl. repeat(rewrite merge_size). rewrite plus_assoc. rewrite H1. reflexivity. simpl. omega.
 Qed. 
 
-add Data.Graph.Inductive.Internal.Heap Lemma deleteMin_size {a} {b} `{(GHC.Base.Ord a)} (h: Heap a b) :
+add Data.Graph.Inductive.Internal.Heap Lemma deleteMin_size {a} {b} `{GHC.Base.Ord a} (h: Heap a b) :
   (h <> Empty) ->
   ((size (deleteMin h) + 1) = size h).
 Proof.
@@ -43,7 +43,7 @@ Proof.
 Qed. 
 
 #can't use ltac, so prove the result as a lemma and apply it
-add Data.Graph.Inductive.Internal.Heap Lemma toList_termination {a} {b} `{(GHC.Base.Ord a)} (h: Heap a b):
+add Data.Graph.Inductive.Internal.Heap Lemma toList_termination {a} {b} `{GHC.Base.Ord a} (h: Heap a b):
   (Empty <> h) ->
   (size (deleteMin h) < size h).
 Proof.
@@ -56,8 +56,8 @@ termination Data.Graph.Inductive.Internal.Heap.toList        {measure (Data.Grap
 obligations Data.Graph.Inductive.Internal.Heap.toList       (Tactics.program_simpl; apply toList_termination; auto)
 
 #more defaut constrants 
-set type Data.Graph.Inductive.Internal.Heap.toList: forall {a} {b} `{(GHC.Base.Ord a)} `{(Err.Default (a * b))}, (Heap a b) -> list (a * b)
-set type Data.Graph.Inductive.Internal.Heap.heapsort: forall {a} `{(GHC.Base.Ord a)} `{(Err.Default (a * a))}, list a -> list a 
+set type Data.Graph.Inductive.Internal.Heap.toList: forall {a} {b} `{GHC.Base.Ord a} `{Err.Default (a * b)}, (Heap a b) -> list (a * b)
+set type Data.Graph.Inductive.Internal.Heap.heapsort: forall {a} `{GHC.Base.Ord a} `{Err.Default (a * a)}, list a -> list a
 
 #recursive definition that is difficult to translate
 skip class GHC.Base.Ord

--- a/examples/graph/module-edits/Data/Graph/Inductive/Internal/Queue/edits
+++ b/examples/graph/module-edits/Data/Graph/Inductive/Internal/Queue/edits
@@ -1,3 +1,3 @@
 #does not terminate on empty queue
-set type Data.Graph.Inductive.Internal.Queue.queueGet: forall {a} `{(Err.Default (a * Queue a))}, Queue a -> (a * Queue a)
+set type Data.Graph.Inductive.Internal.Queue.queueGet: forall {a} `{Err.Default (a * Queue a)}, Queue a -> (a * Queue a)
 termination Data.Graph.Inductive.Internal.Queue.queueGet  deferred

--- a/examples/graph/module-edits/Data/Graph/Inductive/Query/SP/edits
+++ b/examples/graph/module-edits/Data/Graph/Inductive/Query/SP/edits
@@ -1,3 +1,3 @@
-set type Data.Graph.Inductive.Query.SP.dijkstra: forall {gr} {b} {a} `{(Data.Graph.Inductive.Graph.Graph gr)} `{(GHC.Real.Real b)} `{(Err.Default b)}, (Data.Graph.Inductive.Internal.Heap.Heap b (Data.Graph.Inductive.Graph.LPath b)) -> ((gr a b) -> (Data.Graph.Inductive.Internal.RootPath.LRTree b))
+set type Data.Graph.Inductive.Query.SP.dijkstra: forall {gr} {b} {a} `{Data.Graph.Inductive.Graph.Graph gr} `{GHC.Real.Real b} `{Err.Default b}, (Data.Graph.Inductive.Internal.Heap.Heap b (Data.Graph.Inductive.Graph.LPath b)) -> ((gr a b) -> (Data.Graph.Inductive.Internal.RootPath.LRTree b))
 
 termination Data.Graph.Inductive.Query.SP.dijkstra      deferred

--- a/examples/tests/Makefile
+++ b/examples/tests/Makefile
@@ -40,12 +40,12 @@ PASS = \
   Promote2 \
   ExceptIn \
   ParserTests \
+  StrictPair \
 
 # tests that *should* pass but currently fail
 TODO_PASS = \
   InstVar \
   TypeAnnotations \
-  StrictPair \
   MutrecInst \
   TopBind \
   ExceptInDataDefinition \

--- a/examples/tests/Makefile
+++ b/examples/tests/Makefile
@@ -39,6 +39,7 @@ PASS = \
   Promote \
   Promote2 \
   ExceptIn \
+  ParserTests \
 
 # tests that *should* pass but currently fail
 TODO_PASS = \

--- a/examples/tests/ParserTests.hs
+++ b/examples/tests/ParserTests.hs
@@ -1,0 +1,10 @@
+module ParserTests where
+
+class C a where
+  c :: a -> a
+
+a1 :: C a => a -> a
+a1 = c
+
+a2 :: (a -> b) -> a -> b
+a2 x = x

--- a/examples/tests/ParserTests/edits
+++ b/examples/tests/ParserTests/edits
@@ -1,0 +1,7 @@
+# Tests for the parser
+
+# Generalizable binder
+redefine Definition ParserTests.a1 `{C a} : a -> a := c.
+
+# Right-nested arrows
+redefine Definition ParserTests.a2 {a} {b} : (a -> b) -> a -> b := fun x => x.

--- a/examples/transformers/module-edits/Control/Monad/Trans/Maybe/edits
+++ b/examples/transformers/module-edits/Control/Monad/Trans/Maybe/edits
@@ -11,7 +11,7 @@ redefine Definition Control.Monad.Trans.Maybe.Monad__MaybeT_op_zgzgze__ {inst_m}
 
 skip Control.Monad.Trans.Maybe.liftCatch
 
-redefine Local Definition Control.Monad.Trans.Maybe.Applicative__MaybeT_op_ztzg__ {inst_m} `{(GHC.Base.Monad inst_m)}
+redefine Local Definition Control.Monad.Trans.Maybe.Applicative__MaybeT_op_ztzg__ {inst_m} `{GHC.Base.Monad inst_m}
    : forall {a} {b},
      (MaybeT inst_m a) -> ((MaybeT inst_m b) -> (MaybeT inst_m b)) :=
   fun {a} {b} => fun m k => Monad_tmp m (fun arg_0__ => k).

--- a/src/lib/HsToCoq/ConvertHaskell/Parameters/Parsers.y
+++ b/src/lib/HsToCoq/ConvertHaskell/Parameters/Parsers.y
@@ -16,6 +16,7 @@ import Data.Either
 import Data.List.NonEmpty (NonEmpty(..), (<|))
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Text as T
+import qualified Data.Set as S
 
 import Control.Monad.Except
 import Control.Monad.State
@@ -26,6 +27,7 @@ import HsToCoq.Util.GHC.Module (ModuleName(), mkModuleNameT)
 import HsToCoq.Coq.Gallina
 import HsToCoq.Coq.Gallina.Util
 import HsToCoq.Coq.Gallina.Orphans ()
+import HsToCoq.Coq.Pretty (showP)
 
 import HsToCoq.ConvertHaskell.Parameters.Edits
 import HsToCoq.ConvertHaskell.Parameters.Parsers.Lexing
@@ -216,6 +218,11 @@ SepBy(p,sep)
 SepByIf(intro,p,sep)
   : OptionalList(AndThen(intro, SepBy1(p, sep)))    { $1 }
 
+-- Keep the separator
+ExplicitBeginBy1(p,sep)
+  : sep p { [($1, $2)] }
+  | sep p ExplicitBeginBy1(p,sep) { ($1, $2) : $3 }
+
 Optional(p)
   : p              { Just $1 }
   | {- empty -}    { Nothing }
@@ -361,6 +368,7 @@ EqlessTerm :: { Term }
 
 Term :: { Term }
   : LargeTerm    { $1 }
+  | MediumTerm(QualOp, Term)    { $1 }
   | SmallTerm    { $1 }
 
 LargeTerm :: { Term }
@@ -368,17 +376,18 @@ LargeTerm :: { Term }
   | fix   FixBodies             { Fix   $2 }
   | cofix FixBodies             { Cofix $2 }
   | forall Binders ',' Term     { Forall $2 $4 }
-  | MediumTerm(QualOp, Term)    { $1 }
 
 -- Lets us implement EqlessTerm
-MediumTerm(Binop, LetRHS) :: { Term }
-  : 'let' Qualid Many(Binder) Optional(TypeAnnotation) ':=' Term 'in' LetRHS    { Let $2 $3 $4 $6 $8 }
-  | match SepBy1(MatchItem, ',') with Many(Equation) end                        { Match $2 Nothing $4 }
-  | SmallTerm BinopRHS(Binop)                                                   { $2 $1 }
+MediumTerm(Binop, RTerm) :: { Term }
+  : 'let' Qualid Many(Binder) Optional(TypeAnnotation) ':=' Term 'in' RTerm     { Let $2 $3 $4 $6 $8 }
+  | SmallTerm           ':' RTerm { HasType $1 $3 }
+  | SmallishTerm(Binop) ':' RTerm { HasType $1 $3 }
+  | SmallishTerm(Binop) { $1 }
 
-BinopRHS(Binop) :: { Term -> Term }
-  : ':'   SmallTerm    { \lhs -> HasType lhs $2 }
-  | Binop SmallTerm    { if $1 == "->" then \lhs -> Arrow lhs $2 else \lhs -> mkInfix lhs $1 $2 }
+-- SmallTerms separated by binary operators
+SmallishTerm(Binop) :: { Term }
+  : SmallTerm ExplicitBeginBy1(SmallTerm, Binop)
+    {% buildSTB $1 $2 }
 
 SmallTerm :: { Term }
   : Atom Many(Arg)           { appList     $1 $2 } -- App or Atom
@@ -394,6 +403,8 @@ Atom :: { Term }
   | Num             { Num $1 }
   | '_'             { Underscore }
   | StringLit       { String $1 }
+  | match SepBy1(MatchItem, ',') with Many(Equation) end
+                    { Match $2 Nothing $4 }
 
 TypeAnnotation :: { Term }
   : ':' Term    { $2 }
@@ -628,4 +639,32 @@ prechomp :: T.Text -> T.Text
 prechomp t = case T.stripPrefix "\n" t of
                Just t' -> t'
                Nothing -> t
+
+buildSTB :: MonadParse m => Term -> [(Qualid, Term)] -> m Term
+buildSTB t b = do
+  let (ambig, t1) = buildSTB' t b
+  unless (null ambig) . parseError $
+    "ambiguous expression, mixing operators " ++ show (qualidToOp' <$> snub ambig) ++ ": " ++ showP t
+  pure t1
+
+qualidToOp' :: Qualid -> Op
+qualidToOp' x = fromMaybe (error $ "internal error: malformed qualid (should be an op): " ++ show x) (qualidToOp x)
+
+snub :: Ord a => [a] -> [a]
+snub = S.toList . S.fromList
+
+buildSTB' :: Term -> [(Qualid, Term)] -> ([Qualid], Term)
+buildSTB' t suffix =
+  case more_ of
+    [] -> (ambig, t0)
+    (_, tmore) : more ->
+      let (ambig1, t1) = buildSTB' tmore more in
+      (ambig ++ ambig1, Arrow t0 t1)
+  where
+    ambig = case operands of
+      [] -> []
+      [_] -> []
+      _ : _ : _ -> fmap fst operands
+    (operands, more_) = span (\(op, _) -> op /= "->") suffix
+    t0 = foldl (\t0 (op, t1) -> mkInfix t0 op t1) t operands
 }


### PR DESCRIPTION
- Generalizable binders no longer require parentheses (``` `{(Monad m)}``` must now be written ``` `{Monad m}```).
- Arrow type constructor can now associate to the right. `a -> (b -> c)` can now be written `a -> b -> c` Also allow mixing infix type operators with arrows `a -> b + c` (meaning `a -> (b + c)`).
- Generate infix notations for types and constructors.