### PR TITLE
Edits for polymorphic recursion and structural recursion

### DIFF
--- a/base/Control/Arrow.h2ci
+++ b/base/Control/Arrow.h2ci
@@ -6,53 +6,53 @@ superclassCount:
   Control.Arrow.ArrowPlus: '3'
   Control.Arrow.ArrowLoop: '2'
 defaultMethods:
-  Control.Arrow.Arrow: fromList [(Qualified "Control.Arrow" "first",Parens (Fun (Inferred
-    Explicit (Ident (Bare "arg_0__")) :| []) (App (Qualid (Qualified "Control.Arrow"
-    "op_ztztzt__")) (PosArg (Qualid (Bare "arg_0__")) :| [PosArg (Qualid (Qualified
-    "Control.Category" "id"))])))),(Qualified "Control.Arrow" "op_zazaza__",Fun (Inferred
-    Explicit (Ident (Bare "f")) :| [Inferred Explicit (Ident (Bare "g"))]) (App (Qualid
-    (Qualified "Control.Category" "op_zgzgzg__")) (PosArg (App (Qualid (Qualified
-    "Control.Arrow" "arr")) (PosArg (Parens (Fun (Inferred Explicit (Ident (Bare "b"))
-    :| []) (App (Qualid (Bare "pair")) (PosArg (Qualid (Bare "b")) :| [PosArg (Qualid
-    (Bare "b"))])))) :| [])) :| [PosArg (App (Qualid (Qualified "Control.Arrow" "op_ztztzt__"))
-    (PosArg (Qualid (Bare "f")) :| [PosArg (Qualid (Bare "g"))]))]))),(Qualified "Control.Arrow"
-    "op_ztztzt__",Fun (Inferred Explicit (Ident (Bare "f")) :| [Inferred Explicit
-    (Ident (Bare "g"))]) (Let (Bare "swap") [] Nothing (Fun (Inferred Explicit (Ident
-    (Bare "arg_0__")) :| []) (Match (MatchItem (Qualid (Bare "arg_0__")) Nothing Nothing
-    :| []) Nothing [Equation (MultPattern (ArgsPat (Bare "pair") [QualidPat (Bare
-    "x"),QualidPat (Bare "y")] :| []) :| []) (App (Qualid (Bare "pair")) (PosArg (Qualid
-    (Bare "y")) :| [PosArg (Qualid (Bare "x"))]))])) (App (Qualid (Qualified "Control.Category"
-    "op_zgzgzg__")) (PosArg (App (Qualid (Qualified "Control.Arrow" "first")) (PosArg
-    (Qualid (Bare "f")) :| [])) :| [PosArg (App (Qualid (Qualified "Control.Category"
+  Control.Arrow.Arrow: fromList [(Qualified "Control.Arrow" "first",Parens (Fun (ExplicitBinder
+    (Ident (Bare "arg_0__")) :| []) (App (Qualid (Qualified "Control.Arrow" "op_ztztzt__"))
+    (PosArg (Qualid (Bare "arg_0__")) :| [PosArg (Qualid (Qualified "Control.Category"
+    "id"))])))),(Qualified "Control.Arrow" "op_zazaza__",Fun (ExplicitBinder (Ident
+    (Bare "f")) :| [ExplicitBinder (Ident (Bare "g"))]) (App (Qualid (Qualified "Control.Category"
     "op_zgzgzg__")) (PosArg (App (Qualid (Qualified "Control.Arrow" "arr")) (PosArg
-    (Qualid (Bare "swap")) :| [])) :| [PosArg (App (Qualid (Qualified "Control.Category"
-    "op_zgzgzg__")) (PosArg (App (Qualid (Qualified "Control.Arrow" "first")) (PosArg
-    (Qualid (Bare "g")) :| [])) :| [PosArg (App (Qualid (Qualified "Control.Arrow"
-    "arr")) (PosArg (Qualid (Bare "swap")) :| []))]))]))])))),(Qualified "Control.Arrow"
-    "second",Parens (Fun (Inferred Explicit (Ident (Bare "arg_0__")) :| []) (App (Qualid
-    (Qualified "Control.Arrow" "op_ztztzt__")) (PosArg (Qualid (Qualified "Control.Category"
-    "id")) :| [PosArg (Qualid (Bare "arg_0__"))]))))]
+    (Parens (Fun (ExplicitBinder (Ident (Bare "b")) :| []) (App (Qualid (Bare "pair"))
+    (PosArg (Qualid (Bare "b")) :| [PosArg (Qualid (Bare "b"))])))) :| [])) :| [PosArg
+    (App (Qualid (Qualified "Control.Arrow" "op_ztztzt__")) (PosArg (Qualid (Bare
+    "f")) :| [PosArg (Qualid (Bare "g"))]))]))),(Qualified "Control.Arrow" "op_ztztzt__",Fun
+    (ExplicitBinder (Ident (Bare "f")) :| [ExplicitBinder (Ident (Bare "g"))]) (Let
+    (Bare "swap") [] Nothing (Fun (ExplicitBinder (Ident (Bare "arg_0__")) :| [])
+    (Match (MatchItem (Qualid (Bare "arg_0__")) Nothing Nothing :| []) Nothing [Equation
+    (MultPattern (ArgsPat (Bare "pair") [QualidPat (Bare "x"),QualidPat (Bare "y")]
+    :| []) :| []) (App (Qualid (Bare "pair")) (PosArg (Qualid (Bare "y")) :| [PosArg
+    (Qualid (Bare "x"))]))])) (App (Qualid (Qualified "Control.Category" "op_zgzgzg__"))
+    (PosArg (App (Qualid (Qualified "Control.Arrow" "first")) (PosArg (Qualid (Bare
+    "f")) :| [])) :| [PosArg (App (Qualid (Qualified "Control.Category" "op_zgzgzg__"))
+    (PosArg (App (Qualid (Qualified "Control.Arrow" "arr")) (PosArg (Qualid (Bare
+    "swap")) :| [])) :| [PosArg (App (Qualid (Qualified "Control.Category" "op_zgzgzg__"))
+    (PosArg (App (Qualid (Qualified "Control.Arrow" "first")) (PosArg (Qualid (Bare
+    "g")) :| [])) :| [PosArg (App (Qualid (Qualified "Control.Arrow" "arr")) (PosArg
+    (Qualid (Bare "swap")) :| []))]))]))])))),(Qualified "Control.Arrow" "second",Parens
+    (Fun (ExplicitBinder (Ident (Bare "arg_0__")) :| []) (App (Qualid (Qualified "Control.Arrow"
+    "op_ztztzt__")) (PosArg (Qualid (Qualified "Control.Category" "id")) :| [PosArg
+    (Qualid (Bare "arg_0__"))]))))]
   Control.Arrow.ArrowChoice: fromList [(Qualified "Control.Arrow" "left_",Parens (Fun
-    (Inferred Explicit (Ident (Bare "arg_0__")) :| []) (App (Qualid (Qualified "Control.Arrow"
+    (ExplicitBinder (Ident (Bare "arg_0__")) :| []) (App (Qualid (Qualified "Control.Arrow"
     "op_zpzpzp__")) (PosArg (Qualid (Bare "arg_0__")) :| [PosArg (Qualid (Qualified
-    "Control.Category" "id"))])))),(Qualified "Control.Arrow" "op_zbzbzb__",Fun (Inferred
-    Explicit (Ident (Bare "f")) :| [Inferred Explicit (Ident (Bare "g"))]) (Let (Bare
-    "untag") [] Nothing (Fun (Inferred Explicit (Ident (Bare "arg_0__")) :| []) (Match
-    (MatchItem (Qualid (Bare "arg_0__")) Nothing Nothing :| []) Nothing [Equation
-    (MultPattern (ArgsPat (Qualified "Data.Either" "Left") [QualidPat (Bare "x")]
-    :| []) :| []) (Qualid (Bare "x")),Equation (MultPattern (ArgsPat (Qualified "Data.Either"
-    "Right") [QualidPat (Bare "y")] :| []) :| []) (Qualid (Bare "y"))])) (App (Qualid
-    (Qualified "Control.Category" "op_zgzgzg__")) (PosArg (App (Qualid (Qualified
-    "Control.Arrow" "op_zpzpzp__")) (PosArg (Qualid (Bare "f")) :| [PosArg (Qualid
-    (Bare "g"))])) :| [PosArg (App (Qualid (Qualified "Control.Arrow" "arr")) (PosArg
-    (Qualid (Bare "untag")) :| []))])))),(Qualified "Control.Arrow" "op_zpzpzp__",Fun
-    (Inferred Explicit (Ident (Bare "f")) :| [Inferred Explicit (Ident (Bare "g"))])
-    (Let (Bare "mirror") [Inferred Implicit (Ident (Bare "x")),Inferred Implicit (Ident
-    (Bare "y"))] (Just (Arrow (App (App (Qualid (Qualified "Data.Either" "Either"))
-    (PosArg (Qualid (Bare "x")) :| [])) (PosArg (Qualid (Bare "y")) :| [])) (App (App
-    (Qualid (Qualified "Data.Either" "Either")) (PosArg (Qualid (Bare "y")) :| []))
-    (PosArg (Qualid (Bare "x")) :| [])))) (Fun (Inferred Explicit (Ident (Bare "arg_0__"))
-    :| []) (Match (MatchItem (Qualid (Bare "arg_0__")) Nothing Nothing :| []) Nothing
+    "Control.Category" "id"))])))),(Qualified "Control.Arrow" "op_zbzbzb__",Fun (ExplicitBinder
+    (Ident (Bare "f")) :| [ExplicitBinder (Ident (Bare "g"))]) (Let (Bare "untag")
+    [] Nothing (Fun (ExplicitBinder (Ident (Bare "arg_0__")) :| []) (Match (MatchItem
+    (Qualid (Bare "arg_0__")) Nothing Nothing :| []) Nothing [Equation (MultPattern
+    (ArgsPat (Qualified "Data.Either" "Left") [QualidPat (Bare "x")] :| []) :| [])
+    (Qualid (Bare "x")),Equation (MultPattern (ArgsPat (Qualified "Data.Either" "Right")
+    [QualidPat (Bare "y")] :| []) :| []) (Qualid (Bare "y"))])) (App (Qualid (Qualified
+    "Control.Category" "op_zgzgzg__")) (PosArg (App (Qualid (Qualified "Control.Arrow"
+    "op_zpzpzp__")) (PosArg (Qualid (Bare "f")) :| [PosArg (Qualid (Bare "g"))]))
+    :| [PosArg (App (Qualid (Qualified "Control.Arrow" "arr")) (PosArg (Qualid (Bare
+    "untag")) :| []))])))),(Qualified "Control.Arrow" "op_zpzpzp__",Fun (ExplicitBinder
+    (Ident (Bare "f")) :| [ExplicitBinder (Ident (Bare "g"))]) (Let (Bare "mirror")
+    [ImplicitBinders (Ident (Bare "x") :| []),ImplicitBinders (Ident (Bare "y") :|
+    [])] (Just (Arrow (App (App (Qualid (Qualified "Data.Either" "Either")) (PosArg
+    (Qualid (Bare "x")) :| [])) (PosArg (Qualid (Bare "y")) :| [])) (App (App (Qualid
+    (Qualified "Data.Either" "Either")) (PosArg (Qualid (Bare "y")) :| [])) (PosArg
+    (Qualid (Bare "x")) :| [])))) (Fun (ExplicitBinder (Ident (Bare "arg_0__")) :|
+    []) (Match (MatchItem (Qualid (Bare "arg_0__")) Nothing Nothing :| []) Nothing
     [Equation (MultPattern (ArgsPat (Qualified "Data.Either" "Left") [QualidPat (Bare
     "x")] :| []) :| []) (App (Qualid (Qualified "Data.Either" "Right")) (PosArg (Qualid
     (Bare "x")) :| [])),Equation (MultPattern (ArgsPat (Qualified "Data.Either" "Right")
@@ -65,7 +65,7 @@ defaultMethods:
     "op_zgzgzg__")) (PosArg (App (Qualid (Qualified "Control.Arrow" "left_")) (PosArg
     (Qualid (Bare "g")) :| [])) :| [PosArg (App (Qualid (Qualified "Control.Arrow"
     "arr")) (PosArg (Qualid (Bare "mirror")) :| []))]))]))])))),(Qualified "Control.Arrow"
-    "right_",Parens (Fun (Inferred Explicit (Ident (Bare "arg_0__")) :| []) (App (Qualid
+    "right_",Parens (Fun (ExplicitBinder (Ident (Bare "arg_0__")) :| []) (App (Qualid
     (Qualified "Control.Arrow" "op_zpzpzp__")) (PosArg (Qualid (Qualified "Control.Category"
     "id")) :| [PosArg (Qualid (Bare "arg_0__"))]))))]
 classTypes:
@@ -88,34 +88,35 @@ classDefns:
     Ungeneralizable Explicit (Ident (Bare "a") :| []) (Arrow (Qualid (Bare "Type"))
     (Arrow (Qualid (Bare "Type")) (Qualid (Bare "Type")))),Generalized Implicit (App
     (Qualid (Qualified "Control.Category" "Category")) (PosArg (Qualid (Bare "a"))
-    :| []))] Nothing [(Qualified "Control.Arrow" "arr",Forall (Inferred Implicit (Ident
-    (Bare "b")) :| [Inferred Implicit (Ident (Bare "c"))]) (Arrow (Parens (Arrow (Qualid
-    (Bare "b")) (Qualid (Bare "c")))) (App (App (Qualid (Bare "a")) (PosArg (Qualid
-    (Bare "b")) :| [])) (PosArg (Qualid (Bare "c")) :| [])))),(Qualified "Control.Arrow"
-    "first",Forall (Inferred Implicit (Ident (Bare "b")) :| [Inferred Implicit (Ident
-    (Bare "c")),Inferred Implicit (Ident (Bare "d"))]) (Arrow (App (App (Qualid (Bare
-    "a")) (PosArg (Qualid (Bare "b")) :| [])) (PosArg (Qualid (Bare "c")) :| []))
-    (App (App (Qualid (Bare "a")) (PosArg (InScope (App (Qualid (Bare "op_zt__"))
-    (PosArg (Qualid (Bare "b")) :| [PosArg (Qualid (Bare "d"))])) "type") :| []))
-    (PosArg (InScope (App (Qualid (Bare "op_zt__")) (PosArg (Qualid (Bare "c")) :|
-    [PosArg (Qualid (Bare "d"))])) "type") :| [])))),(Qualified "Control.Arrow" "op_zazaza__",Forall
-    (Inferred Implicit (Ident (Bare "b")) :| [Inferred Implicit (Ident (Bare "c")),Inferred
-    Implicit (Ident (Bare "c'"))]) (Arrow (App (App (Qualid (Bare "a")) (PosArg (Qualid
-    (Bare "b")) :| [])) (PosArg (Qualid (Bare "c")) :| [])) (Arrow (App (App (Qualid
-    (Bare "a")) (PosArg (Qualid (Bare "b")) :| [])) (PosArg (Qualid (Bare "c'")) :|
-    [])) (App (App (Qualid (Bare "a")) (PosArg (Qualid (Bare "b")) :| [])) (PosArg
-    (InScope (App (Qualid (Bare "op_zt__")) (PosArg (Qualid (Bare "c")) :| [PosArg
-    (Qualid (Bare "c'"))])) "type") :| []))))),(Qualified "Control.Arrow" "op_ztztzt__",Forall
-    (Inferred Implicit (Ident (Bare "b")) :| [Inferred Implicit (Ident (Bare "c")),Inferred
-    Implicit (Ident (Bare "b'")),Inferred Implicit (Ident (Bare "c'"))]) (Arrow (App
+    :| []))] Nothing [(Qualified "Control.Arrow" "arr",Forall (ImplicitBinders (Ident
+    (Bare "b") :| []) :| [ImplicitBinders (Ident (Bare "c") :| [])]) (Arrow (Parens
+    (Arrow (Qualid (Bare "b")) (Qualid (Bare "c")))) (App (App (Qualid (Bare "a"))
+    (PosArg (Qualid (Bare "b")) :| [])) (PosArg (Qualid (Bare "c")) :| [])))),(Qualified
+    "Control.Arrow" "first",Forall (ImplicitBinders (Ident (Bare "b") :| []) :| [ImplicitBinders
+    (Ident (Bare "c") :| []),ImplicitBinders (Ident (Bare "d") :| [])]) (Arrow (App
     (App (Qualid (Bare "a")) (PosArg (Qualid (Bare "b")) :| [])) (PosArg (Qualid (Bare
-    "c")) :| [])) (Arrow (App (App (Qualid (Bare "a")) (PosArg (Qualid (Bare "b'"))
+    "c")) :| [])) (App (App (Qualid (Bare "a")) (PosArg (InScope (App (Qualid (Bare
+    "op_zt__")) (PosArg (Qualid (Bare "b")) :| [PosArg (Qualid (Bare "d"))])) "type")
+    :| [])) (PosArg (InScope (App (Qualid (Bare "op_zt__")) (PosArg (Qualid (Bare
+    "c")) :| [PosArg (Qualid (Bare "d"))])) "type") :| [])))),(Qualified "Control.Arrow"
+    "op_zazaza__",Forall (ImplicitBinders (Ident (Bare "b") :| []) :| [ImplicitBinders
+    (Ident (Bare "c") :| []),ImplicitBinders (Ident (Bare "c'") :| [])]) (Arrow (App
+    (App (Qualid (Bare "a")) (PosArg (Qualid (Bare "b")) :| [])) (PosArg (Qualid (Bare
+    "c")) :| [])) (Arrow (App (App (Qualid (Bare "a")) (PosArg (Qualid (Bare "b"))
     :| [])) (PosArg (Qualid (Bare "c'")) :| [])) (App (App (Qualid (Bare "a")) (PosArg
-    (InScope (App (Qualid (Bare "op_zt__")) (PosArg (Qualid (Bare "b")) :| [PosArg
-    (Qualid (Bare "b'"))])) "type") :| [])) (PosArg (InScope (App (Qualid (Bare "op_zt__"))
-    (PosArg (Qualid (Bare "c")) :| [PosArg (Qualid (Bare "c'"))])) "type") :| []))))),(Qualified
-    "Control.Arrow" "second",Forall (Inferred Implicit (Ident (Bare "b")) :| [Inferred
-    Implicit (Ident (Bare "c")),Inferred Implicit (Ident (Bare "d"))]) (Arrow (App
+    (Qualid (Bare "b")) :| [])) (PosArg (InScope (App (Qualid (Bare "op_zt__")) (PosArg
+    (Qualid (Bare "c")) :| [PosArg (Qualid (Bare "c'"))])) "type") :| []))))),(Qualified
+    "Control.Arrow" "op_ztztzt__",Forall (ImplicitBinders (Ident (Bare "b") :| [])
+    :| [ImplicitBinders (Ident (Bare "c") :| []),ImplicitBinders (Ident (Bare "b'")
+    :| []),ImplicitBinders (Ident (Bare "c'") :| [])]) (Arrow (App (App (Qualid (Bare
+    "a")) (PosArg (Qualid (Bare "b")) :| [])) (PosArg (Qualid (Bare "c")) :| []))
+    (Arrow (App (App (Qualid (Bare "a")) (PosArg (Qualid (Bare "b'")) :| [])) (PosArg
+    (Qualid (Bare "c'")) :| [])) (App (App (Qualid (Bare "a")) (PosArg (InScope (App
+    (Qualid (Bare "op_zt__")) (PosArg (Qualid (Bare "b")) :| [PosArg (Qualid (Bare
+    "b'"))])) "type") :| [])) (PosArg (InScope (App (Qualid (Bare "op_zt__")) (PosArg
+    (Qualid (Bare "c")) :| [PosArg (Qualid (Bare "c'"))])) "type") :| []))))),(Qualified
+    "Control.Arrow" "second",Forall (ImplicitBinders (Ident (Bare "b") :| []) :| [ImplicitBinders
+    (Ident (Bare "c") :| []),ImplicitBinders (Ident (Bare "d") :| [])]) (Arrow (App
     (App (Qualid (Bare "a")) (PosArg (Qualid (Bare "b")) :| [])) (PosArg (Qualid (Bare
     "c")) :| [])) (App (App (Qualid (Bare "a")) (PosArg (InScope (App (Qualid (Bare
     "op_zt__")) (PosArg (Qualid (Bare "d")) :| [PosArg (Qualid (Bare "b"))])) "type")
@@ -125,70 +126,70 @@ classDefns:
     [Typed Ungeneralizable Explicit (Ident (Bare "a") :| []) (Arrow (Qualid (Bare
     "Type")) (Arrow (Qualid (Bare "Type")) (Qualid (Bare "Type")))),Generalized Implicit
     (App (Qualid (Qualified "Control.Arrow" "Arrow")) (PosArg (Qualid (Bare "a"))
-    :| []))] Nothing [(Qualified "Control.Arrow" "app",Forall (Inferred Implicit (Ident
-    (Bare "b")) :| [Inferred Implicit (Ident (Bare "c"))]) (App (App (Qualid (Bare
-    "a")) (PosArg (InScope (App (Qualid (Bare "op_zt__")) (PosArg (App (App (Qualid
-    (Bare "a")) (PosArg (Qualid (Bare "b")) :| [])) (PosArg (Qualid (Bare "c")) :|
-    [])) :| [PosArg (Qualid (Bare "b"))])) "type") :| [])) (PosArg (Qualid (Bare "c"))
-    :| [])))]
+    :| []))] Nothing [(Qualified "Control.Arrow" "app",Forall (ImplicitBinders (Ident
+    (Bare "b") :| []) :| [ImplicitBinders (Ident (Bare "c") :| [])]) (App (App (Qualid
+    (Bare "a")) (PosArg (InScope (App (Qualid (Bare "op_zt__")) (PosArg (App (App
+    (Qualid (Bare "a")) (PosArg (Qualid (Bare "b")) :| [])) (PosArg (Qualid (Bare
+    "c")) :| [])) :| [PosArg (Qualid (Bare "b"))])) "type") :| [])) (PosArg (Qualid
+    (Bare "c")) :| [])))]
   Control.Arrow.ArrowChoice: ClassDefinition (Qualified "Control.Arrow" "ArrowChoice")
-    [Inferred Explicit (Ident (Bare "a")),Generalized Implicit (App (Qualid (Qualified
+    [ExplicitBinder (Ident (Bare "a")),Generalized Implicit (App (Qualid (Qualified
     "Control.Arrow" "Arrow")) (PosArg (Qualid (Bare "a")) :| []))] Nothing [(Qualified
-    "Control.Arrow" "left_",Forall (Inferred Implicit (Ident (Bare "b")) :| [Inferred
-    Implicit (Ident (Bare "c")),Inferred Implicit (Ident (Bare "d"))]) (Arrow (App
+    "Control.Arrow" "left_",Forall (ImplicitBinders (Ident (Bare "b") :| []) :| [ImplicitBinders
+    (Ident (Bare "c") :| []),ImplicitBinders (Ident (Bare "d") :| [])]) (Arrow (App
     (App (Qualid (Bare "a")) (PosArg (Qualid (Bare "b")) :| [])) (PosArg (Qualid (Bare
     "c")) :| [])) (App (App (Qualid (Bare "a")) (PosArg (Parens (App (App (Qualid
     (Qualified "Data.Either" "Either")) (PosArg (Qualid (Bare "b")) :| [])) (PosArg
     (Qualid (Bare "d")) :| []))) :| [])) (PosArg (Parens (App (App (Qualid (Qualified
     "Data.Either" "Either")) (PosArg (Qualid (Bare "c")) :| [])) (PosArg (Qualid (Bare
-    "d")) :| []))) :| [])))),(Qualified "Control.Arrow" "op_zbzbzb__",Forall (Inferred
-    Implicit (Ident (Bare "b")) :| [Inferred Implicit (Ident (Bare "d")),Inferred
-    Implicit (Ident (Bare "c"))]) (Arrow (App (App (Qualid (Bare "a")) (PosArg (Qualid
+    "d")) :| []))) :| [])))),(Qualified "Control.Arrow" "op_zbzbzb__",Forall (ImplicitBinders
+    (Ident (Bare "b") :| []) :| [ImplicitBinders (Ident (Bare "d") :| []),ImplicitBinders
+    (Ident (Bare "c") :| [])]) (Arrow (App (App (Qualid (Bare "a")) (PosArg (Qualid
     (Bare "b")) :| [])) (PosArg (Qualid (Bare "d")) :| [])) (Arrow (App (App (Qualid
     (Bare "a")) (PosArg (Qualid (Bare "c")) :| [])) (PosArg (Qualid (Bare "d")) :|
     [])) (App (App (Qualid (Bare "a")) (PosArg (Parens (App (App (Qualid (Qualified
     "Data.Either" "Either")) (PosArg (Qualid (Bare "b")) :| [])) (PosArg (Qualid (Bare
     "c")) :| []))) :| [])) (PosArg (Qualid (Bare "d")) :| []))))),(Qualified "Control.Arrow"
-    "op_zpzpzp__",Forall (Inferred Implicit (Ident (Bare "b")) :| [Inferred Implicit
-    (Ident (Bare "c")),Inferred Implicit (Ident (Bare "b'")),Inferred Implicit (Ident
-    (Bare "c'"))]) (Arrow (App (App (Qualid (Bare "a")) (PosArg (Qualid (Bare "b"))
-    :| [])) (PosArg (Qualid (Bare "c")) :| [])) (Arrow (App (App (Qualid (Bare "a"))
-    (PosArg (Qualid (Bare "b'")) :| [])) (PosArg (Qualid (Bare "c'")) :| [])) (App
-    (App (Qualid (Bare "a")) (PosArg (Parens (App (App (Qualid (Qualified "Data.Either"
-    "Either")) (PosArg (Qualid (Bare "b")) :| [])) (PosArg (Qualid (Bare "b'")) :|
-    []))) :| [])) (PosArg (Parens (App (App (Qualid (Qualified "Data.Either" "Either"))
-    (PosArg (Qualid (Bare "c")) :| [])) (PosArg (Qualid (Bare "c'")) :| []))) :| []))))),(Qualified
-    "Control.Arrow" "right_",Forall (Inferred Implicit (Ident (Bare "b")) :| [Inferred
-    Implicit (Ident (Bare "c")),Inferred Implicit (Ident (Bare "d"))]) (Arrow (App
-    (App (Qualid (Bare "a")) (PosArg (Qualid (Bare "b")) :| [])) (PosArg (Qualid (Bare
-    "c")) :| [])) (App (App (Qualid (Bare "a")) (PosArg (Parens (App (App (Qualid
-    (Qualified "Data.Either" "Either")) (PosArg (Qualid (Bare "d")) :| [])) (PosArg
-    (Qualid (Bare "b")) :| []))) :| [])) (PosArg (Parens (App (App (Qualid (Qualified
-    "Data.Either" "Either")) (PosArg (Qualid (Bare "d")) :| [])) (PosArg (Qualid (Bare
-    "c")) :| []))) :| []))))]
+    "op_zpzpzp__",Forall (ImplicitBinders (Ident (Bare "b") :| []) :| [ImplicitBinders
+    (Ident (Bare "c") :| []),ImplicitBinders (Ident (Bare "b'") :| []),ImplicitBinders
+    (Ident (Bare "c'") :| [])]) (Arrow (App (App (Qualid (Bare "a")) (PosArg (Qualid
+    (Bare "b")) :| [])) (PosArg (Qualid (Bare "c")) :| [])) (Arrow (App (App (Qualid
+    (Bare "a")) (PosArg (Qualid (Bare "b'")) :| [])) (PosArg (Qualid (Bare "c'"))
+    :| [])) (App (App (Qualid (Bare "a")) (PosArg (Parens (App (App (Qualid (Qualified
+    "Data.Either" "Either")) (PosArg (Qualid (Bare "b")) :| [])) (PosArg (Qualid (Bare
+    "b'")) :| []))) :| [])) (PosArg (Parens (App (App (Qualid (Qualified "Data.Either"
+    "Either")) (PosArg (Qualid (Bare "c")) :| [])) (PosArg (Qualid (Bare "c'")) :|
+    []))) :| []))))),(Qualified "Control.Arrow" "right_",Forall (ImplicitBinders (Ident
+    (Bare "b") :| []) :| [ImplicitBinders (Ident (Bare "c") :| []),ImplicitBinders
+    (Ident (Bare "d") :| [])]) (Arrow (App (App (Qualid (Bare "a")) (PosArg (Qualid
+    (Bare "b")) :| [])) (PosArg (Qualid (Bare "c")) :| [])) (App (App (Qualid (Bare
+    "a")) (PosArg (Parens (App (App (Qualid (Qualified "Data.Either" "Either")) (PosArg
+    (Qualid (Bare "d")) :| [])) (PosArg (Qualid (Bare "b")) :| []))) :| [])) (PosArg
+    (Parens (App (App (Qualid (Qualified "Data.Either" "Either")) (PosArg (Qualid
+    (Bare "d")) :| [])) (PosArg (Qualid (Bare "c")) :| []))) :| []))))]
   Control.Arrow.ArrowZero: ClassDefinition (Qualified "Control.Arrow" "ArrowZero")
     [Typed Ungeneralizable Explicit (Ident (Bare "a") :| []) (Arrow (Qualid (Bare
     "Type")) (Arrow (Qualid (Bare "Type")) (Qualid (Bare "Type")))),Generalized Implicit
     (App (Qualid (Qualified "Control.Arrow" "Arrow")) (PosArg (Qualid (Bare "a"))
-    :| []))] Nothing [(Qualified "Control.Arrow" "zeroArrow",Forall (Inferred Implicit
-    (Ident (Bare "b")) :| [Inferred Implicit (Ident (Bare "c"))]) (App (App (Qualid
-    (Bare "a")) (PosArg (Qualid (Bare "b")) :| [])) (PosArg (Qualid (Bare "c")) :|
-    [])))]
+    :| []))] Nothing [(Qualified "Control.Arrow" "zeroArrow",Forall (ImplicitBinders
+    (Ident (Bare "b") :| []) :| [ImplicitBinders (Ident (Bare "c") :| [])]) (App (App
+    (Qualid (Bare "a")) (PosArg (Qualid (Bare "b")) :| [])) (PosArg (Qualid (Bare
+    "c")) :| [])))]
   Control.Arrow.ArrowPlus: ClassDefinition (Qualified "Control.Arrow" "ArrowPlus")
     [Typed Ungeneralizable Explicit (Ident (Bare "a") :| []) (Arrow (Qualid (Bare
     "Type")) (Arrow (Qualid (Bare "Type")) (Qualid (Bare "Type")))),Generalized Implicit
     (App (Qualid (Qualified "Control.Arrow" "ArrowZero")) (PosArg (Qualid (Bare "a"))
-    :| []))] Nothing [(Qualified "Control.Arrow" "op_zlzpzg__",Forall (Inferred Implicit
-    (Ident (Bare "b")) :| [Inferred Implicit (Ident (Bare "c"))]) (Arrow (App (App
-    (Qualid (Bare "a")) (PosArg (Qualid (Bare "b")) :| [])) (PosArg (Qualid (Bare
-    "c")) :| [])) (Arrow (App (App (Qualid (Bare "a")) (PosArg (Qualid (Bare "b"))
-    :| [])) (PosArg (Qualid (Bare "c")) :| [])) (App (App (Qualid (Bare "a")) (PosArg
-    (Qualid (Bare "b")) :| [])) (PosArg (Qualid (Bare "c")) :| [])))))]
+    :| []))] Nothing [(Qualified "Control.Arrow" "op_zlzpzg__",Forall (ImplicitBinders
+    (Ident (Bare "b") :| []) :| [ImplicitBinders (Ident (Bare "c") :| [])]) (Arrow
+    (App (App (Qualid (Bare "a")) (PosArg (Qualid (Bare "b")) :| [])) (PosArg (Qualid
+    (Bare "c")) :| [])) (Arrow (App (App (Qualid (Bare "a")) (PosArg (Qualid (Bare
+    "b")) :| [])) (PosArg (Qualid (Bare "c")) :| [])) (App (App (Qualid (Bare "a"))
+    (PosArg (Qualid (Bare "b")) :| [])) (PosArg (Qualid (Bare "c")) :| [])))))]
   Control.Arrow.ArrowLoop: ClassDefinition (Qualified "Control.Arrow" "ArrowLoop")
-    [Inferred Explicit (Ident (Bare "a")),Generalized Implicit (App (Qualid (Qualified
+    [ExplicitBinder (Ident (Bare "a")),Generalized Implicit (App (Qualid (Qualified
     "Control.Arrow" "Arrow")) (PosArg (Qualid (Bare "a")) :| []))] Nothing [(Qualified
-    "Control.Arrow" "loop",Forall (Inferred Implicit (Ident (Bare "b")) :| [Inferred
-    Implicit (Ident (Bare "d")),Inferred Implicit (Ident (Bare "c"))]) (Arrow (App
+    "Control.Arrow" "loop",Forall (ImplicitBinders (Ident (Bare "b") :| []) :| [ImplicitBinders
+    (Ident (Bare "d") :| []),ImplicitBinders (Ident (Bare "c") :| [])]) (Arrow (App
     (App (Qualid (Bare "a")) (PosArg (InScope (App (Qualid (Bare "op_zt__")) (PosArg
     (Qualid (Bare "b")) :| [PosArg (Qualid (Bare "d"))])) "type") :| [])) (PosArg
     (InScope (App (Qualid (Bare "op_zt__")) (PosArg (Qualid (Bare "c")) :| [PosArg

--- a/base/Control/Category.h2ci
+++ b/base/Control/Category.h2ci
@@ -6,11 +6,11 @@ classDefns:
   Control.Category.Category: ClassDefinition (Qualified "Control.Category" "Category")
     [Typed Ungeneralizable Explicit (Ident (Bare "cat") :| []) (Arrow (Qualid (Bare
     "Type")) (Arrow (Qualid (Bare "Type")) (Qualid (Bare "Type"))))] Nothing [(Qualified
-    "Control.Category" "id",Forall (Inferred Implicit (Ident (Bare "a")) :| []) (App
-    (App (Qualid (Bare "cat")) (PosArg (Qualid (Bare "a")) :| [])) (PosArg (Qualid
-    (Bare "a")) :| []))),(Qualified "Control.Category" "op_z2218U__",Forall (Inferred
-    Implicit (Ident (Bare "b")) :| [Inferred Implicit (Ident (Bare "c")),Inferred
-    Implicit (Ident (Bare "a"))]) (Arrow (App (App (Qualid (Bare "cat")) (PosArg (Qualid
+    "Control.Category" "id",Forall (ImplicitBinders (Ident (Bare "a") :| []) :| [])
+    (App (App (Qualid (Bare "cat")) (PosArg (Qualid (Bare "a")) :| [])) (PosArg (Qualid
+    (Bare "a")) :| []))),(Qualified "Control.Category" "op_z2218U__",Forall (ImplicitBinders
+    (Ident (Bare "b") :| []) :| [ImplicitBinders (Ident (Bare "c") :| []),ImplicitBinders
+    (Ident (Bare "a") :| [])]) (Arrow (App (App (Qualid (Bare "cat")) (PosArg (Qualid
     (Bare "b")) :| [])) (PosArg (Qualid (Bare "c")) :| [])) (Arrow (App (App (Qualid
     (Bare "cat")) (PosArg (Qualid (Bare "a")) :| [])) (PosArg (Qualid (Bare "b"))
     :| [])) (App (App (Qualid (Bare "cat")) (PosArg (Qualid (Bare "a")) :| [])) (PosArg

--- a/base/Control/Monad/Fail.h2ci
+++ b/base/Control/Monad/Fail.h2ci
@@ -7,6 +7,6 @@ classDefns:
     [Typed Ungeneralizable Explicit (Ident (Bare "m") :| []) (Arrow (Qualid (Bare
     "Type")) (Qualid (Bare "Type"))),Generalized Implicit (App (Qualid (Qualified
     "GHC.Base" "Monad")) (PosArg (Qualid (Bare "m")) :| []))] Nothing [(Qualified
-    "Control.Monad.Fail" "fail",Forall (Inferred Implicit (Ident (Bare "a")) :| [])
-    (Arrow (Qualid (Qualified "GHC.Base" "String")) (App (Qualid (Bare "m")) (PosArg
+    "Control.Monad.Fail" "fail",Forall (ImplicitBinders (Ident (Bare "a") :| []) :|
+    []) (Arrow (Qualid (Qualified "GHC.Base" "String")) (App (Qualid (Bare "m")) (PosArg
     (Qualid (Bare "a")) :| []))))]

--- a/base/Control/Monad/Zip.h2ci
+++ b/base/Control/Monad/Zip.h2ci
@@ -2,39 +2,39 @@ superclassCount:
   Control.Monad.Zip.MonadZip: '3'
 defaultMethods:
   Control.Monad.Zip.MonadZip: fromList [(Qualified "Control.Monad.Zip" "munzip",Fun
-    (Inferred Explicit (Ident (Bare "mab")) :| []) (App (Qualid (Bare "pair")) (PosArg
+    (ExplicitBinder (Ident (Bare "mab")) :| []) (App (Qualid (Bare "pair")) (PosArg
     (App (App (Qualid (Qualified "GHC.Base" "liftM")) (PosArg (Qualid (Qualified "Data.Tuple"
     "fst")) :| [])) (PosArg (Qualid (Bare "mab")) :| [])) :| [PosArg (App (App (Qualid
     (Qualified "GHC.Base" "liftM")) (PosArg (Qualid (Qualified "Data.Tuple" "snd"))
     :| [])) (PosArg (Qualid (Bare "mab")) :| []))]))),(Qualified "Control.Monad.Zip"
     "mzip",App (Qualid (Qualified "Control.Monad.Zip" "mzipWith")) (PosArg (Qualid
     (Qualified "GHC.Tuple" "pair2")) :| [])),(Qualified "Control.Monad.Zip" "mzipWith",Fun
-    (Inferred Explicit (Ident (Bare "f")) :| [Inferred Explicit (Ident (Bare "ma")),Inferred
-    Explicit (Ident (Bare "mb"))]) (App (App (Qualid (Qualified "GHC.Base" "liftM"))
-    (PosArg (Parens (App (Qualid (Qualified "Data.Tuple" "uncurry")) (PosArg (Qualid
-    (Bare "f")) :| []))) :| [])) (PosArg (Parens (App (App (Qualid (Qualified "Control.Monad.Zip"
+    (ExplicitBinder (Ident (Bare "f")) :| [ExplicitBinder (Ident (Bare "ma")),ExplicitBinder
+    (Ident (Bare "mb"))]) (App (App (Qualid (Qualified "GHC.Base" "liftM")) (PosArg
+    (Parens (App (Qualid (Qualified "Data.Tuple" "uncurry")) (PosArg (Qualid (Bare
+    "f")) :| []))) :| [])) (PosArg (Parens (App (App (Qualid (Qualified "Control.Monad.Zip"
     "mzip")) (PosArg (Qualid (Bare "ma")) :| [])) (PosArg (Qualid (Bare "mb")) :|
     []))) :| [])))]
 classTypes:
   Control.Monad.Zip.MonadZip: fromList []
 classDefns:
   Control.Monad.Zip.MonadZip: ClassDefinition (Qualified "Control.Monad.Zip" "MonadZip")
-    [Inferred Explicit (Ident (Bare "m")),Generalized Implicit (App (Qualid (Qualified
+    [ExplicitBinder (Ident (Bare "m")),Generalized Implicit (App (Qualid (Qualified
     "GHC.Base" "Monad")) (PosArg (Qualid (Bare "m")) :| []))] Nothing [(Qualified
-    "Control.Monad.Zip" "munzip",Forall (Inferred Implicit (Ident (Bare "a")) :| [Inferred
-    Implicit (Ident (Bare "b"))]) (Arrow (App (Qualid (Bare "m")) (PosArg (InScope
-    (App (Qualid (Bare "op_zt__")) (PosArg (Qualid (Bare "a")) :| [PosArg (Qualid
-    (Bare "b"))])) "type") :| [])) (InScope (App (Qualid (Bare "op_zt__")) (PosArg
-    (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "a")) :| [])) :| [PosArg (App (Qualid
-    (Bare "m")) (PosArg (Qualid (Bare "b")) :| []))])) "type"))),(Qualified "Control.Monad.Zip"
-    "mzip",Forall (Inferred Implicit (Ident (Bare "a")) :| [Inferred Implicit (Ident
-    (Bare "b"))]) (Arrow (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "a")) :| []))
-    (Arrow (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "b")) :| [])) (App (Qualid
-    (Bare "m")) (PosArg (InScope (App (Qualid (Bare "op_zt__")) (PosArg (Qualid (Bare
-    "a")) :| [PosArg (Qualid (Bare "b"))])) "type") :| []))))),(Qualified "Control.Monad.Zip"
-    "mzipWith",Forall (Inferred Implicit (Ident (Bare "a")) :| [Inferred Implicit
-    (Ident (Bare "b")),Inferred Implicit (Ident (Bare "c"))]) (Arrow (Parens (Arrow
-    (Qualid (Bare "a")) (Arrow (Qualid (Bare "b")) (Qualid (Bare "c"))))) (Arrow (App
-    (Qualid (Bare "m")) (PosArg (Qualid (Bare "a")) :| [])) (Arrow (App (Qualid (Bare
-    "m")) (PosArg (Qualid (Bare "b")) :| [])) (App (Qualid (Bare "m")) (PosArg (Qualid
-    (Bare "c")) :| []))))))]
+    "Control.Monad.Zip" "munzip",Forall (ImplicitBinders (Ident (Bare "a") :| [])
+    :| [ImplicitBinders (Ident (Bare "b") :| [])]) (Arrow (App (Qualid (Bare "m"))
+    (PosArg (InScope (App (Qualid (Bare "op_zt__")) (PosArg (Qualid (Bare "a")) :|
+    [PosArg (Qualid (Bare "b"))])) "type") :| [])) (InScope (App (Qualid (Bare "op_zt__"))
+    (PosArg (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "a")) :| [])) :| [PosArg
+    (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "b")) :| []))])) "type"))),(Qualified
+    "Control.Monad.Zip" "mzip",Forall (ImplicitBinders (Ident (Bare "a") :| []) :|
+    [ImplicitBinders (Ident (Bare "b") :| [])]) (Arrow (App (Qualid (Bare "m")) (PosArg
+    (Qualid (Bare "a")) :| [])) (Arrow (App (Qualid (Bare "m")) (PosArg (Qualid (Bare
+    "b")) :| [])) (App (Qualid (Bare "m")) (PosArg (InScope (App (Qualid (Bare "op_zt__"))
+    (PosArg (Qualid (Bare "a")) :| [PosArg (Qualid (Bare "b"))])) "type") :| []))))),(Qualified
+    "Control.Monad.Zip" "mzipWith",Forall (ImplicitBinders (Ident (Bare "a") :| [])
+    :| [ImplicitBinders (Ident (Bare "b") :| []),ImplicitBinders (Ident (Bare "c")
+    :| [])]) (Arrow (Parens (Arrow (Qualid (Bare "a")) (Arrow (Qualid (Bare "b"))
+    (Qualid (Bare "c"))))) (Arrow (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "a"))
+    :| [])) (Arrow (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "b")) :| [])) (App
+    (Qualid (Bare "m")) (PosArg (Qualid (Bare "c")) :| []))))))]

--- a/base/Data/Bifoldable.h2ci
+++ b/base/Data/Bifoldable.h2ci
@@ -4,62 +4,62 @@ defaultMethods:
   Data.Bifoldable.Bifoldable: fromList [(Qualified "Data.Bifoldable" "bifold",App
     (App (Qualid (Qualified "Data.Bifoldable" "bifoldMap")) (PosArg (Qualid (Qualified
     "GHC.Base" "id")) :| [])) (PosArg (Qualid (Qualified "GHC.Base" "id")) :| [])),(Qualified
-    "Data.Bifoldable" "bifoldMap",Fun (Inferred Explicit (Ident (Bare "f")) :| [Inferred
-    Explicit (Ident (Bare "g"))]) (App (App (App (Qualid (Qualified "Data.Bifoldable"
-    "bifoldr")) (PosArg (Parens (App (Qualid (Qualified "GHC.Base" "op_z2218U__"))
-    (PosArg (Qualid (Qualified "GHC.Base" "mappend")) :| [PosArg (Qualid (Bare "f"))])))
-    :| [])) (PosArg (Parens (App (Qualid (Qualified "GHC.Base" "op_z2218U__")) (PosArg
-    (Qualid (Qualified "GHC.Base" "mappend")) :| [PosArg (Qualid (Bare "g"))]))) :|
-    [])) (PosArg (Qualid (Qualified "GHC.Base" "mempty")) :| []))),(Qualified "Data.Bifoldable"
-    "bifoldl",Fun (Inferred Explicit (Ident (Bare "f")) :| [Inferred Explicit (Ident
-    (Bare "g")),Inferred Explicit (Ident (Bare "z")),Inferred Explicit (Ident (Bare
-    "t"))]) (App (App (Qualid (Qualified "Data.SemigroupInternal" "appEndo")) (PosArg
-    (Parens (App (Qualid (Qualified "Data.SemigroupInternal" "getDual")) (PosArg (Parens
-    (App (App (App (Qualid (Qualified "Data.Bifoldable" "bifoldMap")) (PosArg (Parens
-    (App (Qualid (Qualified "GHC.Base" "op_z2218U__")) (PosArg (Qualid (Qualified
-    "Data.SemigroupInternal" "Mk_Dual")) :| [PosArg (App (Qualid (Qualified "GHC.Base"
-    "op_z2218U__")) (PosArg (Qualid (Qualified "Data.SemigroupInternal" "Mk_Endo"))
-    :| [PosArg (App (Qualid (Qualified "GHC.Base" "flip")) (PosArg (Qualid (Bare "f"))
-    :| []))]))]))) :| [])) (PosArg (Parens (App (Qualid (Qualified "GHC.Base" "op_z2218U__"))
+    "Data.Bifoldable" "bifoldMap",Fun (ExplicitBinder (Ident (Bare "f")) :| [ExplicitBinder
+    (Ident (Bare "g"))]) (App (App (App (Qualid (Qualified "Data.Bifoldable" "bifoldr"))
+    (PosArg (Parens (App (Qualid (Qualified "GHC.Base" "op_z2218U__")) (PosArg (Qualid
+    (Qualified "GHC.Base" "mappend")) :| [PosArg (Qualid (Bare "f"))]))) :| [])) (PosArg
+    (Parens (App (Qualid (Qualified "GHC.Base" "op_z2218U__")) (PosArg (Qualid (Qualified
+    "GHC.Base" "mappend")) :| [PosArg (Qualid (Bare "g"))]))) :| [])) (PosArg (Qualid
+    (Qualified "GHC.Base" "mempty")) :| []))),(Qualified "Data.Bifoldable" "bifoldl",Fun
+    (ExplicitBinder (Ident (Bare "f")) :| [ExplicitBinder (Ident (Bare "g")),ExplicitBinder
+    (Ident (Bare "z")),ExplicitBinder (Ident (Bare "t"))]) (App (App (Qualid (Qualified
+    "Data.SemigroupInternal" "appEndo")) (PosArg (Parens (App (Qualid (Qualified "Data.SemigroupInternal"
+    "getDual")) (PosArg (Parens (App (App (App (Qualid (Qualified "Data.Bifoldable"
+    "bifoldMap")) (PosArg (Parens (App (Qualid (Qualified "GHC.Base" "op_z2218U__"))
     (PosArg (Qualid (Qualified "Data.SemigroupInternal" "Mk_Dual")) :| [PosArg (App
     (Qualid (Qualified "GHC.Base" "op_z2218U__")) (PosArg (Qualid (Qualified "Data.SemigroupInternal"
     "Mk_Endo")) :| [PosArg (App (Qualid (Qualified "GHC.Base" "flip")) (PosArg (Qualid
-    (Bare "g")) :| []))]))]))) :| [])) (PosArg (Qualid (Bare "t")) :| []))) :| [])))
-    :| [])) (PosArg (Qualid (Bare "z")) :| []))),(Qualified "Data.Bifoldable" "bifoldr",Fun
-    (Inferred Explicit (Ident (Bare "f")) :| [Inferred Explicit (Ident (Bare "g")),Inferred
-    Explicit (Ident (Bare "z")),Inferred Explicit (Ident (Bare "t"))]) (App (App (Qualid
-    (Qualified "Data.SemigroupInternal" "appEndo")) (PosArg (Parens (App (App (App
-    (Qualid (Qualified "Data.Bifoldable" "bifoldMap")) (PosArg (Parens (App (Qualid
-    (Qualified "Coq.Program.Basics" "compose")) (PosArg (Qualid (Qualified "Data.SemigroupInternal"
-    "Mk_Endo")) :| [PosArg (Qualid (Bare "f"))]))) :| [])) (PosArg (Parens (App (Qualid
-    (Qualified "Coq.Program.Basics" "compose")) (PosArg (Qualid (Qualified "Data.SemigroupInternal"
-    "Mk_Endo")) :| [PosArg (Qualid (Bare "g"))]))) :| [])) (PosArg (Qualid (Bare "t"))
-    :| []))) :| [])) (PosArg (Qualid (Bare "z")) :| [])))]
+    (Bare "f")) :| []))]))]))) :| [])) (PosArg (Parens (App (Qualid (Qualified "GHC.Base"
+    "op_z2218U__")) (PosArg (Qualid (Qualified "Data.SemigroupInternal" "Mk_Dual"))
+    :| [PosArg (App (Qualid (Qualified "GHC.Base" "op_z2218U__")) (PosArg (Qualid
+    (Qualified "Data.SemigroupInternal" "Mk_Endo")) :| [PosArg (App (Qualid (Qualified
+    "GHC.Base" "flip")) (PosArg (Qualid (Bare "g")) :| []))]))]))) :| [])) (PosArg
+    (Qualid (Bare "t")) :| []))) :| []))) :| [])) (PosArg (Qualid (Bare "z")) :| []))),(Qualified
+    "Data.Bifoldable" "bifoldr",Fun (ExplicitBinder (Ident (Bare "f")) :| [ExplicitBinder
+    (Ident (Bare "g")),ExplicitBinder (Ident (Bare "z")),ExplicitBinder (Ident (Bare
+    "t"))]) (App (App (Qualid (Qualified "Data.SemigroupInternal" "appEndo")) (PosArg
+    (Parens (App (App (App (Qualid (Qualified "Data.Bifoldable" "bifoldMap")) (PosArg
+    (Parens (App (Qualid (Qualified "Coq.Program.Basics" "compose")) (PosArg (Qualid
+    (Qualified "Data.SemigroupInternal" "Mk_Endo")) :| [PosArg (Qualid (Bare "f"))])))
+    :| [])) (PosArg (Parens (App (Qualid (Qualified "Coq.Program.Basics" "compose"))
+    (PosArg (Qualid (Qualified "Data.SemigroupInternal" "Mk_Endo")) :| [PosArg (Qualid
+    (Bare "g"))]))) :| [])) (PosArg (Qualid (Bare "t")) :| []))) :| [])) (PosArg (Qualid
+    (Bare "z")) :| [])))]
 classTypes:
   Data.Bifoldable.Bifoldable: fromList []
 classDefns:
   Data.Bifoldable.Bifoldable: ClassDefinition (Qualified "Data.Bifoldable" "Bifoldable")
-    [Inferred Explicit (Ident (Bare "p"))] Nothing [(Qualified "Data.Bifoldable" "bifold",Forall
-    (Inferred Implicit (Ident (Bare "m")) :| []) (Forall (Generalized Implicit (App
-    (Qualid (Qualified "GHC.Base" "Monoid")) (PosArg (Qualid (Bare "m")) :| [])) :|
-    []) (Arrow (App (App (Qualid (Bare "p")) (PosArg (Qualid (Bare "m")) :| [])) (PosArg
-    (Qualid (Bare "m")) :| [])) (Qualid (Bare "m"))))),(Qualified "Data.Bifoldable"
-    "bifoldMap",Forall (Inferred Implicit (Ident (Bare "m")) :| [Inferred Implicit
-    (Ident (Bare "a")),Inferred Implicit (Ident (Bare "b"))]) (Forall (Generalized
+    [ExplicitBinder (Ident (Bare "p"))] Nothing [(Qualified "Data.Bifoldable" "bifold",Forall
+    (ImplicitBinders (Ident (Bare "m") :| []) :| []) (Forall (Generalized Implicit
+    (App (Qualid (Qualified "GHC.Base" "Monoid")) (PosArg (Qualid (Bare "m")) :| []))
+    :| []) (Arrow (App (App (Qualid (Bare "p")) (PosArg (Qualid (Bare "m")) :| []))
+    (PosArg (Qualid (Bare "m")) :| [])) (Qualid (Bare "m"))))),(Qualified "Data.Bifoldable"
+    "bifoldMap",Forall (ImplicitBinders (Ident (Bare "m") :| []) :| [ImplicitBinders
+    (Ident (Bare "a") :| []),ImplicitBinders (Ident (Bare "b") :| [])]) (Forall (Generalized
     Implicit (App (Qualid (Qualified "GHC.Base" "Monoid")) (PosArg (Qualid (Bare "m"))
     :| [])) :| []) (Arrow (Parens (Arrow (Qualid (Bare "a")) (Qualid (Bare "m"))))
     (Arrow (Parens (Arrow (Qualid (Bare "b")) (Qualid (Bare "m")))) (Arrow (App (App
     (Qualid (Bare "p")) (PosArg (Qualid (Bare "a")) :| [])) (PosArg (Qualid (Bare
     "b")) :| [])) (Qualid (Bare "m"))))))),(Qualified "Data.Bifoldable" "bifoldl",Forall
-    (Inferred Implicit (Ident (Bare "c")) :| [Inferred Implicit (Ident (Bare "a")),Inferred
-    Implicit (Ident (Bare "b"))]) (Arrow (Parens (Arrow (Qualid (Bare "c")) (Arrow
-    (Qualid (Bare "a")) (Qualid (Bare "c"))))) (Arrow (Parens (Arrow (Qualid (Bare
-    "c")) (Arrow (Qualid (Bare "b")) (Qualid (Bare "c"))))) (Arrow (Qualid (Bare "c"))
-    (Arrow (App (App (Qualid (Bare "p")) (PosArg (Qualid (Bare "a")) :| [])) (PosArg
-    (Qualid (Bare "b")) :| [])) (Qualid (Bare "c"))))))),(Qualified "Data.Bifoldable"
-    "bifoldr",Forall (Inferred Implicit (Ident (Bare "a")) :| [Inferred Implicit (Ident
-    (Bare "c")),Inferred Implicit (Ident (Bare "b"))]) (Arrow (Parens (Arrow (Qualid
-    (Bare "a")) (Arrow (Qualid (Bare "c")) (Qualid (Bare "c"))))) (Arrow (Parens (Arrow
-    (Qualid (Bare "b")) (Arrow (Qualid (Bare "c")) (Qualid (Bare "c"))))) (Arrow (Qualid
+    (ImplicitBinders (Ident (Bare "c") :| []) :| [ImplicitBinders (Ident (Bare "a")
+    :| []),ImplicitBinders (Ident (Bare "b") :| [])]) (Arrow (Parens (Arrow (Qualid
+    (Bare "c")) (Arrow (Qualid (Bare "a")) (Qualid (Bare "c"))))) (Arrow (Parens (Arrow
+    (Qualid (Bare "c")) (Arrow (Qualid (Bare "b")) (Qualid (Bare "c"))))) (Arrow (Qualid
     (Bare "c")) (Arrow (App (App (Qualid (Bare "p")) (PosArg (Qualid (Bare "a")) :|
-    [])) (PosArg (Qualid (Bare "b")) :| [])) (Qualid (Bare "c")))))))]
+    [])) (PosArg (Qualid (Bare "b")) :| [])) (Qualid (Bare "c"))))))),(Qualified "Data.Bifoldable"
+    "bifoldr",Forall (ImplicitBinders (Ident (Bare "a") :| []) :| [ImplicitBinders
+    (Ident (Bare "c") :| []),ImplicitBinders (Ident (Bare "b") :| [])]) (Arrow (Parens
+    (Arrow (Qualid (Bare "a")) (Arrow (Qualid (Bare "c")) (Qualid (Bare "c"))))) (Arrow
+    (Parens (Arrow (Qualid (Bare "b")) (Arrow (Qualid (Bare "c")) (Qualid (Bare "c")))))
+    (Arrow (Qualid (Bare "c")) (Arrow (App (App (Qualid (Bare "p")) (PosArg (Qualid
+    (Bare "a")) :| [])) (PosArg (Qualid (Bare "b")) :| [])) (Qualid (Bare "c")))))))]

--- a/base/Data/Bifunctor.h2ci
+++ b/base/Data/Bifunctor.h2ci
@@ -1,36 +1,36 @@
 superclassCount:
   Data.Bifunctor.Bifunctor: '0'
 defaultMethods:
-  Data.Bifunctor.Bifunctor: fromList [(Qualified "Data.Bifunctor" "bimap",Fun (Inferred
-    Explicit (Ident (Bare "f")) :| [Inferred Explicit (Ident (Bare "g"))]) (App (Qualid
-    (Qualified "GHC.Base" "op_z2218U__")) (PosArg (App (Qualid (Qualified "Data.Bifunctor"
-    "first")) (PosArg (Qualid (Bare "f")) :| [])) :| [PosArg (App (Qualid (Qualified
-    "Data.Bifunctor" "second")) (PosArg (Qualid (Bare "g")) :| []))]))),(Qualified
-    "Data.Bifunctor" "first",Fun (Inferred Explicit (Ident (Bare "f")) :| []) (App
-    (App (Qualid (Qualified "Data.Bifunctor" "bimap")) (PosArg (Qualid (Bare "f"))
-    :| [])) (PosArg (Qualid (Qualified "GHC.Base" "id")) :| []))),(Qualified "Data.Bifunctor"
-    "second",App (Qualid (Qualified "Data.Bifunctor" "bimap")) (PosArg (Qualid (Qualified
-    "GHC.Base" "id")) :| []))]
+  Data.Bifunctor.Bifunctor: fromList [(Qualified "Data.Bifunctor" "bimap",Fun (ExplicitBinder
+    (Ident (Bare "f")) :| [ExplicitBinder (Ident (Bare "g"))]) (App (Qualid (Qualified
+    "GHC.Base" "op_z2218U__")) (PosArg (App (Qualid (Qualified "Data.Bifunctor" "first"))
+    (PosArg (Qualid (Bare "f")) :| [])) :| [PosArg (App (Qualid (Qualified "Data.Bifunctor"
+    "second")) (PosArg (Qualid (Bare "g")) :| []))]))),(Qualified "Data.Bifunctor"
+    "first",Fun (ExplicitBinder (Ident (Bare "f")) :| []) (App (App (Qualid (Qualified
+    "Data.Bifunctor" "bimap")) (PosArg (Qualid (Bare "f")) :| [])) (PosArg (Qualid
+    (Qualified "GHC.Base" "id")) :| []))),(Qualified "Data.Bifunctor" "second",App
+    (Qualid (Qualified "Data.Bifunctor" "bimap")) (PosArg (Qualid (Qualified "GHC.Base"
+    "id")) :| []))]
 classTypes:
   Data.Bifunctor.Bifunctor: fromList []
 classDefns:
   Data.Bifunctor.Bifunctor: ClassDefinition (Qualified "Data.Bifunctor" "Bifunctor")
-    [Inferred Explicit (Ident (Bare "p"))] Nothing [(Qualified "Data.Bifunctor" "bimap",Forall
-    (Inferred Implicit (Ident (Bare "a")) :| [Inferred Implicit (Ident (Bare "b")),Inferred
-    Implicit (Ident (Bare "c")),Inferred Implicit (Ident (Bare "d"))]) (Arrow (Parens
-    (Arrow (Qualid (Bare "a")) (Qualid (Bare "b")))) (Arrow (Parens (Arrow (Qualid
-    (Bare "c")) (Qualid (Bare "d")))) (Arrow (App (App (Qualid (Bare "p")) (PosArg
-    (Qualid (Bare "a")) :| [])) (PosArg (Qualid (Bare "c")) :| [])) (App (App (Qualid
-    (Bare "p")) (PosArg (Qualid (Bare "b")) :| [])) (PosArg (Qualid (Bare "d")) :|
-    [])))))),(Qualified "Data.Bifunctor" "first",Forall (Inferred Implicit (Ident
-    (Bare "a")) :| [Inferred Implicit (Ident (Bare "b")),Inferred Implicit (Ident
-    (Bare "c"))]) (Arrow (Parens (Arrow (Qualid (Bare "a")) (Qualid (Bare "b"))))
-    (Arrow (App (App (Qualid (Bare "p")) (PosArg (Qualid (Bare "a")) :| [])) (PosArg
-    (Qualid (Bare "c")) :| [])) (App (App (Qualid (Bare "p")) (PosArg (Qualid (Bare
-    "b")) :| [])) (PosArg (Qualid (Bare "c")) :| []))))),(Qualified "Data.Bifunctor"
-    "second",Forall (Inferred Implicit (Ident (Bare "b")) :| [Inferred Implicit (Ident
-    (Bare "c")),Inferred Implicit (Ident (Bare "a"))]) (Arrow (Parens (Arrow (Qualid
-    (Bare "b")) (Qualid (Bare "c")))) (Arrow (App (App (Qualid (Bare "p")) (PosArg
-    (Qualid (Bare "a")) :| [])) (PosArg (Qualid (Bare "b")) :| [])) (App (App (Qualid
+    [ExplicitBinder (Ident (Bare "p"))] Nothing [(Qualified "Data.Bifunctor" "bimap",Forall
+    (ImplicitBinders (Ident (Bare "a") :| []) :| [ImplicitBinders (Ident (Bare "b")
+    :| []),ImplicitBinders (Ident (Bare "c") :| []),ImplicitBinders (Ident (Bare "d")
+    :| [])]) (Arrow (Parens (Arrow (Qualid (Bare "a")) (Qualid (Bare "b")))) (Arrow
+    (Parens (Arrow (Qualid (Bare "c")) (Qualid (Bare "d")))) (Arrow (App (App (Qualid
     (Bare "p")) (PosArg (Qualid (Bare "a")) :| [])) (PosArg (Qualid (Bare "c")) :|
-    [])))))]
+    [])) (App (App (Qualid (Bare "p")) (PosArg (Qualid (Bare "b")) :| [])) (PosArg
+    (Qualid (Bare "d")) :| [])))))),(Qualified "Data.Bifunctor" "first",Forall (ImplicitBinders
+    (Ident (Bare "a") :| []) :| [ImplicitBinders (Ident (Bare "b") :| []),ImplicitBinders
+    (Ident (Bare "c") :| [])]) (Arrow (Parens (Arrow (Qualid (Bare "a")) (Qualid (Bare
+    "b")))) (Arrow (App (App (Qualid (Bare "p")) (PosArg (Qualid (Bare "a")) :| []))
+    (PosArg (Qualid (Bare "c")) :| [])) (App (App (Qualid (Bare "p")) (PosArg (Qualid
+    (Bare "b")) :| [])) (PosArg (Qualid (Bare "c")) :| []))))),(Qualified "Data.Bifunctor"
+    "second",Forall (ImplicitBinders (Ident (Bare "b") :| []) :| [ImplicitBinders
+    (Ident (Bare "c") :| []),ImplicitBinders (Ident (Bare "a") :| [])]) (Arrow (Parens
+    (Arrow (Qualid (Bare "b")) (Qualid (Bare "c")))) (Arrow (App (App (Qualid (Bare
+    "p")) (PosArg (Qualid (Bare "a")) :| [])) (PosArg (Qualid (Bare "b")) :| []))
+    (App (App (Qualid (Bare "p")) (PosArg (Qualid (Bare "a")) :| [])) (PosArg (Qualid
+    (Bare "c")) :| [])))))]

--- a/base/Data/Bitraversable.h2ci
+++ b/base/Data/Bitraversable.h2ci
@@ -2,26 +2,26 @@ superclassCount:
   Data.Bitraversable.Bitraversable: '2'
 defaultMethods:
   Data.Bitraversable.Bitraversable: fromList [(Qualified "Data.Bitraversable" "bitraverse",Fun
-    (Inferred Explicit (Ident (Bare "f")) :| [Inferred Explicit (Ident (Bare "g"))])
-    (App (Qualid (Qualified "GHC.Base" "op_z2218U__")) (PosArg (Qualid (Qualified
-    "Data.Bitraversable" "bisequenceA")) :| [PosArg (App (App (Qualid (Qualified "Data.Bifunctor"
-    "bimap")) (PosArg (Qualid (Bare "f")) :| [])) (PosArg (Qualid (Bare "g")) :| []))])))]
+    (ExplicitBinder (Ident (Bare "f")) :| [ExplicitBinder (Ident (Bare "g"))]) (App
+    (Qualid (Qualified "GHC.Base" "op_z2218U__")) (PosArg (Qualid (Qualified "Data.Bitraversable"
+    "bisequenceA")) :| [PosArg (App (App (Qualid (Qualified "Data.Bifunctor" "bimap"))
+    (PosArg (Qualid (Bare "f")) :| [])) (PosArg (Qualid (Bare "g")) :| []))])))]
 classTypes:
   Data.Bitraversable.Bitraversable: fromList []
 classDefns:
   Data.Bitraversable.Bitraversable: ClassDefinition (Qualified "Data.Bitraversable"
-    "Bitraversable") [Inferred Explicit (Ident (Bare "t")),Generalized Implicit (App
+    "Bitraversable") [ExplicitBinder (Ident (Bare "t")),Generalized Implicit (App
     (Qualid (Qualified "Data.Bifunctor" "Bifunctor")) (PosArg (Qualid (Bare "t"))
     :| [])),Generalized Implicit (App (Qualid (Qualified "Data.Bifoldable" "Bifoldable"))
     (PosArg (Qualid (Bare "t")) :| []))] Nothing [(Qualified "Data.Bitraversable"
-    "bitraverse",Forall (Inferred Implicit (Ident (Bare "f")) :| [Inferred Implicit
-    (Ident (Bare "a")),Inferred Implicit (Ident (Bare "c")),Inferred Implicit (Ident
-    (Bare "b")),Inferred Implicit (Ident (Bare "d"))]) (Forall (Generalized Implicit
-    (App (Qualid (Qualified "GHC.Base" "Applicative")) (PosArg (Qualid (Bare "f"))
-    :| [])) :| []) (Arrow (Parens (Arrow (Qualid (Bare "a")) (App (Qualid (Bare "f"))
-    (PosArg (Qualid (Bare "c")) :| [])))) (Arrow (Parens (Arrow (Qualid (Bare "b"))
-    (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "d")) :| [])))) (Arrow (App (App
-    (Qualid (Bare "t")) (PosArg (Qualid (Bare "a")) :| [])) (PosArg (Qualid (Bare
+    "bitraverse",Forall (ImplicitBinders (Ident (Bare "f") :| []) :| [ImplicitBinders
+    (Ident (Bare "a") :| []),ImplicitBinders (Ident (Bare "c") :| []),ImplicitBinders
+    (Ident (Bare "b") :| []),ImplicitBinders (Ident (Bare "d") :| [])]) (Forall (Generalized
+    Implicit (App (Qualid (Qualified "GHC.Base" "Applicative")) (PosArg (Qualid (Bare
+    "f")) :| [])) :| []) (Arrow (Parens (Arrow (Qualid (Bare "a")) (App (Qualid (Bare
+    "f")) (PosArg (Qualid (Bare "c")) :| [])))) (Arrow (Parens (Arrow (Qualid (Bare
+    "b")) (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "d")) :| [])))) (Arrow (App
+    (App (Qualid (Bare "t")) (PosArg (Qualid (Bare "a")) :| [])) (PosArg (Qualid (Bare
     "b")) :| [])) (App (Qualid (Bare "f")) (PosArg (Parens (App (App (Qualid (Bare
     "t")) (PosArg (Qualid (Bare "c")) :| [])) (PosArg (Qualid (Bare "d")) :| [])))
     :| [])))))))]

--- a/base/Data/Foldable.h2ci
+++ b/base/Data/Foldable.h2ci
@@ -5,59 +5,58 @@ defaultMethods:
     (Qualified "GHC.Base" "op_z2218U__")) (PosArg (Qualid (Qualified "Data.Foldable"
     "any")) :| [PosArg (Qualid (Qualified "GHC.Base" "op_zeze__"))])),(Qualified "Data.Foldable"
     "fold",App (Qualid (Qualified "Data.Foldable" "foldMap")) (PosArg (Qualid (Qualified
-    "GHC.Base" "id")) :| [])),(Qualified "Data.Foldable" "foldMap",Fun (Inferred Explicit
+    "GHC.Base" "id")) :| [])),(Qualified "Data.Foldable" "foldMap",Fun (ExplicitBinder
     (Ident (Bare "f")) :| []) (App (App (Qualid (Qualified "Data.Foldable" "foldr"))
     (PosArg (Parens (App (Qualid (Qualified "GHC.Base" "op_z2218U__")) (PosArg (Qualid
     (Qualified "GHC.Base" "mappend")) :| [PosArg (Qualid (Bare "f"))]))) :| [])) (PosArg
     (Qualid (Qualified "GHC.Base" "mempty")) :| []))),(Qualified "Data.Foldable" "foldl",Fun
-    (Inferred Explicit (Ident (Bare "f")) :| [Inferred Explicit (Ident (Bare "z")),Inferred
-    Explicit (Ident (Bare "t"))]) (App (App (Qualid (Qualified "Data.SemigroupInternal"
-    "appEndo")) (PosArg (Parens (App (Qualid (Qualified "Data.SemigroupInternal" "getDual"))
-    (PosArg (Parens (App (App (Qualid (Qualified "Data.Foldable" "foldMap")) (PosArg
-    (Parens (App (Qualid (Qualified "GHC.Base" "op_z2218U__")) (PosArg (Qualid (Qualified
+    (ExplicitBinder (Ident (Bare "f")) :| [ExplicitBinder (Ident (Bare "z")),ExplicitBinder
+    (Ident (Bare "t"))]) (App (App (Qualid (Qualified "Data.SemigroupInternal" "appEndo"))
+    (PosArg (Parens (App (Qualid (Qualified "Data.SemigroupInternal" "getDual")) (PosArg
+    (Parens (App (App (Qualid (Qualified "Data.Foldable" "foldMap")) (PosArg (Parens
+    (App (Qualid (Qualified "GHC.Base" "op_z2218U__")) (PosArg (Qualid (Qualified
     "Data.SemigroupInternal" "Mk_Dual")) :| [PosArg (App (Qualid (Qualified "GHC.Base"
     "op_z2218U__")) (PosArg (Qualid (Qualified "Data.SemigroupInternal" "Mk_Endo"))
     :| [PosArg (App (Qualid (Qualified "GHC.Base" "flip")) (PosArg (Qualid (Bare "f"))
     :| []))]))]))) :| [])) (PosArg (Qualid (Bare "t")) :| []))) :| []))) :| [])) (PosArg
-    (Qualid (Bare "z")) :| []))),(Qualified "Data.Foldable" "foldl''",Fun (Inferred
-    Explicit (Ident (Bare "f")) :| [Inferred Explicit (Ident (Bare "z0")),Inferred
-    Explicit (Ident (Bare "xs"))]) (Let (Bare "f''") [] Nothing (Fun (Inferred Explicit
-    (Ident (Bare "x")) :| [Inferred Explicit (Ident (Bare "k")),Inferred Explicit
-    (Ident (Bare "z"))]) (App (Qualid (Bare "k")) (PosArg (App (Qualid (Bare "f"))
-    (PosArg (Qualid (Bare "z")) :| [PosArg (Qualid (Bare "x"))])) :| []))) (App (App
-    (App (App (Qualid (Qualified "Data.Foldable" "foldr")) (PosArg (Qualid (Bare "f''"))
-    :| [])) (PosArg (Qualid (Qualified "GHC.Base" "id")) :| [])) (PosArg (Qualid (Bare
-    "xs")) :| [])) (PosArg (Qualid (Bare "z0")) :| [])))),(Qualified "Data.Foldable"
-    "foldl1",Fun (Inferred Explicit (Ident (Bare "f")) :| [Inferred Explicit (Ident
-    (Bare "xs"))]) (Let (Bare "mf") [] Nothing (Fun (Inferred Explicit (Ident (Bare
-    "m")) :| [Inferred Explicit (Ident (Bare "y"))]) (App (Qualid (Bare "Some")) (PosArg
-    (Parens (Match (MatchItem (Qualid (Bare "m")) Nothing Nothing :| []) Nothing [Equation
-    (MultPattern (ArgsPat (Bare "None") [] :| []) :| []) (Qualid (Bare "y")),Equation
-    (MultPattern (ArgsPat (Bare "Some") [QualidPat (Bare "x")] :| []) :| []) (App
-    (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "x")) :| [])) (PosArg (Qualid (Bare
-    "y")) :| []))])) :| []))) (App (App (Qualid (Qualified "Data.Maybe" "fromMaybe"))
-    (PosArg (Parens (App (Qualid (Qualified "GHC.Err" "errorWithoutStackTrace")) (PosArg
-    (HsString "foldl1: empty structure") :| []))) :| [])) (PosArg (Parens (App (App
-    (App (Qualid (Qualified "Data.Foldable" "foldl")) (PosArg (Qualid (Bare "mf"))
-    :| [])) (PosArg (Qualid (Bare "None")) :| [])) (PosArg (Qualid (Bare "xs")) :|
-    []))) :| [])))),(Qualified "Data.Foldable" "foldr",Fun (Inferred Explicit (Ident
-    (Bare "f")) :| [Inferred Explicit (Ident (Bare "z")),Inferred Explicit (Ident
-    (Bare "t"))]) (App (App (Qualid (Qualified "Data.SemigroupInternal" "appEndo"))
-    (PosArg (Parens (App (App (Qualid (Qualified "Data.Foldable" "foldMap")) (PosArg
-    (Parens (App (Qualid (Qualified "Coq.Program.Basics" "compose")) (PosArg (Qualid
-    (Qualified "Data.SemigroupInternal" "Mk_Endo")) :| [PosArg (Qualid (Bare "f"))])))
-    :| [])) (PosArg (Qualid (Bare "t")) :| []))) :| [])) (PosArg (Qualid (Bare "z"))
-    :| []))),(Qualified "Data.Foldable" "foldr''",Fun (Inferred Explicit (Ident (Bare
-    "f")) :| [Inferred Explicit (Ident (Bare "z0")),Inferred Explicit (Ident (Bare
-    "xs"))]) (Let (Bare "f''") [] Nothing (Fun (Inferred Explicit (Ident (Bare "k"))
-    :| [Inferred Explicit (Ident (Bare "x")),Inferred Explicit (Ident (Bare "z"))])
+    (Qualid (Bare "z")) :| []))),(Qualified "Data.Foldable" "foldl''",Fun (ExplicitBinder
+    (Ident (Bare "f")) :| [ExplicitBinder (Ident (Bare "z0")),ExplicitBinder (Ident
+    (Bare "xs"))]) (Let (Bare "f''") [] Nothing (Fun (ExplicitBinder (Ident (Bare
+    "x")) :| [ExplicitBinder (Ident (Bare "k")),ExplicitBinder (Ident (Bare "z"))])
     (App (Qualid (Bare "k")) (PosArg (App (Qualid (Bare "f")) (PosArg (Qualid (Bare
-    "x")) :| [PosArg (Qualid (Bare "z"))])) :| []))) (App (App (App (App (Qualid (Qualified
-    "Data.Foldable" "foldl")) (PosArg (Qualid (Bare "f''")) :| [])) (PosArg (Qualid
+    "z")) :| [PosArg (Qualid (Bare "x"))])) :| []))) (App (App (App (App (Qualid (Qualified
+    "Data.Foldable" "foldr")) (PosArg (Qualid (Bare "f''")) :| [])) (PosArg (Qualid
     (Qualified "GHC.Base" "id")) :| [])) (PosArg (Qualid (Bare "xs")) :| [])) (PosArg
-    (Qualid (Bare "z0")) :| [])))),(Qualified "Data.Foldable" "foldr1",Fun (Inferred
-    Explicit (Ident (Bare "f")) :| [Inferred Explicit (Ident (Bare "xs"))]) (Let (Bare
-    "mf") [] Nothing (Fun (Inferred Explicit (Ident (Bare "x")) :| [Inferred Explicit
+    (Qualid (Bare "z0")) :| [])))),(Qualified "Data.Foldable" "foldl1",Fun (ExplicitBinder
+    (Ident (Bare "f")) :| [ExplicitBinder (Ident (Bare "xs"))]) (Let (Bare "mf") []
+    Nothing (Fun (ExplicitBinder (Ident (Bare "m")) :| [ExplicitBinder (Ident (Bare
+    "y"))]) (App (Qualid (Bare "Some")) (PosArg (Parens (Match (MatchItem (Qualid
+    (Bare "m")) Nothing Nothing :| []) Nothing [Equation (MultPattern (ArgsPat (Bare
+    "None") [] :| []) :| []) (Qualid (Bare "y")),Equation (MultPattern (ArgsPat (Bare
+    "Some") [QualidPat (Bare "x")] :| []) :| []) (App (App (Qualid (Bare "f")) (PosArg
+    (Qualid (Bare "x")) :| [])) (PosArg (Qualid (Bare "y")) :| []))])) :| []))) (App
+    (App (Qualid (Qualified "Data.Maybe" "fromMaybe")) (PosArg (Parens (App (Qualid
+    (Qualified "GHC.Err" "errorWithoutStackTrace")) (PosArg (HsString "foldl1: empty
+    structure") :| []))) :| [])) (PosArg (Parens (App (App (App (Qualid (Qualified
+    "Data.Foldable" "foldl")) (PosArg (Qualid (Bare "mf")) :| [])) (PosArg (Qualid
+    (Bare "None")) :| [])) (PosArg (Qualid (Bare "xs")) :| []))) :| [])))),(Qualified
+    "Data.Foldable" "foldr",Fun (ExplicitBinder (Ident (Bare "f")) :| [ExplicitBinder
+    (Ident (Bare "z")),ExplicitBinder (Ident (Bare "t"))]) (App (App (Qualid (Qualified
+    "Data.SemigroupInternal" "appEndo")) (PosArg (Parens (App (App (Qualid (Qualified
+    "Data.Foldable" "foldMap")) (PosArg (Parens (App (Qualid (Qualified "Coq.Program.Basics"
+    "compose")) (PosArg (Qualid (Qualified "Data.SemigroupInternal" "Mk_Endo")) :|
+    [PosArg (Qualid (Bare "f"))]))) :| [])) (PosArg (Qualid (Bare "t")) :| []))) :|
+    [])) (PosArg (Qualid (Bare "z")) :| []))),(Qualified "Data.Foldable" "foldr''",Fun
+    (ExplicitBinder (Ident (Bare "f")) :| [ExplicitBinder (Ident (Bare "z0")),ExplicitBinder
+    (Ident (Bare "xs"))]) (Let (Bare "f''") [] Nothing (Fun (ExplicitBinder (Ident
+    (Bare "k")) :| [ExplicitBinder (Ident (Bare "x")),ExplicitBinder (Ident (Bare
+    "z"))]) (App (Qualid (Bare "k")) (PosArg (App (Qualid (Bare "f")) (PosArg (Qualid
+    (Bare "x")) :| [PosArg (Qualid (Bare "z"))])) :| []))) (App (App (App (App (Qualid
+    (Qualified "Data.Foldable" "foldl")) (PosArg (Qualid (Bare "f''")) :| [])) (PosArg
+    (Qualid (Qualified "GHC.Base" "id")) :| [])) (PosArg (Qualid (Bare "xs")) :| []))
+    (PosArg (Qualid (Bare "z0")) :| [])))),(Qualified "Data.Foldable" "foldr1",Fun
+    (ExplicitBinder (Ident (Bare "f")) :| [ExplicitBinder (Ident (Bare "xs"))]) (Let
+    (Bare "mf") [] Nothing (Fun (ExplicitBinder (Ident (Bare "x")) :| [ExplicitBinder
     (Ident (Bare "m"))]) (App (Qualid (Bare "Some")) (PosArg (Parens (Match (MatchItem
     (Qualid (Bare "m")) Nothing Nothing :| []) Nothing [Equation (MultPattern (ArgsPat
     (Bare "None") [] :| []) :| []) (Qualid (Bare "x")),Equation (MultPattern (ArgsPat
@@ -69,13 +68,13 @@ defaultMethods:
     (Qualified "Data.Foldable" "foldr")) (PosArg (Qualid (Bare "mf")) :| [])) (PosArg
     (Qualid (Bare "None")) :| [])) (PosArg (Qualid (Bare "xs")) :| []))) :| [])))),(Qualified
     "Data.Foldable" "length",App (App (Qualid (Qualified "Data.Foldable" "foldl''"))
-    (PosArg (Parens (Fun (Inferred Explicit (Ident (Bare "arg_0__")) :| [Inferred
-    Explicit (Ident (Bare "arg_1__"))]) (Match (MatchItem (Qualid (Bare "arg_0__"))
-    Nothing Nothing :| [MatchItem (Qualid (Bare "arg_1__")) Nothing Nothing]) Nothing
-    [Equation (MultPattern (QualidPat (Bare "c") :| [UnderscorePat]) :| []) (App (Qualid
-    (Qualified "GHC.Num" "op_zp__")) (PosArg (Qualid (Bare "c")) :| [PosArg (App (Qualid
-    (Qualified "GHC.Num" "fromInteger")) (PosArg (Num 1) :| []))]))]))) :| [])) (PosArg
-    (App (Qualid (Qualified "GHC.Num" "fromInteger")) (PosArg (Num 0) :| [])) :| [])),(Qualified
+    (PosArg (Parens (Fun (ExplicitBinder (Ident (Bare "arg_0__")) :| [ExplicitBinder
+    (Ident (Bare "arg_1__"))]) (Match (MatchItem (Qualid (Bare "arg_0__")) Nothing
+    Nothing :| [MatchItem (Qualid (Bare "arg_1__")) Nothing Nothing]) Nothing [Equation
+    (MultPattern (QualidPat (Bare "c") :| [UnderscorePat]) :| []) (App (Qualid (Qualified
+    "GHC.Num" "op_zp__")) (PosArg (Qualid (Bare "c")) :| [PosArg (App (Qualid (Qualified
+    "GHC.Num" "fromInteger")) (PosArg (Num 1) :| []))]))]))) :| [])) (PosArg (App
+    (Qualid (Qualified "GHC.Num" "fromInteger")) (PosArg (Num 0) :| [])) :| [])),(Qualified
     "Data.Foldable" "maximum",App (Qualid (Qualified "GHC.Base" "op_z2218U__")) (PosArg
     (App (Qualid (Qualified "Data.Maybe" "fromMaybe")) (PosArg (Parens (App (Qualid
     (Qualified "GHC.Err" "errorWithoutStackTrace")) (PosArg (HsString "maximum: empty
@@ -93,62 +92,62 @@ defaultMethods:
     "Coq.Program.Basics" "compose")) (PosArg (Qualid (Qualified "Data.Functor.Utils"
     "Mk_Min")) :| [PosArg (Qualid (Bare "Some"))]))) :| []))]))])),(Qualified "Data.Foldable"
     "null",App (App (Qualid (Qualified "Data.Foldable" "foldr")) (PosArg (Parens (Fun
-    (Inferred Explicit (Ident (Bare "arg_0__")) :| [Inferred Explicit (Ident (Bare
-    "arg_1__"))]) (Qualid (Bare "false")))) :| [])) (PosArg (Qualid (Bare "true"))
-    :| [])),(Qualified "Data.Foldable" "product",App (Qualid (Qualified "Coq.Program.Basics"
-    "compose")) (PosArg (Qualid (Qualified "Data.SemigroupInternal" "getProduct"))
-    :| [PosArg (App (Qualid (Qualified "Data.Foldable" "foldMap")) (PosArg (Qualid
-    (Qualified "Data.SemigroupInternal" "Mk_Product")) :| []))])),(Qualified "Data.Foldable"
+    (ExplicitBinder (Ident (Bare "arg_0__")) :| [ExplicitBinder (Ident (Bare "arg_1__"))])
+    (Qualid (Bare "false")))) :| [])) (PosArg (Qualid (Bare "true")) :| [])),(Qualified
+    "Data.Foldable" "product",App (Qualid (Qualified "Coq.Program.Basics" "compose"))
+    (PosArg (Qualid (Qualified "Data.SemigroupInternal" "getProduct")) :| [PosArg
+    (App (Qualid (Qualified "Data.Foldable" "foldMap")) (PosArg (Qualid (Qualified
+    "Data.SemigroupInternal" "Mk_Product")) :| []))])),(Qualified "Data.Foldable"
     "sum",App (Qualid (Qualified "Coq.Program.Basics" "compose")) (PosArg (Qualid
     (Qualified "Data.SemigroupInternal" "getSum")) :| [PosArg (App (Qualid (Qualified
     "Data.Foldable" "foldMap")) (PosArg (Qualid (Qualified "Data.SemigroupInternal"
-    "Mk_Sum")) :| []))])),(Qualified "Data.Foldable" "toList",Fun (Inferred Explicit
+    "Mk_Sum")) :| []))])),(Qualified "Data.Foldable" "toList",Fun (ExplicitBinder
     (Ident (Bare "t")) :| []) (App (Qualid (Qualified "GHC.Base" "build''")) (PosArg
-    (Fun (Inferred Explicit UnderscoreName :| []) (Parens (Fun (Inferred Explicit
-    (Ident (Bare "c")) :| [Inferred Explicit (Ident (Bare "n"))]) (App (App (App (Qualid
-    (Qualified "Data.Foldable" "foldr")) (PosArg (Qualid (Bare "c")) :| [])) (PosArg
-    (Qualid (Bare "n")) :| [])) (PosArg (Qualid (Bare "t")) :| []))))) :| [])))]'
+    (Fun (ExplicitBinder UnderscoreName :| []) (Parens (Fun (ExplicitBinder (Ident
+    (Bare "c")) :| [ExplicitBinder (Ident (Bare "n"))]) (App (App (App (Qualid (Qualified
+    "Data.Foldable" "foldr")) (PosArg (Qualid (Bare "c")) :| [])) (PosArg (Qualid
+    (Bare "n")) :| [])) (PosArg (Qualid (Bare "t")) :| []))))) :| [])))]'
 classTypes:
   Data.Foldable.Foldable: fromList []
 classDefns:
-  Data.Foldable.Foldable: ClassDefinition (Qualified "Data.Foldable" "Foldable") [Inferred
-    Explicit (Ident (Bare "t"))] Nothing [(Qualified "Data.Foldable" "fold",Forall
-    (Inferred Implicit (Ident (Bare "m")) :| []) (Forall (Generalized Implicit (App
+  Data.Foldable.Foldable: ClassDefinition (Qualified "Data.Foldable" "Foldable") [ExplicitBinder
+    (Ident (Bare "t"))] Nothing [(Qualified "Data.Foldable" "fold",Forall (ImplicitBinders
+    (Ident (Bare "m") :| []) :| []) (Forall (Generalized Implicit (App (Qualid (Qualified
+    "GHC.Base" "Monoid")) (PosArg (Qualid (Bare "m")) :| [])) :| []) (Arrow (App (Qualid
+    (Bare "t")) (PosArg (Qualid (Bare "m")) :| [])) (Qualid (Bare "m"))))),(Qualified
+    "Data.Foldable" "foldMap",Forall (ImplicitBinders (Ident (Bare "m") :| []) :|
+    [ImplicitBinders (Ident (Bare "a") :| [])]) (Forall (Generalized Implicit (App
     (Qualid (Qualified "GHC.Base" "Monoid")) (PosArg (Qualid (Bare "m")) :| [])) :|
-    []) (Arrow (App (Qualid (Bare "t")) (PosArg (Qualid (Bare "m")) :| [])) (Qualid
-    (Bare "m"))))),(Qualified "Data.Foldable" "foldMap",Forall (Inferred Implicit
-    (Ident (Bare "m")) :| [Inferred Implicit (Ident (Bare "a"))]) (Forall (Generalized
-    Implicit (App (Qualid (Qualified "GHC.Base" "Monoid")) (PosArg (Qualid (Bare "m"))
-    :| [])) :| []) (Arrow (Parens (Arrow (Qualid (Bare "a")) (Qualid (Bare "m"))))
-    (Arrow (App (Qualid (Bare "t")) (PosArg (Qualid (Bare "a")) :| [])) (Qualid (Bare
-    "m")))))),(Qualified "Data.Foldable" "foldl",Forall (Inferred Implicit (Ident
-    (Bare "b")) :| [Inferred Implicit (Ident (Bare "a"))]) (Arrow (Parens (Arrow (Qualid
-    (Bare "b")) (Arrow (Qualid (Bare "a")) (Qualid (Bare "b"))))) (Arrow (Qualid (Bare
-    "b")) (Arrow (App (Qualid (Bare "t")) (PosArg (Qualid (Bare "a")) :| [])) (Qualid
-    (Bare "b")))))),(Qualified "Data.Foldable" "foldl'",Forall (Inferred Implicit
-    (Ident (Bare "b")) :| [Inferred Implicit (Ident (Bare "a"))]) (Arrow (Parens (Arrow
-    (Qualid (Bare "b")) (Arrow (Qualid (Bare "a")) (Qualid (Bare "b"))))) (Arrow (Qualid
-    (Bare "b")) (Arrow (App (Qualid (Bare "t")) (PosArg (Qualid (Bare "a")) :| []))
-    (Qualid (Bare "b")))))),(Qualified "Data.Foldable" "foldr",Forall (Inferred Implicit
-    (Ident (Bare "a")) :| [Inferred Implicit (Ident (Bare "b"))]) (Arrow (Parens (Arrow
-    (Qualid (Bare "a")) (Arrow (Qualid (Bare "b")) (Qualid (Bare "b"))))) (Arrow (Qualid
-    (Bare "b")) (Arrow (App (Qualid (Bare "t")) (PosArg (Qualid (Bare "a")) :| []))
-    (Qualid (Bare "b")))))),(Qualified "Data.Foldable" "foldr'",Forall (Inferred Implicit
-    (Ident (Bare "a")) :| [Inferred Implicit (Ident (Bare "b"))]) (Arrow (Parens (Arrow
-    (Qualid (Bare "a")) (Arrow (Qualid (Bare "b")) (Qualid (Bare "b"))))) (Arrow (Qualid
-    (Bare "b")) (Arrow (App (Qualid (Bare "t")) (PosArg (Qualid (Bare "a")) :| []))
-    (Qualid (Bare "b")))))),(Qualified "Data.Foldable" "length",Forall (Inferred Implicit
-    (Ident (Bare "a")) :| []) (Arrow (App (Qualid (Bare "t")) (PosArg (Qualid (Bare
-    "a")) :| [])) (Qualid (Qualified "GHC.Num" "Int")))),(Qualified "Data.Foldable"
-    "null",Forall (Inferred Implicit (Ident (Bare "a")) :| []) (Arrow (App (Qualid
-    (Bare "t")) (PosArg (Qualid (Bare "a")) :| [])) (Qualid (Bare "bool")))),(Qualified
-    "Data.Foldable" "product",Forall (Inferred Implicit (Ident (Bare "a")) :| [])
-    (Forall (Generalized Implicit (App (Qualid (Qualified "GHC.Num" "Num")) (PosArg
-    (Qualid (Bare "a")) :| [])) :| []) (Arrow (App (Qualid (Bare "t")) (PosArg (Qualid
-    (Bare "a")) :| [])) (Qualid (Bare "a"))))),(Qualified "Data.Foldable" "sum",Forall
-    (Inferred Implicit (Ident (Bare "a")) :| []) (Forall (Generalized Implicit (App
-    (Qualid (Qualified "GHC.Num" "Num")) (PosArg (Qualid (Bare "a")) :| [])) :| [])
-    (Arrow (App (Qualid (Bare "t")) (PosArg (Qualid (Bare "a")) :| [])) (Qualid (Bare
-    "a"))))),(Qualified "Data.Foldable" "toList",Forall (Inferred Implicit (Ident
-    (Bare "a")) :| []) (Arrow (App (Qualid (Bare "t")) (PosArg (Qualid (Bare "a"))
-    :| [])) (App (Qualid (Bare "list")) (PosArg (Qualid (Bare "a")) :| []))))]
+    []) (Arrow (Parens (Arrow (Qualid (Bare "a")) (Qualid (Bare "m")))) (Arrow (App
+    (Qualid (Bare "t")) (PosArg (Qualid (Bare "a")) :| [])) (Qualid (Bare "m")))))),(Qualified
+    "Data.Foldable" "foldl",Forall (ImplicitBinders (Ident (Bare "b") :| []) :| [ImplicitBinders
+    (Ident (Bare "a") :| [])]) (Arrow (Parens (Arrow (Qualid (Bare "b")) (Arrow (Qualid
+    (Bare "a")) (Qualid (Bare "b"))))) (Arrow (Qualid (Bare "b")) (Arrow (App (Qualid
+    (Bare "t")) (PosArg (Qualid (Bare "a")) :| [])) (Qualid (Bare "b")))))),(Qualified
+    "Data.Foldable" "foldl'",Forall (ImplicitBinders (Ident (Bare "b") :| []) :| [ImplicitBinders
+    (Ident (Bare "a") :| [])]) (Arrow (Parens (Arrow (Qualid (Bare "b")) (Arrow (Qualid
+    (Bare "a")) (Qualid (Bare "b"))))) (Arrow (Qualid (Bare "b")) (Arrow (App (Qualid
+    (Bare "t")) (PosArg (Qualid (Bare "a")) :| [])) (Qualid (Bare "b")))))),(Qualified
+    "Data.Foldable" "foldr",Forall (ImplicitBinders (Ident (Bare "a") :| []) :| [ImplicitBinders
+    (Ident (Bare "b") :| [])]) (Arrow (Parens (Arrow (Qualid (Bare "a")) (Arrow (Qualid
+    (Bare "b")) (Qualid (Bare "b"))))) (Arrow (Qualid (Bare "b")) (Arrow (App (Qualid
+    (Bare "t")) (PosArg (Qualid (Bare "a")) :| [])) (Qualid (Bare "b")))))),(Qualified
+    "Data.Foldable" "foldr'",Forall (ImplicitBinders (Ident (Bare "a") :| []) :| [ImplicitBinders
+    (Ident (Bare "b") :| [])]) (Arrow (Parens (Arrow (Qualid (Bare "a")) (Arrow (Qualid
+    (Bare "b")) (Qualid (Bare "b"))))) (Arrow (Qualid (Bare "b")) (Arrow (App (Qualid
+    (Bare "t")) (PosArg (Qualid (Bare "a")) :| [])) (Qualid (Bare "b")))))),(Qualified
+    "Data.Foldable" "length",Forall (ImplicitBinders (Ident (Bare "a") :| []) :| [])
+    (Arrow (App (Qualid (Bare "t")) (PosArg (Qualid (Bare "a")) :| [])) (Qualid (Qualified
+    "GHC.Num" "Int")))),(Qualified "Data.Foldable" "null",Forall (ImplicitBinders
+    (Ident (Bare "a") :| []) :| []) (Arrow (App (Qualid (Bare "t")) (PosArg (Qualid
+    (Bare "a")) :| [])) (Qualid (Bare "bool")))),(Qualified "Data.Foldable" "product",Forall
+    (ImplicitBinders (Ident (Bare "a") :| []) :| []) (Forall (Generalized Implicit
+    (App (Qualid (Qualified "GHC.Num" "Num")) (PosArg (Qualid (Bare "a")) :| []))
+    :| []) (Arrow (App (Qualid (Bare "t")) (PosArg (Qualid (Bare "a")) :| [])) (Qualid
+    (Bare "a"))))),(Qualified "Data.Foldable" "sum",Forall (ImplicitBinders (Ident
+    (Bare "a") :| []) :| []) (Forall (Generalized Implicit (App (Qualid (Qualified
+    "GHC.Num" "Num")) (PosArg (Qualid (Bare "a")) :| [])) :| []) (Arrow (App (Qualid
+    (Bare "t")) (PosArg (Qualid (Bare "a")) :| [])) (Qualid (Bare "a"))))),(Qualified
+    "Data.Foldable" "toList",Forall (ImplicitBinders (Ident (Bare "a") :| []) :| [])
+    (Arrow (App (Qualid (Bare "t")) (PosArg (Qualid (Bare "a")) :| [])) (App (Qualid
+    (Bare "list")) (PosArg (Qualid (Bare "a")) :| []))))]

--- a/base/Data/Functor/Classes.h2ci
+++ b/base/Data/Functor/Classes.h2ci
@@ -10,39 +10,38 @@ classTypes:
   Data.Functor.Classes.Ord2: fromList []
 classDefns:
   Data.Functor.Classes.Eq2: ClassDefinition (Qualified "Data.Functor.Classes" "Eq2")
-    [Inferred Explicit (Ident (Bare "f"))] Nothing [(Qualified "Data.Functor.Classes"
-    "liftEq2",Forall (Inferred Implicit (Ident (Bare "a")) :| [Inferred Implicit (Ident
-    (Bare "b")),Inferred Implicit (Ident (Bare "c")),Inferred Implicit (Ident (Bare
-    "d"))]) (Arrow (Parens (Arrow (Qualid (Bare "a")) (Arrow (Qualid (Bare "b")) (Qualid
-    (Bare "bool"))))) (Arrow (Parens (Arrow (Qualid (Bare "c")) (Arrow (Qualid (Bare
-    "d")) (Qualid (Bare "bool"))))) (Arrow (App (App (Qualid (Bare "f")) (PosArg (Qualid
-    (Bare "a")) :| [])) (PosArg (Qualid (Bare "c")) :| [])) (Arrow (App (App (Qualid
-    (Bare "f")) (PosArg (Qualid (Bare "b")) :| [])) (PosArg (Qualid (Bare "d")) :|
-    [])) (Qualid (Bare "bool")))))))]
+    [ExplicitBinder (Ident (Bare "f"))] Nothing [(Qualified "Data.Functor.Classes"
+    "liftEq2",Forall (ImplicitBinders (Ident (Bare "a") :| []) :| [ImplicitBinders
+    (Ident (Bare "b") :| []),ImplicitBinders (Ident (Bare "c") :| []),ImplicitBinders
+    (Ident (Bare "d") :| [])]) (Arrow (Parens (Arrow (Qualid (Bare "a")) (Arrow (Qualid
+    (Bare "b")) (Qualid (Bare "bool"))))) (Arrow (Parens (Arrow (Qualid (Bare "c"))
+    (Arrow (Qualid (Bare "d")) (Qualid (Bare "bool"))))) (Arrow (App (App (Qualid
+    (Bare "f")) (PosArg (Qualid (Bare "a")) :| [])) (PosArg (Qualid (Bare "c")) :|
+    [])) (Arrow (App (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "b")) :| []))
+    (PosArg (Qualid (Bare "d")) :| [])) (Qualid (Bare "bool")))))))]
   Data.Functor.Classes.Ord1: ClassDefinition (Qualified "Data.Functor.Classes" "Ord1")
-    [Inferred Explicit (Ident (Bare "f")),Generalized Implicit (Parens (App (Qualid
-    (Qualified "Data.Functor.Classes" "Eq1")) (PosArg (Qualid (Bare "f")) :| [])))]
-    Nothing [(Qualified "Data.Functor.Classes" "liftCompare",Forall (Inferred Implicit
-    (Ident (Bare "a")) :| [Inferred Implicit (Ident (Bare "b"))]) (Arrow (Parens (Arrow
-    (Qualid (Bare "a")) (Arrow (Qualid (Bare "b")) (Qualid (Bare "comparison")))))
-    (Arrow (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "a")) :| [])) (Arrow (App
-    (Qualid (Bare "f")) (PosArg (Qualid (Bare "b")) :| [])) (Qualid (Bare "comparison"))))))]
+    [ExplicitBinder (Ident (Bare "f")),Generalized Implicit (Parens (App (Qualid (Qualified
+    "Data.Functor.Classes" "Eq1")) (PosArg (Qualid (Bare "f")) :| [])))] Nothing [(Qualified
+    "Data.Functor.Classes" "liftCompare",Forall (ImplicitBinders (Ident (Bare "a")
+    :| []) :| [ImplicitBinders (Ident (Bare "b") :| [])]) (Arrow (Parens (Arrow (Qualid
+    (Bare "a")) (Arrow (Qualid (Bare "b")) (Qualid (Bare "comparison"))))) (Arrow
+    (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "a")) :| [])) (Arrow (App (Qualid
+    (Bare "f")) (PosArg (Qualid (Bare "b")) :| [])) (Qualid (Bare "comparison"))))))]
   Data.Functor.Classes.Eq1: ClassDefinition (Qualified "Data.Functor.Classes" "Eq1")
-    [Inferred Explicit (Ident (Bare "f"))] Nothing [(Qualified "Data.Functor.Classes"
-    "liftEq",Forall (Inferred Implicit (Ident (Bare "a")) :| [Inferred Implicit (Ident
-    (Bare "b"))]) (Arrow (Parens (Arrow (Qualid (Bare "a")) (Arrow (Qualid (Bare "b"))
-    (Qualid (Bare "bool"))))) (Arrow (App (Qualid (Bare "f")) (PosArg (Qualid (Bare
-    "a")) :| [])) (Arrow (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "b")) :| []))
-    (Qualid (Bare "bool"))))))]
+    [ExplicitBinder (Ident (Bare "f"))] Nothing [(Qualified "Data.Functor.Classes"
+    "liftEq",Forall (ImplicitBinders (Ident (Bare "a") :| []) :| [ImplicitBinders
+    (Ident (Bare "b") :| [])]) (Arrow (Parens (Arrow (Qualid (Bare "a")) (Arrow (Qualid
+    (Bare "b")) (Qualid (Bare "bool"))))) (Arrow (App (Qualid (Bare "f")) (PosArg
+    (Qualid (Bare "a")) :| [])) (Arrow (App (Qualid (Bare "f")) (PosArg (Qualid (Bare
+    "b")) :| [])) (Qualid (Bare "bool"))))))]
   Data.Functor.Classes.Ord2: ClassDefinition (Qualified "Data.Functor.Classes" "Ord2")
-    [Inferred Explicit (Ident (Bare "f")),Generalized Implicit (Parens (App (Qualid
-    (Qualified "Data.Functor.Classes" "Eq2")) (PosArg (Qualid (Bare "f")) :| [])))]
-    Nothing [(Qualified "Data.Functor.Classes" "liftCompare2",Forall (Inferred Implicit
-    (Ident (Bare "a")) :| [Inferred Implicit (Ident (Bare "b")),Inferred Implicit
-    (Ident (Bare "c")),Inferred Implicit (Ident (Bare "d"))]) (Arrow (Parens (Arrow
-    (Qualid (Bare "a")) (Arrow (Qualid (Bare "b")) (Qualid (Bare "comparison")))))
-    (Arrow (Parens (Arrow (Qualid (Bare "c")) (Arrow (Qualid (Bare "d")) (Qualid (Bare
-    "comparison"))))) (Arrow (App (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "a"))
-    :| [])) (PosArg (Qualid (Bare "c")) :| [])) (Arrow (App (App (Qualid (Bare "f"))
-    (PosArg (Qualid (Bare "b")) :| [])) (PosArg (Qualid (Bare "d")) :| [])) (Qualid
-    (Bare "comparison")))))))]
+    [ExplicitBinder (Ident (Bare "f")),Generalized Implicit (Parens (App (Qualid (Qualified
+    "Data.Functor.Classes" "Eq2")) (PosArg (Qualid (Bare "f")) :| [])))] Nothing [(Qualified
+    "Data.Functor.Classes" "liftCompare2",Forall (ImplicitBinders (Ident (Bare "a")
+    :| []) :| [ImplicitBinders (Ident (Bare "b") :| []),ImplicitBinders (Ident (Bare
+    "c") :| []),ImplicitBinders (Ident (Bare "d") :| [])]) (Arrow (Parens (Arrow (Qualid
+    (Bare "a")) (Arrow (Qualid (Bare "b")) (Qualid (Bare "comparison"))))) (Arrow
+    (Parens (Arrow (Qualid (Bare "c")) (Arrow (Qualid (Bare "d")) (Qualid (Bare "comparison")))))
+    (Arrow (App (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "a")) :| [])) (PosArg
+    (Qualid (Bare "c")) :| [])) (Arrow (App (App (Qualid (Bare "f")) (PosArg (Qualid
+    (Bare "b")) :| [])) (PosArg (Qualid (Bare "d")) :| [])) (Qualid (Bare "comparison")))))))]

--- a/base/Data/Traversable.h2ci
+++ b/base/Data/Traversable.h2ci
@@ -5,40 +5,41 @@ defaultMethods:
     (Qualified "Data.Traversable" "traverse")),(Qualified "Data.Traversable" "sequence",Qualid
     (Qualified "Data.Traversable" "sequenceA")),(Qualified "Data.Traversable" "sequenceA",App
     (Qualid (Qualified "Data.Traversable" "traverse")) (PosArg (Qualid (Qualified
-    "GHC.Base" "id")) :| [])),(Qualified "Data.Traversable" "traverse",Fun (Inferred
-    Explicit (Ident (Bare "f")) :| []) (App (Qualid (Qualified "GHC.Base" "op_z2218U__"))
-    (PosArg (Qualid (Qualified "Data.Traversable" "sequenceA")) :| [PosArg (App (Qualid
-    (Qualified "GHC.Base" "fmap")) (PosArg (Qualid (Bare "f")) :| []))])))]
+    "GHC.Base" "id")) :| [])),(Qualified "Data.Traversable" "traverse",Fun (ExplicitBinder
+    (Ident (Bare "f")) :| []) (App (Qualid (Qualified "GHC.Base" "op_z2218U__")) (PosArg
+    (Qualid (Qualified "Data.Traversable" "sequenceA")) :| [PosArg (App (Qualid (Qualified
+    "GHC.Base" "fmap")) (PosArg (Qualid (Bare "f")) :| []))])))]
 classTypes:
   Data.Traversable.Traversable: fromList []
 classDefns:
   Data.Traversable.Traversable: ClassDefinition (Qualified "Data.Traversable" "Traversable")
-    [Inferred Explicit (Ident (Bare "t")),Generalized Implicit (App (Qualid (Qualified
+    [ExplicitBinder (Ident (Bare "t")),Generalized Implicit (App (Qualid (Qualified
     "GHC.Base" "Functor")) (PosArg (Qualid (Bare "t")) :| [])),Generalized Implicit
     (App (Qualid (Qualified "Data.Foldable" "Foldable")) (PosArg (Qualid (Bare "t"))
-    :| []))] Nothing [(Qualified "Data.Traversable" "mapM",Forall (Inferred Implicit
-    (Ident (Bare "m")) :| [Inferred Implicit (Ident (Bare "a")),Inferred Implicit
-    (Ident (Bare "b"))]) (Forall (Generalized Implicit (App (Qualid (Qualified "GHC.Base"
-    "Monad")) (PosArg (Qualid (Bare "m")) :| [])) :| []) (Arrow (Parens (Arrow (Qualid
-    (Bare "a")) (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "b")) :| [])))) (Arrow
-    (App (Qualid (Bare "t")) (PosArg (Qualid (Bare "a")) :| [])) (App (Qualid (Bare
-    "m")) (PosArg (Parens (App (Qualid (Bare "t")) (PosArg (Qualid (Bare "b")) :|
-    []))) :| [])))))),(Qualified "Data.Traversable" "sequence",Forall (Inferred Implicit
-    (Ident (Bare "m")) :| [Inferred Implicit (Ident (Bare "a"))]) (Forall (Generalized
-    Implicit (App (Qualid (Qualified "GHC.Base" "Monad")) (PosArg (Qualid (Bare "m"))
-    :| [])) :| []) (Arrow (App (Qualid (Bare "t")) (PosArg (Parens (App (Qualid (Bare
-    "m")) (PosArg (Qualid (Bare "a")) :| []))) :| [])) (App (Qualid (Bare "m")) (PosArg
-    (Parens (App (Qualid (Bare "t")) (PosArg (Qualid (Bare "a")) :| []))) :| []))))),(Qualified
-    "Data.Traversable" "sequenceA",Forall (Inferred Implicit (Ident (Bare "f")) :|
-    [Inferred Implicit (Ident (Bare "a"))]) (Forall (Generalized Implicit (App (Qualid
-    (Qualified "GHC.Base" "Applicative")) (PosArg (Qualid (Bare "f")) :| [])) :| [])
-    (Arrow (App (Qualid (Bare "t")) (PosArg (Parens (App (Qualid (Bare "f")) (PosArg
-    (Qualid (Bare "a")) :| []))) :| [])) (App (Qualid (Bare "f")) (PosArg (Parens
-    (App (Qualid (Bare "t")) (PosArg (Qualid (Bare "a")) :| []))) :| []))))),(Qualified
-    "Data.Traversable" "traverse",Forall (Inferred Implicit (Ident (Bare "f")) :|
-    [Inferred Implicit (Ident (Bare "a")),Inferred Implicit (Ident (Bare "b"))]) (Forall
-    (Generalized Implicit (App (Qualid (Qualified "GHC.Base" "Applicative")) (PosArg
-    (Qualid (Bare "f")) :| [])) :| []) (Arrow (Parens (Arrow (Qualid (Bare "a")) (App
-    (Qualid (Bare "f")) (PosArg (Qualid (Bare "b")) :| [])))) (Arrow (App (Qualid
-    (Bare "t")) (PosArg (Qualid (Bare "a")) :| [])) (App (Qualid (Bare "f")) (PosArg
-    (Parens (App (Qualid (Bare "t")) (PosArg (Qualid (Bare "b")) :| []))) :| []))))))]
+    :| []))] Nothing [(Qualified "Data.Traversable" "mapM",Forall (ImplicitBinders
+    (Ident (Bare "m") :| []) :| [ImplicitBinders (Ident (Bare "a") :| []),ImplicitBinders
+    (Ident (Bare "b") :| [])]) (Forall (Generalized Implicit (App (Qualid (Qualified
+    "GHC.Base" "Monad")) (PosArg (Qualid (Bare "m")) :| [])) :| []) (Arrow (Parens
+    (Arrow (Qualid (Bare "a")) (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "b"))
+    :| [])))) (Arrow (App (Qualid (Bare "t")) (PosArg (Qualid (Bare "a")) :| []))
+    (App (Qualid (Bare "m")) (PosArg (Parens (App (Qualid (Bare "t")) (PosArg (Qualid
+    (Bare "b")) :| []))) :| [])))))),(Qualified "Data.Traversable" "sequence",Forall
+    (ImplicitBinders (Ident (Bare "m") :| []) :| [ImplicitBinders (Ident (Bare "a")
+    :| [])]) (Forall (Generalized Implicit (App (Qualid (Qualified "GHC.Base" "Monad"))
+    (PosArg (Qualid (Bare "m")) :| [])) :| []) (Arrow (App (Qualid (Bare "t")) (PosArg
+    (Parens (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "a")) :| []))) :| []))
+    (App (Qualid (Bare "m")) (PosArg (Parens (App (Qualid (Bare "t")) (PosArg (Qualid
+    (Bare "a")) :| []))) :| []))))),(Qualified "Data.Traversable" "sequenceA",Forall
+    (ImplicitBinders (Ident (Bare "f") :| []) :| [ImplicitBinders (Ident (Bare "a")
+    :| [])]) (Forall (Generalized Implicit (App (Qualid (Qualified "GHC.Base" "Applicative"))
+    (PosArg (Qualid (Bare "f")) :| [])) :| []) (Arrow (App (Qualid (Bare "t")) (PosArg
+    (Parens (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "a")) :| []))) :| []))
+    (App (Qualid (Bare "f")) (PosArg (Parens (App (Qualid (Bare "t")) (PosArg (Qualid
+    (Bare "a")) :| []))) :| []))))),(Qualified "Data.Traversable" "traverse",Forall
+    (ImplicitBinders (Ident (Bare "f") :| []) :| [ImplicitBinders (Ident (Bare "a")
+    :| []),ImplicitBinders (Ident (Bare "b") :| [])]) (Forall (Generalized Implicit
+    (App (Qualid (Qualified "GHC.Base" "Applicative")) (PosArg (Qualid (Bare "f"))
+    :| [])) :| []) (Arrow (Parens (Arrow (Qualid (Bare "a")) (App (Qualid (Bare "f"))
+    (PosArg (Qualid (Bare "b")) :| [])))) (Arrow (App (Qualid (Bare "t")) (PosArg
+    (Qualid (Bare "a")) :| [])) (App (Qualid (Bare "f")) (PosArg (Parens (App (Qualid
+    (Bare "t")) (PosArg (Qualid (Bare "b")) :| []))) :| []))))))]

--- a/base/GHC/Base.h2ci
+++ b/base/GHC/Base.h2ci
@@ -12,24 +12,24 @@ defaultMethods:
   GHC.Base.Functor: fromList [(Qualified "GHC.Base" "op_zlzd__",App (Qualid (Qualified
     "GHC.Base" "op_z2218U__")) (PosArg (Qualid (Qualified "GHC.Base" "fmap")) :| [PosArg
     (Qualid (Qualified "GHC.Base" "const"))]))]
-  GHC.Base.Applicative: fromList [(Qualified "GHC.Base" "liftA2",Fun (Inferred Explicit
-    (Ident (Bare "f")) :| [Inferred Explicit (Ident (Bare "x"))]) (App (Qualid (Qualified
+  GHC.Base.Applicative: fromList [(Qualified "GHC.Base" "liftA2",Fun (ExplicitBinder
+    (Ident (Bare "f")) :| [ExplicitBinder (Ident (Bare "x"))]) (App (Qualid (Qualified
     "GHC.Base" "op_zlztzg__")) (PosArg (Parens (App (App (Qualid (Qualified "GHC.Base"
     "fmap")) (PosArg (Qualid (Bare "f")) :| [])) (PosArg (Qualid (Bare "x")) :| [])))
     :| []))),(Qualified "GHC.Base" "op_zlzt__",App (Qualid (Qualified "GHC.Base" "liftA2"))
     (PosArg (Qualid (Qualified "GHC.Base" "const")) :| [])),(Qualified "GHC.Base"
     "op_zlztzg__",App (Qualid (Qualified "GHC.Base" "liftA2")) (PosArg (Qualid (Qualified
-    "GHC.Base" "id")) :| [])),(Qualified "GHC.Base" "op_ztzg__",Fun (Inferred Explicit
-    (Ident (Bare "a1")) :| [Inferred Explicit (Ident (Bare "a2"))]) (App (Qualid (Qualified
+    "GHC.Base" "id")) :| [])),(Qualified "GHC.Base" "op_ztzg__",Fun (ExplicitBinder
+    (Ident (Bare "a1")) :| [ExplicitBinder (Ident (Bare "a2"))]) (App (Qualid (Qualified
     "GHC.Base" "op_zlztzg__")) (PosArg (Parens (App (Qualid (Qualified "GHC.Base"
     "op_zlzd__")) (PosArg (Qualid (Qualified "GHC.Base" "id")) :| [PosArg (Qualid
     (Bare "a1"))]))) :| [PosArg (Qualid (Bare "a2"))])))]
-  GHC.Base.Semigroup: fromList [(Qualified "GHC.Base" "sconcat",Fun (Inferred Explicit
+  GHC.Base.Semigroup: fromList [(Qualified "GHC.Base" "sconcat",Fun (ExplicitBinder
     (Ident (Bare "arg_0__")) :| []) (Match (MatchItem (Qualid (Bare "arg_0__")) Nothing
     Nothing :| []) Nothing [Equation (MultPattern (ArgsPat (Qualified "GHC.Base" "NEcons")
     [QualidPat (Bare "a"),QualidPat (Bare "as_")] :| []) :| []) (Let (Bare "go") []
-    Nothing (Fix (FixOne (FixBody (Bare "go") (Inferred Explicit (Ident (Bare "arg_1__"))
-    :| [Inferred Explicit (Ident (Bare "arg_2__"))]) Nothing Nothing (Match (MatchItem
+    Nothing (Fix (FixOne (FixBody (Bare "go") (ExplicitBinder (Ident (Bare "arg_1__"))
+    :| [ExplicitBinder (Ident (Bare "arg_2__"))]) Nothing Nothing (Match (MatchItem
     (Qualid (Bare "arg_1__")) Nothing Nothing :| [MatchItem (Qualid (Bare "arg_2__"))
     Nothing Nothing]) Nothing [Equation (MultPattern (QualidPat (Bare "b") :| [ArgsPat
     (Bare "cons") [QualidPat (Bare "c"),QualidPat (Bare "cs")]]) :| []) (App (Qualid
@@ -39,13 +39,13 @@ defaultMethods:
     (Bare "nil") []]) :| []) (Qualid (Bare "b"))])))) (App (App (Qualid (Bare "go"))
     (PosArg (Qualid (Bare "a")) :| [])) (PosArg (Qualid (Bare "as_")) :| [])))])),(Qualified
     "GHC.Base" "stimes",Qualid (Qualified "Data.SemigroupInternal" "stimesDefault"))]
-  GHC.Base.Monad: fromList [(Qualified "GHC.Base" "fail",Fun (Inferred Explicit (Ident
+  GHC.Base.Monad: fromList [(Qualified "GHC.Base" "fail",Fun (ExplicitBinder (Ident
     (Bare "s")) :| []) (App (Qualid (Qualified "GHC.Err" "errorWithoutStackTrace"))
-    (PosArg (Qualid (Bare "s")) :| []))),(Qualified "GHC.Base" "op_zgzg__",Fun (Inferred
-    Explicit (Ident (Bare "m")) :| [Inferred Explicit (Ident (Bare "k"))]) (App (Qualid
-    (Qualified "GHC.Base" "op_zgzgze__")) (PosArg (Qualid (Bare "m")) :| [PosArg (Fun
-    (Inferred Explicit (Ident (Bare "arg_0__")) :| []) (Qualid (Bare "k")))]))),(Qualified
-    "GHC.Base" "return_",Qualid (Qualified "GHC.Base" "pure"))]
+    (PosArg (Qualid (Bare "s")) :| []))),(Qualified "GHC.Base" "op_zgzg__",Fun (ExplicitBinder
+    (Ident (Bare "m")) :| [ExplicitBinder (Ident (Bare "k"))]) (App (Qualid (Qualified
+    "GHC.Base" "op_zgzgze__")) (PosArg (Qualid (Bare "m")) :| [PosArg (Fun (ExplicitBinder
+    (Ident (Bare "arg_0__")) :| []) (Qualid (Bare "k")))]))),(Qualified "GHC.Base"
+    "return_",Qualid (Qualified "GHC.Base" "pure"))]
 classTypes:
   GHC.Base.Monoid: fromList []
   GHC.Base.Functor: fromList []
@@ -57,55 +57,55 @@ constructors:
 constructorFields:
   GHC.Base.NEcons: NonRecordFields 2
 classDefns:
-  GHC.Base.Monoid: ClassDefinition (Qualified "GHC.Base" "Monoid") [Inferred Explicit
+  GHC.Base.Monoid: ClassDefinition (Qualified "GHC.Base" "Monoid") [ExplicitBinder
     (Ident (Bare "a")),Generalized Implicit (App (Qualid (Qualified "GHC.Base" "Semigroup"))
     (PosArg (Qualid (Bare "a")) :| []))] Nothing [(Qualified "GHC.Base" "mappend",Arrow
     (Qualid (Bare "a")) (Arrow (Qualid (Bare "a")) (Qualid (Bare "a")))),(Qualified
     "GHC.Base" "mconcat",Arrow (App (Qualid (Bare "list")) (PosArg (Qualid (Bare "a"))
     :| [])) (Qualid (Bare "a"))),(Qualified "GHC.Base" "mempty",Qualid (Bare "a"))]
-  GHC.Base.Functor: ClassDefinition (Qualified "GHC.Base" "Functor") [Inferred Explicit
-    (Ident (Bare "f"))] Nothing [(Qualified "GHC.Base" "fmap",Forall (Inferred Implicit
-    (Ident (Bare "a")) :| [Inferred Implicit (Ident (Bare "b"))]) (Arrow (Parens (Arrow
-    (Qualid (Bare "a")) (Qualid (Bare "b")))) (Arrow (App (Qualid (Bare "f")) (PosArg
-    (Qualid (Bare "a")) :| [])) (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "b"))
-    :| []))))),(Qualified "GHC.Base" "op_zlzd__",Forall (Inferred Implicit (Ident
-    (Bare "a")) :| [Inferred Implicit (Ident (Bare "b"))]) (Arrow (Qualid (Bare "a"))
-    (Arrow (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "b")) :| [])) (App (Qualid
-    (Bare "f")) (PosArg (Qualid (Bare "a")) :| [])))))]
-  GHC.Base.Applicative: ClassDefinition (Qualified "GHC.Base" "Applicative") [Inferred
-    Explicit (Ident (Bare "f")),Generalized Implicit (App (Qualid (Qualified "GHC.Base"
-    "Functor")) (PosArg (Qualid (Bare "f")) :| []))] Nothing [(Qualified "GHC.Base"
-    "liftA2",Forall (Inferred Implicit (Ident (Bare "a")) :| [Inferred Implicit (Ident
-    (Bare "b")),Inferred Implicit (Ident (Bare "c"))]) (Arrow (Parens (Arrow (Qualid
+  GHC.Base.Functor: ClassDefinition (Qualified "GHC.Base" "Functor") [ExplicitBinder
+    (Ident (Bare "f"))] Nothing [(Qualified "GHC.Base" "fmap",Forall (ImplicitBinders
+    (Ident (Bare "a") :| []) :| [ImplicitBinders (Ident (Bare "b") :| [])]) (Arrow
+    (Parens (Arrow (Qualid (Bare "a")) (Qualid (Bare "b")))) (Arrow (App (Qualid (Bare
+    "f")) (PosArg (Qualid (Bare "a")) :| [])) (App (Qualid (Bare "f")) (PosArg (Qualid
+    (Bare "b")) :| []))))),(Qualified "GHC.Base" "op_zlzd__",Forall (ImplicitBinders
+    (Ident (Bare "a") :| []) :| [ImplicitBinders (Ident (Bare "b") :| [])]) (Arrow
+    (Qualid (Bare "a")) (Arrow (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "b"))
+    :| [])) (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "a")) :| [])))))]
+  GHC.Base.Applicative: ClassDefinition (Qualified "GHC.Base" "Applicative") [ExplicitBinder
+    (Ident (Bare "f")),Generalized Implicit (App (Qualid (Qualified "GHC.Base" "Functor"))
+    (PosArg (Qualid (Bare "f")) :| []))] Nothing [(Qualified "GHC.Base" "liftA2",Forall
+    (ImplicitBinders (Ident (Bare "a") :| []) :| [ImplicitBinders (Ident (Bare "b")
+    :| []),ImplicitBinders (Ident (Bare "c") :| [])]) (Arrow (Parens (Arrow (Qualid
     (Bare "a")) (Arrow (Qualid (Bare "b")) (Qualid (Bare "c"))))) (Arrow (App (Qualid
     (Bare "f")) (PosArg (Qualid (Bare "a")) :| [])) (Arrow (App (Qualid (Bare "f"))
     (PosArg (Qualid (Bare "b")) :| [])) (App (Qualid (Bare "f")) (PosArg (Qualid (Bare
-    "c")) :| [])))))),(Qualified "GHC.Base" "op_zlztzg__",Forall (Inferred Implicit
-    (Ident (Bare "a")) :| [Inferred Implicit (Ident (Bare "b"))]) (Arrow (App (Qualid
-    (Bare "f")) (PosArg (Parens (Arrow (Qualid (Bare "a")) (Qualid (Bare "b")))) :|
-    [])) (Arrow (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "a")) :| [])) (App
-    (Qualid (Bare "f")) (PosArg (Qualid (Bare "b")) :| []))))),(Qualified "GHC.Base"
-    "op_ztzg__",Forall (Inferred Implicit (Ident (Bare "a")) :| [Inferred Implicit
-    (Ident (Bare "b"))]) (Arrow (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "a"))
-    :| [])) (Arrow (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "b")) :| [])) (App
-    (Qualid (Bare "f")) (PosArg (Qualid (Bare "b")) :| []))))),(Qualified "GHC.Base"
-    "pure",Forall (Inferred Implicit (Ident (Bare "a")) :| []) (Arrow (Qualid (Bare
-    "a")) (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "a")) :| []))))]
-  GHC.Base.Semigroup: ClassDefinition (Qualified "GHC.Base" "Semigroup") [Inferred
-    Explicit (Ident (Bare "a"))] Nothing [(Qualified "GHC.Base" "op_zlzlzgzg__",Arrow
-    (Qualid (Bare "a")) (Arrow (Qualid (Bare "a")) (Qualid (Bare "a"))))]
-  GHC.Base.Monad: ClassDefinition (Qualified "GHC.Base" "Monad") [Inferred Explicit
-    (Ident (Bare "m")),Generalized Implicit (App (Qualid (Qualified "GHC.Base" "Applicative"))
+    "c")) :| [])))))),(Qualified "GHC.Base" "op_zlztzg__",Forall (ImplicitBinders
+    (Ident (Bare "a") :| []) :| [ImplicitBinders (Ident (Bare "b") :| [])]) (Arrow
+    (App (Qualid (Bare "f")) (PosArg (Parens (Arrow (Qualid (Bare "a")) (Qualid (Bare
+    "b")))) :| [])) (Arrow (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "a")) :|
+    [])) (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "b")) :| []))))),(Qualified
+    "GHC.Base" "op_ztzg__",Forall (ImplicitBinders (Ident (Bare "a") :| []) :| [ImplicitBinders
+    (Ident (Bare "b") :| [])]) (Arrow (App (Qualid (Bare "f")) (PosArg (Qualid (Bare
+    "a")) :| [])) (Arrow (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "b")) :| []))
+    (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "b")) :| []))))),(Qualified "GHC.Base"
+    "pure",Forall (ImplicitBinders (Ident (Bare "a") :| []) :| []) (Arrow (Qualid
+    (Bare "a")) (App (Qualid (Bare "f")) (PosArg (Qualid (Bare "a")) :| []))))]
+  GHC.Base.Semigroup: ClassDefinition (Qualified "GHC.Base" "Semigroup") [ExplicitBinder
+    (Ident (Bare "a"))] Nothing [(Qualified "GHC.Base" "op_zlzlzgzg__",Arrow (Qualid
+    (Bare "a")) (Arrow (Qualid (Bare "a")) (Qualid (Bare "a"))))]
+  GHC.Base.Monad: ClassDefinition (Qualified "GHC.Base" "Monad") [ExplicitBinder (Ident
+    (Bare "m")),Generalized Implicit (App (Qualid (Qualified "GHC.Base" "Applicative"))
     (PosArg (Qualid (Bare "m")) :| []))] Nothing [(Qualified "GHC.Base" "op_zgzg__",Forall
-    (Inferred Implicit (Ident (Bare "a")) :| [Inferred Implicit (Ident (Bare "b"))])
-    (Arrow (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "a")) :| [])) (Arrow (App
-    (Qualid (Bare "m")) (PosArg (Qualid (Bare "b")) :| [])) (App (Qualid (Bare "m"))
-    (PosArg (Qualid (Bare "b")) :| []))))),(Qualified "GHC.Base" "op_zgzgze__",Forall
-    (Inferred Implicit (Ident (Bare "a")) :| [Inferred Implicit (Ident (Bare "b"))])
-    (Arrow (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "a")) :| [])) (Arrow (Parens
-    (Arrow (Qualid (Bare "a")) (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "b"))
-    :| [])))) (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "b")) :| []))))),(Qualified
-    "GHC.Base" "return_",Forall (Inferred Implicit (Ident (Bare "a")) :| []) (Arrow
+    (ImplicitBinders (Ident (Bare "a") :| []) :| [ImplicitBinders (Ident (Bare "b")
+    :| [])]) (Arrow (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "a")) :| [])) (Arrow
+    (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "b")) :| [])) (App (Qualid (Bare
+    "m")) (PosArg (Qualid (Bare "b")) :| []))))),(Qualified "GHC.Base" "op_zgzgze__",Forall
+    (ImplicitBinders (Ident (Bare "a") :| []) :| [ImplicitBinders (Ident (Bare "b")
+    :| [])]) (Arrow (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "a")) :| [])) (Arrow
+    (Parens (Arrow (Qualid (Bare "a")) (App (Qualid (Bare "m")) (PosArg (Qualid (Bare
+    "b")) :| [])))) (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "b")) :| []))))),(Qualified
+    "GHC.Base" "return_",Forall (ImplicitBinders (Ident (Bare "a") :| []) :| []) (Arrow
     (Qualid (Bare "a")) (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "a")) :| []))))]
 constructorTypes:
   GHC.Base.NEcons: Qualified "GHC.Base" "NonEmpty"

--- a/doc/source/edits.rst
+++ b/doc/source/edits.rst
@@ -871,6 +871,22 @@ Examples:
 
     promote MyModule.foo
 
+``polyrec`` -- Make a function polymorphic recursive
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. index::
+   single: polyrec, edit
+
+Format:
+  | **polyrec** *qualified_name*
+
+Effect:
+  Translates a function which calls itself recursively at a different type.
+
+Examples:
+  .. code-block:: shell
+
+    polyrec MyModule.foo
 
 ``manual notation`` -- Indicate presence of manual notation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -883,7 +899,7 @@ Format:
   | **manual notation** *name*
 
 Effect:
-  If your preamble inludes custom notation (usually for operators), you need
+  If your preamble includes custom notation (usually for operators), you need
   to indicate this using this edit.
   See Section :ref:`mangling` for more information about
   how ``hs-to-coq`` implements custom notation.
@@ -940,6 +956,16 @@ Examples:
 Format:
   | **termination** *qualified_name* *termination_argument*
 
+Examples:
+  .. code-block:: shell
+
+    termination MyModule.foo {struct arg_33__}
+    termination MyModule.foo {struct 3}
+    termination MyModule.foo {measure myExpr}
+    termination MyModule.foo {wf myRel myExpr}
+    termination MyModule.foo {corecursive}
+    termination MyModule.foo {deferred}
+
 Effect:
 
   By default, ``hs-to-coq`` translates recursive definitions using Coq’s
@@ -959,9 +985,15 @@ Effect:
 
     **{** **struct** *qualified_name* **}**
 
-    Coq’s ``fix`` operator usually determines the recusive argument
+    Coq’s ``fix`` operator usually determines the recursive argument
     automatically, but also supports the user to specify it explicitly. This
     *termination_argument* is just passed along to Coq’s ``fix``.
+
+    **{** **struct** *number* **}**
+
+    This variant specifies the position of the recursive argument, counting from 1
+    and ignoring type arguments. (Note: this variant is not actually valid Coq
+    syntax, it is only allowed in edits files.)
 
   * .. index::
        single: measure, termination argument

--- a/examples/ghc/lib/DynFlags.h2ci
+++ b/examples/ghc/lib/DynFlags.h2ci
@@ -607,11 +607,11 @@ recordFieldTypes:
   DynFlags.modRenamings: Qualified "DynFlags" "ModRenaming"
   DynFlags.lAttributes: Qualified "DynFlags" "LlvmTarget"
 classDefns:
-  DynFlags.HasDynFlags: ClassDefinition (Qualified "DynFlags" "HasDynFlags") [Inferred
-    Explicit (Ident (Bare "m"))] Nothing [(Qualified "DynFlags" "getDynFlags",App
-    (Qualid (Bare "m")) (PosArg (Qualid (Qualified "DynFlags" "DynFlags")) :| []))]
+  DynFlags.HasDynFlags: ClassDefinition (Qualified "DynFlags" "HasDynFlags") [ExplicitBinder
+    (Ident (Bare "m"))] Nothing [(Qualified "DynFlags" "getDynFlags",App (Qualid (Bare
+    "m")) (PosArg (Qualid (Qualified "DynFlags" "DynFlags")) :| []))]
   DynFlags.ContainsDynFlags: ClassDefinition (Qualified "DynFlags" "ContainsDynFlags")
-    [Inferred Explicit (Ident (Bare "t"))] Nothing [(Qualified "DynFlags" "extractDynFlags",Arrow
+    [ExplicitBinder (Ident (Bare "t"))] Nothing [(Qualified "DynFlags" "extractDynFlags",Arrow
     (Qualid (Bare "t")) (Qualid (Qualified "DynFlags" "DynFlags")))]
 constructorTypes:
   DynFlags.Opt_WarnOverlappingPatterns: Qualified "DynFlags" "WarningFlag"

--- a/examples/ghc/lib/Module.h2ci
+++ b/examples/ghc/lib/Module.h2ci
@@ -58,12 +58,12 @@ recordFieldTypes:
   Module.indefModuleName: Qualified "Module" "IndefModule"
   Module.installedModuleName: Qualified "Module" "InstalledModule"
 classDefns:
-  Module.HasModule: ClassDefinition (Qualified "Module" "HasModule") [Inferred Explicit
+  Module.HasModule: ClassDefinition (Qualified "Module" "HasModule") [ExplicitBinder
     (Ident (Bare "m"))] Nothing [(Qualified "Module" "getModule",App (Qualid (Bare
     "m")) (PosArg (Qualid (Qualified "Module" "Module")) :| []))]
-  Module.ContainsModule: ClassDefinition (Qualified "Module" "ContainsModule") [Inferred
-    Explicit (Ident (Bare "t"))] Nothing [(Qualified "Module" "extractModule",Arrow
-    (Qualid (Bare "t")) (Qualid (Qualified "Module" "Module")))]
+  Module.ContainsModule: ClassDefinition (Qualified "Module" "ContainsModule") [ExplicitBinder
+    (Ident (Bare "t"))] Nothing [(Qualified "Module" "extractModule",Arrow (Qualid
+    (Bare "t")) (Qualid (Qualified "Module" "Module")))]
 constructorTypes:
   Module.DefiniteUnitId: Qualified "Module" "UnitId"
   Module.Mk_ComponentId: Qualified "Module" "ComponentId"

--- a/examples/ghc/lib/Name.h2ci
+++ b/examples/ghc/lib/Name.h2ci
@@ -1,10 +1,10 @@
 superclassCount:
   Name.NamedThing: '0'
 defaultMethods:
-  Name.NamedThing: fromList [(Qualified "Name" "getOccName",Fun (Inferred Explicit
-    (Ident (Bare "n")) :| []) (App (Qualid (Qualified "Name" "nameOccName")) (PosArg
-    (Parens (App (Qualid (Qualified "Name" "getName")) (PosArg (Qualid (Bare "n"))
-    :| []))) :| [])))]
+  Name.NamedThing: fromList [(Qualified "Name" "getOccName",Fun (ExplicitBinder (Ident
+    (Bare "n")) :| []) (App (Qualid (Qualified "Name" "nameOccName")) (PosArg (Parens
+    (App (Qualid (Qualified "Name" "getName")) (PosArg (Qualid (Bare "n")) :| [])))
+    :| [])))]
 classTypes:
   Name.NamedThing: fromList []
 constructors:
@@ -27,7 +27,7 @@ recordFieldTypes:
   Name.n_uniq: Qualified "Name" "Name"
   Name.n_occ: Qualified "Name" "Name"
 classDefns:
-  Name.NamedThing: ClassDefinition (Qualified "Name" "NamedThing") [Inferred Explicit
+  Name.NamedThing: ClassDefinition (Qualified "Name" "NamedThing") [ExplicitBinder
     (Ident (Bare "a"))] Nothing [(Qualified "Name" "getName",Arrow (Qualid (Bare "a"))
     (Qualid (Qualified "Name" "Name"))),(Qualified "Name" "getOccName",Arrow (Qualid
     (Bare "a")) (Qualid (Qualified "OccName" "OccName")))]

--- a/examples/ghc/lib/OccName.h2ci
+++ b/examples/ghc/lib/OccName.h2ci
@@ -19,9 +19,9 @@ recordFieldTypes:
   OccName.occNameFS: Qualified "OccName" "OccName"
   OccName.occNameSpace: Qualified "OccName" "OccName"
 classDefns:
-  OccName.HasOccName: ClassDefinition (Qualified "OccName" "HasOccName") [Inferred
-    Explicit (Ident (Bare "name"))] Nothing [(Qualified "OccName" "occName",Arrow
-    (Qualid (Bare "name")) (Qualid (Qualified "OccName" "OccName")))]
+  OccName.HasOccName: ClassDefinition (Qualified "OccName" "HasOccName") [ExplicitBinder
+    (Ident (Bare "name"))] Nothing [(Qualified "OccName" "occName",Arrow (Qualid (Bare
+    "name")) (Qualid (Qualified "OccName" "OccName")))]
 constructorTypes:
   OccName.Mk_OccName: Qualified "OccName" "OccName"
   OccName.A: Qualified "OccName" "OccEnv"

--- a/examples/ghc/lib/TrieMap.h2ci
+++ b/examples/ghc/lib/TrieMap.h2ci
@@ -41,23 +41,23 @@ recordFieldTypes:
   TrieMap.am_data: Qualified "TrieMap" "AltMap"
   TrieMap.tlm_number: Qualified "TrieMap" "TyLitMap"
 classDefns:
-  TrieMap.TrieMap: ClassDefinition (Qualified "TrieMap" "TrieMap") [Inferred Explicit
+  TrieMap.TrieMap: ClassDefinition (Qualified "TrieMap" "TrieMap") [ExplicitBinder
     (Ident (Bare "m"))] Nothing [(Qualified "TrieMap" "Key",Qualid (Bare "Type")),(Qualified
-    "TrieMap" "alterTM",Forall (Inferred Implicit (Ident (Bare "b")) :| []) (Arrow
+    "TrieMap" "alterTM",Forall (ImplicitBinders (Ident (Bare "b") :| []) :| []) (Arrow
     (Qualid (Qualified "TrieMap" "Key")) (Arrow (App (Qualid (Qualified "TrieMap"
     "XT")) (PosArg (Qualid (Bare "b")) :| [])) (Arrow (App (Qualid (Bare "m")) (PosArg
     (Qualid (Bare "b")) :| [])) (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "b"))
-    :| [])))))),(Qualified "TrieMap" "emptyTM",Forall (Inferred Implicit (Ident (Bare
-    "a")) :| []) (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "a")) :| []))),(Qualified
-    "TrieMap" "foldTM",Forall (Inferred Implicit (Ident (Bare "a")) :| [Inferred Implicit
-    (Ident (Bare "b"))]) (Arrow (Parens (Arrow (Qualid (Bare "a")) (Arrow (Qualid
+    :| [])))))),(Qualified "TrieMap" "emptyTM",Forall (ImplicitBinders (Ident (Bare
+    "a") :| []) :| []) (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "a")) :| []))),(Qualified
+    "TrieMap" "foldTM",Forall (ImplicitBinders (Ident (Bare "a") :| []) :| [ImplicitBinders
+    (Ident (Bare "b") :| [])]) (Arrow (Parens (Arrow (Qualid (Bare "a")) (Arrow (Qualid
     (Bare "b")) (Qualid (Bare "b"))))) (Arrow (App (Qualid (Bare "m")) (PosArg (Qualid
     (Bare "a")) :| [])) (Arrow (Qualid (Bare "b")) (Qualid (Bare "b")))))),(Qualified
-    "TrieMap" "lookupTM",Forall (Inferred Implicit (Ident (Bare "b")) :| []) (Arrow
+    "TrieMap" "lookupTM",Forall (ImplicitBinders (Ident (Bare "b") :| []) :| []) (Arrow
     (Qualid (Qualified "TrieMap" "Key")) (Arrow (App (Qualid (Bare "m")) (PosArg (Qualid
     (Bare "b")) :| [])) (App (Qualid (Bare "option")) (PosArg (Qualid (Bare "b"))
-    :| []))))),(Qualified "TrieMap" "mapTM",Forall (Inferred Implicit (Ident (Bare
-    "a")) :| [Inferred Implicit (Ident (Bare "b"))]) (Arrow (Parens (Arrow (Qualid
+    :| []))))),(Qualified "TrieMap" "mapTM",Forall (ImplicitBinders (Ident (Bare "a")
+    :| []) :| [ImplicitBinders (Ident (Bare "b") :| [])]) (Arrow (Parens (Arrow (Qualid
     (Bare "a")) (Qualid (Bare "b")))) (Arrow (App (Qualid (Bare "m")) (PosArg (Qualid
     (Bare "a")) :| [])) (App (Qualid (Bare "m")) (PosArg (Qualid (Bare "b")) :| [])))))]
 constructorTypes:
@@ -73,4 +73,4 @@ constructorTypes:
   TrieMap.Mk_CoercionMapX: Qualified "TrieMap" "CoercionMapX"
   TrieMap.VM: Qualified "TrieMap" "VarMap"
 explicitMethodArguments:
-  TrieMap.Key: ! '[Inferred Explicit (Ident (Bare "m"))]'
+  TrieMap.Key: ! '[ExplicitBinder (Ident (Bare "m"))]'

--- a/examples/ghc/lib/UniqSupply.h2ci
+++ b/examples/ghc/lib/UniqSupply.h2ci
@@ -18,14 +18,14 @@ constructorFields:
 recordFieldTypes:
   UniqSupply.unUSM: Qualified "UniqSupply" "UniqSM"
 classDefns:
-  UniqSupply.MonadUnique: ClassDefinition (Qualified "UniqSupply" "MonadUnique") [Inferred
-    Explicit (Ident (Bare "m")),Generalized Implicit (App (Qualid (Qualified "GHC.Base"
-    "Monad")) (PosArg (Qualid (Bare "m")) :| []))] Nothing [(Qualified "UniqSupply"
-    "getUniqueM",App (Qualid (Bare "m")) (PosArg (Qualid (Qualified "Unique" "Unique"))
-    :| [])),(Qualified "UniqSupply" "getUniqueSupplyM",App (Qualid (Bare "m")) (PosArg
-    (Qualid (Qualified "UniqSupply" "UniqSupply")) :| [])),(Qualified "UniqSupply"
-    "getUniquesM",App (Qualid (Bare "m")) (PosArg (App (Qualid (Bare "list")) (PosArg
-    (Qualid (Qualified "Unique" "Unique")) :| [])) :| []))]
+  UniqSupply.MonadUnique: ClassDefinition (Qualified "UniqSupply" "MonadUnique") [ExplicitBinder
+    (Ident (Bare "m")),Generalized Implicit (App (Qualid (Qualified "GHC.Base" "Monad"))
+    (PosArg (Qualid (Bare "m")) :| []))] Nothing [(Qualified "UniqSupply" "getUniqueM",App
+    (Qualid (Bare "m")) (PosArg (Qualid (Qualified "Unique" "Unique")) :| [])),(Qualified
+    "UniqSupply" "getUniqueSupplyM",App (Qualid (Bare "m")) (PosArg (Qualid (Qualified
+    "UniqSupply" "UniqSupply")) :| [])),(Qualified "UniqSupply" "getUniquesM",App
+    (Qualid (Bare "m")) (PosArg (App (Qualid (Bare "list")) (PosArg (Qualid (Qualified
+    "Unique" "Unique")) :| [])) :| []))]
 constructorTypes:
   UniqSupply.MkSplitUniqSupply: Qualified "UniqSupply" "UniqSupply"
   UniqSupply.USM: Qualified "UniqSupply" "UniqSM"

--- a/examples/ghc/lib/Unique.h2ci
+++ b/examples/ghc/lib/Unique.h2ci
@@ -7,7 +7,7 @@ constructors:
 constructorFields:
   Unique.MkUnique: NonRecordFields 1
 classDefns:
-  Unique.Uniquable: ClassDefinition (Qualified "Unique" "Uniquable") [Inferred Explicit
+  Unique.Uniquable: ClassDefinition (Qualified "Unique" "Uniquable") [ExplicitBinder
     (Ident (Bare "a"))] Nothing [(Qualified "Unique" "getUnique",Arrow (Qualid (Bare
     "a")) (Qualid (Qualified "Unique" "Unique")))]
 constructorTypes:

--- a/examples/transformers/lib/Control/Monad/Trans/Class.h2ci
+++ b/examples/transformers/lib/Control/Monad/Trans/Class.h2ci
@@ -4,9 +4,9 @@ classTypes:
   Control.Monad.Trans.Class.MonadTrans: fromList []
 classDefns:
   Control.Monad.Trans.Class.MonadTrans: ClassDefinition (Qualified "Control.Monad.Trans.Class"
-    "MonadTrans") [Inferred Explicit (Ident (Bare "t"))] Nothing [(Qualified "Control.Monad.Trans.Class"
-    "lift",Forall (Inferred Implicit (Ident (Bare "m")) :| [Inferred Implicit (Ident
-    (Bare "a"))]) (Forall (Generalized Implicit (Parens (App (Qualid (Qualified "GHC.Base"
-    "Monad")) (PosArg (Qualid (Bare "m")) :| []))) :| []) (Arrow (App (Qualid (Bare
-    "m")) (PosArg (Qualid (Bare "a")) :| [])) (App (App (Qualid (Bare "t")) (PosArg
-    (Qualid (Bare "m")) :| [])) (PosArg (Qualid (Bare "a")) :| [])))))]
+    "MonadTrans") [ExplicitBinder (Ident (Bare "t"))] Nothing [(Qualified "Control.Monad.Trans.Class"
+    "lift",Forall (ImplicitBinders (Ident (Bare "m") :| []) :| [ImplicitBinders (Ident
+    (Bare "a") :| [])]) (Forall (Generalized Implicit (Parens (App (Qualid (Qualified
+    "GHC.Base" "Monad")) (PosArg (Qualid (Bare "m")) :| []))) :| []) (Arrow (App (Qualid
+    (Bare "m")) (PosArg (Qualid (Bare "a")) :| [])) (App (App (Qualid (Bare "t"))
+    (PosArg (Qualid (Bare "m")) :| [])) (PosArg (Qualid (Bare "a")) :| [])))))]

--- a/hs-to-coq.cabal
+++ b/hs-to-coq.cabal
@@ -123,7 +123,6 @@ library
                      , array
                      , lens
                      , containers
-                     , contravariant
                      , syb
                      , text
                      , directory

--- a/src/lib/HsToCoq/ConvertHaskell/Declarations/TypeSynonym.hs
+++ b/src/lib/HsToCoq/ConvertHaskell/Declarations/TypeSynonym.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, OverloadedStrings, MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleContexts, OverloadedStrings, PatternSynonyms, MultiParamTypeClasses #-}
 
 module HsToCoq.ConvertHaskell.Declarations.TypeSynonym (SynBody(..), convertSynDecl) where
 
@@ -13,7 +13,7 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Set as S
 
 import HsToCoq.Coq.Gallina as Coq
-import HsToCoq.Coq.Gallina.Util
+import HsToCoq.Coq.Gallina.Util (pattern Var, appList, binderIdents)
 import HsToCoq.Coq.FreeVars
 import HsToCoq.Util.FVs
 

--- a/src/lib/HsToCoq/ConvertHaskell/Definitions.hs
+++ b/src/lib/HsToCoq/ConvertHaskell/Definitions.hs
@@ -60,7 +60,7 @@ decomposeFixpoint (Fix (FixOne (FixBody name binders _ mty body)))
 -- argument is part of the “Gallina” AST, and the concrete representation
 -- is created by the pretty-printer
 decomposeFixpoint (App _wfFix [PosArg _rel, PosArg _measure, PosArg _underscore, PosArg (Fun binders body)])
-    | (b:bs, Inferred Explicit (Ident name)) <- unsnocNEL binders
+    | (b:bs, ExplicitBinder (Ident name)) <- unsnocNEL binders
     = Just (name, b :| bs, Nothing, body)
 decomposeFixpoint _
     = Nothing

--- a/src/lib/HsToCoq/ConvertHaskell/Module.hs
+++ b/src/lib/HsToCoq/ConvertHaskell/Module.hs
@@ -74,7 +74,10 @@ data ConvertedModuleDeclarations =
 
 annotateFixpoint :: [Binder] -> (Maybe Term) -> [Binder]
 annotateFixpoint [] _ = []
-annotateFixpoint ((Inferred e n):tl) (Just (Arrow x y)) = (Typed Generalizable e (fromList [n]) x):(annotateFixpoint tl (Just y))
+annotateFixpoint (ExplicitBinder n:tl) (Just (Arrow x y)) =
+  (Typed Generalizable Explicit (fromList [n]) x):(annotateFixpoint tl (Just y))
+annotateFixpoint (ImplicitBinders ns:tl) (Just (Arrow x y)) =
+  (Typed Generalizable Implicit ns x):(annotateFixpoint tl (Just y))
 annotateFixpoint (a:tl) (Just (Arrow _ y)) = a:(annotateFixpoint tl (Just y))
 annotateFixpoint x _ = x
 

--- a/src/lib/HsToCoq/ConvertHaskell/Module.hs
+++ b/src/lib/HsToCoq/ConvertHaskell/Module.hs
@@ -97,8 +97,8 @@ convertBinding sigs (ConvertedDefinitionBinding cdef@ConvertedDefinition{_convDe
     t  <- view (edits.termination.at name)
     obl <- view (edits.obligations.at name)
     useProgram <- useProgramHere
-    if | Just (WellFounded order) <- t  -- turn into Program Fixpoint
-       ->  pure <$> toProgramFixpointSentence cdef order obl
+    if | Just (WellFoundedTA order) <- t  -- turn into Program Fixpoint
+       ->  pure <$> toProgramFixpointSentence cdef (fromWFOrder order) obl
        | otherwise                   -- no edit
        -> let def = DefinitionDef Global (cdef^.convDefName)
                                          (cdef^.convDefArgs)

--- a/src/lib/HsToCoq/ConvertHaskell/Parameters/Parsers.y
+++ b/src/lib/HsToCoq/ConvertHaskell/Parameters/Parsers.y
@@ -556,7 +556,8 @@ Order :: { Order }
 TerminationArgument :: { TerminationArgument }
   : 'deferred'    { Deferred }
   | 'corecursive' { Corecursive }
-  | Order         { WellFounded $1 }
+  | Order         { fromOrder $1 }
+  | '{' struct Num '}' { StructOrderTA (StructPos_ (fromIntegral $3)) }
 
 Instance :: { InstanceDefinition }
   : 'Instance' Qualid Many(Binder) TypeAnnotation ':=' '{' SepBy(FieldDefinition, ';')  '}'

--- a/src/lib/HsToCoq/ConvertHaskell/Parameters/Parsers.y
+++ b/src/lib/HsToCoq/ConvertHaskell/Parameters/Parsers.y
@@ -96,6 +96,7 @@ import HsToCoq.ConvertHaskell.Parameters.Parsers.Lexing
   original        { TokWord    "original"       }
   name            { TokWord    "name"           }
   promote         { TokWord    "promote"        }
+  polyrec         { TokWord    "polyrec"        }
   except          { TokWord    "except"         }
   '='             { TokOp      "="              }
   ':->'           { TokOp      ":->"            }
@@ -329,6 +330,7 @@ Edit :: { Edit }
   | collapse 'let' Qualid                                 { CollapseLetEdit                  $3                                    }
   | 'in' Qualid Edit                                      { InEdit                           $2 $3                                 }
   | promote Qualid                                        { PromoteEdit                      $2                                    }
+  | polyrec Qualid                                        { PolyrecEdit                      $2                                    }
   | except 'in' SepBy1(Qualid, ',') Edit                  { ExceptInEdit                     $3 $4                                 }
 
 Edits :: { [Edit] }

--- a/src/lib/HsToCoq/ConvertHaskell/Parameters/Parsers.y
+++ b/src/lib/HsToCoq/ConvertHaskell/Parameters/Parsers.y
@@ -448,13 +448,11 @@ BinderName :: { Name }
   | '_'     { UnderscoreName }
 
 ExplicitBinderGuts :: { Binder }
-  : BinderName                                        { Inferred Explicit $1 }
-  | BinderName Some(BinderName) TypeAnnotation        { Typed Ungeneralizable Explicit ($1 <| $2) $3 }
-  | BinderName TypeAnnotation                         { Typed Ungeneralizable Explicit ($1 :| []) $2 }
+  : Some(BinderName) TypeAnnotation   { mkBinders Explicit $1 $2 }
 
 ImplicitBinderGuts :: { Binder }
-  : BinderName                         { Inferred Implicit $1 }
-  | Some(BinderName) TypeAnnotation    { Typed Ungeneralizable Implicit $1 $2 }
+  : Some(BinderName)                  { ImplicitBinders $1 }
+  | Some(BinderName) TypeAnnotation   { mkBinders Implicit $1 $2 }
 
 -- Generalizable binders have an ambiguous syntax:
 --
@@ -478,7 +476,7 @@ GeneralizableBinderGuts :: { Explicitness -> Binder }
     }
 
 Binder :: { Binder }
-  : BinderName                        { Inferred Explicit $1 }
+  : BinderName                        { ExplicitBinder $1 }
   | '(' ExplicitBinderGuts ')'        { $2 }
   | '{' ImplicitBinderGuts '}'        { $2 }
   | '`' '(' GeneralizableBinderGuts ')'    { $3 Explicit }

--- a/src/lib/HsToCoq/ConvertHaskell/Type.hs
+++ b/src/lib/HsToCoq/ConvertHaskell/Type.hs
@@ -44,8 +44,8 @@ import HsToCoq.ConvertHaskell.Literals
 
 convertLHsTyVarBndrs :: LocalConvMonad r m => Explicitness -> [LHsTyVarBndr GhcRn] -> m [Binder]
 convertLHsTyVarBndrs ex tvs = for (map unLoc tvs) $ \case
-  UserTyVar   NOEXTP tv   -> Inferred ex . Ident <$> var TypeNS (unLoc tv)
-  KindedTyVar NOEXTP tv k -> Typed Ungeneralizable ex <$> (pure . Ident <$> var TypeNS (unLoc tv)) <*> convertLType k
+  UserTyVar   NOEXTP tv   -> mkBinder ex . Ident <$> var TypeNS (unLoc tv)
+  KindedTyVar NOEXTP tv k -> mkBinders ex <$> (pure . Ident <$> var TypeNS (unLoc tv)) <*> convertLType k
 #if __GLASGOW_HASKELL__ >= 806
   XTyVarBndr v -> noExtCon v
 #endif
@@ -197,7 +197,7 @@ finishConvertHsSigTypeWithExcls utvm coq_itvs coq_ty excls =
         PreserveUnusedTyVars -> coq_itvs
         DeleteUnusedTyVars   -> let fvs = getFreeVars coq_ty
                                 in filter (`elem` fvs) coq_itvs
-      coq_binders = Inferred Coq.Implicit . Ident <$> coq_tyVars \\ excls
+      coq_binders = mkBinder Coq.Implicit . Ident <$> coq_tyVars \\ excls
   in pure $ maybeForall coq_binders coq_ty
 
 convertLHsSigType :: LocalConvMonad r m => UnusedTyVarMode -> LHsSigType GhcRn -> m Term

--- a/src/lib/HsToCoq/Coq/FreeVars.hs
+++ b/src/lib/HsToCoq/Coq/FreeVars.hs
@@ -72,8 +72,9 @@ instance HasBV Qualid Name where
   bvOf UnderscoreName = mempty
 
 instance HasBV Qualid Binder where
-  bvOf (Inferred _ex x)       = bvOf x
-  bvOf (Typed _gen _ex xs ty) = foldMap bvOf xs <> fvOf' ty
+  bvOf (ExplicitBinder name)  = bvOf name
+  bvOf (ImplicitBinders names) = foldMap bvOf names
+  bvOf (Typed _ex _ei names ty) = foldMap bvOf names <> fvOf' ty
   bvOf (Generalized _ex ty)   = fvOf' ty
 
 instance HasBV Qualid MatchItem where

--- a/src/lib/HsToCoq/Coq/Gallina.hs
+++ b/src/lib/HsToCoq/Coq/Gallina.hs
@@ -6,7 +6,7 @@ License     : MIT
 Maintainer  : antal.b.sz@gmail.com
 Stability   : experimental
 
-<https://coq.inria.fr/distrib/current/refman/Reference-Manual003. Chapter 1, \"The Gallina Specification Language\", in the Coq reference manual.>
+<https://coq.inria.fr/distrib/V8.12.0/refman/language/core/. Chapter 1, \"The Gallina Specification Language\", in the Coq reference manual.>
 -}
 
 {-# LANGUAGE DeriveDataTypeable #-}
@@ -93,7 +93,7 @@ import           Data.Data          (Data (..))
 import           Data.Typeable
 
 -- $Lexical
--- <https://coq.inria.fr/distrib/current/refman/Reference-Manual003.html#lexical §1.1, \"Lexical conventions\", in the Coq reference manual.>
+-- <https://coq.inria.fr/distrib/V8.12.0/refman/language/core/basic.html#lexical-conventions §1.1, \"Lexical conventions\", in the Coq reference manual.>
 --
 -- We don't model the lexical conventions.  Values are just strings or numbers
 -- or what have you.
@@ -111,7 +111,7 @@ type Num         = Natural
 type Op          = Text
 
 -- $Terms
--- <https://coq.inria.fr/distrib/current/refman/Reference-Manual003.html#term §1.2, \"Terms\", in the Coq reference manual.>
+-- <https://coq.inria.fr/distrib/V8.12.0/refman/language/core/basic.html#essential-vocabulary \"Essential vocabulary\", in the Coq reference manual.>
 
 -- |NB: There is a bug in the Coq manual as regards the definition
 -- of destructuring pattern-@let@, i.e. with @let ' /pattern/ …@.  The
@@ -185,8 +185,11 @@ data Explicitness = Explicit                                                    
                   deriving (Eq, Ord, Show, Read, Enum, Bounded, Typeable, Data)
 
 -- |@/binder/ ::=@ – the @/explicitness/@ is extra
-data Binder = Inferred Explicitness Name                                                       -- ^@/name/@ or @{ /name/ }@
-            | Typed Generalizability Explicitness (NonEmpty Name) Term                         -- ^@/generalizability/@ @( /name/ … /name/ : /term/ )@ or @/generalizability/@ @{ /name/ … /name/ : /term/ }@
+--
+-- https://coq.inria.fr/distrib/V8.12.0/refman/language/core/assumptions.html#grammar-token-binder
+data Binder = ExplicitBinder Name                                                              -- ^@/name/@ (inferred type)
+            | ImplicitBinders (NonEmpty Name)                                                  -- ^@{/name/ ... /name/}@ (inferred type)
+            | Typed Generalizability Explicitness (NonEmpty Name) Term                         -- ^@generalizability/ ( /name/ … /name/ : /term/ )@ or @/generalizability/ { /name/ … /name/ : /term/ }@
             | Generalized Explicitness Term                                                    -- ^@` ( /term/ )@ or @` { /term/ }@
             deriving (Eq, Ord, Show, Read, Typeable, Data)
 

--- a/src/lib/HsToCoq/Coq/Gallina/Orphans.hs
+++ b/src/lib/HsToCoq/Coq/Gallina/Orphans.hs
@@ -21,4 +21,4 @@ instance IsString Term where
 instance IsString Qualid where
     fromString x = unsafeIdentToQualid (T.pack x)
 instance IsString Binder where
-    fromString x = Inferred Explicit (Ident (unsafeIdentToQualid (T.pack x)))
+    fromString x = ExplicitBinder (Ident (unsafeIdentToQualid (T.pack x)))

--- a/src/lib/HsToCoq/Coq/Preamble.hs
+++ b/src/lib/HsToCoq/Coq/Preamble.hs
@@ -41,7 +41,7 @@ staticPreamble = T.unlines
 -- an axiom of the type given here is added to the preamble
 builtInAxioms :: M.Map Qualid Term
 builtInAxioms = M.fromList $ map (first Bare)
-    [ "missingValue"   =: Forall [ Inferred Implicit (Ident (Bare "a")) ] a
+    [ "missingValue"   =: Forall [ ImplicitBinders (pure (Ident (Bare "a"))) ] a
     ]
   where
    a = "a"

--- a/src/lib/HsToCoq/Coq/Pretty.hs
+++ b/src/lib/HsToCoq/Coq/Pretty.hs
@@ -255,7 +255,7 @@ instance Gallina Term where
       group $ "fun" <+> hcat (fmap (("'"<>) . parens . renderGallina) pats)
                     <+> nest 2 ("=>" <!> renderGallina' funPrec body)
     where fvs = getFreeVars body
-          check (Inferred Explicit (Ident name) : vars) (MatchItem (Qualid v) Nothing Nothing:ss)
+          check (ExplicitBinder (Ident name) : vars) (MatchItem (Qualid v) Nothing Nothing:ss)
               = v `S.notMember` fvs  && name == v  && check vars ss
           check [] [] = True
           check _ _ = False
@@ -425,8 +425,10 @@ binder_decoration Ungeneralizable ex b = if_explicit ex (if b then parensN else 
 binder_decoration Generalizable   ex _ = ("`" <>) . if_explicit ex parensN
 
 instance Gallina Binder where
-  renderGallina' _ (Inferred ex name)  =
-    binder_decoration Ungeneralizable ex False $ renderGallina name
+  renderGallina' _ (ExplicitBinder name)  =
+    binder_decoration Ungeneralizable Explicit False $ renderGallina name
+  renderGallina' _ (ImplicitBinders names)  =
+    binder_decoration Ungeneralizable Implicit False $ render_args H names
   renderGallina' _ (Typed gen ex names ty) =
     binder_decoration gen ex True $ render_args_ty H names ty
   renderGallina' _ (Generalized ex ty)  =

--- a/src/lib/HsToCoq/Coq/Subst.hs
+++ b/src/lib/HsToCoq/Coq/Subst.hs
@@ -41,8 +41,9 @@ instance Subst IndBody where
              substCon f (qid,binders, Just t)  = (qid, map (subst f) binders, Just (subst f t))
 
 instance Subst Binder where
-  subst _f b@(Inferred _ex _x) = b
-  subst f (Typed gen ex xs ty) = Typed gen ex xs (subst f ty)
+  subst _f b@(ExplicitBinder _) = b
+  subst _f b@(ImplicitBinders _) = b
+  subst f (Typed gen ei names ty) = Typed gen ei names (subst f ty)
   subst f (Generalized ex ty)  = Generalized ex (subst f ty)
 
 instance Subst MatchItem where


### PR DESCRIPTION
- The edit `polyrec myFun` allows `myFun` to be polymorphic recursive (it might be possible to make it the default behavior, but it would take some more refactoring and I'm not sure whether it's a good idea)
- The edit `termination myFun {struct 3}` makes the 3rd argument of `myFun` its decreasing argument.  
    There was already the `{struct arg}` syntax in the parser (where `arg` is an identifier rather than a number) but:
    + it was not actually implemented
    + the arguments in Coq have generated names (`arg_33__`), which are not reliable to name explicitly
- We can now write `forall {a b c}` instead of `forall {a} {b} {c}`